### PR TITLE
feat: Add header and footer block patterns

### DIFF
--- a/includes/patterns/class-loader.php
+++ b/includes/patterns/class-loader.php
@@ -49,6 +49,8 @@ class Loader {
 	 */
 	const ALLOWED_CATEGORIES = array(
 		'homepage',
+		'header',
+		'footer',
 		'hero',
 		'features',
 		'pricing',
@@ -121,6 +123,8 @@ class Loader {
 	public function register_pattern_categories() {
 		$categories = array(
 			'dsgo-homepage'     => __( 'DesignSetGo: Homepage', 'designsetgo' ),
+			'dsgo-header'       => __( 'DesignSetGo: Header', 'designsetgo' ),
+			'dsgo-footer'       => __( 'DesignSetGo: Footer', 'designsetgo' ),
 			'dsgo-hero'         => __( 'DesignSetGo: Hero', 'designsetgo' ),
 			'dsgo-features'     => __( 'DesignSetGo: Features', 'designsetgo' ),
 			'dsgo-pricing'      => __( 'DesignSetGo: Pricing', 'designsetgo' ),

--- a/patterns/footer/footer-centered.php
+++ b/patterns/footer/footer-centered.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Title: Footer Centered
+ * Slug: designsetgo/footer/footer-centered
+ * Categories: dsgo-footer
+ * Description: An elegant centered footer with stacked logo, navigation, social links, and copyright
+ * Keywords: footer, centered, elegant, social, brand
+ * Block Types: core/template-part/footer
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+return array(
+	'title'      => __( 'Footer Centered', 'designsetgo' ),
+	'categories' => array( 'dsgo-footer' ),
+	'blockTypes' => array( 'core/template-part/footer' ),
+	'viewportWidth' => 1200,
+	'content'    => '<!-- wp:designsetgo/section {"tagName":"footer","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|30","right":"var:preset|spacing|30"},"blockGap":"var:preset|spacing|40"}},"metadata":{"categories":["dsgo-footer"],"patternName":"designsetgo/footer/footer-centered","name":"Footer Centered"}} -->
+<footer class="wp-block-designsetgo-section alignfull dsgo-stack" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--30)"><div class="dsgo-stack__inner" style="max-width:var(--wp--style--global--content-size, 1140px);margin-left:auto;margin-right:auto"><!-- wp:designsetgo/row {"style":{"spacing":{"padding":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","justifyContent":"space-between","verticalAlignment":"center","flexWrap":"nowrap"}} -->
+<div class="wp-block-designsetgo-row alignfull dsgo-flex dsgo-no-width-constraint" style="padding-top:0;padding-bottom:0"><div class="dsgo-flex__inner" style="display:flex;justify-content:space-between;align-items:center;flex-wrap:nowrap"><!-- wp:site-logo /-->
+
+<!-- wp:navigation {"overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","justifyContent":"right","flexWrap":"wrap"}} /--></div></div>
+<!-- /wp:designsetgo/row -->
+
+<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+<p class="has-text-align-center has-small-font-size">© 2025 Your Company. All rights reserved.</p>
+<!-- /wp:paragraph --></div></footer>
+<!-- /wp:designsetgo/section -->',
+);

--- a/patterns/footer/footer-classic.php
+++ b/patterns/footer/footer-classic.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Title: Footer Classic
+ * Slug: designsetgo/footer/footer-classic
+ * Categories: dsgo-footer
+ * Description: A clean footer with site logo, horizontal navigation, and copyright line
+ * Keywords: footer, classic, simple, professional, copyright
+ * Block Types: core/template-part/footer
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+return array(
+	'title'      => __( 'Footer Classic', 'designsetgo' ),
+	'categories' => array( 'dsgo-footer' ),
+	'blockTypes' => array( 'core/template-part/footer' ),
+	'viewportWidth' => 1200,
+	'content'    => '<!-- wp:designsetgo/section {"tagName":"footer","constrainWidth":false,"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"0"}},"metadata":{"categories":["dsgo-footer"],"patternName":"designsetgo/footer/footer-classic","name":"Footer Classic"}} -->
+<footer class="wp-block-designsetgo-section alignfull dsgo-stack dsgo-no-width-constraint" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><div class="dsgo-stack__inner"><!-- wp:designsetgo/section {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|30","right":"var:preset|spacing|30"},"blockGap":"var:preset|spacing|40"},"border":{"top":{"color":"var:preset|color|contrast","width":"1px","style":"solid"}}},"metadata":{"categories":["dsgo-footer"],"patternName":"designsetgo/footer/footer-classic","name":"Footer Classic"}} -->
+<div class="wp-block-designsetgo-section alignfull dsgo-stack" style="border-top-color:var(--wp--preset--color--contrast);border-top-style:solid;border-top-width:1px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--30)"><div class="dsgo-stack__inner" style="max-width:var(--wp--style--global--content-size, 1140px);margin-left:auto;margin-right:auto"><!-- wp:site-logo {"width":150,"shouldSyncIcon":true,"align":"center"} /-->
+
+<!-- wp:navigation {"overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","justifyContent":"center","flexWrap":"wrap"}} /-->
+
+<!-- wp:social-links {"size":"has-normal-icon-size","className":"is-style-logos-only","layout":{"type":"flex","justifyContent":"center"}} -->
+<ul class="wp-block-social-links has-normal-icon-size is-style-logos-only"><!-- wp:social-link {"url":"#","service":"facebook"} /-->
+
+<!-- wp:social-link {"url":"#","service":"x"} /-->
+
+<!-- wp:social-link {"url":"#","service":"instagram"} /-->
+
+<!-- wp:social-link {"url":"#","service":"linkedin"} /--></ul>
+<!-- /wp:social-links -->
+
+<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+<p class="has-text-align-center has-small-font-size">© 2025 Your Company. All rights reserved.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:designsetgo/section --></div></footer>
+<!-- /wp:designsetgo/section -->',
+);

--- a/patterns/footer/footer-columns.php
+++ b/patterns/footer/footer-columns.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Title: Footer Columns
+ * Slug: designsetgo/footer/footer-columns
+ * Categories: dsgo-footer
+ * Description: A multi-column footer with logo, navigation columns, and a bottom copyright bar
+ * Keywords: footer, columns, links, multi-column, business
+ * Block Types: core/template-part/footer
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+return array(
+	'title'      => __( 'Footer Columns', 'designsetgo' ),
+	'categories' => array( 'dsgo-footer' ),
+	'blockTypes' => array( 'core/template-part/footer' ),
+	'viewportWidth' => 1200,
+	'content'    => '<!-- wp:designsetgo/section {"tagName":"footer","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"},"blockGap":"var:preset|spacing|50"}},"metadata":{"categories":["dsgo-footer"],"patternName":"designsetgo/footer/footer-columns","name":"Footer Columns"}} -->
+<footer class="wp-block-designsetgo-section alignfull dsgo-stack" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><div class="dsgo-stack__inner" style="max-width:var(--wp--style--global--content-size, 1140px);margin-left:auto;margin-right:auto"><!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"40%"} -->
+<div class="wp-block-column" style="flex-basis:40%"><!-- wp:site-logo /-->
+
+<!-- wp:paragraph {"fontSize":"small"} -->
+<p class="has-small-font-size">Building better digital experiences for small businesses everywhere.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:social-links {"size":"has-normal-icon-size","className":"is-style-logos-only","layout":{"type":"flex","justifyContent":"left"}} -->
+<ul class="wp-block-social-links has-normal-icon-size is-style-logos-only"><!-- wp:social-link {"url":"#","service":"facebook"} /-->
+
+<!-- wp:social-link {"url":"#","service":"x"} /-->
+
+<!-- wp:social-link {"url":"#","service":"instagram"} /-->
+
+<!-- wp:social-link {"url":"#","service":"linkedin"} /--></ul>
+<!-- /wp:social-links --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"20%"} -->
+<div class="wp-block-column" style="flex-basis:20%"><!-- wp:heading {"level":6} -->
+<h6 class="wp-block-heading">Company</h6>
+<!-- /wp:heading -->
+
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"}} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"20%"} -->
+<div class="wp-block-column" style="flex-basis:20%"><!-- wp:heading {"level":6} -->
+<h6 class="wp-block-heading">Services</h6>
+<!-- /wp:heading -->
+
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"}} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"20%"} -->
+<div class="wp-block-column" style="flex-basis:20%"><!-- wp:heading {"level":6} -->
+<h6 class="wp-block-heading">Resources</h6>
+<!-- /wp:heading -->
+
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"}} /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+<p class="has-text-align-center has-small-font-size">© 2025 Your Company. All rights reserved.</p>
+<!-- /wp:paragraph --></div></footer>
+<!-- /wp:designsetgo/section -->',
+);

