### PR TITLE
feat: Enhance llms.txt with full spec compliance

### DIFF
--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -571,6 +571,7 @@ class Settings {
 	 * - 'bool'       — Cast to boolean.
 	 * - 'absint'     — Unsigned integer via absint().
 	 * - 'text'       — sanitize_text_field().
+	 * - 'textarea'   — sanitize_textarea_field() (preserves newlines).
 	 * - 'hex_color'  — sanitize_hex_color().
 	 * - 'key'        — sanitize_key().
 	 * - 'text_list'  — Array of sanitize_text_field() values.
@@ -643,7 +644,7 @@ class Settings {
 			'llms_txt'           => array(
 				'enable'           => 'bool',
 				'post_types'       => 'key_list',
-				'description'      => 'text',
+				'description'      => 'textarea',
 				'generate_full_txt' => 'bool',
 			),
 		);
@@ -665,6 +666,8 @@ class Settings {
 				return absint( $value );
 			case 'text':
 				return sanitize_text_field( $value );
+			case 'textarea':
+				return sanitize_textarea_field( $value );
 			case 'hex_color':
 				$color = sanitize_hex_color( $value );
 				return $color ? $color : $default;

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -127,8 +127,10 @@ class Settings {
 				'default_to_visual'        => true,
 			),
 			'llms_txt'           => array(
-				'enable'     => false,
-				'post_types' => array( 'page', 'post' ),
+				'enable'           => false,
+				'post_types'       => array( 'page', 'post' ),
+				'description'      => '',
+				'generate_full_txt' => false,
 			),
 		);
 	}
@@ -639,8 +641,10 @@ class Settings {
 				'default_to_visual'        => 'bool',
 			),
 			'llms_txt'           => array(
-				'enable'     => 'bool',
-				'post_types' => 'key_list',
+				'enable'           => 'bool',
+				'post_types'       => 'key_list',
+				'description'      => 'text',
+				'generate_full_txt' => 'bool',
 			),
 		);
 	}

