### PR TITLE
fix: Prevent double background layer on Icon Button with rounded corners

### DIFF
--- a/src/blocks/icon-button/block.json
+++ b/src/blocks/icon-button/block.json
@@ -33,6 +33,7 @@
 			"background": true,
 			"text": true,
 			"gradients": true,
+			"__experimentalSkipSerialization": true,
 			"__experimentalDefaultControls": {
 				"background": true,
 				"text": true


### PR DESCRIPTION
## Summary
- Fixed visual bug where Icon Button background colors created a double-layer effect with rounded corners
- Added `__experimentalSkipSerialization: true` to color supports in Icon Button block.json

## Problem
The Icon Button block was applying background colors to **two layers**:
1. Outer wrapper (`.dsgo-icon-button`) - automatically via WordPress color supports
2. Inner button element (`.dsgo-icon-button__wrapper`) - manually via inline styles

When border-radius was applied, the outer background layer would show through or overlap incorrectly, creating visual artifacts.

## Solution
By adding `__experimentalSkipSerialization: true` to the color supports configuration, WordPress now:
- ✅ Provides the color picker UI in the editor
- ✅ Stores color values in block attributes
- ❌ Does NOT automatically apply colors to the outer wrapper

The block continues to manually apply colors to the inner button element where they belong, eliminating the double-layer issue.

## Test Plan
- [x] Build completes successfully
- [ ] Icon Button with background color + border radius displays correctly in editor
- [ ] Icon Button with background color + border radius displays correctly on frontend
- [ ] Hover states work correctly
- [ ] Color picker UI remains functional