### PR TITLE
Fix vertical alignment in sections with min-height

### DIFF
--- a/src/blocks/section/editor.scss
+++ b/src/blocks/section/editor.scss
@@ -10,6 +10,13 @@
 	// CRITICAL: Ensure width includes padding to prevent overflow
 	box-sizing: border-box;
 
+	// CRITICAL: Flex column layout so .dsgo-stack__inner can fill available height
+	// This enables vertical alignment (top/center/bottom/space-between) to work
+	// when the section has a min-height set. Shape dividers are position: absolute
+	// so they don't participate in this flex layout.
+	display: flex;
+	flex-direction: column;
+
 	// Ensure background images respect border radius in editor
 	overflow: hidden;
 
@@ -77,6 +84,10 @@
 	// When constrainWidth is enabled, inline styles will override with max-width
 	.dsgo-stack__inner {
 		width: 100%;
+		// CRITICAL: Fill available height so justify-content (vertical alignment) works
+		// Without this, the inner div shrinks to content height and top/center/bottom/space-between
+		// have no effect because there's no extra space to distribute
+		flex-grow: 1;
 		// Ensure inner container doesn't create positioning context for absolute children
 		position: static;
 	}

--- a/src/blocks/section/style.scss
+++ b/src/blocks/section/style.scss
@@ -10,6 +10,13 @@
 	// CRITICAL: Ensure width includes padding to prevent overflow
 	box-sizing: border-box;
 
+	// CRITICAL: Flex column layout so .dsgo-stack__inner can fill available height
+	// This enables vertical alignment (top/center/bottom/space-between) to work
+	// when the section has a min-height set. Shape dividers are position: absolute
+	// so they don't participate in this flex layout.
+	display: flex;
+	flex-direction: column;
+
 	// Ensure background images respect border radius
 	overflow: hidden;
 
@@ -93,6 +100,10 @@
 	// Width constraints are applied via inline styles when constrainWidth is enabled
 	.dsgo-stack__inner {
 		width: 100%;
+		// CRITICAL: Fill available height so justify-content (vertical alignment) works
+		// Without this, the inner div shrinks to content height and top/center/bottom/space-between
+		// have no effect because there's no extra space to distribute
+		flex-grow: 1;
 		// CRITICAL: Position relative + z-index to ensure content stays above both overlays
 		// z-index: 2 (above ::before overlay at z-index: 1 and ::after hover at z-index: 0)
 		position: relative;


### PR DESCRIPTION
## Description
Fixes vertical alignment (top/center/bottom/space-between) in section blocks when a minimum height is set. The section container now uses flexbox layout to properly distribute space, allowing the inner content container to fill available height and enabling justify-content alignment to work as expected.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issue
<!-- Link to the issue this PR addresses -->
Closes #

## Changes Made

- Added `display: flex` and `flex-direction: column` to `.wp-block-dsgo-section` in both editor and frontend styles
- Added `flex-grow: 1` to `.dsgo-stack__inner` to fill available vertical space
- Added detailed comments explaining the flexbox layout and why it's necessary for vertical alignment to work with min-height sections
- Changes applied consistently to both `src/blocks/section/editor.scss` and `src/blocks/section/style.scss`

## Testing
<!-- Describe how you tested these changes -->

- [ ] Tested in WordPress editor
- [ ] Tested on frontend
- [ ] Tested with Twenty Twenty-Five theme
- [ ] Tested responsive behavior (mobile/tablet/desktop)
- [ ] No console errors
- [ ] No PHP errors

## Checklist
<!-- Ensure all items are checked before requesting review -->

- [ ] My code follows the [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated documentation as needed
- [ ] My changes generate no new warnings or errors
- [ ] I have tested on WordPress 6.4+
- [ ] I have followed the patterns in [CLAUDE.md](.claude/CLAUDE.md)
- [ ] All files are under 300 lines (if applicable)
- [ ] I have added JSDoc comments to new functions
- [ ] Accessibility: WCAG 2.1 AA compliant
- [ ] Security: All user input is validated and sanitized
- [ ] Internationalization: All user-facing strings use `__()` or `_e()`

## Additional Notes
The flexbox layout uses `position: absolute` shape dividers which don't participate in the flex layout, so they continue to work as expected. The inner container's `flex-grow: 1` ensures it expands to fill available space, making vertical alignment options functional when sections have a defined minimum height.

https://claude.ai/code/session_01Bq6X2d7pgyDSctYUCwQ72K