--- a/includes/llms-txt/class-controller.php
+++ b/includes/llms-txt/class-controller.php
@@ -28,6 +28,11 @@ class Controller {
 	const CACHE_KEY = 'designsetgo_llms_txt_cache';
 
 	/**
+	 * Cache key for llms-full.txt transient.
+	 */
+	const FULL_CACHE_KEY = 'designsetgo_llms_full_txt_cache';
+
+	/**
 	 * Cache expiration in seconds (1 day).
 	 */
 	const CACHE_EXPIRATION = DAY_IN_SECONDS;
@@ -97,6 +102,7 @@ class Controller {
 		add_action( 'rest_api_init', array( $this->rest_controller, 'register_routes' ) );
 		add_action( 'admin_notices', array( $this->conflict_detector, 'maybe_show_notice' ) );
 		add_action( 'admin_init', array( $this->conflict_detector, 'handle_dismiss_action' ) );
+		add_filter( 'robots_txt', array( $this, 'add_to_robots_txt' ), 10, 2 );
 	}
 
 	/**
@@ -105,10 +111,16 @@ class Controller {
 	const REWRITE_PATTERN = '^llms\\.txt/?$';
 
 	/**
-	 * Add rewrite rule for llms.txt.
+	 * Rewrite rule pattern for llms-full.txt.
+	 */
+	const FULL_REWRITE_PATTERN = '^llms-full\\.txt/?$';
+
+	/**
+	 * Add rewrite rules for llms.txt and llms-full.txt.
 	 */
 	public function add_rewrite_rule(): void {
 		add_rewrite_rule( self::REWRITE_PATTERN, 'index.php?llms_txt=1', 'top' );
+		add_rewrite_rule( self::FULL_REWRITE_PATTERN, 'index.php?llms_full_txt=1', 'top' );
 
 		if ( get_transient( 'designsetgo_llms_txt_flush_rules' ) ) {
 			delete_transient( 'designsetgo_llms_txt_flush_rules' );
@@ -116,9 +128,9 @@ class Controller {
 			return;
 		}
 
-		// Flush if our rule is missing from stored rules (covers updates without activation).
+		// Flush if our rules are missing from stored rules (covers updates without activation).
 		$rules = get_option( 'rewrite_rules' );
-		if ( is_array( $rules ) && ! isset( $rules[ self::REWRITE_PATTERN ] ) ) {
+		if ( is_array( $rules ) && ( ! isset( $rules[ self::REWRITE_PATTERN ] ) || ! isset( $rules[ self::FULL_REWRITE_PATTERN ] ) ) ) {
 			flush_rewrite_rules();
 		}
 	}
@@ -138,26 +150,31 @@ class Controller {
 	 */
 	public function add_query_var( array $vars ): array {
 		$vars[] = 'llms_txt';
+		$vars[] = 'llms_full_txt';
 		return $vars;
 	}
 
 	/**
-	 * Prevent WordPress from adding a trailing slash to llms.txt.
+	 * Prevent WordPress from adding a trailing slash to llms.txt and llms-full.txt.
 	 *
 	 * @param string|false $redirect_url  The redirect URL, or false if no redirect.
 	 * @param string       $requested_url The requested URL before redirect.
 	 * @return string|false The redirect URL, or false to cancel the redirect.
 	 */
 	public function prevent_trailing_slash( $redirect_url, $requested_url = '' ) {
-		if ( get_query_var( 'llms_txt' ) !== '1' ) {
+		$is_llms     = get_query_var( 'llms_txt' ) === '1';
+		$is_llms_full = get_query_var( 'llms_full_txt' ) === '1';
+
+		if ( ! $is_llms && ! $is_llms_full ) {
 			return $redirect_url;
 		}
 
-		// Verify we're actually on the /llms.txt path to prevent abuse via ?llms_txt=1.
+		// Verify we're actually on a valid path to prevent abuse via query vars.
 		if ( ! empty( $requested_url ) ) {
 			$requested_path = wp_parse_url( $requested_url, PHP_URL_PATH );
 			$normalized     = rtrim( $requested_path, '/' );
-			if ( '/llms.txt' !== $normalized ) {
+			$valid_paths    = array( '/llms.txt', '/llms-full.txt' );
+			if ( ! in_array( $normalized, $valid_paths, true ) ) {
 				return $redirect_url;
 			}
 		}
@@ -166,10 +183,13 @@ class Controller {
 	}
 
 	/**
-	 * Handle llms.txt requests.
+	 * Handle llms.txt and llms-full.txt requests.
 	 */
 	public function handle_request(): void {
-		if ( ! get_query_var( 'llms_txt' ) ) {
+		$is_llms      = (bool) get_query_var( 'llms_txt' );
+		$is_llms_full = (bool) get_query_var( 'llms_full_txt' );
+
+		if ( ! $is_llms && ! $is_llms_full ) {
 			return;
 		}
 
@@ -179,12 +199,20 @@ class Controller {
 			exit;
 		}
 
-		$this->serve_llms_txt();
+		if ( $is_llms_full ) {
+			if ( empty( $settings['llms_txt']['generate_full_txt'] ) ) {
+				status_header( 404 );
+				exit;
+			}
+			$this->serve_llms_full_txt();
+		} else {
+			$this->serve_llms_txt();
+		}
 		exit;
 	}
 
 	/**
-	 * Serve the llms.txt content.
+	 * Serve the llms.txt content with cache headers.
 	 */
 	private function serve_llms_txt(): void {
 		$content = get_transient( self::CACHE_KEY );
@@ -194,8 +222,43 @@ class Controller {
 			set_transient( self::CACHE_KEY, $content, self::CACHE_EXPIRATION );
 		}
 
+		$this->send_text_response( $content );
+	}
+
+	/**
+	 * Serve the llms-full.txt content with cache headers.
+	 */
+	private function serve_llms_full_txt(): void {
+		$content = get_transient( self::FULL_CACHE_KEY );
+
+		if ( false === $content ) {
+			$content = $this->generator->generate_full_content();
+			set_transient( self::FULL_CACHE_KEY, $content, self::CACHE_EXPIRATION );
+		}
+
+		$this->send_text_response( $content );
+	}
+
+	/**
+	 * Send a plain text response with appropriate cache headers.
+	 *
+	 * @param string $content The text content to send.
+	 */
+	private function send_text_response( string $content ): void {
+		// Generate ETag for conditional request support.
+		$etag = '"' . md5( $content ) . '"';
+
+		// Handle conditional requests (304 Not Modified).
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- ETag comparison only.
+		if ( isset( $_SERVER['HTTP_IF_NONE_MATCH'] ) && trim( wp_unslash( $_SERVER['HTTP_IF_NONE_MATCH'] ) ) === $etag ) {
+			status_header( 304 );
+			exit;
+		}
+
 		header( 'Content-Type: text/plain; charset=utf-8' );
 		header( 'X-Robots-Tag: noindex' );
+		header( 'Cache-Control: public, max-age=86400' );
+		header( 'ETag: ' . $etag );
 		echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Plain text file output.
 	}
 
@@ -227,11 +290,16 @@ class Controller {
 	}
 
 	/**
-	 * Refresh the physical llms.txt file if we maintain one.
+	 * Refresh physical llms.txt and llms-full.txt files if we maintain them.
 	 */
 	private function refresh_physical_file(): void {
 		if ( get_option( self::PHYSICAL_FILE_OPTION ) ) {
 			$this->write_physical_file();
+		}
+
+		$settings = \DesignSetGo\Admin\Settings::get_settings();
+		if ( ! empty( $settings['llms_txt']['generate_full_txt'] ) && file_exists( ABSPATH . 'llms-full.txt' ) ) {
+			$this->write_physical_full_file();
 		}
 	}
 
@@ -242,6 +310,7 @@ class Controller {
 	 */
 	public function invalidate_cache( $post_id = null ): void {
 		delete_transient( self::CACHE_KEY );
+		delete_transient( self::FULL_CACHE_KEY );
 
 		if ( $post_id && is_numeric( $post_id ) ) {
 			delete_transient( 'designsetgo_llms_md_' . absint( $post_id ) );
@@ -264,15 +333,32 @@ class Controller {
 
 		if ( $is_enabled !== $was_enabled ) {
 			// Flush immediately so the rule is active before the next request.
-			// Must register the rule first since this may run outside of init.
+			// Must register the rules first since this may run outside of init.
 			add_rewrite_rule( self::REWRITE_PATTERN, 'index.php?llms_txt=1', 'top' );
+			add_rewrite_rule( self::FULL_REWRITE_PATTERN, 'index.php?llms_full_txt=1', 'top' );
 			flush_rewrite_rules();
 
 			if ( $is_enabled ) {
 				$this->file_manager->generate_all_files( $this->generator );
 				$this->write_physical_file();
+				if ( ! empty( $new_value['llms_txt']['generate_full_txt'] ) ) {
+					$this->write_physical_full_file();
+				}
 			} else {
 				$this->delete_physical_file();
+				$this->delete_physical_full_file();
+			}
+		}
+
+		// Handle llms-full.txt toggle independently.
+		if ( $is_enabled ) {
+			$was_full = ! empty( $old_value['llms_txt']['generate_full_txt'] );
+			$is_full  = ! empty( $new_value['llms_txt']['generate_full_txt'] );
+
+			if ( $is_full && ! $was_full ) {
+				$this->write_physical_full_file();
+			} elseif ( ! $is_full && $was_full ) {
+				$this->delete_physical_full_file();
 			}
 		}
 	}
@@ -356,6 +442,68 @@ class Controller {
 		}
 
 		delete_option( self::PHYSICAL_FILE_OPTION );
+	}
+
+	/**
+	 * Write a physical llms-full.txt file to the site root.
+	 *
+	 * @return bool True on success.
+	 */
+	public function write_physical_full_file(): bool {
+		$settings = \DesignSetGo\Admin\Settings::get_settings();
+		if ( empty( $settings['llms_txt']['enable'] ) || empty( $settings['llms_txt']['generate_full_txt'] ) ) {
+			return false;
+		}
+
+		$content = $this->generator->generate_full_content();
+		if ( empty( $content ) ) {
+			return false;
+		}
+
+		$file_path = ABSPATH . 'llms-full.txt';
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Direct write for performance.
+		$result = file_put_contents( $file_path, $content );
+
+		return false !== $result;
+	}
+
+	/**
+	 * Delete the physical llms-full.txt file.
+	 */
+	public function delete_physical_full_file(): void {
+		$file_path = ABSPATH . 'llms-full.txt';
+		if ( file_exists( $file_path ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Direct file operation required.
+			unlink( $file_path );
+		}
+	}
+
+	/**
+	 * Add llms.txt reference to robots.txt output.
+	 *
+	 * @param string $output  The robots.txt content.
+	 * @param bool   $public  Whether the site is public.
+	 * @return string Modified robots.txt content.
+	 */
+	public function add_to_robots_txt( string $output, bool $public ): string {
+		if ( ! $public ) {
+			return $output;
+		}
+
+		$settings = \DesignSetGo\Admin\Settings::get_settings();
+		if ( empty( $settings['llms_txt']['enable'] ) ) {
+			return $output;
+		}
+
+		$output .= "\n# llms.txt - AI language model content index\n";
+		$output .= '# ' . home_url( '/llms.txt' ) . "\n";
+
+		if ( ! empty( $settings['llms_txt']['generate_full_txt'] ) ) {
+			$output .= '# ' . home_url( '/llms-full.txt' ) . "\n";
+		}
+
+		return $output;
 	}
 
 	/**

--- a/includes/llms-txt/class-generator.php
+++ b/includes/llms-txt/class-generator.php
@@ -48,6 +48,11 @@ class Generator {
 	}
 
 	/**
+	 * Maximum length for link description excerpts.
+	 */
+	const EXCERPT_MAX_LENGTH = 160;
+
+	/**
 	 * Generate llms.txt content following the specification.
 	 *
 	 * @return string Generated content.
@@ -65,8 +70,10 @@ class Generator {
 		$lines[] = '# ' . $this->escape_markdown( get_bloginfo( 'name' ) );
 		$lines[] = '';
 
-		// Blockquote - Site description (optional).
-		$description = get_bloginfo( 'description' );
+		// Blockquote - Custom description or WordPress tagline.
+		$description = ! empty( $llms_settings['description'] )
+			? $llms_settings['description']
+			: get_bloginfo( 'description' );
 		if ( ! empty( $description ) ) {
 			$lines[] = '> ' . $this->escape_markdown( $description );
 			$lines[] = '';
@@ -102,13 +109,116 @@ class Generator {
 					$markdown_url = rest_url( 'designsetgo/v1/llms-txt/markdown/' . $post->ID );
 				}
 
-				$lines[] = '- [' . $title . '](' . $url . ') ([markdown](' . $markdown_url . '))';
+				// Build link entry with optional excerpt description.
+				$excerpt = $this->get_post_excerpt( $post );
+				if ( $excerpt ) {
+					$lines[] = '- [' . $title . '](' . $url . '): ' . $excerpt . ' ([markdown](' . $markdown_url . '))';
+				} else {
+					$lines[] = '- [' . $title . '](' . $url . ') ([markdown](' . $markdown_url . '))';
+				}
 			}
 
 			$lines[] = '';
 		}
 
 		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Generate llms-full.txt content with all post content concatenated.
+	 *
+	 * @return string Generated full content.
+	 */
+	public function generate_full_content(): string {
+		$settings      = \DesignSetGo\Admin\Settings::get_settings();
+		$llms_settings = wp_parse_args(
+			$settings['llms_txt'] ?? array(),
+			\DesignSetGo\Admin\Settings::get_defaults()['llms_txt']
+		);
+
+		$lines = array();
+
+		// H1 - Site name.
+		$lines[] = '# ' . $this->escape_markdown( get_bloginfo( 'name' ) );
+		$lines[] = '';
+
+		// Blockquote - Custom description or WordPress tagline.
+		$description = ! empty( $llms_settings['description'] )
+			? $llms_settings['description']
+			: get_bloginfo( 'description' );
+		if ( ! empty( $description ) ) {
+			$lines[] = '> ' . $this->escape_markdown( $description );
+			$lines[] = '';
+		}
+
+		// Get enabled post types.
+		$post_types = $llms_settings['post_types'] ?? array( 'page', 'post' );
+		$converter  = new \DesignSetGo\Markdown\Converter();
+
+		foreach ( $post_types as $post_type ) {
+			$posts = $this->get_public_content( $post_type );
+
+			if ( empty( $posts ) ) {
+				continue;
+			}
+
+			$post_type_obj = get_post_type_object( $post_type );
+			if ( ! $post_type_obj ) {
+				continue;
+			}
+
+			$lines[] = '## ' . $this->escape_markdown( $post_type_obj->labels->name );
+			$lines[] = '';
+
+			foreach ( $posts as $post ) {
+				// Read from static file if available, otherwise convert on the fly.
+				$markdown = '';
+				if ( $this->file_manager->file_exists( $post->ID ) ) {
+					$file_path = $this->file_manager->get_directory() . '/' . $this->file_manager->get_filename( $post ) . '.md';
+					if ( file_exists( $file_path ) ) {
+						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading local static file.
+						$markdown = file_get_contents( $file_path );
+					}
+				}
+
+				if ( empty( $markdown ) ) {
+					$markdown = $converter->convert( $post );
+				}
+
+				$lines[] = $markdown;
+				$lines[] = '';
+				$lines[] = '---';
+				$lines[] = '';
+			}
+		}
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Get a truncated excerpt for a post, suitable for llms.txt link descriptions.
+	 *
+	 * @param \WP_Post $post Post object.
+	 * @return string Escaped excerpt or empty string.
+	 */
+	private function get_post_excerpt( \WP_Post $post ): string {
+		// Prefer manual excerpt, fall back to auto-generated.
+		$excerpt = $post->post_excerpt;
+
+		if ( empty( $excerpt ) ) {
+			$excerpt = wp_trim_words( wp_strip_all_tags( $post->post_content ), 25, '' );
+		}
+
+		if ( empty( $excerpt ) ) {
+			return '';
+		}
+
+		// Truncate to max length.
+		if ( mb_strlen( $excerpt ) > self::EXCERPT_MAX_LENGTH ) {
+			$excerpt = mb_substr( $excerpt, 0, self::EXCERPT_MAX_LENGTH - 3 ) . '...';
+		}
+
+		return $this->escape_markdown( $excerpt );
 	}
 
 	/**

--- a/includes/llms-txt/class-generator.php
+++ b/includes/llms-txt/class-generator.php
@@ -220,8 +220,8 @@ class Generator {
 		}
 
 		// Truncate to max length before escaping.
-		if ( wp_strlen( $excerpt ) > self::EXCERPT_MAX_LENGTH ) {
-			$excerpt = wp_substr( $excerpt, 0, self::EXCERPT_MAX_LENGTH - 3 );
+		if ( \wp_strlen( $excerpt ) > self::EXCERPT_MAX_LENGTH ) {
+			$excerpt = \wp_substr( $excerpt, 0, self::EXCERPT_MAX_LENGTH - 3 );
 			if ( ! str_ends_with( $excerpt, '...' ) ) {
 				$excerpt .= '...';
 			}

--- a/includes/llms-txt/class-rest-controller.php
+++ b/includes/llms-txt/class-rest-controller.php
@@ -212,7 +212,7 @@ class REST_Controller {
 			)
 		);
 
-		// Refresh the physical files if we maintain them and the feature is still enabled.
+		// Refresh the physical files if we own them and the feature is still enabled.
 		$settings = \DesignSetGo\Admin\Settings::get_settings();
 		if ( get_option( Controller::PHYSICAL_FILE_OPTION ) && ! empty( $settings['llms_txt']['enable'] ) ) {
 			$content = $this->generator->generate_content();
@@ -220,13 +220,13 @@ class REST_Controller {
 				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Direct write for performance.
 				file_put_contents( ABSPATH . 'llms.txt', $content );
 			}
+		}
 
-			if ( ! empty( $settings['llms_txt']['generate_full_txt'] ) ) {
-				$full_content = $this->generator->generate_full_content();
-				if ( $full_content ) {
-					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Direct write for performance.
-					file_put_contents( ABSPATH . 'llms-full.txt', $full_content );
-				}
+		if ( get_option( Controller::PHYSICAL_FULL_FILE_OPTION ) && ! empty( $settings['llms_txt']['enable'] ) && ! empty( $settings['llms_txt']['generate_full_txt'] ) ) {
+			$full_content = $this->generator->generate_full_content();
+			if ( $full_content ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Direct write for performance.
+				file_put_contents( ABSPATH . 'llms-full.txt', $full_content );
 			}
 		}
 
@@ -254,18 +254,29 @@ class REST_Controller {
 		if ( ! empty( $settings['llms_txt']['enable'] ) ) {
 			$content = $this->generator->generate_content();
 			if ( $content ) {
-				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Direct write for performance.
-				$written = file_put_contents( ABSPATH . 'llms.txt', $content );
-				if ( false !== $written ) {
-					update_option( Controller::PHYSICAL_FILE_OPTION, true, true );
+				$llms_path = ABSPATH . 'llms.txt';
+				// Only write if we own the file or it doesn't exist yet.
+				if ( get_option( Controller::PHYSICAL_FILE_OPTION ) || ! file_exists( $llms_path ) ) {
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Direct write for performance.
+					$written = file_put_contents( $llms_path, $content );
+					if ( false !== $written ) {
+						update_option( Controller::PHYSICAL_FILE_OPTION, true, true );
+					}
 				}
 			}
 
 			if ( ! empty( $settings['llms_txt']['generate_full_txt'] ) ) {
 				$full_content = $this->generator->generate_full_content();
 				if ( $full_content ) {
-					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Direct write for performance.
-					file_put_contents( ABSPATH . 'llms-full.txt', $full_content );
+					$full_path = ABSPATH . 'llms-full.txt';
+					// Only write if we own the file or it doesn't exist yet.
+					if ( get_option( Controller::PHYSICAL_FULL_FILE_OPTION ) || ! file_exists( $full_path ) ) {
+						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Direct write for performance.
+						$written = file_put_contents( $full_path, $full_content );
+						if ( false !== $written ) {
+							update_option( Controller::PHYSICAL_FULL_FILE_OPTION, true, true );
+						}
+					}
 				}
 			}
 		}

--- a/src/admin/components/settings-panels/LLMSTxtPanel.js
+++ b/src/admin/components/settings-panels/LLMSTxtPanel.js
@@ -12,6 +12,7 @@ import {
 	CardBody,
 	ToggleControl,
 	CheckboxControl,
+	TextareaControl,
 	ExternalLink,
 	Spinner,
 	Button,
@@ -62,6 +63,8 @@ const LLMSTxtPanel = ({ settings, updateSetting }) => {
 
 	const isEnabled = settings?.llms_txt?.enable || false;
 	const enabledPostTypes = settings?.llms_txt?.post_types || ['page', 'post'];
+	const description = settings?.llms_txt?.description || '';
+	const generateFullTxt = settings?.llms_txt?.generate_full_txt || false;
 
 	/**
 	 * Toggle llms.txt on or off, auto-saving immediately.
@@ -417,6 +420,24 @@ const LLMSTxtPanel = ({ settings, updateSetting }) => {
 
 				{isEnabled && (
 					<div className="designsetgo-settings-section">
+						<TextareaControl
+							__nextHasNoMarginBottom
+							label={__('Site Description for AI', 'designsetgo')}
+							help={__(
+								'A concise summary of your site for AI language models. Leave empty to use your WordPress tagline.',
+								'designsetgo'
+							)}
+							value={description}
+							onChange={(value) =>
+								updateSetting(
+									'llms_txt',
+									'description',
+									value.slice(0, 500)
+								)
+							}
+							rows={3}
+						/>
+
 						<h3 className="designsetgo-section-heading">
 							{__('Content Types', 'designsetgo')}
 						</h3>
@@ -485,6 +506,49 @@ const LLMSTxtPanel = ({ settings, updateSetting }) => {
 											'designsetgo'
 										)}
 							</Button>
+						</div>
+
+						<div className="designsetgo-settings-section">
+							<h3 className="designsetgo-section-heading">
+								{__('Full Content File', 'designsetgo')}
+							</h3>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={__(
+									'Generate llms-full.txt',
+									'designsetgo'
+								)}
+								help={
+									generateFullTxt ? (
+										<>
+											{__(
+												'A single file with all your content, available at:',
+												'designsetgo'
+											)}{' '}
+											<ExternalLink
+												href={
+													siteUrl + '/llms-full.txt'
+												}
+											>
+												{siteUrl}/llms-full.txt
+											</ExternalLink>
+										</>
+									) : (
+										__(
+											'Generate a single comprehensive file containing all your content for deep AI ingestion.',
+											'designsetgo'
+										)
+									)
+								}
+								checked={generateFullTxt}
+								onChange={(value) =>
+									updateSetting(
+										'llms_txt',
+										'generate_full_txt',
+										value
+									)
+								}
+							/>
 						</div>
 
 						<div className="designsetgo-settings-section">

--- a/src/admin/components/settings-panels/LLMSTxtPanel.js
+++ b/src/admin/components/settings-panels/LLMSTxtPanel.js
@@ -423,10 +423,25 @@ const LLMSTxtPanel = ({ settings, updateSetting }) => {
 						<TextareaControl
 							__nextHasNoMarginBottom
 							label={__('Site Description for AI', 'designsetgo')}
-							help={__(
-								'A concise summary of your site for AI language models. Leave empty to use your WordPress tagline.',
-								'designsetgo'
-							)}
+							help={
+								<>
+									{__(
+										'A concise summary of your site for AI language models. Leave empty to use your WordPress tagline.',
+										'designsetgo'
+									)}
+									{description && (
+										<span
+											style={{
+												display: 'block',
+												marginTop: '4px',
+											}}
+										>
+											{description.length}/500{' '}
+											{__('characters', 'designsetgo')}
+										</span>
+									)}
+								</>
+							}
 							value={description}
 							onChange={(value) =>
 								updateSetting(
@@ -436,6 +451,7 @@ const LLMSTxtPanel = ({ settings, updateSetting }) => {
 								)
 							}
 							rows={3}
+							maxLength={500}
 						/>
 
 						<h3 className="designsetgo-section-heading">

--- a/tests/phpunit/llms-txt-test.php
+++ b/tests/phpunit/llms-txt-test.php
@@ -77,6 +77,7 @@ class Test_LLMS_Txt extends WP_UnitTestCase {
 	public function tear_down() {
 		// Clear cache after each test.
 		delete_transient( Controller::CACHE_KEY );
+		delete_transient( Controller::FULL_CACHE_KEY );
 		Settings::invalidate_cache();
 
 		parent::tear_down();
@@ -402,6 +403,233 @@ class Test_LLMS_Txt extends WP_UnitTestCase {
 	 */
 	public function test_cache_key() {
 		$this->assertEquals( 'designsetgo_llms_txt_cache', Controller::CACHE_KEY );
+	}
+
+	/**
+	 * Test full cache key constant.
+	 */
+	public function test_full_cache_key() {
+		$this->assertEquals( 'designsetgo_llms_full_txt_cache', Controller::FULL_CACHE_KEY );
+	}
+
+	/**
+	 * Test query vars include both llms_txt and llms_full_txt.
+	 */
+	public function test_query_vars_include_full_txt() {
+		$vars   = array();
+		$result = $this->controller->add_query_var( $vars );
+
+		$this->assertContains( 'llms_txt', $result );
+		$this->assertContains( 'llms_full_txt', $result );
+	}
+
+	/**
+	 * Test cache invalidation also clears full cache.
+	 */
+	public function test_cache_invalidation_clears_full_cache() {
+		set_transient( Controller::CACHE_KEY, 'test' );
+		set_transient( Controller::FULL_CACHE_KEY, 'full test' );
+
+		$this->controller->invalidate_cache();
+
+		$this->assertFalse( get_transient( Controller::CACHE_KEY ) );
+		$this->assertFalse( get_transient( Controller::FULL_CACHE_KEY ) );
+	}
+
+	/**
+	 * Test prevent_trailing_slash handles llms-full.txt path.
+	 */
+	public function test_prevent_trailing_slash_handles_full_txt() {
+		set_query_var( 'llms_full_txt', '1' );
+
+		$result = $this->controller->prevent_trailing_slash(
+			'https://example.com/llms-full.txt/',
+			'https://example.com/llms-full.txt'
+		);
+		$this->assertFalse( $result );
+
+		// Should reject non-llms paths.
+		$url    = 'https://example.com/some-page/';
+		$result = $this->controller->prevent_trailing_slash( $url, 'https://example.com/some-page' );
+		$this->assertEquals( $url, $result );
+
+		set_query_var( 'llms_full_txt', false );
+	}
+
+	/**
+	 * Test full rewrite pattern matches correctly.
+	 */
+	public function test_full_rewrite_pattern_matches() {
+		$pattern = Controller::FULL_REWRITE_PATTERN;
+
+		$this->assertSame( 1, preg_match( '@' . $pattern . '@', 'llms-full.txt' ) );
+		$this->assertSame( 1, preg_match( '@' . $pattern . '@', 'llms-full.txt/' ) );
+		$this->assertSame( 0, preg_match( '@' . $pattern . '@', 'llms-full.txt.bak' ) );
+		$this->assertSame( 0, preg_match( '@' . $pattern . '@', 'llms.txt' ) );
+	}
+
+	/**
+	 * Test robots.txt integration adds llms.txt reference.
+	 */
+	public function test_robots_txt_includes_llms_reference() {
+		update_option(
+			'designsetgo_settings',
+			array(
+				'llms_txt' => array(
+					'enable' => true,
+				),
+			)
+		);
+		Settings::invalidate_cache();
+
+		$output = $this->controller->add_to_robots_txt( "User-agent: *\nDisallow:\n", true );
+
+		$this->assertStringContainsString( 'llms.txt', $output );
+		$this->assertStringContainsString( '# llms.txt - AI language model content index', $output );
+	}
+
+	/**
+	 * Test robots.txt includes llms-full.txt when enabled.
+	 */
+	public function test_robots_txt_includes_full_txt_when_enabled() {
+		update_option(
+			'designsetgo_settings',
+			array(
+				'llms_txt' => array(
+					'enable'           => true,
+					'generate_full_txt' => true,
+				),
+			)
+		);
+		Settings::invalidate_cache();
+
+		$output = $this->controller->add_to_robots_txt( '', true );
+
+		$this->assertStringContainsString( 'llms-full.txt', $output );
+	}
+
+	/**
+	 * Test robots.txt omits reference when feature is disabled.
+	 */
+	public function test_robots_txt_omits_when_disabled() {
+		update_option(
+			'designsetgo_settings',
+			array(
+				'llms_txt' => array(
+					'enable' => false,
+				),
+			)
+		);
+		Settings::invalidate_cache();
+
+		$output = $this->controller->add_to_robots_txt( '', true );
+
+		$this->assertStringNotContainsString( 'llms.txt', $output );
+	}
+
+	/**
+	 * Test robots.txt omits reference when site is not public.
+	 */
+	public function test_robots_txt_omits_when_not_public() {
+		update_option(
+			'designsetgo_settings',
+			array(
+				'llms_txt' => array(
+					'enable' => true,
+				),
+			)
+		);
+		Settings::invalidate_cache();
+
+		$output = $this->controller->add_to_robots_txt( '', false );
+
+		$this->assertStringNotContainsString( 'llms.txt', $output );
+	}
+
+	/**
+	 * Test generate_content includes post excerpt as link description.
+	 */
+	public function test_generate_content_includes_excerpts() {
+		update_option(
+			'designsetgo_settings',
+			array(
+				'llms_txt' => array(
+					'enable'     => true,
+					'post_types' => array( 'post' ),
+				),
+			)
+		);
+		Settings::invalidate_cache();
+
+		$this->factory->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_title'   => 'My Post',
+				'post_excerpt' => 'A custom excerpt for the post.',
+			)
+		);
+
+		$generator = $this->controller->get_generator();
+		$content   = $generator->generate_content();
+
+		$this->assertStringContainsString( 'A custom excerpt for the post', $content );
+	}
+
+	/**
+	 * Test generate_content uses custom description when set.
+	 */
+	public function test_generate_content_uses_custom_description() {
+		update_option(
+			'designsetgo_settings',
+			array(
+				'llms_txt' => array(
+					'enable'      => true,
+					'post_types'  => array( 'post' ),
+					'description' => 'Custom AI description for my site.',
+				),
+			)
+		);
+		Settings::invalidate_cache();
+
+		$generator = $this->controller->get_generator();
+		$content   = $generator->generate_content();
+
+		$this->assertStringContainsString( '> Custom AI description for my site', $content );
+	}
+
+	/**
+	 * Test generate_content falls back to tagline when no custom description.
+	 */
+	public function test_generate_content_falls_back_to_tagline() {
+		update_option( 'blogdescription', 'Just another WordPress site' );
+		update_option(
+			'designsetgo_settings',
+			array(
+				'llms_txt' => array(
+					'enable'      => true,
+					'post_types'  => array( 'post' ),
+					'description' => '',
+				),
+			)
+		);
+		Settings::invalidate_cache();
+
+		$generator = $this->controller->get_generator();
+		$content   = $generator->generate_content();
+
+		$this->assertStringContainsString( '> Just another WordPress site', $content );
+	}
+
+	/**
+	 * Test settings defaults include new llms_txt fields.
+	 */
+	public function test_settings_defaults_include_new_fields() {
+		$defaults = Settings::get_defaults();
+
+		$this->assertArrayHasKey( 'description', $defaults['llms_txt'] );
+		$this->assertArrayHasKey( 'generate_full_txt', $defaults['llms_txt'] );
+		$this->assertSame( '', $defaults['llms_txt']['description'] );
+		$this->assertFalse( $defaults['llms_txt']['generate_full_txt'] );
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Link descriptions**: Each llms.txt entry now includes a post excerpt (truncated to 160 chars) as descriptive text per the spec format: `- [Title](url): Description ([markdown](md_url))`
- **llms-full.txt**: New concatenated markdown file variant for deep AI ingestion, with its own rewrite rule, physical file management, and admin toggle
- **HTTP cache headers**: `Cache-Control: public, max-age=86400`, `ETag` with content hash, and 304 Not Modified support for conditional requests
- **robots.txt integration**: Adds comment-based llms.txt reference via WordPress `robots_txt` filter (respects site public/private setting)
- **Custom site description**: New textarea setting for AI-specific site summary, falls back to WordPress tagline when empty

## Files changed
- `includes/llms-txt/class-generator.php` — Excerpts, custom description, `generate_full_content()`
- `includes/llms-txt/class-controller.php` — llms-full.txt routing/serving, cache headers, robots.txt filter, physical file management
- `includes/llms-txt/class-rest-controller.php` — Full cache invalidation in flush/generate endpoints
- `includes/admin/class-settings.php` — New `description` and `generate_full_txt` settings with sanitization
- `src/admin/components/settings-panels/LLMSTxtPanel.js` — Description textarea + llms-full.txt toggle
- `tests/phpunit/llms-txt-test.php` — 14 new test cases covering all features

## Test plan
- [ ] Enable llms.txt, verify link entries include excerpts from post content
- [ ] Set a custom description in settings, verify it appears in the blockquote
- [ ] Clear custom description, verify WordPress tagline is used as fallback
- [ ] Enable llms-full.txt toggle, verify `/llms-full.txt` serves concatenated content
- [ ] Check response headers on `/llms.txt` include `Cache-Control`, `ETag`
- [ ] Send `If-None-Match` header matching ETag, verify 304 response
- [ ] Check `/robots.txt` includes llms.txt comment reference
- [ ] Disable feature, verify robots.txt reference is removed
- [ ] Run PHP tests: all 14 new tests pass
- [ ] Build passes cleanly, JS/CSS/PHP lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)