### PR TITLE
fix: Stop overriding theme.json fontFamilies

### DIFF
--- a/includes/admin/class-global-styles.php
+++ b/includes/admin/class-global-styles.php
@@ -59,14 +59,7 @@ class Global_Styles {
 					'units'        => array( 'px', 'em', 'rem', 'vh', 'vw', '%' ),
 				),
 				'typography' => array(
-					'fontSizes'    => $this->get_font_sizes( $saved_styles ),
-					'fontFamilies' => array(
-						array(
-							'slug'       => 'system',
-							'fontFamily' => '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif',
-							'name'       => __( 'System Font', 'designsetgo' ),
-						),
-					),
+					'fontSizes' => $this->get_font_sizes( $saved_styles ),
 				),
 				'custom'     => array(
 					'designsetgo' => array(


### PR DESCRIPTION
## Summary

- Removes hardcoded `fontFamilies` array from `extend_theme_json()` that was replacing theme-defined fonts
- The plugin now only extends `fontSizes`, allowing themes to retain full control over their font families

Fixes #132

## Root Cause

The plugin's `Global_Styles::extend_theme_json()` method was including a hardcoded `fontFamilies` array with only a "System Font" entry. When WordPress merged this via `update_with()`, it replaced the theme's entire `fontFamilies` array instead of merging, causing CSS variables like `var(--wp--preset--font-family--somefont)` to become undefined.

## Test plan

- [ ] Activate plugin on a site with custom theme.json fonts
- [ ] Verify font CSS variables are defined (inspect `<html>` element)
- [ ] Verify `var(--wp--preset--font-family--{slug})` works in editor and frontend
- [ ] Test with Twenty Twenty-Five to confirm default fonts remain available