--- a/patterns/footer/footer-dark.php
+++ b/patterns/footer/footer-dark.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Title: Footer Dark
+ * Slug: designsetgo/footer/footer-dark
+ * Categories: dsgo-footer
+ * Description: A bold dark footer with site logo, navigation, CTA button, and copyright
+ * Keywords: footer, dark, bold, modern, agency
+ * Block Types: core/template-part/footer
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+return array(
+	'title'      => __( 'Footer Dark', 'designsetgo' ),
+	'categories' => array( 'dsgo-footer' ),
+	'blockTypes' => array( 'core/template-part/footer' ),
+	'viewportWidth' => 1200,
+	'content'    => '<!-- wp:designsetgo/section {"tagName":"footer","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"},"blockGap":"var:preset|spacing|50"},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"backgroundColor":"contrast","textColor":"base","metadata":{"categories":["dsgo-footer"],"patternName":"designsetgo/footer/footer-dark","name":"Footer Dark"}} -->
+<footer class="wp-block-designsetgo-section alignfull dsgo-stack has-base-color has-contrast-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><div class="dsgo-stack__inner" style="max-width:var(--wp--style--global--content-size, 1140px);margin-left:auto;margin-right:auto"><!-- wp:designsetgo/row {"style":{"spacing":{"padding":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","justifyContent":"space-between","verticalAlignment":"center","flexWrap":"nowrap"}} -->
+<div class="wp-block-designsetgo-row alignfull dsgo-flex dsgo-no-width-constraint" style="padding-top:0;padding-bottom:0"><div class="dsgo-flex__inner" style="display:flex;justify-content:space-between;align-items:center;flex-wrap:nowrap"><!-- wp:site-logo /-->
+
+<!-- wp:designsetgo/row {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"var(\u002d\u002dwp\u002d\u002dpreset\u002d\u002dspacing\u002d\u002d30)"}},"layout":{"type":"flex","justifyContent":"right","verticalAlignment":"center","flexWrap":"nowrap"}} -->
+<div class="wp-block-designsetgo-row alignfull dsgo-flex dsgo-no-width-constraint" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><div class="dsgo-flex__inner" style="display:flex;justify-content:right;align-items:center;flex-wrap:nowrap;gap:var(--wp--preset--spacing--30)"><!-- wp:navigation {"overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","justifyContent":"right","flexWrap":"wrap"}} /-->
+
+<!-- wp:designsetgo/icon-button {"text":"Contact Us","url":"#","icon":"arrow-right","iconPosition":"end","hoverBackgroundColor":"var:preset|color|accent-3","hoverTextColor":"var:preset|color|base","backgroundColor":"base","textColor":"contrast","fontSize":"small","style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}}} -->
+<a class="wp-block-designsetgo-icon-button dsgo-icon-button wp-block-button wp-block-button__link wp-element-button has-small-font-size" style="display:inline-flex;align-items:center;justify-content:center;gap:8px;width:auto;flex-direction:row-reverse;background-color:var(--wp--preset--color--base);color:var(--wp--preset--color--contrast);font-size:var(--wp--preset--font-size--small);padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--30);--dsgo-button-hover-bg:var(--wp--preset--color--accent-3);--dsgo-button-hover-color:var(--wp--preset--color--base)" href="#" target="_self"><span class="dsgo-icon-button__icon dsgo-lazy-icon" style="display:flex;align-items:center;justify-content:center;width:20px;height:20px;flex-shrink:0" data-icon-name="arrow-right" data-icon-size="20"></span><span class="dsgo-icon-button__text">Contact Us</span></a>
+<!-- /wp:designsetgo/icon-button --></div></div>
+<!-- /wp:designsetgo/row --></div></div>
+<!-- /wp:designsetgo/row -->
+
+<!-- wp:designsetgo/row {"style":{"spacing":{"padding":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","justifyContent":"space-between","verticalAlignment":"center","flexWrap":"nowrap"}} -->
+<div class="wp-block-designsetgo-row alignfull dsgo-flex dsgo-no-width-constraint" style="padding-top:0;padding-bottom:0"><div class="dsgo-flex__inner" style="display:flex;justify-content:space-between;align-items:center;flex-wrap:nowrap"><!-- wp:paragraph {"fontSize":"small"} -->
+<p class="has-small-font-size">© 2025 Your Company. All rights reserved.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:social-links {"openInNewTab":true,"size":"has-normal-icon-size","className":"is-style-logos-only","layout":{"type":"flex","justifyContent":"right"}} -->
+<ul class="wp-block-social-links has-normal-icon-size is-style-logos-only"><!-- wp:social-link {"url":"#","service":"facebook"} /-->
+
+<!-- wp:social-link {"url":"#","service":"x"} /-->
+
+<!-- wp:social-link {"url":"#","service":"instagram"} /-->
+
+<!-- wp:social-link {"url":"#","service":"linkedin"} /--></ul>
+<!-- /wp:social-links --></div></div>
+<!-- /wp:designsetgo/row --></div></footer>
+<!-- /wp:designsetgo/section -->',
+);

--- a/patterns/footer/footer-minimal.php
+++ b/patterns/footer/footer-minimal.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Title: Footer Minimal
+ * Slug: designsetgo/footer/footer-minimal
+ * Categories: dsgo-footer
+ * Description: A minimal single-line footer with copyright and navigation links
+ * Keywords: footer, minimal, simple, clean, copyright
+ * Block Types: core/template-part/footer
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+return array(
+	'title'      => __( 'Footer Minimal', 'designsetgo' ),
+	'categories' => array( 'dsgo-footer' ),
+	'blockTypes' => array( 'core/template-part/footer' ),
+	'viewportWidth' => 1200,
+	'content'    => '<!-- wp:designsetgo/section {"tagName":"footer","constrainWidth":false,"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"0"}}} -->
+<footer class="wp-block-designsetgo-section alignfull dsgo-stack dsgo-no-width-constraint" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><div class="dsgo-stack__inner"><!-- wp:designsetgo/section {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"top":{"color":"var:preset|color|contrast","width":"1px","style":"solid"}}},"metadata":{"categories":["dsgo-footer"],"patternName":"designsetgo/footer/footer-minimal","name":"Footer Minimal"}} -->
+<div class="wp-block-designsetgo-section alignfull dsgo-stack" style="border-top-color:var(--wp--preset--color--contrast);border-top-style:solid;border-top-width:1px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><div class="dsgo-stack__inner" style="max-width:var(--wp--style--global--content-size, 1140px);margin-left:auto;margin-right:auto"><!-- wp:designsetgo/row {"style":{"spacing":{"padding":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","justifyContent":"space-between","verticalAlignment":"center","flexWrap":"nowrap"}} -->
+<div class="wp-block-designsetgo-row alignfull dsgo-flex dsgo-no-width-constraint" style="padding-top:0;padding-bottom:0"><div class="dsgo-flex__inner" style="display:flex;justify-content:space-between;align-items:center;flex-wrap:nowrap"><!-- wp:paragraph {"fontSize":"small"} -->
+<p class="has-small-font-size">© 2025 Your Company. All rights reserved.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:navigation {"overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","justifyContent":"right","flexWrap":"wrap"},"fontSize":"small"} /--></div></div>
+<!-- /wp:designsetgo/row --></div></div>
+<!-- /wp:designsetgo/section --></div></footer>
+<!-- /wp:designsetgo/section -->',
+);

