### PR TITLE
Fix icon background layering by making wrapper transparent

### DIFF
--- a/src/blocks/icon/edit.js
+++ b/src/blocks/icon/edit.js
@@ -67,7 +67,6 @@ export default function IconEdit({ attributes, setAttributes, context }) {
 		alignItems: 'center',
 		justifyContent: 'center',
 		transform: rotation !== 0 ? `rotate(${rotation}deg)` : undefined,
-		// Background is inherited via CSS rules (see style.scss and editor.scss)
 		// borderRadius inherits from parent for shape variants
 		borderRadius: 'inherit',
 	};

--- a/src/blocks/icon/editor.scss
+++ b/src/blocks/icon/editor.scss
@@ -72,19 +72,11 @@
 		}
 	}
 
-	// Ensure proper color inheritance from WordPress color controls
-	// Use background-color instead of background shorthand to avoid conflicts with hover
-	&[style*="background-color"]:not([style*="background-image"]) .dsgo-icon__wrapper {
-		background-color: inherit !important;
-	}
-
-	// For background images, inherit full background
-	&[style*="background-image"] .dsgo-icon__wrapper {
-		background: inherit !important;
-	}
-
-	// Transfer background from WordPress color classes (e.g., has-warning-background-color)
-	&.has-background .dsgo-icon__wrapper {
+	// WordPress color support applies background to this outer element.
+	// The wrapper must stay transparent to prevent double-layered backgrounds
+	// (two stacked semi-transparent layers would appear darker over the icon).
+	&.has-background .dsgo-icon__wrapper,
+	&[style*="background-color"] .dsgo-icon__wrapper {
 		background-color: transparent !important;
 	}
 

--- a/src/blocks/icon/save.js
+++ b/src/blocks/icon/save.js
@@ -57,7 +57,6 @@ export default function IconSave({ attributes }) {
 		alignItems: 'center',
 		justifyContent: 'center',
 		transform: rotation !== 0 ? `rotate(${rotation}deg)` : undefined,
-		// Background is inherited via CSS rules (see style.scss)
 		// borderRadius inherits from parent for shape variants
 		borderRadius: 'inherit',
 	};

--- a/src/blocks/icon/style.scss
+++ b/src/blocks/icon/style.scss
@@ -10,8 +10,8 @@
 	justify-content: center;
 	width: fit-content; // Ensure block only takes space needed for icon + padding
 	max-width: fit-content; // Prevent expansion beyond content
-	// Background color will be inherited by child .dsgo-icon__wrapper
-	// No need to force transparent here
+	// Background color is applied to this outer element by WordPress color support.
+	// The inner .dsgo-icon__wrapper should NOT inherit it to avoid double-layering.
 
 	// Link wrapper
 	&__link {
@@ -89,19 +89,11 @@
 		margin-right: auto;
 	}
 
-	// Ensure proper color inheritance from WordPress color controls
-	// Use background-color instead of background shorthand to avoid conflicts with hover
-	&[style*="background-color"]:not([style*="background-image"]) .dsgo-icon__wrapper {
-		background-color: inherit !important;
-	}
-
-	// For background images, inherit full background
-	&[style*="background-image"] .dsgo-icon__wrapper {
-		background: inherit !important;
-	}
-
-	// Transfer background from WordPress color classes (e.g., has-warning-background-color)
-	&.has-background .dsgo-icon__wrapper {
+	// WordPress color support applies background to this outer element.
+	// The wrapper must stay transparent to prevent double-layered backgrounds
+	// (two stacked semi-transparent layers would appear darker over the icon).
+	&.has-background .dsgo-icon__wrapper,
+	&[style*="background-color"] .dsgo-icon__wrapper {
 		background-color: transparent !important;
 	}
 


### PR DESCRIPTION
## Description
Fixes a visual issue where icon backgrounds appeared double-layered and darker than intended. The problem occurred because both the outer icon block and inner wrapper were inheriting/applying background colors, creating two stacked semi-transparent layers.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Code refactoring

## Changes Made

- **Simplified background handling logic**: Consolidated multiple CSS rules into a single, clearer rule that makes the `.dsgo-icon__wrapper` transparent when the outer block has a background applied
- **Removed inheritance rules**: Deleted overly complex rules that attempted to inherit background colors from the parent element
- **Updated comments**: Clarified the background color strategy in both SCSS files and removed outdated comments from JS files
- **Applied consistently**: Updated both `style.scss` and `editor.scss` with the same transparent wrapper approach

## Testing

- [ ] Tested in WordPress editor
- [ ] Tested on frontend
- [ ] Tested with Twenty Twenty-Five theme
- [ ] Tested responsive behavior (mobile/tablet/desktop)
- [ ] No console errors
- [ ] No PHP errors

## Checklist

- [x] My code follows the WordPress Coding Standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

## Additional Notes

The key insight is that WordPress color support applies background colors to the outer block element. By making the inner wrapper transparent instead of trying to inherit the background, we prevent the visual artifact of double-layered backgrounds while maintaining proper color application.

https://claude.ai/code/session_01QthTAYA2KitLDiniuTWVyj