### PR TITLE
Fix failing e2e tests: handle WordPress 6.4+ iframed editor

### DIFF
--- a/tests/e2e/group-enhancements.spec.js
+++ b/tests/e2e/group-enhancements.spec.js
@@ -15,6 +15,7 @@ const {
 	openBlockSettings,
 	savePost,
 	publishPost,
+	getFrontendUrl,
 	selectBlock,
 	blockHasClass,
 } = require('./helpers/wordpress');
@@ -220,9 +221,7 @@ test.describe('Group Block - Clickable with Link', () => {
 		await publishPost(page);
 
 		// Get frontend URL
-		const previewUrl = await page
-			.locator('.edit-post-header-preview__button-external')
-			.getAttribute('href');
+		const previewUrl = await getFrontendUrl(page);
 
 		// Visit the frontend
 		await page.goto(previewUrl);
@@ -305,9 +304,7 @@ test.describe('Group Block - Overlay', () => {
 		await publishPost(page);
 
 		// Get frontend URL
-		const previewUrl = await page
-			.locator('.edit-post-header-preview__button-external')
-			.getAttribute('href');
+		const previewUrl = await getFrontendUrl(page);
 
 		// Visit the frontend
 		await page.goto(previewUrl);
@@ -350,9 +347,7 @@ test.describe('Group Block - Frontend Behavior', () => {
 		await publishPost(page);
 
 		// Get frontend URL
-		const previewUrl = await page
-			.locator('.edit-post-header-preview__button-external')
-			.getAttribute('href');
+		const previewUrl = await getFrontendUrl(page);
 
 		// Visit on desktop (default viewport)
 		await page.goto(previewUrl);

--- a/tests/e2e/helpers/wordpress.js
+++ b/tests/e2e/helpers/wordpress.js
@@ -2,7 +2,19 @@
  * WordPress Helper Functions for Playwright Tests
  *
  * Utilities for interacting with WordPress admin and block editor.
+ * Compatible with WordPress 6.4+ which renders the editor inside an iframe.
  */
+
+/**
+ * Get the editor canvas frame locator.
+ * WordPress 6.4+ renders block content inside an iframe named "editor-canvas".
+ *
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @return {import('@playwright/test').FrameLocator} Frame locator for the editor canvas
+ */
+function getEditorCanvas(page) {
+	return page.frameLocator('iframe[name="editor-canvas"]');
+}
 
 /**
  * Create a new post in the block editor
@@ -13,24 +25,25 @@
 async function createNewPost(page, postType = 'post') {
 	await page.goto(`/wp-admin/post-new.php?post_type=${postType}`);
 
-	// Wait for editor to load
-	await page.waitForSelector('.block-editor-writing-flow', {
+	// WordPress 6.4+ renders the block editor inside an iframe.
+	// Wait for the editor canvas iframe to load.
+	await page.locator('iframe[name="editor-canvas"]').waitFor({
 		timeout: 30000,
 	});
 
-	// Close welcome guide if it appears
-	const welcomeGuide = page.locator('.edit-post-welcome-guide');
-	if (await welcomeGuide.isVisible()) {
-		await page.click('button[aria-label="Close"]');
-	}
+	// Ensure the content inside the iframe is ready
+	const canvas = getEditorCanvas(page);
+	await canvas.locator('body').waitFor({ timeout: 15000 });
 
-	// Close any other modal dialogs
-	const closeButtons = page.locator(
-		'.components-modal__screen-overlay button[aria-label="Close"]'
-	);
-	const count = await closeButtons.count();
-	for (let i = 0; i < count; i++) {
-		await closeButtons.nth(i).click();
+	// Close any modal dialogs (welcome guide, etc.)
+	// These are rendered in the top-level page, not inside the iframe.
+	try {
+		const closeButton = page.locator(
+			'.components-modal__header button[aria-label="Close"]'
+		);
+		await closeButton.first().click({ timeout: 2000 });
+	} catch {
+		// No dialog to close
 	}
 }
 
@@ -41,25 +54,38 @@ async function createNewPost(page, postType = 'post') {
  * @param {string}                          blockName - Block name (e.g., 'core/paragraph', 'core/group')
  */
 async function insertBlock(page, blockName) {
-	// Click the block inserter
-	await page.click('.edit-post-header-toolbar__inserter-toggle');
+	const blockSlug = blockName.split('/').pop();
+	const blockLabel = blockSlug.charAt(0).toUpperCase() + blockSlug.slice(1);
 
-	// Wait for inserter panel
-	await page.waitForSelector('.block-editor-inserter__menu');
+	// Open the global block inserter via the toolbar toggle
+	const inserterToggle = page.getByRole('button', {
+		name: 'Toggle block inserter',
+	});
+	await inserterToggle.click();
 
-	// Search for the block
-	await page.fill('.block-editor-inserter__search input', blockName);
+	// Wait for the inserter panel to appear and search for the block
+	const searchInput = page
+		.locator(
+			'.block-editor-inserter__search input, .components-search-control__input'
+		)
+		.first();
+	await searchInput.waitFor();
+	await searchInput.fill(blockLabel);
 
-	// Wait for search results
+	// Wait for search results to update
 	await page.waitForTimeout(500);
 
-	// Click the first result
-	await page.click(
-		`.block-editor-block-types-list__item[data-id="${blockName}"]`
-	);
+	// Click the first matching block type item
+	await page.locator('.block-editor-block-types-list__item').first().click();
 
-	// Wait for block to be inserted
+	// Wait for the block to be inserted
 	await page.waitForTimeout(500);
+
+	// Close the inserter if still open
+	const isPressed = await inserterToggle.getAttribute('aria-pressed');
+	if (isPressed === 'true') {
+		await inserterToggle.click();
+	}
 }
 
 /**
@@ -68,14 +94,26 @@ async function insertBlock(page, blockName) {
  * @param {import('@playwright/test').Page} page - Playwright page object
  */
 async function openBlockSettings(page) {
-	const settingsButton = page.locator('button[aria-label="Settings"]');
+	const settingsButton = page
+		.locator('button[aria-label="Settings"]')
+		.first();
 
 	// Check if settings sidebar is already open
-	const isOpen = await page.locator('.edit-post-sidebar').isVisible();
+	const sidebar = page.locator('.editor-sidebar, .edit-post-sidebar');
+	const isOpen = await sidebar.first().isVisible().catch(() => false);
 
 	if (!isOpen) {
 		await settingsButton.click();
-		await page.waitForSelector('.edit-post-sidebar');
+		await sidebar.first().waitFor();
+	}
+
+	// Ensure the Block tab is active (not the Post/Page tab)
+	const blockTab = page.getByRole('tab', { name: /block/i });
+	if (await blockTab.isVisible().catch(() => false)) {
+		const isSelected = await blockTab.getAttribute('aria-selected');
+		if (isSelected !== 'true') {
+			await blockTab.click();
+		}
 	}
 }
 
@@ -86,12 +124,15 @@ async function openBlockSettings(page) {
  */
 async function savePost(page) {
 	// Click save button
-	await page.click(
-		'.editor-post-publish-button__button, .editor-post-save-draft'
-	);
+	await page
+		.locator(
+			'button.editor-post-save-draft, button.editor-post-publish-button__button'
+		)
+		.first()
+		.click();
 
 	// Wait for save to complete
-	await page.waitForSelector('.editor-post-saved-state.is-saved', {
+	await page.locator('.editor-post-saved-state.is-saved').waitFor({
 		timeout: 30000,
 	});
 }
@@ -103,16 +144,24 @@ async function savePost(page) {
  */
 async function publishPost(page) {
 	// Click publish button
-	await page.click('.editor-post-publish-panel__toggle');
+	await page.locator('.editor-post-publish-panel__toggle').first().click();
 
 	// Wait for publish panel
-	await page.waitForSelector('.editor-post-publish-panel');
+	await page.locator('.editor-post-publish-panel').waitFor();
 
 	// Click final publish button
-	await page.click('.editor-post-publish-button');
+	await page
+		.locator('.editor-post-publish-panel .editor-post-publish-button')
+		.first()
+		.click();
 
-	// Wait for success message
-	await page.waitForSelector('.components-snackbar', { timeout: 30000 });
+	// Wait for the post-publish panel or snackbar confirmation
+	await page
+		.locator(
+			'.editor-post-publish-panel__postpublish, .components-snackbar'
+		)
+		.first()
+		.waitFor({ timeout: 30000 });
 }
 
 /**
@@ -122,37 +171,48 @@ async function publishPost(page) {
  * @return {Promise<string>} Frontend URL
  */
 async function getFrontendUrl(page) {
-	// Wait for post to be saved/published
-	await page.waitForSelector(
-		'.editor-post-saved-state.is-saved, .editor-post-publish-panel__postpublish'
+	// After publishing, the post-publish panel contains a view link
+	const postPublishPanel = page.locator(
+		'.editor-post-publish-panel__postpublish'
 	);
 
-	// Get the preview link
-	const previewButton = page.locator('.editor-post-preview__button-resize');
-	await previewButton.click();
+	if (await postPublishPanel.isVisible().catch(() => false)) {
+		const viewLink = postPublishPanel
+			.locator('a[href*="/?p="], a[href*="/?page_id="], a')
+			.first();
+		const href = await viewLink.getAttribute('href');
+		if (href) {
+			return href;
+		}
+	}
 
-	const previewLink = page.locator(
-		'.edit-post-header-preview__grouping-external a'
-	);
-	const href = await previewLink.getAttribute('href');
+	// Fallback: construct URL from the current page's post ID
+	const currentUrl = page.url();
+	const match = currentUrl.match(/post=(\d+)/);
+	if (match) {
+		return `/?p=${match[1]}`;
+	}
 
-	return href;
+	throw new Error('Could not determine frontend URL');
 }
 
 /**
- * Select a block by its data-type attribute
+ * Select a block by its data-type attribute.
+ * The block content is inside the editor canvas iframe.
  *
  * @param {import('@playwright/test').Page} page      - Playwright page object
  * @param {string}                          blockType - Block type (e.g., 'core/group')
  * @param {number}                          index     - Index of the block (0-based)
  */
 async function selectBlock(page, blockType, index = 0) {
-	const blocks = page.locator(`[data-type="${blockType}"]`);
+	const canvas = getEditorCanvas(page);
+	const blocks = canvas.locator(`[data-type="${blockType}"]`);
 	await blocks.nth(index).click();
 }
 
 /**
- * Check if a block has a specific class
+ * Check if a block has a specific class.
+ * The block content is inside the editor canvas iframe.
  *
  * @param {import('@playwright/test').Page} page      - Playwright page object
  * @param {string}                          blockType - Block type (e.g., 'core/group')
@@ -161,12 +221,14 @@ async function selectBlock(page, blockType, index = 0) {
  * @return {Promise<boolean>} True if the block has the class, false otherwise
  */
 async function blockHasClass(page, blockType, className, index = 0) {
-	const block = page.locator(`[data-type="${blockType}"]`).nth(index);
+	const canvas = getEditorCanvas(page);
+	const block = canvas.locator(`[data-type="${blockType}"]`).nth(index);
 	const classes = await block.getAttribute('class');
 	return classes?.includes(className) || false;
 }
 
 module.exports = {
+	getEditorCanvas,
 	createNewPost,
 	insertBlock,
 	openBlockSettings,


### PR DESCRIPTION
WordPress 6.4+ renders the block editor content inside an iframe
(name="editor-canvas"). The test helpers were using selectors that
target the top-level page, but the editor content (.block-editor-writing-flow,
block data-type attributes) now lives inside the iframe.

Changes to helpers/wordpress.js:
- Add getEditorCanvas() to access the editor iframe via frameLocator
- Update createNewPost() to wait for the iframe instead of
  .block-editor-writing-flow on the top-level page
- Update selectBlock() and blockHasClass() to query inside the iframe
- Update insertBlock() with robust selectors (getByRole, fallback classes)
- Update openBlockSettings() to handle .editor-sidebar class rename and
  ensure Block tab is active
- Update savePost/publishPost with .first() for strict selector mode
- Rewrite getFrontendUrl() to use post-publish panel link with fallback

Changes to group-enhancements.spec.js:
- Import getFrontendUrl helper
- Replace 3 inline .edit-post-header-preview__button-external usages
  with getFrontendUrl()

https://claude.ai/code/session_0175Mw7k8vhQNvRNVFL6MNzA