### PR TITLE
feat: Add white-label build pipeline for plugin forks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,13 @@
 # Build files are generated fresh by GitHub Actions during deployment
 # .distignore ensures /build/ goes to WordPress.org SVN (not /src/)
 /build
+/dist
 /*.zip
 /deployment-package
 plugincheck.md
+
+# White-label config (per-fork, not committed upstream)
+white-label.json
 
 # Bundle analyzer reports
 bundle-report.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "designsetgo",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "designsetgo",
-      "version": "2.0.22",
+      "version": "2.0.23",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@wordpress/block-editor": "^14.0.0",
@@ -35,6 +35,7 @@
         "lint-staged": "^15.0.0",
         "playwright": "^1.56.1",
         "prettier": "^3.0.0",
+        "string-replace-loader": "^3.3.0",
         "webpack-bundle-analyzer": "^4.10.2"
       }
     },
@@ -31412,6 +31413,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/string-replace-loader": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/string-replace-loader/-/string-replace-loader-3.3.0.tgz",
+      "integrity": "sha512-AZ3y7ktSHhd/Ebipczkp6vdfp01d2kQVwFujCGAgmogTB8t4dRhbsRGDKnyZAYqBbIA9QW7+D/IsACVJOOpcBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "schema-utils": "^4"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "webpack": "^5"
       }
     },
     "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,13 @@
     "clean:cache": "rm -rf node_modules/.cache",
     "clean:cache:wp-env": "rm -rf .wp-env/WordPress",
     "clean:build": "rm -rf build",
-    "clean:all": "npm run clean:cache && npm run clean:cache:wp-env && npm run clean:build"
+    "clean:all": "npm run clean:cache && npm run clean:cache:wp-env && npm run clean:build",
+    "white-label:validate": "node scripts/white-label-validate.js",
+    "white-label:build": "npm run white-label:validate && npm run build && node scripts/white-label-php.js",
+    "white-label:zip": "npm run white-label:build && node scripts/white-label-zip.js",
+    "white-label:clean": "rm -rf dist",
+    "wp-env:white-label": "npm run white-label:build && node scripts/wp-env-white-label.js",
+    "wp-env:white-label:reset": "node scripts/wp-env-white-label.js --reset"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.28.5",
@@ -72,6 +78,7 @@
     "lint-staged": "^15.0.0",
     "playwright": "^1.56.1",
     "prettier": "^3.0.0",
+    "string-replace-loader": "^3.3.0",
     "webpack-bundle-analyzer": "^4.10.2"
   },
   "dependencies": {

--- a/scripts/white-label-json-loader.js
+++ b/scripts/white-label-json-loader.js
@@ -4,7 +4,7 @@
  * Custom webpack loader that transforms block.json files at compile time.
  * Only active when white-label.json exists with non-default values.
  *
- * @package DesignSetGo
+ * @package
  */
 
 'use strict';
@@ -13,31 +13,31 @@ const {
 	loadConfig,
 	buildBlockJsonReplacements,
 	applyReplacements,
-} = require( './white-label-replacements' );
+} = require('./white-label-replacements');
 
 // Cache config and rules across invocations (webpack calls this per-file).
 let cachedRules = null;
 let configChecked = false;
 
