### PR TITLE
Update CI workflow: Add WordPress 6.9 and fix phpunit execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.0', '8.2']
-        wordpress: ['6.7', '6.8', 'latest']
+        wordpress: ['6.7', '6.8', '6.9', 'latest']
 
     steps:
       - name: Checkout code
@@ -326,8 +326,8 @@ jobs:
 
       - name: Run PHP tests in WordPress environment
         run: |
-          # Run tests inside wp-env
-          npx wp-env run tests-cli --env-cwd=wp-content/plugins/designsetgo "composer run-script test"
+          # Run tests inside wp-env (using vendor/bin/phpunit directly since Composer isn't in the container)
+          npx wp-env run tests-cli --env-cwd=wp-content/plugins/designsetgo vendor/bin/phpunit
         continue-on-error: true
 
       - name: Check plugin activation


### PR DESCRIPTION
## Description
Updates the CI workflow to test against WordPress 6.9 and fixes the PHP test execution method in the wp-env environment by calling phpunit directly instead of through Composer.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Code refactoring
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement

## Changes Made

- Added WordPress 6.9 to the test matrix alongside 6.7, 6.8, and latest
- Changed PHP test execution from `composer run-script test` to `vendor/bin/phpunit` directly
- Updated comment to clarify that Composer is not available in the wp-env container

## Testing

- [ ] Tested in WordPress editor
- [ ] Tested on frontend
- [ ] Tested with Twenty Twenty-Five theme
- [ ] Tested responsive behavior (mobile/tablet/desktop)
- [ ] No console errors
- [ ] No PHP errors

## Checklist

- [x] My code follows the WordPress Coding Standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have tested on WordPress 6.4+

## Additional Notes

The change to use `vendor/bin/phpunit` directly addresses a constraint where Composer is not available within the wp-env test container, while still maintaining the same test execution functionality.

https://claude.ai/code/session_01CiL5TZSX2KyiGBqDoCV5Fv