--- a/patterns/header/header-centered.php
+++ b/patterns/header/header-centered.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Title: Header Centered
+ * Slug: designsetgo/header/header-centered
+ * Categories: dsgo-header
+ * Description: An elegant centered header with site logo above and navigation below
+ * Keywords: header, centered, elegant, brand, boutique
+ * Block Types: core/template-part/header
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+return array(
+	'title'      => __( 'Header Centered', 'designsetgo' ),
+	'categories' => array( 'dsgo-header' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'viewportWidth' => 1200,
+	'content'    => '<!-- wp:designsetgo/section {"tagName":"header","constrainWidth":false,"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"0"}}} -->
+<header class="wp-block-designsetgo-section alignfull dsgo-stack dsgo-no-width-constraint" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><div class="dsgo-stack__inner"><!-- wp:designsetgo/section {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"},"blockGap":"var:preset|spacing|30"},"border":{"bottom":{"color":"var:preset|color|contrast","width":"1px","style":"solid"}}},"metadata":{"categories":["dsgo-header"],"patternName":"designsetgo/header/header-centered","name":"Header Centered"}} -->
+<div class="wp-block-designsetgo-section alignfull dsgo-stack" style="border-bottom-color:var(--wp--preset--color--contrast);border-bottom-style:solid;border-bottom-width:1px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><div class="dsgo-stack__inner" style="max-width:var(--wp--style--global--content-size, 1140px);margin-left:auto;margin-right:auto"><!-- wp:site-logo {"width":150,"shouldSyncIcon":true,"align":"center"} /-->
+
+<!-- wp:navigation {"overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","justifyContent":"center","flexWrap":"wrap"}} /--></div></div>
+<!-- /wp:designsetgo/section --></div></header>
+<!-- /wp:designsetgo/section -->',
+);

--- a/patterns/header/header-classic.php
+++ b/patterns/header/header-classic.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Title: Header Classic
+ * Slug: designsetgo/header/header-classic
+ * Categories: dsgo-header
+ * Description: A clean professional header with site logo on the left and navigation on the right
+ * Keywords: header, navigation, classic, simple, professional
+ * Block Types: core/template-part/header
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+return array(
+	'title'      => __( 'Header Classic', 'designsetgo' ),
+	'categories' => array( 'dsgo-header' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'viewportWidth' => 1200,
+	'content'    => '<!-- wp:designsetgo/section {"tagName":"header","constrainWidth":false,"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"0"}}} -->
+<header class="wp-block-designsetgo-section alignfull dsgo-stack dsgo-no-width-constraint" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><div class="dsgo-stack__inner"><!-- wp:designsetgo/section {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"bottom":{"color":"var:preset|color|contrast","width":"1px","style":"solid"}}},"metadata":{"categories":["dsgo-header"],"patternName":"designsetgo/header/header-classic","name":"Header Classic"}} -->
+<div class="wp-block-designsetgo-section alignfull dsgo-stack" style="border-bottom-color:var(--wp--preset--color--contrast);border-bottom-style:solid;border-bottom-width:1px;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--30)"><div class="dsgo-stack__inner" style="max-width:var(--wp--style--global--content-size, 1140px);margin-left:auto;margin-right:auto"><!-- wp:designsetgo/row {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"0","right":"0"},"blockGap":"var(\u002d\u002dwp\u002d\u002dpreset\u002d\u002dspacing\u002d\u002d30)"}},"layout":{"type":"flex","justifyContent":"space-between","verticalAlignment":"center","flexWrap":"nowrap"}} -->
+<div class="wp-block-designsetgo-row alignfull dsgo-flex dsgo-no-width-constraint" style="padding-top:var(--wp--preset--spacing--30);padding-right:0;padding-bottom:var(--wp--preset--spacing--30);padding-left:0"><div class="dsgo-flex__inner" style="display:flex;justify-content:space-between;align-items:center;flex-wrap:nowrap;gap:var(--wp--preset--spacing--30)"><!-- wp:site-logo /-->
+
+<!-- wp:navigation {"overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","justifyContent":"right","flexWrap":"wrap"}} /--></div></div>
+<!-- /wp:designsetgo/row --></div></div>
+<!-- /wp:designsetgo/section --></div></header>
+<!-- /wp:designsetgo/section -->',
+);

