### PR TITLE
fix: Add SVG allowlist and color/gradient CSS functions to KSES filters

### DIFF
--- a/.claude/docs/KSES-ALLOWLIST-GUIDE.md
+++ b/.claude/docs/KSES-ALLOWLIST-GUIDE.md
@@ -118,7 +118,7 @@ If the SVG is missing:
 - CSS functions in the allowlist (`rotate`, `scale`, `blur`, `rgba`, `linear-gradient`, etc.) are purely visual and cannot execute scripts
 - The value check still runs after stripping known-safe functions - if anything suspicious remains (backslash, unmatched parentheses, comments), the value is rejected
 - Dangerous patterns like `expression()`, `-moz-binding`, and `url(javascript:)` are never allowed
-- SVG elements are limited to presentation elements only; no `<script>`, `<foreignObject>`, or event handler attributes are allowed
+- SVG elements are limited to presentation elements (`<svg>`, `<path>`, `<circle>`, etc.); script-capable elements (`<script>`, `<foreignObject>`, `<animate>`) and event handler attributes (`onclick`, `onload`, etc.) are intentionally excluded from the allowlist
 
 ## Tests
 

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -86,9 +86,95 @@ class Plugin {
 	 * functions like rotate() and blur() because they contain parentheses.
 	 * These are standard visual CSS functions that cannot execute scripts.
 	 *
+	 * Covers:
+	 * - Color: rgb(), rgba(), hsl(), hsla()
+	 * - Gradients: linear-gradient(), radial-gradient(), conic-gradient() + repeating-*
+	 * - Transform: rotate(), scale(), translate(), skew(), matrix(), perspective()
+	 * - Filter: blur(), brightness(), contrast(), drop-shadow(), grayscale(), etc.
+	 *
 	 * @var string
 	 */
-	private const SAFE_CSS_FUNCTIONS_PATTERN = '/\b(?:rotate(?:3d|[XYZ])?|scale(?:3d|[XYZ])?|skew[XY]?|translate(?:3d|[XYZ])?|matrix(?:3d)?|blur|brightness|contrast|drop-shadow|grayscale|saturate|sepia|invert|hue-rotate|opacity|perspective)(\((?:[^()]|(?1))*\))/';
+	private const SAFE_CSS_FUNCTIONS_PATTERN = '/\b(?:(?:repeating-)?(?:linear|radial|conic)-gradient|rgba?|hsla?|rotate(?:3d|[XYZ])?|scale(?:3d|[XYZ])?|skew[XY]?|translate(?:3d|[XYZ])?|matrix(?:3d)?|blur|brightness|contrast|drop-shadow|grayscale|saturate|sepia|invert|hue-rotate|opacity|perspective)(\((?:[^()]|(?1))*\))/';
+
+	/**
+	 * SVG elements used in block save() output.
+	 *
+	 * WordPress's default wp_kses_post() strips all SVG elements.
+	 * These are used by shape dividers, icons, comparison tables,
+	 * timeline markers, accordion toggles, and counter decorations.
+	 *
+	 * @var string[]
+	 */
+	private const SVG_ELEMENTS = array(
+		'svg',
+		'path',
+		'circle',
+		'rect',
+		'line',
+		'polyline',
+		'polygon',
+		'ellipse',
+		'g',
+		'defs',
+		'use',
+		'symbol',
+		'clippath',
+		'lineargradient',
+		'radialgradient',
+		'stop',
+	);
+
+	/**
+	 * SVG attributes allowed in block save() output.
+	 *
+	 * @var array<string, bool>
+	 */
+	private const SVG_ATTRIBUTES = array(
+		'xmlns'              => true,
+		'viewbox'            => true,
+		'preserveaspectratio' => true,
+		'width'              => true,
+		'height'             => true,
+		'fill'               => true,
+		'fill-rule'          => true,
+		'fill-opacity'       => true,
+		'stroke'             => true,
+		'stroke-width'       => true,
+		'stroke-linecap'     => true,
+		'stroke-linejoin'    => true,
+		'stroke-dasharray'   => true,
+		'stroke-dashoffset'  => true,
+		'stroke-opacity'     => true,
+		'opacity'            => true,
+		'transform'          => true,
+		'x'                  => true,
+		'y'                  => true,
+		'x1'                 => true,
+		'y1'                 => true,
+		'x2'                 => true,
+		'y2'                 => true,
+		'cx'                 => true,
+		'cy'                 => true,
+		'r'                  => true,
+		'rx'                 => true,
+		'ry'                 => true,
+		'd'                  => true,
+		'points'             => true,
+		'clip-path'          => true,
+		'clip-rule'          => true,
+		'class'              => true,
+		'id'                 => true,
+		'style'              => true,
+		'aria-hidden'        => true,
+		'aria-label'         => true,
+		'role'               => true,
+		'focusable'          => true,
+		'data-*'             => true,
+		// Gradient stop attributes.
+		'offset'             => true,
+		'stop-color'         => true,
+		'stop-opacity'       => true,
+	);
 
 	/**
 	 * Instance of this class.
@@ -400,9 +486,10 @@ class Plugin {
 		// Apply global default hover animation to Form Builder submit buttons.
 		add_filter( 'render_block_designsetgo/form-builder', array( $this, 'apply_default_form_button_hover' ), 10, 2 );
 
-		// Allow block CSS properties and function values through wp_kses_post().
+		// Allow block CSS properties, function values, and SVG through wp_kses_post().
 		add_filter( 'safe_style_css', array( $this, 'allow_block_style_properties' ) );
 		add_filter( 'safecss_filter_attr_allow_css', array( $this, 'allow_block_css_functions' ), 10, 2 );
+		add_filter( 'wp_kses_allowed_html', array( $this, 'allow_block_svg_elements' ), 10, 2 );
 	}
 
 	/**
@@ -785,5 +872,29 @@ class Plugin {
 
 		// After removing safe functions, reject if unsafe characters remain.
 		return ! preg_match( '%[\\\(&=}]|/\*%', $cleaned );
+	}
+
+	/**
+	 * Add SVG elements to WordPress's allowed HTML tags for the 'post' context.
+	 *
+	 * Block save() output includes SVG elements for shape dividers, icons,
+	 * comparison table marks, timeline markers, counter decorations, and
+	 * accordion toggle indicators. Without this, wp_kses_post() strips them.
+	 *
+	 * @since 2.0.23
+	 * @param array[] $tags    Allowed HTML tags and their attributes.
+	 * @param string  $context The KSES context (e.g. 'post').
+	 * @return array[] Extended tags with SVG elements.
+	 */
+	public function allow_block_svg_elements( $tags, $context ) {
+		if ( 'post' !== $context ) {
+			return $tags;
+		}
+
+		foreach ( self::SVG_ELEMENTS as $element ) {
+			$tags[ $element ] = self::SVG_ATTRIBUTES;
+		}
+
+		return $tags;
 	}
 }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -103,6 +103,12 @@ class Plugin {
 	 * These are used by shape dividers, icons, comparison tables,
 	 * timeline markers, accordion toggles, and counter decorations.
 	 *
+	 * Only presentation elements are included. Script-capable elements
+	 * (script, foreignObject, animate, animateMotion, animateTransform, set)
+	 * and link elements (a, image, feImage) are intentionally excluded.
+	 * Event handler attributes (onclick, onload, etc.) are not in
+	 * SVG_ATTRIBUTES and are therefore blocked by KSES.
+	 *
 	 * @var string[]
 	 */
 	private const SVG_ELEMENTS = array(
@@ -116,7 +122,6 @@ class Plugin {
 		'ellipse',
 		'g',
 		'defs',
-		'use',
 		'symbol',
 		'clippath',
 		'lineargradient',
@@ -169,7 +174,6 @@ class Plugin {
 		'aria-label'         => true,
 		'role'               => true,
 		'focusable'          => true,
-		'data-*'             => true,
 		// Gradient stop attributes.
 		'offset'             => true,
 		'stop-color'         => true,
@@ -855,6 +859,11 @@ class Plugin {
 	public function allow_block_css_functions( $allow_css, $css_test_string ) {
 		if ( $allow_css ) {
 			return $allow_css;
+		}
+
+		// Reject overly long values to avoid regex backtracking on adversarial input.
+		if ( strlen( $css_test_string ) > 1000 ) {
+			return false;
 		}
 
 		// Strip known-safe CSS functions (same technique WordPress uses for var/calc/repeat).

--- a/tests/phpunit/plugin-test.php
+++ b/tests/phpunit/plugin-test.php
@@ -313,7 +313,7 @@ class Test_Plugin extends WP_UnitTestCase {
 		$result = wp_kses_post( $html );
 
 		$this->assertStringContainsString( '<svg', $result, 'svg element should survive wp_kses_post' );
-		$this->assertStringContainsString( 'viewBox', $result, 'viewBox attribute should survive (after case restoration)' );
+		$this->assertMatchesRegularExpression( '/view[Bb]ox="0 0 1200 120"/', $result, 'viewBox attribute should survive wp_kses_post' );
 		$this->assertStringContainsString( '<path', $result, 'path element should survive wp_kses_post' );
 		$this->assertStringContainsString( 'd="M0,0', $result, 'path d attribute should survive wp_kses_post' );
 	}


### PR DESCRIPTION
## Summary

- Adds SVG element allowlist (`wp_kses_allowed_html` filter) so inline SVGs in block save() output survive `wp_kses_post()` — fixes shape dividers, icons, accordion toggles, comparison marks, timeline markers, and counter decorations being stripped
- Expands `SAFE_CSS_FUNCTIONS_PATTERN` to include `rgba()`, `rgb()`, `hsl()`, `hsla()`, and gradient functions (`linear-gradient`, `radial-gradient`, `conic-gradient` + repeating variants) — fixes icon backgrounds and progress bar stripes being stripped
- Adds 7 new PHPUnit tests covering SVG elements, color functions, gradient functions, and realistic icon block output
- Updates KSES documentation with SVG guidance and expanded function coverage

## Context

Follow-up to PR #242 which added CSS property name and basic function allowlisting. When the site-designer-api agent programmatically inserted patterns via REST API, three additional KSES issues surfaced:
1. All inline SVG elements were completely stripped (empty containers where shape dividers/icons should be)
2. `rgba()` background colors on icon blocks were stripped
3. `linear-gradient()` with `rgba()` on progress bars was stripped

## Test plan

- [x] PHP lint passes (no syntax errors)
- [x] All 341 PHPUnit tests pass (1 intentionally skipped)
- [x] All 13 KSES-specific tests pass
- [x] All 7 new SVG/color/gradient tests pass
- [ ] Manual: Insert blocks with inline SVG (accordion, shape divider, comparison table) and verify frontend renders
- [ ] Manual: Insert icon block with rgba background and verify color survives save/reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)