### PR TITLE
Fix row block overflow by adding box-sizing: border-box

### DIFF
--- a/src/blocks/row/editor.scss
+++ b/src/blocks/row/editor.scss
@@ -7,6 +7,9 @@
  */
 
 .dsgo-flex {
+	// CRITICAL: Ensure width includes padding/border to prevent overflow
+	box-sizing: border-box;
+
 	// Visual indicator in editor and positioning context for block inserter
 	position: relative;
 	overflow: visible;

--- a/src/blocks/row/style.scss
+++ b/src/blocks/row/style.scss
@@ -7,6 +7,9 @@
  */
 
 .dsgo-flex {
+	// CRITICAL: Ensure width includes padding/border to prevent overflow
+	box-sizing: border-box;
+
 	// Container display - WordPress handles flex layout through native layout support
 	// We only need to override specific behaviors
 


### PR DESCRIPTION
## Description
Add `box-sizing: border-box` to the `.dsgo-flex` class in both editor and frontend styles to prevent layout overflow issues. This ensures that padding and borders are included in the width calculation, preventing the flex container from exceeding its intended dimensions.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issue
Closes #

## Changes Made

- Added `box-sizing: border-box` to `.dsgo-flex` in `src/blocks/row/editor.scss`
- Added `box-sizing: border-box` to `.dsgo-flex` in `src/blocks/row/style.scss`
- Added explanatory comment marking this as a critical fix for overflow prevention

## Testing

- [ ] Tested in WordPress editor
- [ ] Tested on frontend
- [ ] Tested with Twenty Twenty-Five theme
- [ ] Tested responsive behavior (mobile/tablet/desktop)
- [ ] No console errors
- [ ] No PHP errors

## Checklist

- [x] My code follows the [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated documentation as needed
- [x] My changes generate no new warnings or errors
- [ ] I have tested on WordPress 6.4+
- [ ] I have followed the patterns in [CLAUDE.md](.claude/CLAUDE.md)
- [x] All files are under 300 lines (if applicable)
- [ ] I have added JSDoc comments to new functions
- [x] Accessibility: WCAG 2.1 AA compliant
- [x] Security: All user input is validated and sanitized
- [x] Internationalization: All user-facing strings use `__()` or `_e()`

## Additional Notes
This is a minimal CSS fix that applies the standard box-sizing model to prevent flex container overflow. The change is applied consistently across both editor and frontend stylesheets.

https://claude.ai/code/session_015xQhPDVr2wYZ7uHqXSDvFf