--- a/patterns/header/header-cta.php
+++ b/patterns/header/header-cta.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Title: Header with CTA
+ * Slug: designsetgo/header/header-cta
+ * Categories: dsgo-header
+ * Description: A professional header with site logo, navigation, and a call-to-action button
+ * Keywords: header, cta, button, business, services
+ * Block Types: core/template-part/header
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+return array(
+	'title'      => __( 'Header with CTA', 'designsetgo' ),
+	'categories' => array( 'dsgo-header' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'viewportWidth' => 1200,
+	'content'    => '<!-- wp:designsetgo/section {"tagName":"header","constrainWidth":false,"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"0"}}} -->
+<header class="wp-block-designsetgo-section alignfull dsgo-stack dsgo-no-width-constraint" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><div class="dsgo-stack__inner"><!-- wp:designsetgo/section {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}},"backgroundColor":"base","metadata":{"categories":["dsgo-header"],"patternName":"designsetgo/header/header-cta","name":"Header with CTA"}} -->
+<div class="wp-block-designsetgo-section alignfull dsgo-stack has-base-background-color has-background" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><div class="dsgo-stack__inner" style="max-width:var(--wp--style--global--content-size, 1140px);margin-left:auto;margin-right:auto"><!-- wp:designsetgo/row {"style":{"spacing":{"padding":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","justifyContent":"space-between","verticalAlignment":"center","flexWrap":"nowrap"}} -->
+<div class="wp-block-designsetgo-row alignfull dsgo-flex dsgo-no-width-constraint" style="padding-top:0;padding-bottom:0"><div class="dsgo-flex__inner" style="display:flex;justify-content:space-between;align-items:center;flex-wrap:nowrap"><!-- wp:site-logo /-->
+
+<!-- wp:designsetgo/row {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"var(\u002d\u002dwp\u002d\u002dpreset\u002d\u002dspacing\u002d\u002d30)"}},"layout":{"type":"flex","justifyContent":"right","verticalAlignment":"center","flexWrap":"nowrap"}} -->
+<div class="wp-block-designsetgo-row alignfull dsgo-flex dsgo-no-width-constraint" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><div class="dsgo-flex__inner" style="display:flex;justify-content:right;align-items:center;flex-wrap:nowrap;gap:var(--wp--preset--spacing--30)"><!-- wp:navigation {"overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","justifyContent":"right","flexWrap":"wrap"}} /-->
+
+<!-- wp:designsetgo/icon-button {"text":"Get a Quote","url":"#","icon":"arrow-right","iconPosition":"end","hoverBackgroundColor":"var:preset|color|accent-3","hoverTextColor":"var:preset|color|base","backgroundColor":"contrast","textColor":"base","fontSize":"small","style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}}} -->
+<a class="wp-block-designsetgo-icon-button dsgo-icon-button wp-block-button wp-block-button__link wp-element-button has-small-font-size" style="display:inline-flex;align-items:center;justify-content:center;gap:8px;width:auto;flex-direction:row-reverse;background-color:var(--wp--preset--color--contrast);color:var(--wp--preset--color--base);font-size:var(--wp--preset--font-size--small);padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--30);--dsgo-button-hover-bg:var(--wp--preset--color--accent-3);--dsgo-button-hover-color:var(--wp--preset--color--base)" href="#" target="_self"><span class="dsgo-icon-button__icon dsgo-lazy-icon" style="display:flex;align-items:center;justify-content:center;width:20px;height:20px;flex-shrink:0" data-icon-name="arrow-right" data-icon-size="20"></span><span class="dsgo-icon-button__text">Get a Quote</span></a>
+<!-- /wp:designsetgo/icon-button --></div></div>
+<!-- /wp:designsetgo/row --></div></div>
+<!-- /wp:designsetgo/row --></div></div>
+<!-- /wp:designsetgo/section --></div></header>
+<!-- /wp:designsetgo/section -->',
+);

