### PR TITLE
Fix form input styling in block editor

### DIFF
--- a/src/blocks/form-builder/block.json
+++ b/src/blocks/form-builder/block.json
@@ -115,7 +115,7 @@
 		},
 		"enableEmail": {
 			"type": "boolean",
-			"default": false
+			"default": true
 		},
 		"emailTo": {
 			"type": "string",

--- a/src/blocks/form-builder/edit.js
+++ b/src/blocks/form-builder/edit.js
@@ -570,7 +570,7 @@ export default function FormBuilderEdit({
 								type="email"
 								placeholder="admin@example.com"
 								help={__(
-									'Email address to receive notifications',
+									'Leave empty to use the site admin email address',
 									'designsetgo'
 								)}
 								__next40pxDefaultSize

--- a/src/blocks/form-builder/editor.scss
+++ b/src/blocks/form-builder/editor.scss
@@ -22,6 +22,26 @@
 		&.has-child-selected {
 			border-color: var(--wp-admin-theme-color, #2563eb);
 		}
+
+		// Override WP editor default styles on form inputs.
+		// WP applies styles to input[type="text"], select, textarea etc.
+		// with .editor-styles-wrapper ancestor specificity. We need higher
+		// specificity scoped to our form builder to ensure custom properties
+		// (height, padding, border, background) actually apply.
+		.dsgo-form-field__input,
+		.dsgo-form-field__textarea,
+		.dsgo-form-field__select,
+		.dsgo-form-field__country-code {
+			box-sizing: border-box;
+			padding: var(--dsgo-form-input-padding, 0.75rem);
+			min-height: var(--dsgo-form-input-height, 44px);
+			font-size: 1rem;
+			line-height: 1.5;
+			color: inherit;
+			background-color: var(--dsgo-form-field-bg, var(--wp--preset--color--base, #fff));
+			border: 1px solid var(--dsgo-field-border-color, var(--dsgo-form-border-color, #d1d5db));
+			border-radius: var(--dsgo-field-border-radius, var(--dsgo-form-border-radius, 0.375rem));
+		}
 	}
 
 	// Submit button in editor should be disabled

--- a/src/blocks/form-builder/index.js
+++ b/src/blocks/form-builder/index.js
@@ -13,6 +13,7 @@ import Save from './save';
 import { ICON_COLOR } from '../shared/constants';
 
 import './style.scss';
+import './editor.scss';
 
 registerBlockType(metadata.name, {
 	icon: {

--- a/src/blocks/form-checkbox-field/index.js
+++ b/src/blocks/form-checkbox-field/index.js
@@ -13,6 +13,7 @@ import Save from './save';
 import { ICON_COLOR } from '../shared/constants';
 
 import './style.scss';
+import './editor.scss';
 
 registerBlockType(metadata.name, {
 	icon: {

--- a/src/blocks/form-date-field/index.js
+++ b/src/blocks/form-date-field/index.js
@@ -13,6 +13,7 @@ import Save from './save';
 import { ICON_COLOR } from '../shared/constants';
 
 import './style.scss';
+import './editor.scss';
 
 registerBlockType(metadata.name, {
 	icon: {

--- a/src/blocks/form-email-field/index.js
+++ b/src/blocks/form-email-field/index.js
@@ -13,6 +13,7 @@ import Save from './save';
 import { ICON_COLOR } from '../shared/constants';
 
 import './style.scss';
+import './editor.scss';
 
 registerBlockType(metadata.name, {
 	icon: {

--- a/src/blocks/form-hidden-field/index.js
+++ b/src/blocks/form-hidden-field/index.js
@@ -13,6 +13,7 @@ import Save from './save';
 import { ICON_COLOR } from '../shared/constants';
 
 import './style.scss';
+import './editor.scss';
 
 registerBlockType(metadata.name, {
 	icon: {

--- a/src/blocks/form-number-field/index.js
+++ b/src/blocks/form-number-field/index.js
@@ -13,6 +13,7 @@ import Save from './save';
 import { ICON_COLOR } from '../shared/constants';
 
 import './style.scss';
+import './editor.scss';
 
 registerBlockType(metadata.name, {
 	icon: {

--- a/src/blocks/form-phone-field/index.js
+++ b/src/blocks/form-phone-field/index.js
@@ -13,6 +13,7 @@ import Save from './save';
 import { ICON_COLOR } from '../shared/constants';
 
 import './style.scss';
+import './editor.scss';
 
 registerBlockType(metadata.name, {
 	icon: {

--- a/src/blocks/form-phone-field/style.scss
+++ b/src/blocks/form-phone-field/style.scss
@@ -8,3 +8,27 @@
 
 // Phone field uses the same styles as text field
 @use '../form-text-field/style' as *;
+
+// Country code dropdown - match form field styling but with constrained width
+.dsgo-form-field__country-code {
+	box-sizing: border-box;
+	padding: var(--dsgo-form-input-padding, 0.75rem);
+	min-height: var(--dsgo-form-input-height, 44px);
+	font-size: 1rem;
+	line-height: 1.5;
+	color: inherit;
+	background-color: var(--dsgo-form-field-bg, var(--wp--preset--color--base, #fff));
+	border: 1px solid var(--dsgo-field-border-color, var(--dsgo-form-border-color, #d1d5db));
+	border-radius: var(--dsgo-field-border-radius, var(--dsgo-form-border-radius, 0.375rem));
+	transition: all 0.2s ease;
+	cursor: pointer;
+
+	&:hover:not(:disabled) {
+		border-color: var(--dsgo-field-focus-color, var(--dsgo-form-focus-color, #2563eb));
+	}
+
+	&:focus {
+		outline: none;
+		border-color: var(--dsgo-field-focus-color, var(--dsgo-form-focus-color, #2563eb));
+	}
+}

--- a/src/blocks/form-select-field/index.js
+++ b/src/blocks/form-select-field/index.js
@@ -13,6 +13,7 @@ import Save from './save';
 import { ICON_COLOR } from '../shared/constants';
 
 import './style.scss';
+import './editor.scss';
 
 registerBlockType(metadata.name, {
 	icon: {

--- a/src/blocks/form-text-field/index.js
+++ b/src/blocks/form-text-field/index.js
@@ -13,6 +13,7 @@ import Save from './save';
 import { ICON_COLOR } from '../shared/constants';
 
 import './style.scss';
+import './editor.scss';
 
 registerBlockType(metadata.name, {
 	icon: {

--- a/src/blocks/form-textarea-field/index.js
+++ b/src/blocks/form-textarea-field/index.js
@@ -17,6 +17,7 @@ import deprecated from './deprecated';
 import { ICON_COLOR } from '../shared/constants';
 
 import './style.scss';
+import './editor.scss';
 
 /**
  * Register the new block name (designsetgo/form-textarea-field)

--- a/src/blocks/form-time-field/index.js
+++ b/src/blocks/form-time-field/index.js
@@ -13,6 +13,7 @@ import Save from './save';
 import { ICON_COLOR } from '../shared/constants';
 
 import './style.scss';
+import './editor.scss';
 
 registerBlockType(metadata.name, {
 	icon: {

--- a/src/blocks/form-url-field/index.js
+++ b/src/blocks/form-url-field/index.js
@@ -13,6 +13,7 @@ import Save from './save';
 import { ICON_COLOR } from '../shared/constants';
 
 import './style.scss';
+import './editor.scss';
 
 registerBlockType(metadata.name, {
 	icon: {


### PR DESCRIPTION
## Summary
- **Fix editor styling**: Form input height, padding, border, and background settings now apply correctly in the block editor. All 12 form block `editor.scss` files existed but were never imported in their `index.js` entry points — they were dead code. WordPress editor default styles on `input`/`select`/`textarea` elements had higher specificity, overriding the block's custom property-based styling.
- **Style phone country code dropdown**: The `<select>` for country codes now matches the styling of other form fields (border, padding, height, border-radius, hover/focus states).
- **Enable email notifications by default**: New forms now have email notifications enabled by default (`enableEmail: true`), with help text clarifying the admin email fallback.

## Changes
- Add `import './editor.scss'` to all 12 form block `index.js` files
- Add higher-specificity CSS rules in `form-builder/editor.scss` scoped to `.editor-styles-wrapper .dsgo-form-builder` to override WP editor defaults for `--dsgo-form-input-height`, `--dsgo-form-input-padding`, border, and background
- Add `.dsgo-form-field__country-code` styling in `form-phone-field/style.scss`
- Change `enableEmail` default from `false` to `true` in `form-builder/block.json`
- Update recipient email help text in `form-builder/edit.js`

## Test plan
- [ ] Add a Form Builder block in the editor
- [ ] Change Input Height and Input Padding in Field Styling panel — verify inputs visually resize in the editor
- [ ] Change border color and field background in Form Colors — verify they apply in the editor
- [ ] Add a phone field with country code selector enabled — verify the dropdown matches other field styling
- [ ] Verify frontend rendering still works correctly (no regressions)
- [ ] Verify new forms have email notifications enabled by default
- [ ] Check that leaving recipient email empty falls back to site admin email

🤖 Generated with [Claude Code](https://claude.com/claude-code)