### PR TITLE
Add hash link trigger support for modal reopening

### DIFF
--- a/src/blocks/modal/view.js
+++ b/src/blocks/modal/view.js
@@ -1553,20 +1553,11 @@
 			link.addEventListener('click', (e) => {
 				e.preventDefault();
 
-				const instance = modal.dsgoModalInstance;
-
 				// Open the modal if not already open
-				if (!instance.isOpen) {
-					instance.open(link);
-				}
-
-				// Update URL hash if the setting is enabled
-				if (instance.settings.updateUrlOnOpen && instance.modalId) {
-					instance.isUpdatingHash = true;
-					window.location.hash = instance.modalId;
-					setTimeout(() => {
-						instance.isUpdatingHash = false;
-					}, 100);
+				// Note: The open() method handles URL hash updates when updateUrlOnOpen is enabled,
+				// so we don't duplicate that logic here
+				if (!modal.dsgoModalInstance.isOpen) {
+					modal.dsgoModalInstance.open(link);
 				}
 			});
 		});


### PR DESCRIPTION
## Description
This PR adds support for anchor links with hash hrefs (e.g., `href="#modal-id"`) to trigger modal opening. This solves the issue where modals couldn't be reopened when the hash was already present in the URL, since the browser wouldn't fire a `hashchange` event in that scenario.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issue
<!-- Link to the issue this PR addresses -->
Closes #

## Changes Made

- Added `initHashLinkTriggers()` function to initialize click handlers on anchor links with hash hrefs
- Function queries for anchor links that target modals with `allowHashTrigger` enabled
- Implements click prevention and manual modal opening to ensure modals can be reopened
- Handles URL hash updates when `updateUrlOnOpen` setting is enabled
- Uses `data-dsgo-hash-trigger-initialized` attribute to prevent duplicate initialization
- Integrated `initHashLinkTriggers()` into all initialization points (DOM ready, dynamic content, and mutation observer)
- Exposed `initHashLinkTriggers()` as public API via `window.dsgoInitHashLinkTriggers`

## Testing
<!-- Describe how you tested these changes -->

- [ ] Tested in WordPress editor
- [ ] Tested on frontend
- [ ] Tested with Twenty Twenty-Five theme
- [ ] Tested responsive behavior (mobile/tablet/desktop)
- [ ] No console errors
- [ ] No PHP errors

## Checklist

- [ ] My code follows the [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated documentation as needed
- [ ] My changes generate no new warnings or errors
- [ ] I have tested on WordPress 6.4+
- [ ] I have followed the patterns in [CLAUDE.md](.claude/CLAUDE.md)
- [ ] All files are under 300 lines (if applicable)
- [ ] I have added JSDoc comments to new functions
- [ ] Accessibility: WCAG 2.1 AA compliant
- [ ] Security: All user input is validated and sanitized
- [ ] Internationalization: All user-facing strings use `__()` or `_e()`

## Additional Notes
The implementation uses a flag (`isUpdatingHash`) to prevent infinite loops when updating the URL hash, and only processes anchor links that haven't already been initialized to avoid duplicate event listeners.

https://claude.ai/code/session_019Dwy4iy1PgJytGvHNvYfcz