### PR TITLE
Fix alignment of blocks in Group containers by removing float

### DIFF
--- a/src/blocks/icon-button/style.scss
+++ b/src/blocks/icon-button/style.scss
@@ -28,7 +28,10 @@
 	// Constrain button width and use margin for alignment
 	// CRITICAL: Must override inline display: inline-flex with display: flex for auto margins to work
 	// NOTE: Margins don't use !important so user-set margins can override
+	// float: none overrides WordPress flow layout which applies float:left/right to aligned blocks,
+	// causing them to sit beside adjacent content (e.g. headings) in Group blocks
 	&.aligncenter:not(.alignfull) {
+		float: none !important;
 		display: flex !important;
 		width: fit-content !important;
 		margin-left: auto;
@@ -36,12 +39,14 @@
 	}
 
 	&.alignleft:not(.alignfull) {
+		float: none !important;
 		display: flex !important;
 		width: fit-content !important;
 		margin-right: auto;
 	}
 
 	&.alignright:not(.alignfull) {
+		float: none !important;
 		display: flex !important;
 		width: fit-content !important;
 		margin-left: auto;

--- a/src/blocks/icon/style.scss
+++ b/src/blocks/icon/style.scss
@@ -74,15 +74,24 @@
 	}
 
 	// Alignment variants
+	// float: none overrides WordPress flow layout which applies float:left/right to aligned blocks,
+	// causing them to sit beside adjacent content (e.g. headings) in Group blocks
 	&.alignleft {
-		margin-right: 1em;
+		float: none !important;
+		display: flex !important;
+		margin-right: auto !important;
+		margin-left: 0 !important;
 	}
 
 	&.alignright {
-		margin-left: 1em;
+		float: none !important;
+		display: flex !important;
+		margin-left: auto !important;
+		margin-right: 0 !important;
 	}
 
 	&.aligncenter {
+		float: none !important;
 		display: flex;
 		justify-content: center;
 		margin-left: auto;

--- a/src/blocks/modal-trigger/style.scss
+++ b/src/blocks/modal-trigger/style.scss
@@ -58,7 +58,10 @@
 	// Constrain button width and use margin for alignment
 	// CRITICAL: Must override inline display: inline-flex with display: flex for auto margins to work
 	// NOTE: Margins don't use !important so user-set margins can override
+	// float: none overrides WordPress flow layout which applies float:left/right to aligned blocks,
+	// causing them to sit beside adjacent content (e.g. headings) in Group blocks
 	&.aligncenter:not(.alignfull) {
+		float: none !important;
 		display: flex !important;
 		width: fit-content !important;
 		margin-left: auto;
@@ -66,12 +69,14 @@
 	}
 
 	&.alignleft:not(.alignfull) {
+		float: none !important;
 		display: flex !important;
 		width: fit-content !important;
 		margin-right: auto;
 	}
 
 	&.alignright:not(.alignfull) {
+		float: none !important;
 		display: flex !important;
 		width: fit-content !important;
 		margin-left: auto;

--- a/src/blocks/pill/editor.scss
+++ b/src/blocks/pill/editor.scss
@@ -77,8 +77,11 @@
 // Use flexbox to position the inner inline-block content
 // Important is needed to override Stack block's width: auto !important
 // Higher specificity selector to override Stack container rules
+// float: none overrides WordPress flow layout which applies float:left/right to aligned blocks,
+// causing them to sit beside adjacent content (e.g. headings) in Group blocks
 .dsgo-pill.alignleft,
 [class*="wp-container"] > .dsgo-pill.alignleft {
+	float: none !important;
 	display: flex !important;
 	justify-content: flex-start;
 	width: fit-content !important;
@@ -88,6 +91,7 @@
 
 .dsgo-pill.aligncenter,
 [class*="wp-container"] > .dsgo-pill.aligncenter {
+	float: none !important;
 	display: flex !important;
 	justify-content: center;
 	width: fit-content !important;
@@ -97,6 +101,7 @@
 
 .dsgo-pill.alignright,
 [class*="wp-container"] > .dsgo-pill.alignright {
+	float: none !important;
 	display: flex !important;
 	justify-content: flex-end;
 	width: fit-content !important;

--- a/src/blocks/pill/style.scss
+++ b/src/blocks/pill/style.scss
@@ -75,8 +75,11 @@
 // Alignment support - use flexbox to position the inner inline-block content
 // Important is needed to override Stack block's width: auto !important
 // Higher specificity selector to override Stack container rules
+// float: none overrides WordPress flow layout which applies float:left/right to aligned blocks,
+// causing them to sit beside adjacent content (e.g. headings) in Group blocks
 .dsgo-pill.alignleft,
 [class*="wp-container"] > .dsgo-pill.alignleft {
+	float: none !important;
 	display: flex !important;
 	justify-content: flex-start;
 	width: fit-content !important;
@@ -86,6 +89,7 @@
 
 .dsgo-pill.aligncenter,
 [class*="wp-container"] > .dsgo-pill.aligncenter {
+	float: none !important;
 	display: flex !important;
 	justify-content: center;
 	width: fit-content !important;
@@ -95,6 +99,7 @@
 
 .dsgo-pill.alignright,
 [class*="wp-container"] > .dsgo-pill.alignright {
+	float: none !important;
 	display: flex !important;
 	justify-content: flex-end;
 	width: fit-content !important;


### PR DESCRIPTION
## Description
Fixes alignment issues for icon-button, icon, modal-trigger, and pill blocks when used within Group containers. WordPress applies `float: left/right` to aligned blocks, causing them to sit beside adjacent content (e.g., headings) instead of respecting alignment settings. This PR adds `float: none !important` to override this behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue
<!-- Link to the issue this PR addresses -->
Closes #

## Changes Made

- Added `float: none !important` to `.aligncenter`, `.alignleft`, and `.alignright` variants in `icon-button/style.scss`
- Added `float: none !important` to `.aligncenter`, `.alignleft`, and `.alignright` variants in `icon/style.scss`
- Updated icon alignment margins to use `auto` with `!important` for consistent flexbox-based alignment
- Added `float: none !important` to `.aligncenter`, `.alignleft`, and `.alignright` variants in `modal-trigger/style.scss`
- Added `float: none !important` to alignment variants in `pill/style.scss` and `pill/editor.scss`
- Added explanatory comments documenting why `float: none` is necessary

## Testing
<!-- Describe how you tested these changes -->

- [ ] Tested in WordPress editor
- [ ] Tested on frontend
- [ ] Tested with Twenty Twenty-Five theme
- [ ] Tested responsive behavior (mobile/tablet/desktop)
- [ ] No console errors
- [ ] No PHP errors

## Checklist

- [ ] My code follows the [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated documentation as needed
- [ ] My changes generate no new warnings or errors
- [ ] I have tested on WordPress 6.4+
- [ ] I have followed the patterns in [CLAUDE.md](.claude/CLAUDE.md)
- [ ] All files are under 300 lines (if applicable)
- [ ] Accessibility: WCAG 2.1 AA compliant

## Additional Notes
This fix ensures that aligned blocks maintain their intended layout within Group containers by preventing WordPress's default float behavior from interfering with flexbox-based alignment.

https://claude.ai/code/session_01SRMhDTpuCM4tFqejs4FhWr