### PR TITLE
fix: flip card back not visible in editor

### DIFF
--- a/src/blocks/flip-card/editor.scss
+++ b/src/blocks/flip-card/editor.scss
@@ -56,6 +56,11 @@
 		&__container > .wp-block-designsetgo-flip-card-back {
 			box-sizing: border-box;
 			position: relative;
+			// CRITICAL: Override frontend opacity to show both cards in editor
+			opacity: 1 !important;
+			transform: none !important;
+			pointer-events: auto !important;
+			z-index: auto !important;
 
 			// Add label in editor
 			&::before {


### PR DESCRIPTION
## Problem

The flip card back section was not showing background color or text in the WordPress editor. The issue only affected the editor view - frontend display was working correctly.

## Root Cause

Frontend styles set `opacity: 0` on the back card (to hide it initially), but the editor styles didn't override this property. This caused both the background color and all content to be invisible in the editor, making it impossible to edit the back card.

## Solution

Added explicit CSS overrides in the editor styles for flip-card-back:
- `opacity: 1 !important` - Makes the card visible
- `transform: none !important` - Removes any transforms that could hide content
- `pointer-events: auto !important` - Ensures the card is clickable/editable
- `z-index: auto !important` - Resets stacking context

These overrides only apply within `.editor-styles-wrapper` and `.block-editor-block-preview__content`, so frontend display is unaffected.

## Testing

- [x] Verified background colors show correctly in editor
- [x] Verified text content is visible in editor
- [x] Verified both cards are editable in editor
- [x] Verified frontend display unchanged
- [x] Build succeeds with no errors

## Files Changed

- [src/blocks/flip-card/editor.scss](src/blocks/flip-card/editor.scss) - Added opacity/transform overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)