### PR TITLE
Fix modal trigger button styling and responsive behavior

### DIFF
--- a/src/blocks/modal-trigger/style.scss
+++ b/src/blocks/modal-trigger/style.scss
@@ -136,6 +136,11 @@
 		padding: 4px 8px;
 		text-decoration: underline;
 
+		// Compound selector to override wp-element-button padding
+		&.wp-element-button {
+			padding: 4px 8px;
+		}
+
 		&:hover,
 		&:focus {
 			background: transparent;
@@ -214,7 +219,7 @@
 // Responsive Adjustments
 @media (max-width: 768px) {
 
-	.dsgo-modal-trigger {
+	.dsgo-modal-trigger:not(.dsgo-modal-trigger--link) {
 		padding: 10px 20px;
 		font-size: 15px;
 	}


### PR DESCRIPTION
## Description
This PR fixes styling issues with the modal trigger component, specifically addressing padding inconsistencies with WordPress element buttons and improving responsive behavior for link-style triggers.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issue
<!-- Link to the issue this PR addresses -->
Closes #

## Changes Made

- Added compound selector `.dsgo-modal-trigger.wp-element-button` to explicitly set padding (4px 8px) and override default wp-element-button padding
- Updated responsive media query to exclude link-style triggers (`.dsgo-modal-trigger--link`) from responsive padding adjustments using `:not()` pseudo-class
- This ensures link-style triggers maintain their intended compact styling on mobile devices while regular button triggers get appropriate responsive padding

## Testing

- [ ] Tested in WordPress editor
- [ ] Tested on frontend
- [ ] Tested with Twenty Twenty-Five theme
- [x] Tested responsive behavior (mobile/tablet/desktop)
- [ ] No console errors
- [ ] No PHP errors

## Checklist

- [x] My code follows the [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated documentation as needed
- [x] My changes generate no new warnings or errors
- [ ] I have tested on WordPress 6.4+
- [ ] I have followed the patterns in [CLAUDE.md](.claude/CLAUDE.md)
- [x] All files are under 300 lines (if applicable)
- [ ] I have added JSDoc comments to new functions
- [x] Accessibility: WCAG 2.1 AA compliant
- [x] Security: All user input is validated and sanitized
- [x] Internationalization: All user-facing strings use `__()` or `_e()`

## Additional Notes
These changes ensure consistent button styling across different button types while maintaining the intended visual hierarchy for link-style modal triggers on responsive layouts.

https://claude.ai/code/session_01U7CzovEEwJY5tGWHVegkig