### PR TITLE
fix(ci): Only run Claude review on PR creation, add manual re-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, ready_for_review]
 
 jobs:
   claude-review:
@@ -19,50 +19,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get review context
-        id: context
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          EVENT_ACTION="${{ github.event.action }}"
-
-          # Determine if this is an initial review or follow-up
-          if [[ "$EVENT_ACTION" == "opened" || "$EVENT_ACTION" == "ready_for_review" ]]; then
-            echo "review_type=initial" >> $GITHUB_OUTPUT
-            echo "previous_comments=" >> $GITHUB_OUTPUT
-          else
-            echo "review_type=follow_up" >> $GITHUB_OUTPUT
-
-            # Fetch previous Claude review comments from this PR
-            # Get comments that mention Claude or from the github-actions bot
-            PREVIOUS_COMMENTS=$(gh api \
-              -H "Accept: application/vnd.github+json" \
-              "/repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" \
-              --jq '[.[] | select(.user.login == "github-actions[bot]" or (.body | test("Claude|SEVERITY|Critical|High|Medium|Low"; "i"))) | {path: .path, line: .line, body: .body}] | .[0:20]' 2>/dev/null || echo "[]")
-
-            # Also get issue comments (summary comments)
-            SUMMARY_COMMENTS=$(gh api \
-              -H "Accept: application/vnd.github+json" \
-              "/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-              --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | test("Review Summary|issues found|Overall"; "i"))) | .body] | .[0:3]' 2>/dev/null || echo "[]")
-
-            # Get the commits since the last review (commits pushed in this synchronize event)
-            BEFORE_SHA="${{ github.event.before }}"
-            AFTER_SHA="${{ github.event.after }}"
-
-            # Store for use in prompt
-            echo "before_sha=${BEFORE_SHA}" >> $GITHUB_OUTPUT
-            echo "after_sha=${AFTER_SHA}" >> $GITHUB_OUTPUT
-
-            # Write comments to file to handle multi-line content
-            echo "$PREVIOUS_COMMENTS" > /tmp/previous_inline_comments.json
-            echo "$SUMMARY_COMMENTS" > /tmp/previous_summary_comments.json
-          fi
-
-      - name: Run Claude Code Review (Initial)
-        if: steps.context.outputs.review_type == 'initial'
-        id: claude-review-initial
+      - name: Run Claude Code Review
+        id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -124,81 +82,3 @@ jobs:
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
-
-      - name: Run Claude Code Review (Follow-up)
-        if: steps.context.outputs.review_type == 'follow_up'
-        id: claude-review-followup
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          track_progress: true
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-            REVIEW TYPE: INCREMENTAL FOLLOW-UP (not initial review)
-            COMMITS IN THIS PUSH: ${{ steps.context.outputs.before_sha }}..${{ steps.context.outputs.after_sha }}
-
-            You are performing an INCREMENTAL follow-up review on a WordPress plugin PR.
-            This PR has already been reviewed. Focus only on NEW changes and issue resolution.
-
-            ## CRITICAL: Be Concise - Avoid Redundant Comments
-            - DO NOT re-review code that hasn't changed since the last review
-            - DO NOT repeat issues already raised in previous comments
-            - ONLY comment on genuinely NEW issues in the new commits
-
-            ## Step 1: Understand What Changed Since Last Review
-            Run these commands to see ONLY the new changes:
-            ```
-            git diff ${{ steps.context.outputs.before_sha }}..${{ steps.context.outputs.after_sha }} --name-only
-            git diff ${{ steps.context.outputs.before_sha }}..${{ steps.context.outputs.after_sha }}
-            ```
-
-            ## Step 2: Check Previous Review Context
-            Previous inline review comments were made on these areas (avoid duplicating):
-            - Review the existing inline comments on this PR to understand what was already flagged
-            - Run `gh pr view ${{ github.event.pull_request.number }} --comments` to see previous summary comments
-
-            ## Step 3: Incremental Review Focus
-            For the NEW changes only, check:
-
-            **Security (only in new/modified code):**
-            - XSS, SQL injection, CSRF issues
-            - Input validation gaps
-
-            **Issue Resolution Check:**
-            - Were previously flagged issues addressed in this commit?
-            - Are there any regressions?
-
-            **New Issues Only:**
-            - Logic errors in new code
-            - Code quality problems in new code
-
-            ## Output Format - BE BRIEF
-
-            **For new issues:** Use inline comments with SEVERITY, but ONLY for genuinely new problems.
-
-            **Summary comment format (use `gh pr comment`):**
-            ```
-            ## Follow-up Review: [X] new commit(s)
-
-            ### Changes Reviewed
-            - [List files changed in this push]
-
-            ### Previously Flagged Issues
-            - ✅ Resolved: [list any fixed issues]
-            - ⏳ Still Open: [list any unresolved issues, if applicable]
-
-            ### New Issues Found
-            - [Only if there are genuinely NEW issues]
-
-            ### Status
-            [Brief overall status - e.g., "Changes look good" or "X new issues need attention"]
-            ```
-
-            IMPORTANT: If the new commits look good and address previous feedback,
-            a brief "Changes look good, previous issues resolved" is sufficient.
-            Do NOT repeat the full review checklist - this is a follow-up, not a new review.
-
-          claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Read,Grep,Glob"
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,9 +11,104 @@ on:
     types: [submitted]
 
 jobs:
+  # Handle @claude review or /review commands on PRs
+  claude-review:
+    if: |
+      github.event.issue.pull_request &&
+      (
+        (github.event_name == 'issue_comment' &&
+         (contains(github.event.comment.body, '@claude review') ||
+          contains(github.event.comment.body, '/review')))
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.issue.number }}
+            REVIEW TYPE: Re-review requested by @${{ github.event.comment.user.login }}
+
+            You are reviewing a WordPress plugin codebase. Perform a thorough code review.
+            This is a re-review request - previous reviews may exist on this PR.
+
+            ## Instructions
+            1. First, run `gh pr diff ${{ github.event.issue.number }}` to see all changes
+            2. Run `gh pr view ${{ github.event.issue.number }} --comments` to see previous review comments
+            3. Read and analyze every changed file carefully
+            4. Use inline comments for specific code issues
+            5. Post a summary comment at the end
+
+            ## Security Review (CRITICAL - Check Every Item)
+            - XSS vulnerabilities: unescaped output, missing esc_html/esc_attr/wp_kses
+            - SQL injection: direct variable interpolation in queries, missing $wpdb->prepare()
+            - CSRF: missing nonce verification on forms/AJAX
+            - Sanitization ordering: HTML entities must be decoded BEFORE tag stripping
+            - Input validation: validate and sanitize all user inputs
+            - File operations: path traversal, unsafe file uploads
+            - Authentication/authorization: capability checks, nonce validation
+
+            ## Logic and Correctness
+            - Off-by-one errors, boundary conditions
+            - Null/undefined checks, type coercion issues
+            - Validation logic flaws (e.g., incorrectly rejecting falsy values like 0, false, '0')
+            - Race conditions, timing issues
+            - Error handling gaps
+            - Edge cases not covered
+
+            ## Code Quality
+            - DRY violations: duplicated code that should be extracted
+            - Functions doing too many things
+            - Missing or incorrect error handling
+            - Inconsistent patterns within the codebase
+            - Unused variables or dead code
+
+            ## WordPress Best Practices
+            - Proper hook usage and priorities
+            - Correct use of WordPress APIs
+            - Proper enqueueing of scripts/styles
+            - Translation function usage
+
+            ## Output Format
+            For each issue found:
+            1. Use `mcp__github_inline_comment__create_inline_comment` to add inline comments on specific lines
+            2. Clearly state: SEVERITY (Critical/High/Medium/Low), the problem, and how to fix it
+
+            Post a final summary comment using `gh pr comment` with:
+            - Count of issues by severity
+            - Key findings that need attention
+            - Overall assessment
+            - Note which previously flagged issues have been resolved (if any)
+
+            Be thorough - a shallow review that misses real issues is worse than no review.
+            If you find NO issues, explain what you checked and why the code is correct.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
+
+  # Handle general @claude mentions (not review requests)
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       !contains(github.event.comment.body, '@claude review') &&
+       !contains(github.event.comment.body, '/review')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
@@ -47,4 +142,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
- Auto-review now only triggers on PR opened and ready_for_review events
- Removed synchronize/reopened triggers to avoid duplicate reviews on pushes
- Added @claude review and /review commands for manual re-review requests
- Simplified claude-code-review.yml by removing unused follow-up review logic
- General @claude mentions continue to work for other requests

https://claude.ai/code/session_01Bt9xbNRsqp5kPg1XJweqoc