--- a/patterns/header/header-dark.php
+++ b/patterns/header/header-dark.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Title: Header Dark
+ * Slug: designsetgo/header/header-dark
+ * Categories: dsgo-header
+ * Description: A bold dark header with site logo, navigation, and a contrasting CTA button
+ * Keywords: header, dark, bold, modern, agency
+ * Block Types: core/template-part/header
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+return array(
+	'title'      => __( 'Header Dark', 'designsetgo' ),
+	'categories' => array( 'dsgo-header' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'viewportWidth' => 1200,
+	'content'    => '<!-- wp:designsetgo/section {"tagName":"header","constrainWidth":false,"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"0"}}} -->
+<header class="wp-block-designsetgo-section alignfull dsgo-stack dsgo-no-width-constraint" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><div class="dsgo-stack__inner"><!-- wp:designsetgo/section {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"backgroundColor":"contrast","textColor":"base","metadata":{"categories":["dsgo-header"],"patternName":"designsetgo/header/header-dark","name":"Header Dark"}} -->
+<div class="wp-block-designsetgo-section alignfull dsgo-stack has-base-color has-contrast-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><div class="dsgo-stack__inner" style="max-width:var(--wp--style--global--content-size, 1140px);margin-left:auto;margin-right:auto"><!-- wp:designsetgo/row {"style":{"spacing":{"padding":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","justifyContent":"space-between","verticalAlignment":"center","flexWrap":"nowrap"}} -->
+<div class="wp-block-designsetgo-row alignfull dsgo-flex dsgo-no-width-constraint" style="padding-top:0;padding-bottom:0"><div class="dsgo-flex__inner" style="display:flex;justify-content:space-between;align-items:center;flex-wrap:nowrap"><!-- wp:site-logo /-->
+
+<!-- wp:designsetgo/row {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"var(\u002d\u002dwp\u002d\u002dpreset\u002d\u002dspacing\u002d\u002d30)"}},"layout":{"type":"flex","justifyContent":"right","verticalAlignment":"center","flexWrap":"nowrap"}} -->
+<div class="wp-block-designsetgo-row alignfull dsgo-flex dsgo-no-width-constraint" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><div class="dsgo-flex__inner" style="display:flex;justify-content:right;align-items:center;flex-wrap:nowrap;gap:var(--wp--preset--spacing--30)"><!-- wp:navigation {"overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","justifyContent":"right","flexWrap":"wrap"}} /-->
+
+<!-- wp:designsetgo/icon-button {"text":"Get a Quote","url":"#","icon":"arrow-right","iconPosition":"end","hoverBackgroundColor":"var:preset|color|accent-3","hoverTextColor":"var:preset|color|base","backgroundColor":"base","textColor":"contrast","fontSize":"small","style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}}} -->
+<a class="wp-block-designsetgo-icon-button dsgo-icon-button wp-block-button wp-block-button__link wp-element-button has-small-font-size" style="display:inline-flex;align-items:center;justify-content:center;gap:8px;width:auto;flex-direction:row-reverse;background-color:var(--wp--preset--color--base);color:var(--wp--preset--color--contrast);font-size:var(--wp--preset--font-size--small);padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--30);--dsgo-button-hover-bg:var(--wp--preset--color--accent-3);--dsgo-button-hover-color:var(--wp--preset--color--base)" href="#" target="_self"><span class="dsgo-icon-button__icon dsgo-lazy-icon" style="display:flex;align-items:center;justify-content:center;width:20px;height:20px;flex-shrink:0" data-icon-name="arrow-right" data-icon-size="20"></span><span class="dsgo-icon-button__text">Get a Quote</span></a>
+<!-- /wp:designsetgo/icon-button --></div></div>
+<!-- /wp:designsetgo/row --></div></div>
+<!-- /wp:designsetgo/row --></div></div>
+<!-- /wp:designsetgo/section --></div></header>
+<!-- /wp:designsetgo/section -->',
+);