-module.exports = function whiteLabelJsonLoader( source ) {
+module.exports = function whiteLabelJsonLoader(source) {
 	// Only transform block.json files.
-	if ( ! this.resourcePath.endsWith( 'block.json' ) ) {
+	if (!this.resourcePath.endsWith('block.json')) {
 		return source;
 	}
 
 	// Load config once.
-	if ( ! configChecked ) {
+	if (!configChecked) {
 		const config = loadConfig();
-		if ( config ) {
-			cachedRules = buildBlockJsonReplacements( config );
+		if (config) {
+			cachedRules = buildBlockJsonReplacements(config);
 		}
 		configChecked = true;
 	}
 
 	// No transformation needed.
-	if ( ! cachedRules ) {
+	if (!cachedRules) {
 		return source;
 	}
 
-	return applyReplacements( source, cachedRules );
+	return applyReplacements(source, cachedRules);
 };

--- a/scripts/white-label-json-loader.js
+++ b/scripts/white-label-json-loader.js
@@ -1,0 +1,43 @@
+/**
+ * White Label block.json Webpack Loader
+ *
+ * Custom webpack loader that transforms block.json files at compile time.
+ * Only active when white-label.json exists with non-default values.
+ *
+ * @package DesignSetGo
+ */
+
+'use strict';
+
+const {
+	loadConfig,
+	buildBlockJsonReplacements,
+	applyReplacements,
+} = require( './white-label-replacements' );
+
+// Cache config and rules across invocations (webpack calls this per-file).
+let cachedRules = null;
+let configChecked = false;
+
+module.exports = function whiteLabelJsonLoader( source ) {
+	// Only transform block.json files.
+	if ( ! this.resourcePath.endsWith( 'block.json' ) ) {
+		return source;
+	}
+
+	// Load config once.
+	if ( ! configChecked ) {
+		const config = loadConfig();
+		if ( config ) {
+			cachedRules = buildBlockJsonReplacements( config );
+		}
+		configChecked = true;
+	}
+
+	// No transformation needed.
+	if ( ! cachedRules ) {
+		return source;
+	}
+
+	return applyReplacements( source, cachedRules );
+};

--- a/scripts/white-label-php.js
+++ b/scripts/white-label-php.js
@@ -152,140 +152,192 @@ console.log(
 	`\nWhite-label: Building rebranded plugin "${config.pluginName}"...`
 );
 
-// Clean dist/ directory.
-if (fs.existsSync(DIST)) {
-	fs.rmSync(DIST, { recursive: true, force: true });
+// Safety: DIST must be inside ROOT and not ROOT itself.
+if (!DIST.startsWith(ROOT + path.sep) || DIST === ROOT) {
+	console.error('Error: Invalid dist path — refusing to continue.');
+	process.exit(1);
 }
+
+// Clean dist/ directory (force: true handles the case where it doesn't exist).
+fs.rmSync(DIST, { recursive: true, force: true });
 fs.mkdirSync(DIST, { recursive: true });
 
-// 1. Transform and copy main plugin file (rename if slug changed).
-const mainPhpSrc = path.join(ROOT, 'designsetgo.php');
-const mainPhpDest = path.join(DIST, `${config.pluginSlug}.php`);
-let mainPhpContent = fs.readFileSync(mainPhpSrc, 'utf8');
-mainPhpContent = applyReplacements(mainPhpContent, headerRules);
-mainPhpContent = transformPhp(mainPhpContent);
-fs.writeFileSync(mainPhpDest, mainPhpContent, 'utf8');
-console.log(`  Main plugin file: ${config.pluginSlug}.php`);
+try {
+	// 1. Transform and copy main plugin file (rename if slug changed).
+	const mainPhpSrc = path.join(ROOT, 'designsetgo.php');
+	const mainPhpDest = path.join(DIST, `${config.pluginSlug}.php`);
+	let mainPhpContent = fs.readFileSync(mainPhpSrc, 'utf8');
+	mainPhpContent = applyReplacements(mainPhpContent, headerRules);
+	mainPhpContent = transformPhp(mainPhpContent);
+	fs.writeFileSync(mainPhpDest, mainPhpContent, 'utf8');
+	console.log(`  Main plugin file: ${config.pluginSlug}.php`);
 
-// 2. Transform and copy uninstall.php.
-const uninstallSrc = path.join(ROOT, 'uninstall.php');
-if (fs.existsSync(uninstallSrc)) {
-	const uninstallContent = transformPhp(
-		fs.readFileSync(uninstallSrc, 'utf8')
+	// 2. Transform and copy uninstall.php.
+	const uninstallSrc = path.join(ROOT, 'uninstall.php');
+	if (fs.existsSync(uninstallSrc)) {
+		const uninstallContent = transformPhp(
+			fs.readFileSync(uninstallSrc, 'utf8')
+		);
+		fs.writeFileSync(
+			path.join(DIST, 'uninstall.php'),
+			uninstallContent,
+			'utf8'
+		);
+		console.log('  uninstall.php');
+	}
+
+	// 3. Transform and copy includes/ directory (PHP, CSS, JS, JSON).
+	function transformIncludesFile(content, filePath) {
+		if (filePath.endsWith('.php')) {
+			return transformPhp(content);
+		}
+		if (filePath.endsWith('.css')) {
+			return applyReplacements(content, cssRules);
+		}
+		if (filePath.endsWith('.js')) {
+			return applyReplacements(content, jsRules);
+		}
+		if (filePath.endsWith('.json')) {
+			return applyReplacements(content, blockJsonRules);
+		}
+		return content;
+	}
+	copyDirWithTransform(
+		path.join(ROOT, 'includes'),
+		path.join(DIST, 'includes'),
+		transformIncludesFile,
+		/\.(php|css|js|json)$/
 	);
-	fs.writeFileSync(
-		path.join(DIST, 'uninstall.php'),
-		uninstallContent,
-		'utf8'
+	console.log('  includes/');
+
+	// 4. Transform and copy patterns/ directory (PHP files with block content).
+	copyDirWithTransform(
+		path.join(ROOT, 'patterns'),
+		path.join(DIST, 'patterns'),
+		transformPhp,
+		/\.php$/
 	);
-	console.log('  uninstall.php');
-}
+	console.log('  patterns/');
 
-// 3. Transform and copy includes/ directory (PHP, CSS, JS, JSON).
-function transformIncludesFile(content, filePath) {
-	if (filePath.endsWith('.php')) {
-		return transformPhp(content);
+	// 5. Copy build/ directory with post-build transformations.
+	// CSS: sass-loader bypasses webpack loaders for partials, so transform compiled CSS here.
+	// PHP: render.php files copied by @wordpress/scripts.
+	// JSON: block.json files copied as-is by @wordpress/scripts (webpack loader only intercepts imports).
+	// JS: Second pass to catch any remaining references the webpack loader missed.
+	function transformBuildFile(content, filePath) {
+		if (filePath.endsWith('.css')) {
+			return applyReplacements(content, cssRules);
+		}
+		if (filePath.endsWith('.php')) {
+			return transformPhp(content);
+		}
+		if (filePath.endsWith('block.json')) {
+			return applyReplacements(content, blockJsonRules);
+		}
+		if (filePath.endsWith('.js')) {
+			return applyReplacements(content, jsRules);
+		}
+		return content;
 	}
-	if (filePath.endsWith('.css')) {
-		return applyReplacements(content, cssRules);
-	}
-	if (filePath.endsWith('.js')) {
-		return applyReplacements(content, jsRules);
-	}
-	if (filePath.endsWith('.json')) {
-		return applyReplacements(content, blockJsonRules);
-	}
-	return content;
-}
-copyDirWithTransform(
-	path.join(ROOT, 'includes'),
-	path.join(DIST, 'includes'),
-	transformIncludesFile,
-	/\.(php|css|js|json)$/
-);
-console.log('  includes/');
-
-// 4. Transform and copy patterns/ directory (PHP files with block content).
-copyDirWithTransform(
-	path.join(ROOT, 'patterns'),
-	path.join(DIST, 'patterns'),
-	transformPhp,
-	/\.php$/
-);
-console.log('  patterns/');
-
-// 5. Copy build/ directory with post-build transformations.
-// CSS: sass-loader bypasses webpack loaders for partials, so transform compiled CSS here.
-// PHP: render.php files copied by @wordpress/scripts.
-// JSON: block.json files copied as-is by @wordpress/scripts (webpack loader only intercepts imports).
-// JS: Second pass to catch any remaining references the webpack loader missed.
-function transformBuildFile(content, filePath) {
-	if (filePath.endsWith('.css')) {
-		return applyReplacements(content, cssRules);
-	}
-	if (filePath.endsWith('.php')) {
-		return transformPhp(content);
-	}
-	if (filePath.endsWith('block.json')) {
-		return applyReplacements(content, blockJsonRules);
-	}
-	if (filePath.endsWith('.js')) {
-		return applyReplacements(content, jsRules);
-	}
-	return content;
-}
-copyDirWithTransform(
-	path.join(ROOT, 'build'),
-	path.join(DIST, 'build'),
-	transformBuildFile,
-	/\.(css|php|json|js)$/
-);
-console.log('  build/ (CSS + PHP + JSON + JS transformed)');
-
-// 6. Copy languages/ directory as-is.
-copyDir(path.join(ROOT, 'languages'), path.join(DIST, 'languages'));
-console.log('  languages/');
-
-// 7. Copy vendor/ directory as-is (if exists).
-const vendorSrc = path.join(ROOT, 'vendor');
-if (fs.existsSync(vendorSrc)) {
-	copyDir(vendorSrc, path.join(DIST, 'vendor'));
-	console.log('  vendor/');
-}
-
-// 8. Transform and copy readme.txt.
-const readmeSrc = path.join(ROOT, 'readme.txt');
-if (fs.existsSync(readmeSrc)) {
-	let readmeContent = fs.readFileSync(readmeSrc, 'utf8');
-	// Replace plugin name in readme header (first line is "=== PluginName ===").
-	readmeContent = readmeContent.replace(
-		`=== ${DEFAULTS.pluginName} ===`,
-		`=== ${config.pluginName} ===`
+	copyDirWithTransform(
+		path.join(ROOT, 'build'),
+		path.join(DIST, 'build'),
+		transformBuildFile,
+		/\.(css|php|json|js)$/
 	);
-	readmeContent = applyReplacements(readmeContent, phpRules);
-	fs.writeFileSync(path.join(DIST, 'readme.txt'), readmeContent, 'utf8');
-	console.log('  readme.txt');
-}
+	console.log('  build/ (CSS + PHP + JSON + JS transformed)');
 
-// 9. Copy license file.
-const licenseSrc = path.join(ROOT, 'LICENSE.txt');
-if (fs.existsSync(licenseSrc)) {
-	fs.copyFileSync(licenseSrc, path.join(DIST, 'LICENSE.txt'));
-	console.log('  LICENSE.txt');
-}
-
-// 10. Handle custom logo if specified.
-if (config.logoPath && config.logoPath !== DEFAULTS.logoPath) {
-	const logoSrc = path.join(ROOT, config.logoPath);
-	if (fs.existsSync(logoSrc)) {
-		const logoDest = path.join(DIST, 'build', 'admin', 'assets');
-		fs.mkdirSync(logoDest, { recursive: true });
-		fs.copyFileSync(logoSrc, path.join(logoDest, path.basename(logoSrc)));
-		console.log(`  Custom logo: ${config.logoPath}`);
-	} else {
-		console.warn(`  Warning: Logo file not found: ${config.logoPath}`);
+	// 5b. Remove default logo if forker hasn't provided a custom one.
+	// The default logo.png contains DesignSetGo branding baked into the image.
+	// Dashboard.js conditionally renders the logo only when logoUrl is non-empty.
+	if (!config.logoPath || config.logoPath === DEFAULTS.logoPath) {
+		const defaultLogo = path.join(
+			DIST,
+			'build',
+			'admin',
+			'assets',
+			'logo.png'
+		);
+		if (fs.existsSync(defaultLogo)) {
+			fs.unlinkSync(defaultLogo);
+		}
+		// Blank out the logoUrl in the admin menu PHP so Dashboard.js hides the logo.
+		const adminMenuPhp = path.join(
+			DIST,
+			'includes',
+			'admin',
+			`class-admin-menu.php`
+		);
+		if (fs.existsSync(adminMenuPhp)) {
+			let adminContent = fs.readFileSync(adminMenuPhp, 'utf8');
+			// Match the logoUrl line regardless of constant name (already transformed).
+			adminContent = adminContent.replace(
+				/'logoUrl'\s*=>\s*esc_url\([^)]+\)/,
+				"'logoUrl'         => ''"
+			);
+			fs.writeFileSync(adminMenuPhp, adminContent, 'utf8');
+		}
+		console.log('  Removed default branded logo (forker can set logoPath)');
 	}
-}
 
-console.log(`\nWhite-label build complete: dist/`);
-console.log(`Plugin: ${config.pluginName} (${config.pluginSlug})`);
+	// 6. Copy languages/ directory as-is.
+	copyDir(path.join(ROOT, 'languages'), path.join(DIST, 'languages'));
+	console.log('  languages/');
+
+	// 7. Copy vendor/ directory as-is (if exists).
+	const vendorSrc = path.join(ROOT, 'vendor');
+	if (fs.existsSync(vendorSrc)) {
+		copyDir(vendorSrc, path.join(DIST, 'vendor'));
+		console.log('  vendor/');
+	}
+
+	// 8. Transform and copy readme.txt.
+	const readmeSrc = path.join(ROOT, 'readme.txt');
+	if (fs.existsSync(readmeSrc)) {
+		let readmeContent = fs.readFileSync(readmeSrc, 'utf8');
+		// Replace plugin name in readme header (first line is "=== PluginName ===").
+		readmeContent = readmeContent.replace(
+			`=== ${DEFAULTS.pluginName} ===`,
+			`=== ${config.pluginName} ===`
+		);
+		readmeContent = applyReplacements(readmeContent, phpRules);
+		fs.writeFileSync(path.join(DIST, 'readme.txt'), readmeContent, 'utf8');
+		console.log('  readme.txt');
+	}
+
+	// 9. Copy license file.
+	const licenseSrc = path.join(ROOT, 'LICENSE.txt');
+	if (fs.existsSync(licenseSrc)) {
+		fs.copyFileSync(licenseSrc, path.join(DIST, 'LICENSE.txt'));
+		console.log('  LICENSE.txt');
+	}
+
+	// 10. Handle custom logo if specified.
+	if (config.logoPath && config.logoPath !== DEFAULTS.logoPath) {
+		const logoSrc = path.resolve(ROOT, config.logoPath);
+
+		// Prevent path traversal — logo must be within the project root.
+		if (!logoSrc.startsWith(ROOT + path.sep)) {
+			console.error(
+				`  Error: logoPath "${config.logoPath}" resolves outside the project directory. Skipping.`
+			);
+		} else if (fs.existsSync(logoSrc)) {
+			const logoDest = path.join(DIST, 'build', 'admin', 'assets');
+			fs.mkdirSync(logoDest, { recursive: true });
+			// Use the default logo filename so plugin code references stay valid.
+			const defaultLogoName = path.basename(DEFAULTS.logoPath);
+			fs.copyFileSync(logoSrc, path.join(logoDest, defaultLogoName));
+			console.log(
+				`  Custom logo: ${config.logoPath} → ${defaultLogoName}`
+			);
+		} else {
+			console.warn(`  Warning: Logo file not found: ${config.logoPath}`);
+		}
+	}
+
+	console.log(`\nWhite-label build complete: dist/`);
+	console.log(`Plugin: ${config.pluginName} (${config.pluginSlug})`);
+} catch (err) {
+	console.error(`\nWhite-label build failed: ${err.message}`);
+	process.exit(1);
+}

--- a/scripts/white-label-php.js
+++ b/scripts/white-label-php.js
@@ -1,0 +1,284 @@
+/**
+ * White Label PHP/Pattern Transformer
+ *
+ * Post-build step that copies and transforms PHP files, patterns,
+ * and metadata into the dist/ directory with rebranded identifiers.
+ *
+ * Run after webpack build: node scripts/white-label-php.js
+ *
+ * @package DesignSetGo
+ */
+
+'use strict';
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+const {
+	loadConfig,
+	buildPhpReplacements,
+	buildCssReplacements,
+	buildBlockJsonReplacements,
+	buildJsScssReplacements,
+	buildPluginHeaderReplacements,
+	applyReplacements,
+	DEFAULTS,
+} = require( './white-label-replacements' );
+
+const ROOT = path.resolve( __dirname, '..' );
+const DIST = path.resolve( ROOT, 'dist' );
+
+const config = loadConfig();
+if ( ! config ) {
+	console.log(
+		'No white-label.json found or config matches defaults. Skipping PHP transform.'
+	);
+	process.exit( 0 );
+}
+
+const phpRules = buildPhpReplacements( config );
+const cssRules = buildCssReplacements( config );
+const blockJsonRules = buildBlockJsonReplacements( config );
+const jsRules = buildJsScssReplacements( config );
+const headerRules = buildPluginHeaderReplacements( config );
+
+/**
+ * Build filename renaming rules (branded prefixes in file/directory names).
+ *
+ * @return {Array} Array of { search, replace } pairs for filenames.
+ */
+function buildFilenameRules() {
+	const rules = [];
+	function add( from, to ) {
+		if ( from !== to ) {
+			rules.push( { search: from, replace: to } );
+		}
+	}
+	// Order: longest first to prevent partial matches.
+	add( 'designsetgo', config.textDomain );
+	add( 'dsgo-', `${ config.cssPrefix }-` );
+	add( 'dsgo_', `${ config.cssPrefix }_` );
+	return rules;
+}
+const filenameRules = buildFilenameRules();
+
+/**
+ * Rename a file or directory name by applying branded prefix replacements.
+ *
+ * @param {string} name Original filename.
+ * @return {string} Renamed filename (unchanged if no branded prefixes found).
+ */
+function renameEntry( name ) {
+	let result = name;
+	for ( const rule of filenameRules ) {
+		result = result.split( rule.search ).join( rule.replace );
+	}
+	return result;
+}
+
+/**
+ * Recursively copy a directory, applying transform function to matching files.
+ *
+ * @param {string}   src       Source directory.
+ * @param {string}   dest      Destination directory.
+ * @param {Function} transform Function(content, filePath) => transformed content.
+ * @param {RegExp}   pattern   File pattern to transform (others are copied as-is).
+ */
+function copyDirWithTransform( src, dest, transform, pattern ) {
+	if ( ! fs.existsSync( src ) ) {
+		return;
+	}
+
+	fs.mkdirSync( dest, { recursive: true } );
+
+	const entries = fs.readdirSync( src, { withFileTypes: true } );
+	for ( const entry of entries ) {
+		const srcPath = path.join( src, entry.name );
+		const renamedName = renameEntry( entry.name );
+		const destPath = path.join( dest, renamedName );
+
+		if ( entry.isDirectory() ) {
+			copyDirWithTransform( srcPath, destPath, transform, pattern );
+		} else if ( pattern && pattern.test( entry.name ) ) {
+			const content = fs.readFileSync( srcPath, 'utf8' );
+			const transformed = transform( content, srcPath );
+			fs.writeFileSync( destPath, transformed, 'utf8' );
+		} else {
+			fs.copyFileSync( srcPath, destPath );
+		}
+	}
+}
+
+/**
+ * Copy a directory as-is (no transformation).
+ *
+ * @param {string} src  Source directory.
+ * @param {string} dest Destination directory.
+ */
+function copyDir( src, dest ) {
+	if ( ! fs.existsSync( src ) ) {
+		return;
+	}
+
+	fs.mkdirSync( dest, { recursive: true } );
+
+	const entries = fs.readdirSync( src, { withFileTypes: true } );
+	for ( const entry of entries ) {
+		const srcPath = path.join( src, entry.name );
+		const renamedName = renameEntry( entry.name );
+		const destPath = path.join( dest, renamedName );
+
+		if ( entry.isDirectory() ) {
+			copyDir( srcPath, destPath );
+		} else {
+			fs.copyFileSync( srcPath, destPath );
+		}
+	}
+}
+
+/**
+ * Apply PHP replacements to file content.
+ *
+ * @param {string} content  File content.
+ * @return {string} Transformed content.
+ */
+function transformPhp( content ) {
+	return applyReplacements( content, phpRules );
+}
+
+// ---- Main ----
+
+console.log( `\nWhite-label: Building rebranded plugin "${ config.pluginName }"...` );
+
+// Clean dist/ directory.
+if ( fs.existsSync( DIST ) ) {
+	fs.rmSync( DIST, { recursive: true, force: true } );
+}
+fs.mkdirSync( DIST, { recursive: true } );
+
+// 1. Transform and copy main plugin file (rename if slug changed).
+const mainPhpSrc = path.join( ROOT, 'designsetgo.php' );
+const mainPhpDest = path.join( DIST, `${ config.pluginSlug }.php` );
+let mainPhpContent = fs.readFileSync( mainPhpSrc, 'utf8' );
+mainPhpContent = applyReplacements( mainPhpContent, headerRules );
+mainPhpContent = transformPhp( mainPhpContent );
+fs.writeFileSync( mainPhpDest, mainPhpContent, 'utf8' );
+console.log( `  Main plugin file: ${ config.pluginSlug }.php` );
+
+// 2. Transform and copy uninstall.php.
+const uninstallSrc = path.join( ROOT, 'uninstall.php' );
+if ( fs.existsSync( uninstallSrc ) ) {
+	const uninstallContent = transformPhp(
+		fs.readFileSync( uninstallSrc, 'utf8' )
+	);
+	fs.writeFileSync( path.join( DIST, 'uninstall.php' ), uninstallContent, 'utf8' );
+	console.log( '  uninstall.php' );
+}
+
+// 3. Transform and copy includes/ directory (PHP, CSS, JS, JSON).
+function transformIncludesFile( content, filePath ) {
+	if ( filePath.endsWith( '.php' ) ) {
+		return transformPhp( content );
+	}
+	if ( filePath.endsWith( '.css' ) ) {
+		return applyReplacements( content, cssRules );
+	}
+	if ( filePath.endsWith( '.js' ) ) {
+		return applyReplacements( content, jsRules );
+	}
+	if ( filePath.endsWith( '.json' ) ) {
+		return applyReplacements( content, blockJsonRules );
+	}
+	return content;
+}
+copyDirWithTransform(
+	path.join( ROOT, 'includes' ),
+	path.join( DIST, 'includes' ),
+	transformIncludesFile,
+	/\.(php|css|js|json)$/
+);
+console.log( '  includes/' );
+
+// 4. Transform and copy patterns/ directory (PHP files with block content).
+copyDirWithTransform(
+	path.join( ROOT, 'patterns' ),
+	path.join( DIST, 'patterns' ),
+	transformPhp,
+	/\.php$/
+);
+console.log( '  patterns/' );
+
+// 5. Copy build/ directory with post-build transformations.
+// CSS: sass-loader bypasses webpack loaders for partials, so transform compiled CSS here.
+// PHP: render.php files copied by @wordpress/scripts.
+// JSON: block.json files copied as-is by @wordpress/scripts (webpack loader only intercepts imports).
+// JS: Second pass to catch any remaining references the webpack loader missed.
+function transformBuildFile( content, filePath ) {
+	if ( filePath.endsWith( '.css' ) ) {
+		return applyReplacements( content, cssRules );
+	}
+	if ( filePath.endsWith( '.php' ) ) {
+		return transformPhp( content );
+	}
+	if ( filePath.endsWith( 'block.json' ) ) {
+		return applyReplacements( content, blockJsonRules );
+	}
+	if ( filePath.endsWith( '.js' ) ) {
+		return applyReplacements( content, jsRules );
+	}
+	return content;
+}
+copyDirWithTransform(
+	path.join( ROOT, 'build' ),
+	path.join( DIST, 'build' ),
+	transformBuildFile,
+	/\.(css|php|json|js)$/
+);
+console.log( '  build/ (CSS + PHP + JSON + JS transformed)' );
+
+// 6. Copy languages/ directory as-is.
+copyDir( path.join( ROOT, 'languages' ), path.join( DIST, 'languages' ) );
+console.log( '  languages/' );
+
+// 7. Copy vendor/ directory as-is (if exists).
+const vendorSrc = path.join( ROOT, 'vendor' );
+if ( fs.existsSync( vendorSrc ) ) {
+	copyDir( vendorSrc, path.join( DIST, 'vendor' ) );
+	console.log( '  vendor/' );
+}
+
+// 8. Transform and copy readme.txt.
+const readmeSrc = path.join( ROOT, 'readme.txt' );
+if ( fs.existsSync( readmeSrc ) ) {
+	let readmeContent = fs.readFileSync( readmeSrc, 'utf8' );
+	// Replace plugin name in readme header (first line is "=== PluginName ===").
+	readmeContent = readmeContent.replace(
+		`=== ${ DEFAULTS.pluginName } ===`,
+		`=== ${ config.pluginName } ===`
+	);
+	readmeContent = applyReplacements( readmeContent, phpRules );
+	fs.writeFileSync( path.join( DIST, 'readme.txt' ), readmeContent, 'utf8' );
+	console.log( '  readme.txt' );
+}
+
+// 9. Copy license file.
+const licenseSrc = path.join( ROOT, 'LICENSE.txt' );
+if ( fs.existsSync( licenseSrc ) ) {
+	fs.copyFileSync( licenseSrc, path.join( DIST, 'LICENSE.txt' ) );
+	console.log( '  LICENSE.txt' );
+}
+
+// 10. Handle custom logo if specified.
+if ( config.logoPath && config.logoPath !== DEFAULTS.logoPath ) {
+	const logoSrc = path.join( ROOT, config.logoPath );
+	if ( fs.existsSync( logoSrc ) ) {
+		const logoDest = path.join( DIST, 'build', 'admin', 'assets' );
+		fs.mkdirSync( logoDest, { recursive: true } );
+		fs.copyFileSync( logoSrc, path.join( logoDest, path.basename( logoSrc ) ) );
+		console.log( `  Custom logo: ${ config.logoPath }` );
+	} else {
+		console.warn( `  Warning: Logo file not found: ${ config.logoPath }` );
+	}
+}
+
+console.log( `\nWhite-label build complete: dist/` );
+console.log( `Plugin: ${ config.pluginName } (${ config.pluginSlug })` );

--- a/scripts/white-label-php.js
+++ b/scripts/white-label-php.js
@@ -6,13 +6,14 @@
  *
  * Run after webpack build: node scripts/white-label-php.js
  *
- * @package DesignSetGo
+ * @package
  */
 
 'use strict';
+/* eslint-disable no-console */
 
-const fs = require( 'fs' );
-const path = require( 'path' );
+const fs = require('fs');
+const path = require('path');
 const {
 	loadConfig,
 	buildPhpReplacements,
@@ -22,24 +23,24 @@ const {
 	buildPluginHeaderReplacements,
 	applyReplacements,
 	DEFAULTS,
-} = require( './white-label-replacements' );
+} = require('./white-label-replacements');
 
-const ROOT = path.resolve( __dirname, '..' );
-const DIST = path.resolve( ROOT, 'dist' );
+const ROOT = path.resolve(__dirname, '..');
+const DIST = path.resolve(ROOT, 'dist');
 
 const config = loadConfig();
-if ( ! config ) {
+if (!config) {
 	console.log(
 		'No white-label.json found or config matches defaults. Skipping PHP transform.'
 	);
-	process.exit( 0 );
+	process.exit(0);
 }
 
-const phpRules = buildPhpReplacements( config );
-const cssRules = buildCssReplacements( config );
-const blockJsonRules = buildBlockJsonReplacements( config );
-const jsRules = buildJsScssReplacements( config );
-const headerRules = buildPluginHeaderReplacements( config );
+const phpRules = buildPhpReplacements(config);
+const cssRules = buildCssReplacements(config);
+const blockJsonRules = buildBlockJsonReplacements(config);
+const jsRules = buildJsScssReplacements(config);
+const headerRules = buildPluginHeaderReplacements(config);
 
 /**
  * Build filename renaming rules (branded prefixes in file/directory names).
@@ -48,15 +49,15 @@ const headerRules = buildPluginHeaderReplacements( config );
  */
 function buildFilenameRules() {
 	const rules = [];
-	function add( from, to ) {
-		if ( from !== to ) {
-			rules.push( { search: from, replace: to } );
+	function add(from, to) {
+		if (from !== to) {
+			rules.push({ search: from, replace: to });
 		}
 	}
 	// Order: longest first to prevent partial matches.
-	add( 'designsetgo', config.textDomain );
-	add( 'dsgo-', `${ config.cssPrefix }-` );
-	add( 'dsgo_', `${ config.cssPrefix }_` );
+	add('designsetgo', config.textDomain);
+	add('dsgo-', `${config.cssPrefix}-`);
+	add('dsgo_', `${config.cssPrefix}_`);
 	return rules;
 }
 const filenameRules = buildFilenameRules();
@@ -67,10 +68,10 @@ const filenameRules = buildFilenameRules();
  * @param {string} name Original filename.
  * @return {string} Renamed filename (unchanged if no branded prefixes found).
  */
-function renameEntry( name ) {
+function renameEntry(name) {
 	let result = name;
-	for ( const rule of filenameRules ) {
-		result = result.split( rule.search ).join( rule.replace );
+	for (const rule of filenameRules) {
+		result = result.split(rule.search).join(rule.replace);
 	}
 	return result;
 }
@@ -83,27 +84,27 @@ function renameEntry( name ) {
  * @param {Function} transform Function(content, filePath) => transformed content.
  * @param {RegExp}   pattern   File pattern to transform (others are copied as-is).
  */
-function copyDirWithTransform( src, dest, transform, pattern ) {
-	if ( ! fs.existsSync( src ) ) {
+function copyDirWithTransform(src, dest, transform, pattern) {
+	if (!fs.existsSync(src)) {
 		return;
 	}
 
-	fs.mkdirSync( dest, { recursive: true } );
+	fs.mkdirSync(dest, { recursive: true });
 
-	const entries = fs.readdirSync( src, { withFileTypes: true } );
-	for ( const entry of entries ) {
-		const srcPath = path.join( src, entry.name );
-		const renamedName = renameEntry( entry.name );
-		const destPath = path.join( dest, renamedName );
+	const entries = fs.readdirSync(src, { withFileTypes: true });
+	for (const entry of entries) {
+		const srcPath = path.join(src, entry.name);
+		const renamedName = renameEntry(entry.name);
+		const destPath = path.join(dest, renamedName);
 
-		if ( entry.isDirectory() ) {
-			copyDirWithTransform( srcPath, destPath, transform, pattern );
-		} else if ( pattern && pattern.test( entry.name ) ) {
-			const content = fs.readFileSync( srcPath, 'utf8' );
-			const transformed = transform( content, srcPath );
-			fs.writeFileSync( destPath, transformed, 'utf8' );
+		if (entry.isDirectory()) {
+			copyDirWithTransform(srcPath, destPath, transform, pattern);
+		} else if (pattern && pattern.test(entry.name)) {
+			const content = fs.readFileSync(srcPath, 'utf8');
+			const transformed = transform(content, srcPath);
+			fs.writeFileSync(destPath, transformed, 'utf8');
 		} else {
-			fs.copyFileSync( srcPath, destPath );
+			fs.copyFileSync(srcPath, destPath);
 		}
 	}
 }
@@ -114,23 +115,23 @@ function copyDirWithTransform( src, dest, transform, pattern ) {
  * @param {string} src  Source directory.
  * @param {string} dest Destination directory.
  */
-function copyDir( src, dest ) {
-	if ( ! fs.existsSync( src ) ) {
+function copyDir(src, dest) {
+	if (!fs.existsSync(src)) {
 		return;
 	}
 
-	fs.mkdirSync( dest, { recursive: true } );
+	fs.mkdirSync(dest, { recursive: true });
 
-	const entries = fs.readdirSync( src, { withFileTypes: true } );
-	for ( const entry of entries ) {
-		const srcPath = path.join( src, entry.name );
-		const renamedName = renameEntry( entry.name );
-		const destPath = path.join( dest, renamedName );
+	const entries = fs.readdirSync(src, { withFileTypes: true });
+	for (const entry of entries) {
+		const srcPath = path.join(src, entry.name);
+		const renamedName = renameEntry(entry.name);
+		const destPath = path.join(dest, renamedName);
 
-		if ( entry.isDirectory() ) {
-			copyDir( srcPath, destPath );
+		if (entry.isDirectory()) {
+			copyDir(srcPath, destPath);
 		} else {
-			fs.copyFileSync( srcPath, destPath );
+			fs.copyFileSync(srcPath, destPath);
 		}
 	}
 }
@@ -138,147 +139,153 @@ function copyDir( src, dest ) {
 /**
  * Apply PHP replacements to file content.
  *
- * @param {string} content  File content.
+ * @param {string} content File content.
  * @return {string} Transformed content.
  */
-function transformPhp( content ) {
-	return applyReplacements( content, phpRules );
+function transformPhp(content) {
+	return applyReplacements(content, phpRules);
 }
 
 // ---- Main ----
 
-console.log( `\nWhite-label: Building rebranded plugin "${ config.pluginName }"...` );
+console.log(
+	`\nWhite-label: Building rebranded plugin "${config.pluginName}"...`
+);
 
 // Clean dist/ directory.
-if ( fs.existsSync( DIST ) ) {
-	fs.rmSync( DIST, { recursive: true, force: true } );
+if (fs.existsSync(DIST)) {
+	fs.rmSync(DIST, { recursive: true, force: true });
 }
-fs.mkdirSync( DIST, { recursive: true } );
+fs.mkdirSync(DIST, { recursive: true });
 
 // 1. Transform and copy main plugin file (rename if slug changed).
-const mainPhpSrc = path.join( ROOT, 'designsetgo.php' );
-const mainPhpDest = path.join( DIST, `${ config.pluginSlug }.php` );
-let mainPhpContent = fs.readFileSync( mainPhpSrc, 'utf8' );
-mainPhpContent = applyReplacements( mainPhpContent, headerRules );
-mainPhpContent = transformPhp( mainPhpContent );
-fs.writeFileSync( mainPhpDest, mainPhpContent, 'utf8' );
-console.log( `  Main plugin file: ${ config.pluginSlug }.php` );
+const mainPhpSrc = path.join(ROOT, 'designsetgo.php');
+const mainPhpDest = path.join(DIST, `${config.pluginSlug}.php`);
+let mainPhpContent = fs.readFileSync(mainPhpSrc, 'utf8');
+mainPhpContent = applyReplacements(mainPhpContent, headerRules);
+mainPhpContent = transformPhp(mainPhpContent);
+fs.writeFileSync(mainPhpDest, mainPhpContent, 'utf8');
+console.log(`  Main plugin file: ${config.pluginSlug}.php`);
 
 // 2. Transform and copy uninstall.php.
-const uninstallSrc = path.join( ROOT, 'uninstall.php' );
-if ( fs.existsSync( uninstallSrc ) ) {
+const uninstallSrc = path.join(ROOT, 'uninstall.php');
+if (fs.existsSync(uninstallSrc)) {
 	const uninstallContent = transformPhp(
-		fs.readFileSync( uninstallSrc, 'utf8' )
+		fs.readFileSync(uninstallSrc, 'utf8')
 	);
-	fs.writeFileSync( path.join( DIST, 'uninstall.php' ), uninstallContent, 'utf8' );
-	console.log( '  uninstall.php' );
+	fs.writeFileSync(
+		path.join(DIST, 'uninstall.php'),
+		uninstallContent,
+		'utf8'
+	);
+	console.log('  uninstall.php');
 }
 
 // 3. Transform and copy includes/ directory (PHP, CSS, JS, JSON).
-function transformIncludesFile( content, filePath ) {
-	if ( filePath.endsWith( '.php' ) ) {
-		return transformPhp( content );
+function transformIncludesFile(content, filePath) {
+	if (filePath.endsWith('.php')) {
+		return transformPhp(content);
 	}
-	if ( filePath.endsWith( '.css' ) ) {
-		return applyReplacements( content, cssRules );
+	if (filePath.endsWith('.css')) {
+		return applyReplacements(content, cssRules);
 	}
-	if ( filePath.endsWith( '.js' ) ) {
-		return applyReplacements( content, jsRules );
+	if (filePath.endsWith('.js')) {
+		return applyReplacements(content, jsRules);
 	}
-	if ( filePath.endsWith( '.json' ) ) {
-		return applyReplacements( content, blockJsonRules );
+	if (filePath.endsWith('.json')) {
+		return applyReplacements(content, blockJsonRules);
 	}
 	return content;
 }
 copyDirWithTransform(
-	path.join( ROOT, 'includes' ),
-	path.join( DIST, 'includes' ),
+	path.join(ROOT, 'includes'),
+	path.join(DIST, 'includes'),
 	transformIncludesFile,
 	/\.(php|css|js|json)$/
 );
-console.log( '  includes/' );
+console.log('  includes/');
 
 // 4. Transform and copy patterns/ directory (PHP files with block content).
 copyDirWithTransform(
-	path.join( ROOT, 'patterns' ),
-	path.join( DIST, 'patterns' ),
+	path.join(ROOT, 'patterns'),
+	path.join(DIST, 'patterns'),
 	transformPhp,
 	/\.php$/
 );
-console.log( '  patterns/' );
+console.log('  patterns/');
 
 // 5. Copy build/ directory with post-build transformations.
 // CSS: sass-loader bypasses webpack loaders for partials, so transform compiled CSS here.
 // PHP: render.php files copied by @wordpress/scripts.
 // JSON: block.json files copied as-is by @wordpress/scripts (webpack loader only intercepts imports).
 // JS: Second pass to catch any remaining references the webpack loader missed.
-function transformBuildFile( content, filePath ) {
-	if ( filePath.endsWith( '.css' ) ) {
-		return applyReplacements( content, cssRules );
+function transformBuildFile(content, filePath) {
+	if (filePath.endsWith('.css')) {
+		return applyReplacements(content, cssRules);
 	}
-	if ( filePath.endsWith( '.php' ) ) {
-		return transformPhp( content );
+	if (filePath.endsWith('.php')) {
+		return transformPhp(content);
 	}
-	if ( filePath.endsWith( 'block.json' ) ) {
-		return applyReplacements( content, blockJsonRules );
+	if (filePath.endsWith('block.json')) {
+		return applyReplacements(content, blockJsonRules);
 	}
-	if ( filePath.endsWith( '.js' ) ) {
-		return applyReplacements( content, jsRules );
+	if (filePath.endsWith('.js')) {
+		return applyReplacements(content, jsRules);
 	}
 	return content;
 }
 copyDirWithTransform(
-	path.join( ROOT, 'build' ),
-	path.join( DIST, 'build' ),
+	path.join(ROOT, 'build'),
+	path.join(DIST, 'build'),
 	transformBuildFile,
 	/\.(css|php|json|js)$/
 );
-console.log( '  build/ (CSS + PHP + JSON + JS transformed)' );
+console.log('  build/ (CSS + PHP + JSON + JS transformed)');
 
 // 6. Copy languages/ directory as-is.
-copyDir( path.join( ROOT, 'languages' ), path.join( DIST, 'languages' ) );
-console.log( '  languages/' );
+copyDir(path.join(ROOT, 'languages'), path.join(DIST, 'languages'));
+console.log('  languages/');
 
 // 7. Copy vendor/ directory as-is (if exists).
-const vendorSrc = path.join( ROOT, 'vendor' );
-if ( fs.existsSync( vendorSrc ) ) {
-	copyDir( vendorSrc, path.join( DIST, 'vendor' ) );
-	console.log( '  vendor/' );
+const vendorSrc = path.join(ROOT, 'vendor');
+if (fs.existsSync(vendorSrc)) {
+	copyDir(vendorSrc, path.join(DIST, 'vendor'));
+	console.log('  vendor/');
 }
 
 // 8. Transform and copy readme.txt.
-const readmeSrc = path.join( ROOT, 'readme.txt' );
-if ( fs.existsSync( readmeSrc ) ) {
-	let readmeContent = fs.readFileSync( readmeSrc, 'utf8' );
+const readmeSrc = path.join(ROOT, 'readme.txt');
+if (fs.existsSync(readmeSrc)) {
+	let readmeContent = fs.readFileSync(readmeSrc, 'utf8');
 	// Replace plugin name in readme header (first line is "=== PluginName ===").
 	readmeContent = readmeContent.replace(
-		`=== ${ DEFAULTS.pluginName } ===`,
-		`=== ${ config.pluginName } ===`
+		`=== ${DEFAULTS.pluginName} ===`,
+		`=== ${config.pluginName} ===`
 	);
-	readmeContent = applyReplacements( readmeContent, phpRules );
-	fs.writeFileSync( path.join( DIST, 'readme.txt' ), readmeContent, 'utf8' );
-	console.log( '  readme.txt' );
+	readmeContent = applyReplacements(readmeContent, phpRules);
+	fs.writeFileSync(path.join(DIST, 'readme.txt'), readmeContent, 'utf8');
+	console.log('  readme.txt');
 }
 
 // 9. Copy license file.
-const licenseSrc = path.join( ROOT, 'LICENSE.txt' );
-if ( fs.existsSync( licenseSrc ) ) {
-	fs.copyFileSync( licenseSrc, path.join( DIST, 'LICENSE.txt' ) );
-	console.log( '  LICENSE.txt' );
+const licenseSrc = path.join(ROOT, 'LICENSE.txt');
+if (fs.existsSync(licenseSrc)) {
+	fs.copyFileSync(licenseSrc, path.join(DIST, 'LICENSE.txt'));
+	console.log('  LICENSE.txt');
 }
 
 // 10. Handle custom logo if specified.
-if ( config.logoPath && config.logoPath !== DEFAULTS.logoPath ) {
-	const logoSrc = path.join( ROOT, config.logoPath );
-	if ( fs.existsSync( logoSrc ) ) {
-		const logoDest = path.join( DIST, 'build', 'admin', 'assets' );
-		fs.mkdirSync( logoDest, { recursive: true } );
-		fs.copyFileSync( logoSrc, path.join( logoDest, path.basename( logoSrc ) ) );
-		console.log( `  Custom logo: ${ config.logoPath }` );
+if (config.logoPath && config.logoPath !== DEFAULTS.logoPath) {
+	const logoSrc = path.join(ROOT, config.logoPath);
+	if (fs.existsSync(logoSrc)) {
+		const logoDest = path.join(DIST, 'build', 'admin', 'assets');
+		fs.mkdirSync(logoDest, { recursive: true });
+		fs.copyFileSync(logoSrc, path.join(logoDest, path.basename(logoSrc)));
+		console.log(`  Custom logo: ${config.logoPath}`);
 	} else {
-		console.warn( `  Warning: Logo file not found: ${ config.logoPath }` );
+		console.warn(`  Warning: Logo file not found: ${config.logoPath}`);
 	}
 }
 
-console.log( `\nWhite-label build complete: dist/` );
-console.log( `Plugin: ${ config.pluginName } (${ config.pluginSlug })` );
+console.log(`\nWhite-label build complete: dist/`);
+console.log(`Plugin: ${config.pluginName} (${config.pluginSlug})`);

--- a/scripts/white-label-replacements.js
+++ b/scripts/white-label-replacements.js
@@ -62,7 +62,22 @@ function loadConfig() {
 		return null;
 	}
 
-	const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+	let config;
+	try {
+		config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+	} catch (err) {
+		// eslint-disable-next-line no-console
+		console.error(
+			`Error: Failed to parse white-label.json: ${err.message}`
+		);
+		return null;
+	}
+
+	if (!config || typeof config !== 'object' || Array.isArray(config)) {
+		// eslint-disable-next-line no-console
+		console.error('Error: white-label.json must contain a JSON object.');
+		return null;
+	}
 
 	// Strip JSON Schema reference and comment fields.
 	const cleaned = { ...config };

--- a/scripts/white-label-replacements.js
+++ b/scripts/white-label-replacements.js
@@ -1,0 +1,471 @@
+/**
+ * White Label Replacement Rules
+ *
+ * Centralized replacement definitions shared by webpack loaders
+ * and the post-build PHP/pattern transformer.
+ *
+ * @package DesignSetGo
+ */
+
+'use strict';
+
+const path = require( 'path' );
+const fs = require( 'fs' );
+
+/**
+ * Default values matching the current DesignSetGo branding.
+ * When config matches these, no transformation occurs.
+ */
+const DEFAULTS = {
+	pluginName: 'DesignSetGo',
+	pluginSlug: 'designsetgo',
+	pluginUri: 'https://designsetgoblocks.com',
+	pluginDescription:
+		'Professional Gutenberg block library with 52 blocks and 16 powerful extensions - complete Form Builder, container system, interactive elements, maps, modals, breadcrumbs, timelines, scroll effects, and animations. Built with WordPress standards for guaranteed editor/frontend parity.',
+	pluginAuthor: 'DesignSetGo',
+	pluginAuthorUri: 'https://designsetgoblocks.com/nealey',
+	textDomain: 'designsetgo',
+	blockNamespace: 'designsetgo',
+	cssPrefix: 'dsgo',
+	shortPrefix: 'dsg',
+	phpNamespace: 'DesignSetGo',
+	phpFunctionPrefix: 'designsetgo',
+	phpConstantPrefix: 'DESIGNSETGO',
+	restNamespace: 'designsetgo/v1',
+	patternCategoryPrefix: 'dsgo',
+	postTypeSlug: 'dsgo_form_submission',
+	metaKeyPrefix: '_dsg',
+	transientPrefix: 'dsgo',
+	optionPrefix: 'designsetgo',
+	logoPath: 'src/admin/assets/logo.png',
+};
+
+/**
+ * Convert a hyphenated slug to camelCase.
+ * E.g., "my-blocks" → "myBlocks", "myblocks" → "myblocks"
+ *
+ * @param {string} slug Hyphenated slug.
+ * @return {string} camelCase version.
+ */
+function toCamelCase( slug ) {
+	return slug.replace( /-([a-z])/g, ( _, c ) => c.toUpperCase() );
+}
+
+/**
+ * Load white-label config, returning null if not found or matching defaults.
+ *
+ * @return {Object|null} Config object or null if no transformation needed.
+ */
+function loadConfig() {
+	const configPath = path.resolve( __dirname, '..', 'white-label.json' );
+	if ( ! fs.existsSync( configPath ) ) {
+		return null;
+	}
+
+	const config = JSON.parse( fs.readFileSync( configPath, 'utf8' ) );
+
+	// Strip JSON Schema reference and comment fields.
+	const cleaned = { ...config };
+	delete cleaned.$schema;
+	Object.keys( cleaned ).forEach( ( key ) => {
+		if ( key.startsWith( '_comment' ) ) {
+			delete cleaned[ key ];
+		}
+	} );
+
+	// Check if all values match defaults (no transformation needed).
+	const isDefault = Object.keys( DEFAULTS ).every(
+		( key ) => cleaned[ key ] === DEFAULTS[ key ]
+	);
+	if ( isDefault ) {
+		return null;
+	}
+
+	return { ...DEFAULTS, ...cleaned };
+}
+
+/**
+ * Build replacement pairs for JS and SCSS files (webpack string-replace-loader).
+ *
+ * Returns an array of { search: RegExp, replace: string } objects,
+ * ordered longest-match-first.
+ *
+ * @param {Object} config White-label config.
+ * @return {Array} Replacement rules for string-replace-loader.
+ */
+function buildJsScssReplacements( config ) {
+	const rules = [];
+
+	// Helper: add a literal string replacement.
+	function literal( from, to ) {
+		if ( from !== to ) {
+			rules.push( {
+				search: from,
+				replace: to,
+				from, // Keep original for sorting.
+			} );
+		}
+	}
+
+	// --- Longest patterns first ---
+
+	// WP auto-generated block CSS classes.
+	literal( 'wp-block-designsetgo-', `wp-block-${ config.blockNamespace }-` );
+
+	// Block comment markers in pattern content.
+	literal( 'wp:designsetgo/', `wp:${ config.blockNamespace }/` );
+
+	// Block namespace in strings (block names, context keys).
+	literal( 'designsetgo/', `${ config.blockNamespace }/` );
+
+	// Data attributes.
+	literal( 'data-dsgo-', `data-${ config.cssPrefix }-` );
+
+	// CSS custom properties.
+	literal( '--dsgo-', `--${ config.cssPrefix }-` );
+
+	// CSS classes (dot-prefixed).
+	literal( '.dsgo-', `.${ config.cssPrefix }-` );
+
+	// CSS classes (without dot, for classnames() calls and string concatenation).
+	literal( 'dsgo-', `${ config.cssPrefix }-` );
+
+	// JS global names passed via wp_localize_script.
+	literal( 'designSetGoRevisions', `${ toCamelCase( config.pluginSlug ) }Revisions` );
+	literal( 'designSetGoAdmin', `${ toCamelCase( config.pluginSlug ) }Admin` );
+	literal( 'designsetgoForm', `${ config.textDomain }Form` );
+
+	// WP script handles (hyphenated) in JS references.
+	literal( 'designsetgo-', `${ config.pluginSlug }-` );
+
+	// Display name in JS strings.
+	literal( 'DesignSetGo', config.pluginName );
+
+	// Text domain in i18n calls.
+	literal( 'designsetgo', config.textDomain );
+
+	// Short prefix for camelCase identifiers (animation keyframes, attribute names, globals).
+	// Match dsg followed by uppercase letter — e.g., dsgFadeIn, dsgLinkUrl, dsgStickyHeaderSettings.
+	// This must NOT match dsgo- (safe: dsgo is never followed by uppercase).
+	if ( config.shortPrefix !== DEFAULTS.shortPrefix ) {
+		rules.push( {
+			search: new RegExp( `\\b${ DEFAULTS.shortPrefix }([A-Z])`, 'g' ),
+			replace: `${ config.shortPrefix }$1`,
+			from: `${ DEFAULTS.shortPrefix }[A-Z]`,
+		} );
+	}
+
+	// Sort literal rules: longest 'from' first to prevent partial matches.
+	// Regex rules go last since they handle what literals miss.
+	return rules.sort( ( a, b ) => {
+		const aIsRegex = a.search instanceof RegExp;
+		const bIsRegex = b.search instanceof RegExp;
+		if ( aIsRegex && ! bIsRegex ) {
+			return 1;
+		}
+		if ( ! aIsRegex && bIsRegex ) {
+			return -1;
+		}
+		return ( b.from || '' ).length - ( a.from || '' ).length;
+	} );
+}
+
+/**
+ * Build replacement pairs for PHP files.
+ *
+ * Returns an array of { search: string|RegExp, replace: string } objects.
+ *
+ * @param {Object} config White-label config.
+ * @return {Array} Replacement rules.
+ */
+function buildPhpReplacements( config ) {
+	const rules = [];
+
+	function literal( from, to ) {
+		if ( from !== to ) {
+			rules.push( { search: from, replace: to, from } );
+		}
+	}
+
+	// --- PHP-specific replacements (longest first) ---
+
+	// PHP namespace (backslash-prefixed references).
+	literal( '\\DesignSetGo\\', `\\${ config.phpNamespace }\\` );
+
+	// PHP namespace declarations.
+	literal( 'namespace DesignSetGo', `namespace ${ config.phpNamespace }` );
+
+	// @package docblock tag.
+	literal( '@package DesignSetGo', `@package ${ config.phpNamespace }` );
+
+	// PHP constants (order: longest constant names first).
+	literal( 'DESIGNSETGO_BASENAME', `${ config.phpConstantPrefix }_BASENAME` );
+	literal( 'DESIGNSETGO_VERSION', `${ config.phpConstantPrefix }_VERSION` );
+	literal( 'DESIGNSETGO_FILE', `${ config.phpConstantPrefix }_FILE` );
+	literal( 'DESIGNSETGO_PATH', `${ config.phpConstantPrefix }_PATH` );
+	literal( 'DESIGNSETGO_URL', `${ config.phpConstantPrefix }_URL` );
+
+	// REST namespace.
+	literal( 'designsetgo/v1', config.restNamespace );
+
+	// Post type slug.
+	literal( 'dsgo_form_submission', config.postTypeSlug );
+
+	// Option names.
+	literal( 'designsetgo_global_styles', `${ config.optionPrefix }_global_styles` );
+	literal( 'designsetgo_settings', `${ config.optionPrefix }_settings` );
+
+	// Transient prefixes.
+	literal( 'dsgo_has_blocks_', `${ config.transientPrefix }_has_blocks_` );
+	literal(
+		'dsgo_form_submissions_count',
+		`${ config.transientPrefix }_form_submissions_count`
+	);
+
+	// JS global names passed via wp_localize_script (must match JS side).
+	// These use camelCase variants of the plugin name.
+	literal( 'designSetGoRevisions', `${ toCamelCase( config.pluginSlug ) }Revisions` );
+	literal( 'designSetGoAdmin', `${ toCamelCase( config.pluginSlug ) }Admin` );
+	literal( 'designsetgoForm', `${ config.textDomain }Form` );
+
+	// Cache group.
+	literal( "'designsetgo'", `'${ config.textDomain }'` );
+
+	// WP auto-generated block CSS classes.
+	literal( 'wp-block-designsetgo-', `wp-block-${ config.blockNamespace }-` );
+
+	// Block comment markers in pattern content.
+	literal( 'wp:designsetgo/', `wp:${ config.blockNamespace }/` );
+
+	// Block namespace in strings.
+	literal( 'designsetgo/', `${ config.blockNamespace }/` );
+
+	// Function prefix (hook names, function names).
+	literal( 'designsetgo_', `${ config.phpFunctionPrefix }_` );
+
+	// WP script/style handles and admin page slugs (hyphenated).
+	literal( 'designsetgo-', `${ config.pluginSlug }-` );
+
+	// Data attributes in PHP HTML output.
+	literal( 'data-dsgo-', `data-${ config.cssPrefix }-` );
+
+	// CSS custom properties in PHP inline styles.
+	literal( '--dsgo-', `--${ config.cssPrefix }-` );
+
+	// CSS class prefix in PHP HTML output (with dot for selectors).
+	literal( '.dsgo-', `.${ config.cssPrefix }-` );
+
+	// CSS class prefix in PHP HTML output (without dot for class attributes).
+	literal( 'dsgo-', `${ config.cssPrefix }-` );
+
+	// Pattern category prefix.
+	literal( 'dsgo-hero', `${ config.patternCategoryPrefix }-hero` );
+	literal( 'dsgo-contact', `${ config.patternCategoryPrefix }-contact` );
+	literal( 'dsgo-features', `${ config.patternCategoryPrefix }-features` );
+	literal( 'dsgo-cta', `${ config.patternCategoryPrefix }-cta` );
+	literal( 'dsgo-faq', `${ config.patternCategoryPrefix }-faq` );
+	literal( 'dsgo-gallery', `${ config.patternCategoryPrefix }-gallery` );
+	literal( 'dsgo-homepage', `${ config.patternCategoryPrefix }-homepage` );
+	literal( 'dsgo-modal', `${ config.patternCategoryPrefix }-modal` );
+	literal( 'dsgo-pricing', `${ config.patternCategoryPrefix }-pricing` );
+	literal( 'dsgo-team', `${ config.patternCategoryPrefix }-team` );
+	literal(
+		'dsgo-testimonials',
+		`${ config.patternCategoryPrefix }-testimonials`
+	);
+	literal( 'dsgo-content', `${ config.patternCategoryPrefix }-content` );
+
+	// Meta key prefix.
+	literal( '_dsg_', `${ config.metaKeyPrefix }_` );
+
+	// Short prefix for camelCase identifiers.
+	if ( config.shortPrefix !== DEFAULTS.shortPrefix ) {
+		rules.push( {
+			search: new RegExp( `\\b${ DEFAULTS.shortPrefix }([A-Z])`, 'g' ),
+			replace: `${ config.shortPrefix }$1`,
+			from: `${ DEFAULTS.shortPrefix }[A-Z]`,
+		} );
+	}
+
+	// Display name.
+	literal( 'DesignSetGo', config.pluginName );
+
+	// Catch-all: bare "designsetgo" (admin menu slug, page params, remaining occurrences).
+	// Must come last since it's the shortest and most general match.
+	literal( 'designsetgo', config.textDomain );
+
+	// Sort: longest literal first, regexes last.
+	return rules.sort( ( a, b ) => {
+		const aIsRegex = a.search instanceof RegExp;
+		const bIsRegex = b.search instanceof RegExp;
+		if ( aIsRegex && ! bIsRegex ) {
+			return 1;
+		}
+		if ( ! aIsRegex && bIsRegex ) {
+			return -1;
+		}
+		return ( b.from || '' ).length - ( a.from || '' ).length;
+	} );
+}
+
+/**
+ * Build replacement pairs for block.json files.
+ *
+ * @param {Object} config White-label config.
+ * @return {Array} Replacement rules.
+ */
+function buildBlockJsonReplacements( config ) {
+	const rules = [];
+
+	function literal( from, to ) {
+		if ( from !== to ) {
+			rules.push( { search: from, replace: to, from } );
+		}
+	}
+
+	// Block name namespace.
+	literal( '"designsetgo/', `"${ config.blockNamespace }/` );
+
+	// Context provider keys.
+	literal( 'designsetgo/', `${ config.blockNamespace }/` );
+
+	// Text domain.
+	literal( '"designsetgo"', `"${ config.textDomain }"` );
+
+	// CSS class references in block.json metadata.
+	literal( 'dsgo-', `${ config.cssPrefix }-` );
+
+	// CSS custom property references.
+	literal( '--dsgo-', `--${ config.cssPrefix }-` );
+
+	// WP auto-generated class prefix.
+	literal( 'wp-block-designsetgo-', `wp-block-${ config.blockNamespace }-` );
+
+	return rules.sort(
+		( a, b ) => ( b.from || '' ).length - ( a.from || '' ).length
+	);
+}
+
+/**
+ * Build replacement pairs for compiled CSS files (post-build).
+ *
+ * Applied to the CSS output after sass compilation, so SCSS variables
+ * are already resolved and only CSS class names, custom properties,
+ * data attributes, and keyframe names remain.
+ *
+ * @param {Object} config White-label config.
+ * @return {Array} Replacement rules.
+ */
+function buildCssReplacements( config ) {
+	const rules = [];
+
+	function literal( from, to ) {
+		if ( from !== to ) {
+			rules.push( { search: from, replace: to, from } );
+		}
+	}
+
+	// WP auto-generated block CSS classes.
+	literal( 'wp-block-designsetgo-', `wp-block-${ config.blockNamespace }-` );
+
+	// Data attributes.
+	literal( 'data-dsgo-', `data-${ config.cssPrefix }-` );
+
+	// CSS custom properties.
+	literal( '--dsgo-', `--${ config.cssPrefix }-` );
+
+	// CSS classes (dot-prefixed selectors).
+	literal( '.dsgo-', `.${ config.cssPrefix }-` );
+
+	// CSS classes (without dot, e.g., in attribute selectors or animations).
+	literal( 'dsgo-', `${ config.cssPrefix }-` );
+
+	// Admin dashboard CSS classes and WP theme.json custom properties using full name.
+	// E.g., .designsetgo-info-box, --wp--custom--designsetgo--border-radius
+	literal( 'designsetgo-', `${ config.pluginSlug }-` );
+	literal( 'designsetgo', config.textDomain );
+
+	// Display name in CSS comments (e.g., @package DesignSetGo).
+	literal( 'DesignSetGo', config.pluginName );
+
+	// Short prefix for CSS @keyframes names (dsgFadeIn, dsgSlideInUp, etc.).
+	if ( config.shortPrefix !== DEFAULTS.shortPrefix ) {
+		rules.push( {
+			search: new RegExp( `${ DEFAULTS.shortPrefix }([A-Z])`, 'g' ),
+			replace: `${ config.shortPrefix }$1`,
+			from: `${ DEFAULTS.shortPrefix }[A-Z]`,
+		} );
+	}
+
+	// Sort: longest literal first, regexes last.
+	return rules.sort( ( a, b ) => {
+		const aIsRegex = a.search instanceof RegExp;
+		const bIsRegex = b.search instanceof RegExp;
+		if ( aIsRegex && ! bIsRegex ) {
+			return 1;
+		}
+		if ( ! aIsRegex && bIsRegex ) {
+			return -1;
+		}
+		return ( b.from || '' ).length - ( a.from || '' ).length;
+	} );
+}
+
+/**
+ * Build plugin file header replacements.
+ *
+ * @param {Object} config White-label config.
+ * @return {Array} Replacement rules for the main plugin PHP file header.
+ */
+function buildPluginHeaderReplacements( config ) {
+	const rules = [];
+
+	function headerField( field, defaultVal, newVal ) {
+		if ( newVal !== defaultVal ) {
+			rules.push( {
+				search: `${ field }${ defaultVal }`,
+				replace: `${ field }${ newVal }`,
+				from: `${ field }${ defaultVal }`,
+			} );
+		}
+	}
+
+	headerField( ' * Plugin Name:       ', DEFAULTS.pluginName, config.pluginName );
+	headerField( ' * Plugin URI:        ', DEFAULTS.pluginUri, config.pluginUri );
+	headerField( ' * Description:       ', DEFAULTS.pluginDescription, config.pluginDescription );
+	headerField( ' * Author:            ', DEFAULTS.pluginAuthor, config.pluginAuthor );
+	headerField( ' * Author URI:        ', DEFAULTS.pluginAuthorUri, config.pluginAuthorUri );
+	headerField( ' * Text Domain:       ', DEFAULTS.textDomain, config.textDomain );
+
+	return rules;
+}
+
+/**
+ * Apply replacement rules to a string.
+ *
+ * @param {string} content Source content.
+ * @param {Array}  rules   Replacement rules from any build*Replacements function.
+ * @return {string} Transformed content.
+ */
+function applyReplacements( content, rules ) {
+	let result = content;
+	for ( const rule of rules ) {
+		if ( rule.search instanceof RegExp ) {
+			result = result.replace( rule.search, rule.replace );
+		} else {
+			result = result.split( rule.search ).join( rule.replace );
+		}
+	}
+	return result;
+}
+
+module.exports = {
+	DEFAULTS,
+	loadConfig,
+	buildJsScssReplacements,
+	buildPhpReplacements,
+	buildBlockJsonReplacements,
+	buildCssReplacements,
+	buildPluginHeaderReplacements,
+	applyReplacements,
+};

--- a/scripts/white-label-replacements.js
+++ b/scripts/white-label-replacements.js
@@ -4,13 +4,13 @@
  * Centralized replacement definitions shared by webpack loaders
  * and the post-build PHP/pattern transformer.
  *
- * @package DesignSetGo
+ * @package
  */
 
 'use strict';
 
-const path = require( 'path' );
-const fs = require( 'fs' );
+const path = require('path');
+const fs = require('fs');
 
 /**
  * Default values matching the current DesignSetGo branding.
@@ -47,8 +47,8 @@ const DEFAULTS = {
  * @param {string} slug Hyphenated slug.
  * @return {string} camelCase version.
  */
-function toCamelCase( slug ) {
-	return slug.replace( /-([a-z])/g, ( _, c ) => c.toUpperCase() );
+function toCamelCase(slug) {
+	return slug.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
 }
 
 /**
@@ -57,27 +57,27 @@ function toCamelCase( slug ) {
  * @return {Object|null} Config object or null if no transformation needed.
  */
 function loadConfig() {
-	const configPath = path.resolve( __dirname, '..', 'white-label.json' );
-	if ( ! fs.existsSync( configPath ) ) {
+	const configPath = path.resolve(__dirname, '..', 'white-label.json');
+	if (!fs.existsSync(configPath)) {
 		return null;
 	}
 
-	const config = JSON.parse( fs.readFileSync( configPath, 'utf8' ) );
+	const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
 
 	// Strip JSON Schema reference and comment fields.
 	const cleaned = { ...config };
 	delete cleaned.$schema;
-	Object.keys( cleaned ).forEach( ( key ) => {
-		if ( key.startsWith( '_comment' ) ) {
-			delete cleaned[ key ];
+	Object.keys(cleaned).forEach((key) => {
+		if (key.startsWith('_comment')) {
+			delete cleaned[key];
 		}
-	} );
+	});
 
 	// Check if all values match defaults (no transformation needed).
-	const isDefault = Object.keys( DEFAULTS ).every(
-		( key ) => cleaned[ key ] === DEFAULTS[ key ]
+	const isDefault = Object.keys(DEFAULTS).every(
+		(key) => cleaned[key] === DEFAULTS[key]
 	);
-	if ( isDefault ) {
+	if (isDefault) {
 		return null;
 	}
 
@@ -93,81 +93,84 @@ function loadConfig() {
  * @param {Object} config White-label config.
  * @return {Array} Replacement rules for string-replace-loader.
  */
-function buildJsScssReplacements( config ) {
+function buildJsScssReplacements(config) {
 	const rules = [];
 
 	// Helper: add a literal string replacement.
-	function literal( from, to ) {
-		if ( from !== to ) {
-			rules.push( {
+	function literal(from, to) {
+		if (from !== to) {
+			rules.push({
 				search: from,
 				replace: to,
 				from, // Keep original for sorting.
-			} );
+			});
 		}
 	}
 
 	// --- Longest patterns first ---
 
 	// WP auto-generated block CSS classes.
-	literal( 'wp-block-designsetgo-', `wp-block-${ config.blockNamespace }-` );
+	literal('wp-block-designsetgo-', `wp-block-${config.blockNamespace}-`);
 
 	// Block comment markers in pattern content.
-	literal( 'wp:designsetgo/', `wp:${ config.blockNamespace }/` );
+	literal('wp:designsetgo/', `wp:${config.blockNamespace}/`);
 
 	// Block namespace in strings (block names, context keys).
-	literal( 'designsetgo/', `${ config.blockNamespace }/` );
+	literal('designsetgo/', `${config.blockNamespace}/`);
 
 	// Data attributes.
-	literal( 'data-dsgo-', `data-${ config.cssPrefix }-` );
+	literal('data-dsgo-', `data-${config.cssPrefix}-`);
 
 	// CSS custom properties.
-	literal( '--dsgo-', `--${ config.cssPrefix }-` );
+	literal('--dsgo-', `--${config.cssPrefix}-`);
 
 	// CSS classes (dot-prefixed).
-	literal( '.dsgo-', `.${ config.cssPrefix }-` );
+	literal('.dsgo-', `.${config.cssPrefix}-`);
 
 	// CSS classes (without dot, for classnames() calls and string concatenation).
-	literal( 'dsgo-', `${ config.cssPrefix }-` );
+	literal('dsgo-', `${config.cssPrefix}-`);
 
 	// JS global names passed via wp_localize_script.
-	literal( 'designSetGoRevisions', `${ toCamelCase( config.pluginSlug ) }Revisions` );
-	literal( 'designSetGoAdmin', `${ toCamelCase( config.pluginSlug ) }Admin` );
-	literal( 'designsetgoForm', `${ config.textDomain }Form` );
+	literal(
+		'designSetGoRevisions',
+		`${toCamelCase(config.pluginSlug)}Revisions`
+	);
+	literal('designSetGoAdmin', `${toCamelCase(config.pluginSlug)}Admin`);
+	literal('designsetgoForm', `${config.textDomain}Form`);
 
 	// WP script handles (hyphenated) in JS references.
-	literal( 'designsetgo-', `${ config.pluginSlug }-` );
+	literal('designsetgo-', `${config.pluginSlug}-`);
 
 	// Display name in JS strings.
-	literal( 'DesignSetGo', config.pluginName );
+	literal('DesignSetGo', config.pluginName);
 
 	// Text domain in i18n calls.
-	literal( 'designsetgo', config.textDomain );
+	literal('designsetgo', config.textDomain);
 
 	// Short prefix for camelCase identifiers (animation keyframes, attribute names, globals).
 	// Match dsg followed by uppercase letter — e.g., dsgFadeIn, dsgLinkUrl, dsgStickyHeaderSettings.
 	// This must NOT match dsgo- (safe: dsgo is never followed by uppercase).
-	if ( config.shortPrefix !== DEFAULTS.shortPrefix ) {
-		rules.push( {
-			search: new RegExp( `\\b${ DEFAULTS.shortPrefix }([A-Z])`, 'g' ),
-			replace: `${ config.shortPrefix }$1`,
-			from: `${ DEFAULTS.shortPrefix }[A-Z]`,
-		} );
+	if (config.shortPrefix !== DEFAULTS.shortPrefix) {
+		rules.push({
+			search: new RegExp(`\\b${DEFAULTS.shortPrefix}([A-Z])`, 'g'),
+			replace: `${config.shortPrefix}$1`,
+			from: `${DEFAULTS.shortPrefix}[A-Z]`,
+		});
 	}
 
 	// Sort literal rules: longest 'from' first to prevent partial matches.
 	// Regex rules go last since they handle what literals miss.
-	return rules.sort( ( a, b ) => {
+	return rules.sort((a, b) => {
 		const aIsRegex = a.search instanceof RegExp;
 		const bIsRegex = b.search instanceof RegExp;
-		if ( aIsRegex && ! bIsRegex ) {
+		if (aIsRegex && !bIsRegex) {
 			return 1;
 		}
-		if ( ! aIsRegex && bIsRegex ) {
+		if (!aIsRegex && bIsRegex) {
 			return -1;
 		}
-		return ( b.from || '' ).length - ( a.from || '' ).length;
-	} );
+		return (b.from || '').length - (a.from || '').length;
+	});
 }
 
 /**
@@ -178,134 +181,140 @@ function buildJsScssReplacements( config ) {
  * @param {Object} config White-label config.
  * @return {Array} Replacement rules.
  */
-function buildPhpReplacements( config ) {
+function buildPhpReplacements(config) {
 	const rules = [];
 
-	function literal( from, to ) {
-		if ( from !== to ) {
-			rules.push( { search: from, replace: to, from } );
+	function literal(from, to) {
+		if (from !== to) {
+			rules.push({ search: from, replace: to, from });
 		}
 	}
 
 	// --- PHP-specific replacements (longest first) ---
 
 	// PHP namespace (backslash-prefixed references).
-	literal( '\\DesignSetGo\\', `\\${ config.phpNamespace }\\` );
+	literal('\\DesignSetGo\\', `\\${config.phpNamespace}\\`);
 
 	// PHP namespace declarations.
-	literal( 'namespace DesignSetGo', `namespace ${ config.phpNamespace }` );
+	literal('namespace DesignSetGo', `namespace ${config.phpNamespace}`);
 
 	// @package docblock tag.
-	literal( '@package DesignSetGo', `@package ${ config.phpNamespace }` );
+	literal('@package DesignSetGo', `@package ${config.phpNamespace}`);
 
 	// PHP constants (order: longest constant names first).
-	literal( 'DESIGNSETGO_BASENAME', `${ config.phpConstantPrefix }_BASENAME` );
-	literal( 'DESIGNSETGO_VERSION', `${ config.phpConstantPrefix }_VERSION` );
-	literal( 'DESIGNSETGO_FILE', `${ config.phpConstantPrefix }_FILE` );
-	literal( 'DESIGNSETGO_PATH', `${ config.phpConstantPrefix }_PATH` );
-	literal( 'DESIGNSETGO_URL', `${ config.phpConstantPrefix }_URL` );
+	literal('DESIGNSETGO_BASENAME', `${config.phpConstantPrefix}_BASENAME`);
+	literal('DESIGNSETGO_VERSION', `${config.phpConstantPrefix}_VERSION`);
+	literal('DESIGNSETGO_FILE', `${config.phpConstantPrefix}_FILE`);
+	literal('DESIGNSETGO_PATH', `${config.phpConstantPrefix}_PATH`);
+	literal('DESIGNSETGO_URL', `${config.phpConstantPrefix}_URL`);
 
 	// REST namespace.
-	literal( 'designsetgo/v1', config.restNamespace );
+	literal('designsetgo/v1', config.restNamespace);
 
 	// Post type slug.
-	literal( 'dsgo_form_submission', config.postTypeSlug );
+	literal('dsgo_form_submission', config.postTypeSlug);
 
 	// Option names.
-	literal( 'designsetgo_global_styles', `${ config.optionPrefix }_global_styles` );
-	literal( 'designsetgo_settings', `${ config.optionPrefix }_settings` );
+	literal(
+		'designsetgo_global_styles',
+		`${config.optionPrefix}_global_styles`
+	);
+	literal('designsetgo_settings', `${config.optionPrefix}_settings`);
 
 	// Transient prefixes.
-	literal( 'dsgo_has_blocks_', `${ config.transientPrefix }_has_blocks_` );
+	literal('dsgo_has_blocks_', `${config.transientPrefix}_has_blocks_`);
 	literal(
 		'dsgo_form_submissions_count',
-		`${ config.transientPrefix }_form_submissions_count`
+		`${config.transientPrefix}_form_submissions_count`
 	);
 
 	// JS global names passed via wp_localize_script (must match JS side).
 	// These use camelCase variants of the plugin name.
-	literal( 'designSetGoRevisions', `${ toCamelCase( config.pluginSlug ) }Revisions` );
-	literal( 'designSetGoAdmin', `${ toCamelCase( config.pluginSlug ) }Admin` );
-	literal( 'designsetgoForm', `${ config.textDomain }Form` );
+	literal(
+		'designSetGoRevisions',
+		`${toCamelCase(config.pluginSlug)}Revisions`
+	);
+	literal('designSetGoAdmin', `${toCamelCase(config.pluginSlug)}Admin`);
+	literal('designsetgoForm', `${config.textDomain}Form`);
 
 	// Cache group.
-	literal( "'designsetgo'", `'${ config.textDomain }'` );
+	literal("'designsetgo'", `'${config.textDomain}'`);
 
 	// WP auto-generated block CSS classes.
-	literal( 'wp-block-designsetgo-', `wp-block-${ config.blockNamespace }-` );
+	literal('wp-block-designsetgo-', `wp-block-${config.blockNamespace}-`);
 
 	// Block comment markers in pattern content.
-	literal( 'wp:designsetgo/', `wp:${ config.blockNamespace }/` );
+	literal('wp:designsetgo/', `wp:${config.blockNamespace}/`);
 
 	// Block namespace in strings.
-	literal( 'designsetgo/', `${ config.blockNamespace }/` );
+	literal('designsetgo/', `${config.blockNamespace}/`);
 
 	// Function prefix (hook names, function names).
-	literal( 'designsetgo_', `${ config.phpFunctionPrefix }_` );
+	literal('designsetgo_', `${config.phpFunctionPrefix}_`);
 
 	// WP script/style handles and admin page slugs (hyphenated).
-	literal( 'designsetgo-', `${ config.pluginSlug }-` );
+	literal('designsetgo-', `${config.pluginSlug}-`);
 
 	// Data attributes in PHP HTML output.
-	literal( 'data-dsgo-', `data-${ config.cssPrefix }-` );
+	literal('data-dsgo-', `data-${config.cssPrefix}-`);
 
 	// CSS custom properties in PHP inline styles.
-	literal( '--dsgo-', `--${ config.cssPrefix }-` );
+	literal('--dsgo-', `--${config.cssPrefix}-`);
 
 	// CSS class prefix in PHP HTML output (with dot for selectors).
-	literal( '.dsgo-', `.${ config.cssPrefix }-` );
+	literal('.dsgo-', `.${config.cssPrefix}-`);
 
 	// CSS class prefix in PHP HTML output (without dot for class attributes).
-	literal( 'dsgo-', `${ config.cssPrefix }-` );
+	literal('dsgo-', `${config.cssPrefix}-`);
 
 	// Pattern category prefix.
-	literal( 'dsgo-hero', `${ config.patternCategoryPrefix }-hero` );
-	literal( 'dsgo-contact', `${ config.patternCategoryPrefix }-contact` );
-	literal( 'dsgo-features', `${ config.patternCategoryPrefix }-features` );
-	literal( 'dsgo-cta', `${ config.patternCategoryPrefix }-cta` );
-	literal( 'dsgo-faq', `${ config.patternCategoryPrefix }-faq` );
-	literal( 'dsgo-gallery', `${ config.patternCategoryPrefix }-gallery` );
-	literal( 'dsgo-homepage', `${ config.patternCategoryPrefix }-homepage` );
-	literal( 'dsgo-modal', `${ config.patternCategoryPrefix }-modal` );
-	literal( 'dsgo-pricing', `${ config.patternCategoryPrefix }-pricing` );
-	literal( 'dsgo-team', `${ config.patternCategoryPrefix }-team` );
+	literal('dsgo-hero', `${config.patternCategoryPrefix}-hero`);
+	literal('dsgo-contact', `${config.patternCategoryPrefix}-contact`);
+	literal('dsgo-features', `${config.patternCategoryPrefix}-features`);
+	literal('dsgo-cta', `${config.patternCategoryPrefix}-cta`);
+	literal('dsgo-faq', `${config.patternCategoryPrefix}-faq`);
+	literal('dsgo-gallery', `${config.patternCategoryPrefix}-gallery`);
+	literal('dsgo-homepage', `${config.patternCategoryPrefix}-homepage`);
+	literal('dsgo-modal', `${config.patternCategoryPrefix}-modal`);
+	literal('dsgo-pricing', `${config.patternCategoryPrefix}-pricing`);
+	literal('dsgo-team', `${config.patternCategoryPrefix}-team`);
 	literal(
 		'dsgo-testimonials',
-		`${ config.patternCategoryPrefix }-testimonials`
+		`${config.patternCategoryPrefix}-testimonials`
 	);
-	literal( 'dsgo-content', `${ config.patternCategoryPrefix }-content` );
+	literal('dsgo-content', `${config.patternCategoryPrefix}-content`);
 
 	// Meta key prefix.
-	literal( '_dsg_', `${ config.metaKeyPrefix }_` );
+	literal('_dsg_', `${config.metaKeyPrefix}_`);
 
 	// Short prefix for camelCase identifiers.
-	if ( config.shortPrefix !== DEFAULTS.shortPrefix ) {
-		rules.push( {
-			search: new RegExp( `\\b${ DEFAULTS.shortPrefix }([A-Z])`, 'g' ),
-			replace: `${ config.shortPrefix }$1`,
-			from: `${ DEFAULTS.shortPrefix }[A-Z]`,
-		} );
+	if (config.shortPrefix !== DEFAULTS.shortPrefix) {
+		rules.push({
+			search: new RegExp(`\\b${DEFAULTS.shortPrefix}([A-Z])`, 'g'),
+			replace: `${config.shortPrefix}$1`,
+			from: `${DEFAULTS.shortPrefix}[A-Z]`,
+		});
 	}
 
 	// Display name.
-	literal( 'DesignSetGo', config.pluginName );
+	literal('DesignSetGo', config.pluginName);
 
 	// Catch-all: bare "designsetgo" (admin menu slug, page params, remaining occurrences).
 	// Must come last since it's the shortest and most general match.
-	literal( 'designsetgo', config.textDomain );
+	literal('designsetgo', config.textDomain);
 
 	// Sort: longest literal first, regexes last.
-	return rules.sort( ( a, b ) => {
+	return rules.sort((a, b) => {
 		const aIsRegex = a.search instanceof RegExp;
 		const bIsRegex = b.search instanceof RegExp;
-		if ( aIsRegex && ! bIsRegex ) {
+		if (aIsRegex && !bIsRegex) {
 			return 1;
 		}
-		if ( ! aIsRegex && bIsRegex ) {
+		if (!aIsRegex && bIsRegex) {
 			return -1;
 		}
-		return ( b.from || '' ).length - ( a.from || '' ).length;
-	} );
+		return (b.from || '').length - (a.from || '').length;
+	});
 }
 
 /**
@@ -314,36 +323,34 @@ function buildPhpReplacements( config ) {
  * @param {Object} config White-label config.
  * @return {Array} Replacement rules.
  */
-function buildBlockJsonReplacements( config ) {
+function buildBlockJsonReplacements(config) {
 	const rules = [];
 
-	function literal( from, to ) {
-		if ( from !== to ) {
-			rules.push( { search: from, replace: to, from } );
+	function literal(from, to) {
+		if (from !== to) {
+			rules.push({ search: from, replace: to, from });
 		}
 	}
 
 	// Block name namespace.
-	literal( '"designsetgo/', `"${ config.blockNamespace }/` );
+	literal('"designsetgo/', `"${config.blockNamespace}/`);
 
 	// Context provider keys.
-	literal( 'designsetgo/', `${ config.blockNamespace }/` );
+	literal('designsetgo/', `${config.blockNamespace}/`);
 
 	// Text domain.
-	literal( '"designsetgo"', `"${ config.textDomain }"` );
+	literal('"designsetgo"', `"${config.textDomain}"`);
 
 	// CSS class references in block.json metadata.
-	literal( 'dsgo-', `${ config.cssPrefix }-` );
+	literal('dsgo-', `${config.cssPrefix}-`);
 
 	// CSS custom property references.
-	literal( '--dsgo-', `--${ config.cssPrefix }-` );
+	literal('--dsgo-', `--${config.cssPrefix}-`);
 
 	// WP auto-generated class prefix.
-	literal( 'wp-block-designsetgo-', `wp-block-${ config.blockNamespace }-` );
+	literal('wp-block-designsetgo-', `wp-block-${config.blockNamespace}-`);
 
-	return rules.sort(
-		( a, b ) => ( b.from || '' ).length - ( a.from || '' ).length
-	);
+	return rules.sort((a, b) => (b.from || '').length - (a.from || '').length);
 }
 
 /**
@@ -356,59 +363,59 @@ function buildBlockJsonReplacements( config ) {
  * @param {Object} config White-label config.
  * @return {Array} Replacement rules.
  */
-function buildCssReplacements( config ) {
+function buildCssReplacements(config) {
 	const rules = [];
 
-	function literal( from, to ) {
-		if ( from !== to ) {
-			rules.push( { search: from, replace: to, from } );
+	function literal(from, to) {
+		if (from !== to) {
+			rules.push({ search: from, replace: to, from });
 		}
 	}
 
 	// WP auto-generated block CSS classes.
-	literal( 'wp-block-designsetgo-', `wp-block-${ config.blockNamespace }-` );
+	literal('wp-block-designsetgo-', `wp-block-${config.blockNamespace}-`);
 
 	// Data attributes.
-	literal( 'data-dsgo-', `data-${ config.cssPrefix }-` );
+	literal('data-dsgo-', `data-${config.cssPrefix}-`);
 
 	// CSS custom properties.
-	literal( '--dsgo-', `--${ config.cssPrefix }-` );
+	literal('--dsgo-', `--${config.cssPrefix}-`);
 
 	// CSS classes (dot-prefixed selectors).
-	literal( '.dsgo-', `.${ config.cssPrefix }-` );
+	literal('.dsgo-', `.${config.cssPrefix}-`);
 
 	// CSS classes (without dot, e.g., in attribute selectors or animations).
-	literal( 'dsgo-', `${ config.cssPrefix }-` );
+	literal('dsgo-', `${config.cssPrefix}-`);
 
 	// Admin dashboard CSS classes and WP theme.json custom properties using full name.
 	// E.g., .designsetgo-info-box, --wp--custom--designsetgo--border-radius
-	literal( 'designsetgo-', `${ config.pluginSlug }-` );
-	literal( 'designsetgo', config.textDomain );
+	literal('designsetgo-', `${config.pluginSlug}-`);
+	literal('designsetgo', config.textDomain);
 
 	// Display name in CSS comments (e.g., @package DesignSetGo).
-	literal( 'DesignSetGo', config.pluginName );
+	literal('DesignSetGo', config.pluginName);
 
 	// Short prefix for CSS @keyframes names (dsgFadeIn, dsgSlideInUp, etc.).
-	if ( config.shortPrefix !== DEFAULTS.shortPrefix ) {
-		rules.push( {
-			search: new RegExp( `${ DEFAULTS.shortPrefix }([A-Z])`, 'g' ),
-			replace: `${ config.shortPrefix }$1`,
-			from: `${ DEFAULTS.shortPrefix }[A-Z]`,
-		} );
+	if (config.shortPrefix !== DEFAULTS.shortPrefix) {
+		rules.push({
+			search: new RegExp(`${DEFAULTS.shortPrefix}([A-Z])`, 'g'),
+			replace: `${config.shortPrefix}$1`,
+			from: `${DEFAULTS.shortPrefix}[A-Z]`,
+		});
 	}
 
 	// Sort: longest literal first, regexes last.
-	return rules.sort( ( a, b ) => {
+	return rules.sort((a, b) => {
 		const aIsRegex = a.search instanceof RegExp;
 		const bIsRegex = b.search instanceof RegExp;
-		if ( aIsRegex && ! bIsRegex ) {
+		if (aIsRegex && !bIsRegex) {
 			return 1;
 		}
-		if ( ! aIsRegex && bIsRegex ) {
+		if (!aIsRegex && bIsRegex) {
 			return -1;
 		}
-		return ( b.from || '' ).length - ( a.from || '' ).length;
-	} );
+		return (b.from || '').length - (a.from || '').length;
+	});
 }
 
 /**
@@ -417,25 +424,45 @@ function buildCssReplacements( config ) {
  * @param {Object} config White-label config.
  * @return {Array} Replacement rules for the main plugin PHP file header.
  */
-function buildPluginHeaderReplacements( config ) {
+function buildPluginHeaderReplacements(config) {
 	const rules = [];
 
-	function headerField( field, defaultVal, newVal ) {
-		if ( newVal !== defaultVal ) {
-			rules.push( {
-				search: `${ field }${ defaultVal }`,
-				replace: `${ field }${ newVal }`,
-				from: `${ field }${ defaultVal }`,
-			} );
+	function headerField(field, defaultVal, newVal) {
+		if (newVal !== defaultVal) {
+			rules.push({
+				search: `${field}${defaultVal}`,
+				replace: `${field}${newVal}`,
+				from: `${field}${defaultVal}`,
+			});
 		}
 	}
 
-	headerField( ' * Plugin Name:       ', DEFAULTS.pluginName, config.pluginName );
-	headerField( ' * Plugin URI:        ', DEFAULTS.pluginUri, config.pluginUri );
-	headerField( ' * Description:       ', DEFAULTS.pluginDescription, config.pluginDescription );
-	headerField( ' * Author:            ', DEFAULTS.pluginAuthor, config.pluginAuthor );
-	headerField( ' * Author URI:        ', DEFAULTS.pluginAuthorUri, config.pluginAuthorUri );
-	headerField( ' * Text Domain:       ', DEFAULTS.textDomain, config.textDomain );
+	headerField(
+		' * Plugin Name:       ',
+		DEFAULTS.pluginName,
+		config.pluginName
+	);
+	headerField(' * Plugin URI:        ', DEFAULTS.pluginUri, config.pluginUri);
+	headerField(
+		' * Description:       ',
+		DEFAULTS.pluginDescription,
+		config.pluginDescription
+	);
+	headerField(
+		' * Author:            ',
+		DEFAULTS.pluginAuthor,
+		config.pluginAuthor
+	);
+	headerField(
+		' * Author URI:        ',
+		DEFAULTS.pluginAuthorUri,
+		config.pluginAuthorUri
+	);
+	headerField(
+		' * Text Domain:       ',
+		DEFAULTS.textDomain,
+		config.textDomain
+	);
 
 	return rules;
 }
@@ -447,13 +474,13 @@ function buildPluginHeaderReplacements( config ) {
  * @param {Array}  rules   Replacement rules from any build*Replacements function.
  * @return {string} Transformed content.
  */
-function applyReplacements( content, rules ) {
+function applyReplacements(content, rules) {
 	let result = content;
-	for ( const rule of rules ) {
-		if ( rule.search instanceof RegExp ) {
-			result = result.replace( rule.search, rule.replace );
+	for (const rule of rules) {
+		if (rule.search instanceof RegExp) {
+			result = result.replace(rule.search, rule.replace);
 		} else {
-			result = result.split( rule.search ).join( rule.replace );
+			result = result.split(rule.search).join(rule.replace);
 		}
 	}
 	return result;

--- a/scripts/white-label-replacements.js
+++ b/scripts/white-label-replacements.js
@@ -147,6 +147,16 @@ function buildJsScssReplacements(config) {
 	// Text domain in i18n calls.
 	literal('designsetgo', config.textDomain);
 
+	// CSS prefix in camelCase form for block attributes (dsgoAnimationEnabled, dsgoTextRevealColor, etc.).
+	// Must come before short prefix rule since dsgo starts with dsg.
+	if (config.cssPrefix !== DEFAULTS.cssPrefix) {
+		rules.push({
+			search: new RegExp(`\\b${DEFAULTS.cssPrefix}([A-Z])`, 'g'),
+			replace: `${config.cssPrefix}$1`,
+			from: `${DEFAULTS.cssPrefix}[A-Z]`,
+		});
+	}
+
 	// Short prefix for camelCase identifiers (animation keyframes, attribute names, globals).
 	// Match dsg followed by uppercase letter — e.g., dsgFadeIn, dsgLinkUrl, dsgStickyHeaderSettings.
 	// This must NOT match dsgo- (safe: dsgo is never followed by uppercase).
@@ -287,6 +297,15 @@ function buildPhpReplacements(config) {
 	// Meta key prefix.
 	literal('_dsg_', `${config.metaKeyPrefix}_`);
 
+	// CSS prefix in camelCase form for block attributes (dsgoAnimationEnabled, dsgoTextRevealColor, etc.).
+	if (config.cssPrefix !== DEFAULTS.cssPrefix) {
+		rules.push({
+			search: new RegExp(`\\b${DEFAULTS.cssPrefix}([A-Z])`, 'g'),
+			replace: `${config.cssPrefix}$1`,
+			from: `${DEFAULTS.cssPrefix}[A-Z]`,
+		});
+	}
+
 	// Short prefix for camelCase identifiers.
 	if (config.shortPrefix !== DEFAULTS.shortPrefix) {
 		rules.push({
@@ -350,7 +369,26 @@ function buildBlockJsonReplacements(config) {
 	// WP auto-generated class prefix.
 	literal('wp-block-designsetgo-', `wp-block-${config.blockNamespace}-`);
 
-	return rules.sort((a, b) => (b.from || '').length - (a.from || '').length);
+	// CSS prefix in camelCase form for block attribute names (dsgoAnimationEnabled, etc.).
+	if (config.cssPrefix !== DEFAULTS.cssPrefix) {
+		rules.push({
+			search: new RegExp(`${DEFAULTS.cssPrefix}([A-Z])`, 'g'),
+			replace: `${config.cssPrefix}$1`,
+			from: `${DEFAULTS.cssPrefix}[A-Z]`,
+		});
+	}
+
+	return rules.sort((a, b) => {
+		const aIsRegex = a.search instanceof RegExp;
+		const bIsRegex = b.search instanceof RegExp;
+		if (aIsRegex && !bIsRegex) {
+			return 1;
+		}
+		if (!aIsRegex && bIsRegex) {
+			return -1;
+		}
+		return (b.from || '').length - (a.from || '').length;
+	});
 }
 
 /**
@@ -394,6 +432,15 @@ function buildCssReplacements(config) {
 
 	// Display name in CSS comments (e.g., @package DesignSetGo).
 	literal('DesignSetGo', config.pluginName);
+
+	// CSS prefix in camelCase form (dsgoAnimationEnabled in data attributes, etc.).
+	if (config.cssPrefix !== DEFAULTS.cssPrefix) {
+		rules.push({
+			search: new RegExp(`${DEFAULTS.cssPrefix}([A-Z])`, 'g'),
+			replace: `${config.cssPrefix}$1`,
+			from: `${DEFAULTS.cssPrefix}[A-Z]`,
+		});
+	}
 
 	// Short prefix for CSS @keyframes names (dsgFadeIn, dsgSlideInUp, etc.).
 	if (config.shortPrefix !== DEFAULTS.shortPrefix) {

--- a/scripts/white-label-validate.js
+++ b/scripts/white-label-validate.js
@@ -4,55 +4,64 @@
  * Validates white-label.json before building.
  * Run: node scripts/white-label-validate.js
  *
- * @package DesignSetGo
+ * @package
  */
 
 'use strict';
+/* eslint-disable no-console */
 
-const fs = require( 'fs' );
-const path = require( 'path' );
+const fs = require('fs');
+const path = require('path');
 
-const configPath = path.resolve( __dirname, '..', 'white-label.json' );
+const configPath = path.resolve(__dirname, '..', 'white-label.json');
 
-if ( ! fs.existsSync( configPath ) ) {
+if (!fs.existsSync(configPath)) {
 	console.error(
 		'Error: white-label.json not found.\n' +
 			'Copy white-label.json.example to white-label.json and customize it.'
 	);
-	process.exit( 1 );
+	process.exit(1);
 }
 
 let config;
 try {
-	config = JSON.parse( fs.readFileSync( configPath, 'utf8' ) );
-} catch ( err ) {
-	console.error( `Error: Invalid JSON in white-label.json:\n${ err.message }` );
-	process.exit( 1 );
+	config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+} catch (err) {
+	console.error(`Error: Invalid JSON in white-label.json:\n${err.message}`);
+	process.exit(1);
 }
 
 const errors = [];
 
-function required( field, label ) {
-	if ( ! config[ field ] || typeof config[ field ] !== 'string' || config[ field ].trim() === '' ) {
-		errors.push( `${ label } (${ field }) is required and must be a non-empty string.` );
+function required(field, label) {
+	if (
+		!config[field] ||
+		typeof config[field] !== 'string' ||
+		config[field].trim() === ''
+	) {
+		errors.push(
+			`${label} (${field}) is required and must be a non-empty string.`
+		);
 		return false;
 	}
 	return true;
 }
 
-function matchesPattern( field, label, pattern, hint ) {
-	if ( ! required( field, label ) ) {
+function matchesPattern(field, label, pattern, hint) {
+	if (!required(field, label)) {
 		return;
 	}
-	if ( ! pattern.test( config[ field ] ) ) {
-		errors.push( `${ label } (${ field }): "${ config[ field ] }" is invalid. ${ hint }` );
+	if (!pattern.test(config[field])) {
+		errors.push(
+			`${label} (${field}): "${config[field]}" is invalid. ${hint}`
+		);
 	}
 }
 
-function maxLength( field, label, max ) {
-	if ( config[ field ] && config[ field ].length > max ) {
+function maxLength(field, label, max) {
+	if (config[field] && config[field].length > max) {
 		errors.push(
-			`${ label } (${ field }): "${ config[ field ] }" exceeds max length of ${ max } characters (currently ${ config[ field ].length }).`
+			`${label} (${field}): "${config[field]}" exceeds max length of ${max} characters (currently ${config[field].length}).`
 		);
 	}
 }
@@ -66,9 +75,13 @@ matchesPattern(
 );
 
 // Text domain must match plugin slug.
-if ( config.textDomain && config.pluginSlug && config.textDomain !== config.pluginSlug ) {
+if (
+	config.textDomain &&
+	config.pluginSlug &&
+	config.textDomain !== config.pluginSlug
+) {
 	errors.push(
-		`Text domain ("${ config.textDomain }") should match plugin slug ("${ config.pluginSlug }"). WordPress convention requires these to be identical.`
+		`Text domain ("${config.textDomain}") should match plugin slug ("${config.pluginSlug}"). WordPress convention requires these to be identical.`
 	);
 }
 
@@ -87,9 +100,12 @@ matchesPattern(
 	/^[a-z][a-z0-9]*$/,
 	'Must be lowercase letters and numbers only (no hyphens).'
 );
-if ( config.cssPrefix && ( config.cssPrefix.length < 2 || config.cssPrefix.length > 6 ) ) {
+if (
+	config.cssPrefix &&
+	(config.cssPrefix.length < 2 || config.cssPrefix.length > 6)
+) {
 	errors.push(
-		`CSS prefix (${ config.cssPrefix }): Recommended 2-6 characters (currently ${ config.cssPrefix.length }).`
+		`CSS prefix (${config.cssPrefix}): Recommended 2-6 characters (currently ${config.cssPrefix.length}).`
 	);
 }
 
@@ -140,13 +156,13 @@ matchesPattern(
 	/^[a-z][a-z0-9_]*$/,
 	'Must be lowercase with underscores.'
 );
-maxLength( 'postTypeSlug', 'Post type slug', 20 );
+maxLength('postTypeSlug', 'Post type slug', 20);
 
 // Meta key prefix.
-if ( required( 'metaKeyPrefix', 'Meta key prefix' ) ) {
-	if ( ! /^_?[a-z][a-z0-9]*$/.test( config.metaKeyPrefix ) ) {
+if (required('metaKeyPrefix', 'Meta key prefix')) {
+	if (!/^_?[a-z][a-z0-9]*$/.test(config.metaKeyPrefix)) {
 		errors.push(
-			`Meta key prefix ("${ config.metaKeyPrefix }") is invalid. Must be lowercase, optionally starting with underscore.`
+			`Meta key prefix ("${config.metaKeyPrefix}") is invalid. Must be lowercase, optionally starting with underscore.`
 		);
 	}
 }
@@ -176,25 +192,27 @@ matchesPattern(
 );
 
 // Plugin name (display).
-required( 'pluginName', 'Plugin name' );
+required('pluginName', 'Plugin name');
 
 // Check for prefix collision: shortPrefix must not be a prefix of cssPrefix + hyphen pattern.
 // e.g., if cssPrefix is "mb" and shortPrefix is "mb", that's fine because
 // shortPrefix matches /mb[A-Z]/ and cssPrefix matches /mb-/.
 // But if shortPrefix is "dsgo" it would match "dsgoA" which could collide.
 
-if ( errors.length > 0 ) {
-	console.error( 'White-label configuration errors:\n' );
-	errors.forEach( ( err ) => console.error( `  - ${ err }` ) );
-	console.error( `\n${ errors.length } error(s) found. Fix white-label.json and try again.` );
-	process.exit( 1 );
+if (errors.length > 0) {
+	console.error('White-label configuration errors:\n');
+	errors.forEach((err) => console.error(`  - ${err}`));
+	console.error(
+		`\n${errors.length} error(s) found. Fix white-label.json and try again.`
+	);
+	process.exit(1);
 }
 
-console.log( 'White-label configuration is valid.' );
-console.log( `  Plugin: ${ config.pluginName } (${ config.pluginSlug })` );
-console.log( `  Block namespace: ${ config.blockNamespace }` );
-console.log( `  CSS prefix: ${ config.cssPrefix }-` );
-console.log( `  Short prefix: ${ config.shortPrefix }` );
-console.log( `  PHP namespace: ${ config.phpNamespace }` );
-console.log( `  REST namespace: ${ config.restNamespace }` );
-console.log( `  Post type: ${ config.postTypeSlug }` );
+console.log('White-label configuration is valid.');
+console.log(`  Plugin: ${config.pluginName} (${config.pluginSlug})`);
+console.log(`  Block namespace: ${config.blockNamespace}`);
+console.log(`  CSS prefix: ${config.cssPrefix}-`);
+console.log(`  Short prefix: ${config.shortPrefix}`);
+console.log(`  PHP namespace: ${config.phpNamespace}`);
+console.log(`  REST namespace: ${config.restNamespace}`);
+console.log(`  Post type: ${config.postTypeSlug}`);

--- a/scripts/white-label-validate.js
+++ b/scripts/white-label-validate.js
@@ -1,0 +1,200 @@
+/**
+ * White Label Config Validator
+ *
+ * Validates white-label.json before building.
+ * Run: node scripts/white-label-validate.js
+ *
+ * @package DesignSetGo
+ */
+
+'use strict';
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+const configPath = path.resolve( __dirname, '..', 'white-label.json' );
+
+if ( ! fs.existsSync( configPath ) ) {
+	console.error(
+		'Error: white-label.json not found.\n' +
+			'Copy white-label.json.example to white-label.json and customize it.'
+	);
+	process.exit( 1 );
+}
+
+let config;
+try {
+	config = JSON.parse( fs.readFileSync( configPath, 'utf8' ) );
+} catch ( err ) {
+	console.error( `Error: Invalid JSON in white-label.json:\n${ err.message }` );
+	process.exit( 1 );
+}
+
+const errors = [];
+
+function required( field, label ) {
+	if ( ! config[ field ] || typeof config[ field ] !== 'string' || config[ field ].trim() === '' ) {
+		errors.push( `${ label } (${ field }) is required and must be a non-empty string.` );
+		return false;
+	}
+	return true;
+}
+
+function matchesPattern( field, label, pattern, hint ) {
+	if ( ! required( field, label ) ) {
+		return;
+	}
+	if ( ! pattern.test( config[ field ] ) ) {
+		errors.push( `${ label } (${ field }): "${ config[ field ] }" is invalid. ${ hint }` );
+	}
+}
+
+function maxLength( field, label, max ) {
+	if ( config[ field ] && config[ field ].length > max ) {
+		errors.push(
+			`${ label } (${ field }): "${ config[ field ] }" exceeds max length of ${ max } characters (currently ${ config[ field ].length }).`
+		);
+	}
+}
+
+// Plugin slug: lowercase, hyphens, no leading hyphen.
+matchesPattern(
+	'pluginSlug',
+	'Plugin slug',
+	/^[a-z][a-z0-9-]*$/,
+	'Must be lowercase letters, numbers, and hyphens. Must start with a letter.'
+);
+
+// Text domain must match plugin slug.
+if ( config.textDomain && config.pluginSlug && config.textDomain !== config.pluginSlug ) {
+	errors.push(
+		`Text domain ("${ config.textDomain }") should match plugin slug ("${ config.pluginSlug }"). WordPress convention requires these to be identical.`
+	);
+}
+
+// Block namespace.
+matchesPattern(
+	'blockNamespace',
+	'Block namespace',
+	/^[a-z][a-z0-9-]*$/,
+	'Must be lowercase letters, numbers, and hyphens.'
+);
+
+// CSS prefix.
+matchesPattern(
+	'cssPrefix',
+	'CSS prefix',
+	/^[a-z][a-z0-9]*$/,
+	'Must be lowercase letters and numbers only (no hyphens).'
+);
+if ( config.cssPrefix && ( config.cssPrefix.length < 2 || config.cssPrefix.length > 6 ) ) {
+	errors.push(
+		`CSS prefix (${ config.cssPrefix }): Recommended 2-6 characters (currently ${ config.cssPrefix.length }).`
+	);
+}
+
+// Short prefix.
+matchesPattern(
+	'shortPrefix',
+	'Short prefix',
+	/^[a-z][a-z0-9]*$/,
+	'Must be lowercase letters and numbers only.'
+);
+
+// PHP namespace.
+matchesPattern(
+	'phpNamespace',
+	'PHP namespace',
+	/^[A-Z][A-Za-z0-9]*$/,
+	'Must be PascalCase (start with uppercase, letters and numbers only).'
+);
+
+// PHP function prefix.
+matchesPattern(
+	'phpFunctionPrefix',
+	'PHP function prefix',
+	/^[a-z][a-z0-9_]*$/,
+	'Must be lowercase with underscores.'
+);
+
+// PHP constant prefix.
+matchesPattern(
+	'phpConstantPrefix',
+	'PHP constant prefix',
+	/^[A-Z][A-Z0-9_]*$/,
+	'Must be UPPERCASE with underscores.'
+);
+
+// REST namespace.
+matchesPattern(
+	'restNamespace',
+	'REST namespace',
+	/^[a-z][a-z0-9-]*\/v[0-9]+$/,
+	'Must be in format "slug/v1".'
+);
+
+// Post type slug: max 20 characters.
+matchesPattern(
+	'postTypeSlug',
+	'Post type slug',
+	/^[a-z][a-z0-9_]*$/,
+	'Must be lowercase with underscores.'
+);
+maxLength( 'postTypeSlug', 'Post type slug', 20 );
+
+// Meta key prefix.
+if ( required( 'metaKeyPrefix', 'Meta key prefix' ) ) {
+	if ( ! /^_?[a-z][a-z0-9]*$/.test( config.metaKeyPrefix ) ) {
+		errors.push(
+			`Meta key prefix ("${ config.metaKeyPrefix }") is invalid. Must be lowercase, optionally starting with underscore.`
+		);
+	}
+}
+
+// Pattern category prefix.
+matchesPattern(
+	'patternCategoryPrefix',
+	'Pattern category prefix',
+	/^[a-z][a-z0-9]*$/,
+	'Must be lowercase letters and numbers only.'
+);
+
+// Transient prefix.
+matchesPattern(
+	'transientPrefix',
+	'Transient prefix',
+	/^[a-z][a-z0-9]*$/,
+	'Must be lowercase letters and numbers only.'
+);
+
+// Option prefix.
+matchesPattern(
+	'optionPrefix',
+	'Option prefix',
+	/^[a-z][a-z0-9_]*$/,
+	'Must be lowercase with underscores.'
+);
+
+// Plugin name (display).
+required( 'pluginName', 'Plugin name' );
+
+// Check for prefix collision: shortPrefix must not be a prefix of cssPrefix + hyphen pattern.
+// e.g., if cssPrefix is "mb" and shortPrefix is "mb", that's fine because
+// shortPrefix matches /mb[A-Z]/ and cssPrefix matches /mb-/.
+// But if shortPrefix is "dsgo" it would match "dsgoA" which could collide.
+
+if ( errors.length > 0 ) {
+	console.error( 'White-label configuration errors:\n' );
+	errors.forEach( ( err ) => console.error( `  - ${ err }` ) );
+	console.error( `\n${ errors.length } error(s) found. Fix white-label.json and try again.` );
+	process.exit( 1 );
+}
+
+console.log( 'White-label configuration is valid.' );
+console.log( `  Plugin: ${ config.pluginName } (${ config.pluginSlug })` );
+console.log( `  Block namespace: ${ config.blockNamespace }` );
+console.log( `  CSS prefix: ${ config.cssPrefix }-` );
+console.log( `  Short prefix: ${ config.shortPrefix }` );
+console.log( `  PHP namespace: ${ config.phpNamespace }` );
+console.log( `  REST namespace: ${ config.restNamespace }` );
+console.log( `  Post type: ${ config.postTypeSlug }` );

--- a/scripts/white-label-zip.js
+++ b/scripts/white-label-zip.js
@@ -6,66 +6,67 @@
  *
  * Run: node scripts/white-label-zip.js
  *
- * @package DesignSetGo
+ * @package
  */
 
 'use strict';
+/* eslint-disable no-console */
 
-const fs = require( 'fs' );
-const path = require( 'path' );
-const { execFileSync } = require( 'child_process' );
-const { loadConfig } = require( './white-label-replacements' );
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { loadConfig } = require('./white-label-replacements');
 
-const ROOT = path.resolve( __dirname, '..' );
-const DIST = path.resolve( ROOT, 'dist' );
+const ROOT = path.resolve(__dirname, '..');
+const DIST = path.resolve(ROOT, 'dist');
 
 const config = loadConfig();
-if ( ! config ) {
+if (!config) {
 	console.error(
 		'Error: No white-label.json found or config matches defaults.'
 	);
-	process.exit( 1 );
+	process.exit(1);
 }
 
-if ( ! fs.existsSync( DIST ) ) {
+if (!fs.existsSync(DIST)) {
 	console.error(
 		'Error: dist/ directory not found. Run "npm run white-label:build" first.'
 	);
-	process.exit( 1 );
+	process.exit(1);
 }
 
-const zipName = `${ config.pluginSlug }.zip`;
-const zipPath = path.resolve( ROOT, zipName );
+const zipName = `${config.pluginSlug}.zip`;
+const zipPath = path.resolve(ROOT, zipName);
 
 // Remove existing zip if present.
-if ( fs.existsSync( zipPath ) ) {
-	fs.unlinkSync( zipPath );
+if (fs.existsSync(zipPath)) {
+	fs.unlinkSync(zipPath);
 }
 
 // WordPress expects the zip to contain a directory named after the plugin slug.
 // Rename dist/ temporarily for zipping, then rename back.
-const tempDir = path.resolve( ROOT, config.pluginSlug );
+const tempDir = path.resolve(ROOT, config.pluginSlug);
 
 // If temp dir already exists (shouldn't happen), clean it.
-if ( fs.existsSync( tempDir ) ) {
-	fs.rmSync( tempDir, { recursive: true, force: true } );
+if (fs.existsSync(tempDir)) {
+	fs.rmSync(tempDir, { recursive: true, force: true });
 }
 
-fs.renameSync( DIST, tempDir );
+fs.renameSync(DIST, tempDir);
 
 try {
-	execFileSync( 'zip', [ '-r', zipName, config.pluginSlug ], {
+	execFileSync('zip', ['-r', zipName, config.pluginSlug], {
 		cwd: ROOT,
 		stdio: 'pipe',
-	} );
-	console.log( `\nCreated: ${ zipName }` );
+	});
+	console.log(`\nCreated: ${zipName}`);
 	console.log(
 		'Install by uploading to WordPress > Plugins > Add New > Upload Plugin.'
 	);
-} catch ( err ) {
-	console.error( `Error creating zip: ${ err.message }` );
-	process.exit( 1 );
+} catch (err) {
+	console.error(`Error creating zip: ${err.message}`);
+	process.exit(1);
 } finally {
 	// Restore dist/ directory.
-	fs.renameSync( tempDir, DIST );
+	fs.renameSync(tempDir, DIST);
 }

--- a/scripts/white-label-zip.js
+++ b/scripts/white-label-zip.js
@@ -1,0 +1,71 @@
+/**
+ * White Label Zip Utility
+ *
+ * Zips the dist/ directory into an installable WordPress plugin zip.
+ * The zip contains a top-level directory named after the plugin slug.
+ *
+ * Run: node scripts/white-label-zip.js
+ *
+ * @package DesignSetGo
+ */
+
+'use strict';
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+const { execFileSync } = require( 'child_process' );
+const { loadConfig } = require( './white-label-replacements' );
+
+const ROOT = path.resolve( __dirname, '..' );
+const DIST = path.resolve( ROOT, 'dist' );
+
+const config = loadConfig();
+if ( ! config ) {
+	console.error(
+		'Error: No white-label.json found or config matches defaults.'
+	);
+	process.exit( 1 );
+}
+
+if ( ! fs.existsSync( DIST ) ) {
+	console.error(
+		'Error: dist/ directory not found. Run "npm run white-label:build" first.'
+	);
+	process.exit( 1 );
+}
+
+const zipName = `${ config.pluginSlug }.zip`;
+const zipPath = path.resolve( ROOT, zipName );
+
+// Remove existing zip if present.
+if ( fs.existsSync( zipPath ) ) {
+	fs.unlinkSync( zipPath );
+}
+
+// WordPress expects the zip to contain a directory named after the plugin slug.
+// Rename dist/ temporarily for zipping, then rename back.
+const tempDir = path.resolve( ROOT, config.pluginSlug );
+
+// If temp dir already exists (shouldn't happen), clean it.
+if ( fs.existsSync( tempDir ) ) {
+	fs.rmSync( tempDir, { recursive: true, force: true } );
+}
+
+fs.renameSync( DIST, tempDir );
+
+try {
+	execFileSync( 'zip', [ '-r', zipName, config.pluginSlug ], {
+		cwd: ROOT,
+		stdio: 'pipe',
+	} );
+	console.log( `\nCreated: ${ zipName }` );
+	console.log(
+		'Install by uploading to WordPress > Plugins > Add New > Upload Plugin.'
+	);
+} catch ( err ) {
+	console.error( `Error creating zip: ${ err.message }` );
+	process.exit( 1 );
+} finally {
+	// Restore dist/ directory.
+	fs.renameSync( tempDir, DIST );
+}

--- a/scripts/wp-env-white-label.js
+++ b/scripts/wp-env-white-label.js
@@ -69,7 +69,10 @@ console.log(`  Plugin source: dist/ (${config.pluginSlug})`);
 console.log('');
 console.log('Next steps:');
 console.log(
-	'  npm run wp-env:start    — Start/restart wp-env with the white-labeled plugin'
+	'  npx wp-env start --update    — Start/restart wp-env with the white-labeled plugin'
+);
+console.log(
+	'                                 (--update is required to pick up config changes)'
 );
 console.log('');
 console.log('To revert to normal development:');

--- a/scripts/wp-env-white-label.js
+++ b/scripts/wp-env-white-label.js
@@ -1,0 +1,67 @@
+/**
+ * Toggle wp-env to use the white-labeled dist/ build.
+ *
+ * Creates .wp-env.override.json that swaps the plugin source from . to ./dist.
+ * Run `npm run wp-env:white-label:reset` to revert to normal development.
+ *
+ * Usage: node scripts/wp-env-white-label.js [--reset]
+ *
+ * @package DesignSetGo
+ */
+
+'use strict';
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+const { loadConfig } = require( './white-label-replacements' );
+
+const ROOT = path.resolve( __dirname, '..' );
+const OVERRIDE_FILE = path.join( ROOT, '.wp-env.override.json' );
+const DIST = path.join( ROOT, 'dist' );
+
+const isReset = process.argv.includes( '--reset' );
+
+if ( isReset ) {
+	if ( fs.existsSync( OVERRIDE_FILE ) ) {
+		fs.unlinkSync( OVERRIDE_FILE );
+		console.log( 'Removed .wp-env.override.json' );
+		console.log( 'Run `npm run wp-env:start` to restart with normal (source) plugin.' );
+	} else {
+		console.log( 'No .wp-env.override.json found — already in normal mode.' );
+	}
+	process.exit( 0 );
+}
+
+// Validate that white-label config exists.
+const config = loadConfig();
+if ( ! config ) {
+	console.error(
+		'Error: No white-label.json found (or it matches defaults).\n' +
+		'Copy white-label.json.example to white-label.json and customize it first.'
+	);
+	process.exit( 1 );
+}
+
+// Validate that dist/ exists (should be created by white-label:build).
+if ( ! fs.existsSync( DIST ) ) {
+	console.error(
+		'Error: dist/ directory not found.\n' +
+		'Run `npm run white-label:build` first to create the rebranded build.'
+	);
+	process.exit( 1 );
+}
+
+// Write the override file pointing wp-env to dist/.
+const override = {
+	plugins: [ './dist' ],
+};
+fs.writeFileSync( OVERRIDE_FILE, JSON.stringify( override, null, '\t' ) + '\n', 'utf8' );
+
+console.log( `\nWhite-label wp-env mode enabled for "${ config.pluginName }".` );
+console.log( `  Plugin source: dist/ (${ config.pluginSlug })` );
+console.log( '' );
+console.log( 'Next steps:' );
+console.log( '  npm run wp-env:start    — Start/restart wp-env with the white-labeled plugin' );
+console.log( '' );
+console.log( 'To revert to normal development:' );
+console.log( '  npm run wp-env:white-label:reset' );

--- a/scripts/wp-env-white-label.js
+++ b/scripts/wp-env-white-label.js
@@ -6,62 +6,71 @@
  *
  * Usage: node scripts/wp-env-white-label.js [--reset]
  *
- * @package DesignSetGo
+ * @package
  */
 
 'use strict';
+/* eslint-disable no-console */
 
-const fs = require( 'fs' );
-const path = require( 'path' );
-const { loadConfig } = require( './white-label-replacements' );
+const fs = require('fs');
+const path = require('path');
+const { loadConfig } = require('./white-label-replacements');
 
-const ROOT = path.resolve( __dirname, '..' );
-const OVERRIDE_FILE = path.join( ROOT, '.wp-env.override.json' );
-const DIST = path.join( ROOT, 'dist' );
+const ROOT = path.resolve(__dirname, '..');
+const OVERRIDE_FILE = path.join(ROOT, '.wp-env.override.json');
+const DIST = path.join(ROOT, 'dist');
 
-const isReset = process.argv.includes( '--reset' );
+const isReset = process.argv.includes('--reset');
 
-if ( isReset ) {
-	if ( fs.existsSync( OVERRIDE_FILE ) ) {
-		fs.unlinkSync( OVERRIDE_FILE );
-		console.log( 'Removed .wp-env.override.json' );
-		console.log( 'Run `npm run wp-env:start` to restart with normal (source) plugin.' );
+if (isReset) {
+	if (fs.existsSync(OVERRIDE_FILE)) {
+		fs.unlinkSync(OVERRIDE_FILE);
+		console.log('Removed .wp-env.override.json');
+		console.log(
+			'Run `npm run wp-env:start` to restart with normal (source) plugin.'
+		);
 	} else {
-		console.log( 'No .wp-env.override.json found — already in normal mode.' );
+		console.log('No .wp-env.override.json found — already in normal mode.');
 	}
-	process.exit( 0 );
+	process.exit(0);
 }
 
 // Validate that white-label config exists.
 const config = loadConfig();
-if ( ! config ) {
+if (!config) {
 	console.error(
 		'Error: No white-label.json found (or it matches defaults).\n' +
-		'Copy white-label.json.example to white-label.json and customize it first.'
+			'Copy white-label.json.example to white-label.json and customize it first.'
 	);
-	process.exit( 1 );
+	process.exit(1);
 }
 
 // Validate that dist/ exists (should be created by white-label:build).
-if ( ! fs.existsSync( DIST ) ) {
+if (!fs.existsSync(DIST)) {
 	console.error(
 		'Error: dist/ directory not found.\n' +
-		'Run `npm run white-label:build` first to create the rebranded build.'
+			'Run `npm run white-label:build` first to create the rebranded build.'
 	);
-	process.exit( 1 );
+	process.exit(1);
 }
 
 // Write the override file pointing wp-env to dist/.
 const override = {
-	plugins: [ './dist' ],
+	plugins: ['./dist'],
 };
-fs.writeFileSync( OVERRIDE_FILE, JSON.stringify( override, null, '\t' ) + '\n', 'utf8' );
+fs.writeFileSync(
+	OVERRIDE_FILE,
+	JSON.stringify(override, null, '\t') + '\n',
+	'utf8'
+);
 
-console.log( `\nWhite-label wp-env mode enabled for "${ config.pluginName }".` );
-console.log( `  Plugin source: dist/ (${ config.pluginSlug })` );
-console.log( '' );
-console.log( 'Next steps:' );
-console.log( '  npm run wp-env:start    — Start/restart wp-env with the white-labeled plugin' );
-console.log( '' );
-console.log( 'To revert to normal development:' );
-console.log( '  npm run wp-env:white-label:reset' );
+console.log(`\nWhite-label wp-env mode enabled for "${config.pluginName}".`);
+console.log(`  Plugin source: dist/ (${config.pluginSlug})`);
+console.log('');
+console.log('Next steps:');
+console.log(
+	'  npm run wp-env:start    — Start/restart wp-env with the white-labeled plugin'
+);
+console.log('');
+console.log('To revert to normal development:');
+console.log('  npm run wp-env:white-label:reset');

--- a/src/admin/components/Dashboard.js
+++ b/src/admin/components/Dashboard.js
@@ -90,11 +90,13 @@ const Dashboard = () => {
 		<div className="designsetgo-dashboard">
 			<div className="designsetgo-dashboard__header">
 				<div className="designsetgo-dashboard__branding">
-					<img
-						src={window.designSetGoAdmin?.logoUrl}
-						alt="DesignSetGo"
-						className="designsetgo-logo"
-					/>
+					{window.designSetGoAdmin?.logoUrl && (
+						<img
+							src={window.designSetGoAdmin.logoUrl}
+							alt="DesignSetGo"
+							className="designsetgo-logo"
+						/>
+					)}
 					<p className="description">
 						{__(
 							'Manage your DesignSetGo blocks, extensions, and settings.',

--- a/white-label.json.example
+++ b/white-label.json.example
@@ -1,0 +1,33 @@
+{
+  "$schema": "./white-label.schema.json",
+
+  "_comment": "White Label Configuration for DesignSetGo forks.",
+  "_comment2": "Copy this file to white-label.json and customize values below.",
+  "_comment3": "Run 'npm run white-label:build' to produce a fully rebranded plugin in dist/.",
+
+  "pluginName": "MyBlocks",
+  "pluginSlug": "myblocks",
+  "pluginUri": "https://example.com",
+  "pluginDescription": "A professional Gutenberg block library.",
+  "pluginAuthor": "Your Name",
+  "pluginAuthorUri": "https://example.com/about",
+
+  "textDomain": "myblocks",
+  "blockNamespace": "myblocks",
+
+  "cssPrefix": "mb",
+  "shortPrefix": "mb",
+
+  "phpNamespace": "MyBlocks",
+  "phpFunctionPrefix": "myblocks",
+  "phpConstantPrefix": "MYBLOCKS",
+
+  "restNamespace": "myblocks/v1",
+  "patternCategoryPrefix": "mb",
+  "postTypeSlug": "mb_form_submission",
+  "metaKeyPrefix": "_mb",
+  "transientPrefix": "mb",
+  "optionPrefix": "myblocks",
+
+  "logoPath": "src/admin/assets/logo.png"
+}

--- a/white-label.schema.json
+++ b/white-label.schema.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DesignSetGo White Label Configuration",
+  "description": "Configuration for rebranding DesignSetGo plugin forks at build time.",
+  "type": "object",
+  "required": [
+    "pluginName",
+    "pluginSlug",
+    "textDomain",
+    "blockNamespace",
+    "cssPrefix",
+    "shortPrefix",
+    "phpNamespace",
+    "phpFunctionPrefix",
+    "phpConstantPrefix",
+    "restNamespace",
+    "patternCategoryPrefix",
+    "postTypeSlug",
+    "metaKeyPrefix",
+    "transientPrefix",
+    "optionPrefix"
+  ],
+  "properties": {
+    "pluginName": {
+      "type": "string",
+      "description": "Display name shown in admin UI, menus, and plugin header.",
+      "minLength": 1,
+      "examples": ["MyBlocks"]
+    },
+    "pluginSlug": {
+      "type": "string",
+      "description": "Plugin directory/file slug. Lowercase, hyphens only. Becomes the main PHP filename.",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "minLength": 2,
+      "examples": ["myblocks"]
+    },
+    "pluginUri": {
+      "type": "string",
+      "description": "Plugin website URL for the plugin header.",
+      "format": "uri",
+      "examples": ["https://example.com"]
+    },
+    "pluginDescription": {
+      "type": "string",
+      "description": "Plugin description for the plugin header.",
+      "examples": ["A professional Gutenberg block library."]
+    },
+    "pluginAuthor": {
+      "type": "string",
+      "description": "Author name for the plugin header.",
+      "examples": ["Your Name"]
+    },
+    "pluginAuthorUri": {
+      "type": "string",
+      "description": "Author website URL for the plugin header.",
+      "format": "uri",
+      "examples": ["https://example.com/about"]
+    },
+    "textDomain": {
+      "type": "string",
+      "description": "WordPress text domain for i18n. Should match pluginSlug.",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "minLength": 2,
+      "examples": ["myblocks"]
+    },
+    "blockNamespace": {
+      "type": "string",
+      "description": "Block namespace prefix (e.g., 'myblocks' for 'myblocks/accordion'). Lowercase, hyphens only.",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "minLength": 2,
+      "examples": ["myblocks"]
+    },
+    "cssPrefix": {
+      "type": "string",
+      "description": "CSS class prefix (e.g., 'mb' for '.mb-accordion'). Used with hyphens in class names, data attributes, and CSS custom properties.",
+      "pattern": "^[a-z][a-z0-9]*$",
+      "minLength": 2,
+      "maxLength": 6,
+      "examples": ["mb"]
+    },
+    "shortPrefix": {
+      "type": "string",
+      "description": "Short camelCase prefix for JS identifiers and CSS @keyframes (e.g., 'mb' for 'mbFadeIn', 'mbLinkUrl'). Must not end with a character that would collide with cssPrefix.",
+      "pattern": "^[a-z][a-z0-9]*$",
+      "minLength": 2,
+      "maxLength": 6,
+      "examples": ["mb"]
+    },
+    "phpNamespace": {
+      "type": "string",
+      "description": "PHP namespace (e.g., 'MyBlocks' for 'namespace MyBlocks;'). PascalCase.",
+      "pattern": "^[A-Z][A-Za-z0-9]*$",
+      "minLength": 2,
+      "examples": ["MyBlocks"]
+    },
+    "phpFunctionPrefix": {
+      "type": "string",
+      "description": "PHP function name prefix (e.g., 'myblocks' for 'myblocks_init()'). Lowercase with underscores.",
+      "pattern": "^[a-z][a-z0-9_]*$",
+      "minLength": 2,
+      "examples": ["myblocks"]
+    },
+    "phpConstantPrefix": {
+      "type": "string",
+      "description": "PHP constant prefix (e.g., 'MYBLOCKS' for 'MYBLOCKS_VERSION'). UPPERCASE.",
+      "pattern": "^[A-Z][A-Z0-9_]*$",
+      "minLength": 2,
+      "examples": ["MYBLOCKS"]
+    },
+    "restNamespace": {
+      "type": "string",
+      "description": "WordPress REST API namespace (e.g., 'myblocks/v1').",
+      "pattern": "^[a-z][a-z0-9-]*/v[0-9]+$",
+      "examples": ["myblocks/v1"]
+    },
+    "patternCategoryPrefix": {
+      "type": "string",
+      "description": "Pattern category slug prefix (e.g., 'mb' for 'mb-hero').",
+      "pattern": "^[a-z][a-z0-9]*$",
+      "minLength": 2,
+      "maxLength": 6,
+      "examples": ["mb"]
+    },
+    "postTypeSlug": {
+      "type": "string",
+      "description": "Custom post type slug for form submissions. Max 20 characters (WordPress limit).",
+      "pattern": "^[a-z][a-z0-9_]*$",
+      "minLength": 2,
+      "maxLength": 20,
+      "examples": ["mb_form_submission"]
+    },
+    "metaKeyPrefix": {
+      "type": "string",
+      "description": "Post meta key prefix (e.g., '_mb' for '_mb_form_id'). Include leading underscore for hidden meta.",
+      "pattern": "^_?[a-z][a-z0-9]*$",
+      "minLength": 2,
+      "examples": ["_mb"]
+    },
+    "transientPrefix": {
+      "type": "string",
+      "description": "WordPress transient name prefix (e.g., 'mb' for 'mb_has_blocks_').",
+      "pattern": "^[a-z][a-z0-9]*$",
+      "minLength": 2,
+      "examples": ["mb"]
+    },
+    "optionPrefix": {
+      "type": "string",
+      "description": "WordPress option name prefix (e.g., 'myblocks' for 'myblocks_settings').",
+      "pattern": "^[a-z][a-z0-9_]*$",
+      "minLength": 2,
+      "examples": ["myblocks"]
+    },
+    "logoPath": {
+      "type": "string",
+      "description": "Relative path to the admin logo file. Defaults to the existing logo if not specified.",
+      "examples": ["src/admin/assets/logo.png"]
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

- Adds a config-driven build pipeline that transforms all branded identifiers at build time, so forkers edit one file (`white-label.json`) and run `npm run white-label:build` to get a fully rebranded plugin in `dist/`
- Source files stay untouched — forkers can pull upstream updates cleanly
- Includes wp-env toggle for local testing of the white-labeled build

### What gets rebranded
Plugin name, text domain, block namespace (`designsetgo/accordion` → `myblocks/accordion`), CSS prefix (`dsgo-` → `mb-`), short prefix (`dsgFadeIn` → `mbFadeIn`), PHP namespace, constants, function prefixes, REST routes, pattern categories, post type slug, meta keys, option names, file names, and plugin header metadata.

### How it works
1. **Webpack phase** — `string-replace-loader` transforms JS/JSX at compile time; custom loader transforms `block.json` files
2. **Post-build phase** — Node script copies PHP, patterns, CSS, and remaining JS/JSON to `dist/`, applying transformations and renaming branded filenames
3. **No white-label.json = no-op** — default builds are completely unaffected

### New npm scripts
| Script | Purpose |
|---|---|
| `white-label:build` | Validate config + webpack build + post-build transform to `dist/` |
| `white-label:zip` | Build + package as installable `.zip` |
| `white-label:validate` | Validate config only |
| `white-label:clean` | Remove `dist/` |
| `wp-env:white-label` | Build + enable wp-env with `dist/` |
| `wp-env:white-label:reset` | Revert wp-env to source |

### Verified
- Zero remaining branded references in `dist/` across PHP, JS, CSS, and JSON (excluding `vendor/` and `languages/`)
- Default build (no `white-label.json`) produces identical output to current behavior
- File renaming works (e.g., `class-dsgo-handlers.php` → `class-mb-handlers.php`)

## Test plan

- [ ] Delete `white-label.json`, run `npm run build` — confirm output matches current behavior
- [ ] Copy `white-label.json.example` to `white-label.json`, run `npm run white-label:build`
- [ ] Verify `grep -r "designsetgo\|dsgo-\|_dsg_\|DesignSetGo\|DESIGNSETGO" dist/` returns zero results (excluding vendor/languages)
- [ ] Run `npm run wp-env:white-label` then `npm run wp-env:start` — plugin should activate without errors
- [ ] Verify blocks register and render in the editor
- [ ] Run `npm run wp-env:white-label:reset` to revert
- [ ] Run `npm run white-label:zip` — verify installable zip is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)