### PR TITLE
Fix: Prevent sticky header from affecting footer template parts

### DIFF
--- a/src/styles/utilities/_sticky-header.scss
+++ b/src/styles/utilities/_sticky-header.scss
@@ -11,12 +11,11 @@
 /**
  * Core Sticky Header Support
  * Only applies when enabled globally (body class) OR per-block (template part class)
- * Targets template parts that contain navigation or are headers
+ * Targets semantic headers or explicitly enabled template parts
+ * Note: Excludes footer elements to prevent unintended stickiness
  */
-body:not(.block-editor-page).dsgo-sticky-header-enabled .wp-block-template-part:first-of-type,
+body:not(.block-editor-page).dsgo-sticky-header-enabled .wp-block-template-part:not(footer):first-of-type,
 body:not(.block-editor-page).dsgo-sticky-header-enabled header.wp-block-template-part,
-body:not(.block-editor-page).dsgo-sticky-header-enabled .wp-block-template-part:has(.wp-block-navigation),
-body:not(.block-editor-page).dsgo-sticky-header-enabled .wp-block-template-part:has(.is-position-sticky),
 body:not(.block-editor-page) .wp-block-template-part.dsgo-sticky-header-enabled {
 	position: sticky;
 	top: 0;
@@ -29,20 +28,16 @@ body:not(.block-editor-page) .wp-block-template-part.dsgo-sticky-header-enabled 
  * Account for WordPress admin bar when user is logged in
  */
 /* stylelint-disable selector-class-pattern */
-body:not(.block-editor-page).admin-bar.dsgo-sticky-header-enabled .wp-block-template-part:first-of-type,
+body:not(.block-editor-page).admin-bar.dsgo-sticky-header-enabled .wp-block-template-part:not(footer):first-of-type,
 body:not(.block-editor-page).admin-bar.dsgo-sticky-header-enabled header.wp-block-template-part,
-body:not(.block-editor-page).admin-bar.dsgo-sticky-header-enabled .wp-block-template-part:has(.wp-block-navigation),
-body:not(.block-editor-page).admin-bar.dsgo-sticky-header-enabled .wp-block-template-part:has(.is-position-sticky),
 body:not(.block-editor-page).admin-bar .wp-block-template-part.dsgo-sticky-header-enabled {
 	top: 32px; /* WordPress admin bar height on desktop */
 }
 
 @media screen and (max-width: 782px) {
 
-	body:not(.block-editor-page).admin-bar.dsgo-sticky-header-enabled .wp-block-template-part:first-of-type,
+	body:not(.block-editor-page).admin-bar.dsgo-sticky-header-enabled .wp-block-template-part:not(footer):first-of-type,
 	body:not(.block-editor-page).admin-bar.dsgo-sticky-header-enabled header.wp-block-template-part,
-	body:not(.block-editor-page).admin-bar.dsgo-sticky-header-enabled .wp-block-template-part:has(.wp-block-navigation),
-	body:not(.block-editor-page).admin-bar.dsgo-sticky-header-enabled .wp-block-template-part:has(.is-position-sticky),
 	body:not(.block-editor-page).admin-bar .wp-block-template-part.dsgo-sticky-header-enabled {
 		top: 46px; /* WordPress admin bar height on mobile */
 	}


### PR DESCRIPTION
## Summary
Fixed sticky header CSS selectors that were incorrectly applying to footer template parts, causing footers to become sticky when only headers should be affected.

## Changes
- ✅ Removed `.wp-block-template-part:has(.wp-block-navigation)` selector (was catching footers with navigation)
- ✅ Removed `.wp-block-template-part:has(.is-position-sticky)` selector (too broad)
- ✅ Added `:not(footer)` to `:first-of-type` selector to explicitly exclude footer elements
- ✅ Updated all three selector groups: core sticky styles, admin bar offset, and mobile admin bar offset

## Impact
**Before**: Footers with navigation were becoming sticky due to overly broad CSS selectors.

**After**: Only the following elements receive sticky positioning:
- Semantic `<header>` elements with class `wp-block-template-part`
- Template parts with explicit `.dsgo-sticky-header-enabled` class
- First template part that is not a footer (when global sticky header is enabled)

## Files Changed
- `src/styles/utilities/_sticky-header.scss` - Refined CSS selectors (1 file, -10/+5 lines)

## Testing
- [ ] Verify header becomes sticky when sticky header is enabled
- [ ] Verify footer does NOT become sticky
- [ ] Test with and without WordPress admin bar
- [ ] Test responsive behavior on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)