--- a/patterns/header/header-topbar.php
+++ b/patterns/header/header-topbar.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Title: Header with Topbar
+ * Slug: designsetgo/header/header-topbar
+ * Categories: dsgo-header
+ * Description: A professional header with a contact info topbar and main navigation below
+ * Keywords: header, topbar, contact, phone, email, professional
+ * Block Types: core/template-part/header
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+return array(
+	'title'      => __( 'Header with Topbar', 'designsetgo' ),
+	'categories' => array( 'dsgo-header' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'viewportWidth' => 1200,
+	'content'    => '<!-- wp:designsetgo/section {"tagName":"header","constrainWidth":false,"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"0"}}} -->
+<header class="wp-block-designsetgo-section alignfull dsgo-stack dsgo-no-width-constraint" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><div class="dsgo-stack__inner"><!-- wp:designsetgo/section {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}},"backgroundColor":"contrast","textColor":"base"} -->
+<div class="wp-block-designsetgo-section alignfull dsgo-stack has-base-color has-contrast-background-color has-text-color has-background" style="padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--30)"><div class="dsgo-stack__inner" style="max-width:var(--wp--style--global--content-size, 1140px);margin-left:auto;margin-right:auto"><!-- wp:designsetgo/row {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"0","right":"0"},"blockGap":"var(\u002d\u002dwp\u002d\u002dpreset\u002d\u002dspacing\u002d\u002d30)"}},"layout":{"type":"flex","justifyContent":"space-between","verticalAlignment":"center","flexWrap":"nowrap"}} -->
+<div class="wp-block-designsetgo-row alignfull dsgo-flex dsgo-no-width-constraint" style="padding-top:var(--wp--preset--spacing--20);padding-right:0;padding-bottom:var(--wp--preset--spacing--20);padding-left:0"><div class="dsgo-flex__inner" style="display:flex;justify-content:space-between;align-items:center;flex-wrap:nowrap;gap:var(--wp--preset--spacing--30)"><!-- wp:paragraph {"textColor":"base","fontSize":"small"} -->
+<p class="has-base-color has-text-color has-small-font-size">info@yourbusiness.com&nbsp; · &nbsp;(555) 123-4567</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:social-links {"size":"has-small-icon-size","className":"is-style-logos-only","layout":{"type":"flex","justifyContent":"right"}} -->
+<ul class="wp-block-social-links has-small-icon-size is-style-logos-only"><!-- wp:social-link {"url":"#","service":"facebook"} /-->
+
+<!-- wp:social-link {"url":"#","service":"x"} /-->
+
+<!-- wp:social-link {"url":"#","service":"instagram"} /-->
+
+<!-- wp:social-link {"url":"#","service":"linkedin"} /--></ul>
+<!-- /wp:social-links --></div></div>
+<!-- /wp:designsetgo/row --></div></div>
+<!-- /wp:designsetgo/section -->
+
+<!-- wp:designsetgo/section {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}},"backgroundColor":"base","metadata":{"categories":["dsgo-header"],"patternName":"designsetgo/header/header-topbar","name":"Header with Topbar"}} -->
+<div class="wp-block-designsetgo-section alignfull dsgo-stack has-base-background-color has-background" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><div class="dsgo-stack__inner" style="max-width:var(--wp--style--global--content-size, 1140px);margin-left:auto;margin-right:auto"><!-- wp:designsetgo/row {"style":{"spacing":{"padding":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","justifyContent":"space-between","verticalAlignment":"center","flexWrap":"nowrap"}} -->
+<div class="wp-block-designsetgo-row alignfull dsgo-flex dsgo-no-width-constraint" style="padding-top:0;padding-bottom:0"><div class="dsgo-flex__inner" style="display:flex;justify-content:space-between;align-items:center;flex-wrap:nowrap"><!-- wp:site-logo /-->
+
+<!-- wp:designsetgo/row {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"var(\u002d\u002dwp\u002d\u002dpreset\u002d\u002dspacing\u002d\u002d30)"}},"layout":{"type":"flex","justifyContent":"right","verticalAlignment":"center","flexWrap":"nowrap"}} -->
+<div class="wp-block-designsetgo-row alignfull dsgo-flex dsgo-no-width-constraint" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><div class="dsgo-flex__inner" style="display:flex;justify-content:right;align-items:center;flex-wrap:nowrap;gap:var(--wp--preset--spacing--30)"><!-- wp:navigation {"overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","justifyContent":"right","flexWrap":"wrap"}} /-->
+
+<!-- wp:designsetgo/icon-button {"text":"Get a Quote","url":"#","icon":"arrow-right","iconPosition":"end","hoverBackgroundColor":"var:preset|color|accent-3","hoverTextColor":"var:preset|color|base","backgroundColor":"contrast","textColor":"base","fontSize":"small","style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}}} -->
+<a class="wp-block-designsetgo-icon-button dsgo-icon-button wp-block-button wp-block-button__link wp-element-button has-small-font-size" style="display:inline-flex;align-items:center;justify-content:center;gap:8px;width:auto;flex-direction:row-reverse;background-color:var(--wp--preset--color--contrast);color:var(--wp--preset--color--base);font-size:var(--wp--preset--font-size--small);padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--30);--dsgo-button-hover-bg:var(--wp--preset--color--accent-3);--dsgo-button-hover-color:var(--wp--preset--color--base)" href="#" target="_self"><span class="dsgo-icon-button__icon dsgo-lazy-icon" style="display:flex;align-items:center;justify-content:center;width:20px;height:20px;flex-shrink:0" data-icon-name="arrow-right" data-icon-size="20"></span><span class="dsgo-icon-button__text">Get a Quote</span></a>
+<!-- /wp:designsetgo/icon-button --></div></div>
+<!-- /wp:designsetgo/row --></div></div>
+<!-- /wp:designsetgo/row --></div></div>
+<!-- /wp:designsetgo/section --></div></header>
+<!-- /wp:designsetgo/section -->',
+);


