### PR TITLE
Configure Copilot to review only changed lines in PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,18 @@
 
 This repository is a WordPress Gutenberg block plugin. When reviewing code or providing suggestions, follow these guidelines:
 
+## ⚠️ REVIEW SCOPE - READ THIS FIRST
+
+**ONLY review the lines that were changed in this pull request (the diff).**
+
+- ✅ Review: New lines added (green +)
+- ✅ Review: Modified lines (red - / green +)
+- ❌ Do NOT review: Unchanged lines in the file
+- ❌ Do NOT review: Entire files or full context
+- ❌ Do NOT review: Files in the diff that have no meaningful changes
+
+**If there are no issues in the changed lines, do not leave a review.**
+
 ## WordPress Block Development Standards
 
 ### Critical Patterns

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,10 @@
 ## Description
 <!-- Provide a clear description of the changes in this PR -->
 
+---
+**For Copilot Reviewers:** Please review ONLY the changed lines (diff) in this PR, not the entire files or unchanged code.
+---
+
 ## Type of Change
 <!-- Check the relevant box -->
 


### PR DESCRIPTION
## Summary
Updates GitHub Copilot configuration to focus reviews on changed lines (the diff) only, rather than reviewing entire files or unchanged code.

## Changes Made
- Updated `.github/copilot-instructions.md` with explicit scope instructions
- Added review scope reminder to `.github/pull_request_template.md`
- Configured Copilot to skip unchanged code and full file reviews

## Why This Change?
Copilot was reviewing more code than necessary, including unchanged lines and full file contexts. This configuration makes reviews more focused and relevant to the actual changes in each PR.

## Test Plan
- [x] Configuration files updated
- [ ] Next PR will test the new Copilot review behavior
- [ ] Verify Copilot only comments on changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)