### PR TITLE
Make tabs block titles inline-editable with RichText

### DIFF
--- a/src/blocks/tabs/edit.js
+++ b/src/blocks/tabs/edit.js
@@ -4,7 +4,7 @@
  * Parent block that manages tab navigation and panels
  */
 
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	useBlockProps,
 	InspectorControls,
@@ -93,13 +93,15 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 	// Handle keyboard navigation
 	const handleKeyDown = (e, index) => {
 		// Don't interfere with text editing in RichText
-		if (e.target.isContentEditable) {
+		if (e.target.closest('[contenteditable="true"]')) {
 			return;
 		}
 
 		// Handle Enter/Space for tab activation (divs need explicit handling unlike buttons)
 		if (e.key === 'Enter' || e.key === ' ') {
-			handleTabClick(index);
+			if (index !== activeTab) {
+				handleTabClick(index);
+			}
 			e.preventDefault();
 			return;
 		}
@@ -490,19 +492,29 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 										tagName="span"
 										className="dsgo-tabs__tab-title"
 										value={title}
-										onChange={(value) =>
+										onChange={(value) => {
+											// Strip any residual HTML to ensure plain text storage
+											const plainText = value.replace(/<[^>]*>/g, '');
 											updateBlockAttributes(
 												block.clientId,
-												{ title: value }
-											)
-										}
-										placeholder={`Tab ${index + 1}`}
+												{ title: plainText }
+											);
+										}}
+										placeholder={sprintf(
+											/* translators: %d: tab number */
+											__('Tab %d', 'designsetgo'),
+											index + 1
+										)}
 										allowedFormats={[]}
 										withoutInteractiveFormatting
 									/>
 								) : (
 									<span className="dsgo-tabs__tab-title">
-										{title || `Tab ${index + 1}`}
+										{title || sprintf(
+											/* translators: %d: tab number */
+											__('Tab %d', 'designsetgo'),
+											index + 1
+										)}
 									</span>
 								)}
 

--- a/src/blocks/tabs/editor.scss
+++ b/src/blocks/tabs/editor.scss
@@ -79,6 +79,21 @@
 			background: var(--dsgo-tab-bg-active, transparent);
 			color: var(--dsgo-tab-color-active, var(--wp--preset--color--accent-2, #2563eb));
 			font-weight: 600;
+			cursor: text;
+		}
+
+		// Inline-editable tab title (RichText)
+		&.is-active .dsgo-tabs__tab-title {
+			cursor: text;
+
+			[contenteditable] {
+				outline: none;
+				cursor: text;
+			}
+
+			&:focus-within {
+				outline: none;
+			}
 		}
 	}
 

--- a/src/blocks/tabs/editor.scss
+++ b/src/blocks/tabs/editor.scss
@@ -62,10 +62,11 @@
 		font-weight: 500;
 		transition: all 0.2s ease;
 
-		// Remove focus outline
-		&:focus,
+		// Subtle focus indicator for keyboard navigation (WCAG 2.1)
 		&:focus-visible {
-			outline: none;
+			outline: 2px solid var(--dsgo-tab-color-active, var(--wp--preset--color--accent-2, #2563eb));
+			outline-offset: -2px;
+			border-radius: 2px;
 		}
 
 		// Subtle hover effect
@@ -79,10 +80,9 @@
 			background: var(--dsgo-tab-bg-active, transparent);
 			color: var(--dsgo-tab-color-active, var(--wp--preset--color--accent-2, #2563eb));
 			font-weight: 600;
-			cursor: text;
 		}
 
-		// Inline-editable tab title (RichText)
+		// Inline-editable tab title (RichText) — cursor only on text, not icons/padding
 		&.is-active .dsgo-tabs__tab-title {
 			cursor: text;
 
@@ -92,7 +92,9 @@
 			}
 
 			&:focus-within {
-				outline: none;
+				outline: 1px dashed var(--dsgo-tab-color-active, var(--wp--preset--color--accent-2, #2563eb));
+				outline-offset: 2px;
+				border-radius: 2px;
 			}
 		}
 	}


### PR DESCRIPTION
## Description
This PR enhances the tabs block by making tab titles directly editable inline using WordPress's RichText component. Previously, tab titles could only be edited through the block inspector. Now, users can click on the active tab title to edit it directly, improving the editing experience.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issue
Closes #

## Changes Made

- Imported `RichText` component from `@wordpress/block-editor`
- Added `updateBlockAttributes` to the dispatch actions from `blockEditorStore`
- Changed tab trigger element from `<button>` to `<div>` to allow nested RichText editing
- Implemented inline RichText editing for active tab titles with plain text formatting only
- Enhanced keyboard navigation to handle Enter/Space keys and avoid interfering with text editing
- Added conditional rendering: RichText for active tabs, plain text for inactive tabs
- Updated click handler to prevent unnecessary re-selection of already active tabs
- Added editor styles for text cursor and focus states on editable tab titles

## Testing
- [ ] Tested in WordPress editor
- [ ] Tested on frontend
- [ ] Tested with Twenty Twenty-Five theme
- [ ] Tested responsive behavior (mobile/tablet/desktop)
- [ ] No console errors
- [ ] No PHP errors

## Screenshots/Videos
<!-- If applicable, add screenshots or videos demonstrating the changes -->

## Checklist

- [ ] My code follows the [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated documentation as needed
- [ ] My changes generate no new warnings or errors
- [ ] I have tested on WordPress 6.4+
- [ ] I have followed the patterns in [CLAUDE.md](.claude/CLAUDE.md)
- [ ] All files are under 300 lines (if applicable)
- [ ] I have added JSDoc comments to new functions
- [ ] Accessibility: WCAG 2.1 AA compliant
- [ ] Security: All user input is validated and sanitized
- [ ] Internationalization: All user-facing strings use `__()` or `_e()`

## Additional Notes
The change from `<button>` to `<div>` maintains accessibility through proper ARIA attributes (`role="tab"`, `aria-selected`, `aria-controls`) and keyboard navigation support. RichText is only active on the selected tab to prevent multiple simultaneous edits and maintain a clean UX.

https://claude.ai/code/session_015GgNeB8zHXsLigtEUzkaBw