### PR DESCRIPTION
## Summary
- Add 5 header patterns: classic, centered, CTA, dark, and topbar — covering common SMB header layouts with site-logo, navigation, social links, and CTA buttons
- Add 5 footer patterns: classic, centered, columns, dark, and minimal — providing flexible footer options with copyright, nav, social links, and multi-column layouts
- Register `header` and `footer` in `ALLOWED_CATEGORIES` and add `dsgo-header`/`dsgo-footer` pattern categories in the loader

## Patterns

### Headers
| Pattern | Description |
|---------|-------------|
| **Header Classic** | Logo left, navigation right, bottom border |
| **Header Centered** | Centered logo (150px) above centered navigation |
| **Header CTA** | Logo + nav + "Get a Quote" CTA button |
| **Header Dark** | Dark background with light text and inverted CTA |
| **Header Topbar** | Contact info + social topbar above main header |

### Footers
| Pattern | Description |
|---------|-------------|
| **Footer Classic** | Centered logo, nav, social links, copyright |
| **Footer Centered** | Logo left + nav right row, centered copyright |
| **Footer Columns** | 4-column: logo/tagline/social + 3 vertical nav columns |
| **Footer Dark** | Dark bg, logo + nav + CTA row, copyright + social row |
| **Footer Minimal** | Single-line: copyright left, nav right |

## Test plan
- [ ] Verify all 10 patterns appear in the block editor pattern inserter under their categories
- [ ] Insert each pattern into a page and confirm correct layout rendering
- [ ] Test pattern previews render correctly at 1200px viewport width
- [ ] Verify patterns work in the Site Editor for template part (header/footer) selection
- [ ] Test responsive behavior on mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)