### PR TITLE
Update spacing variable syntax to new preset format

### DIFF
--- a/src/blocks/fifty-fifty/block.json
+++ b/src/blocks/fifty-fifty/block.json
@@ -79,7 +79,7 @@
 		},
 		"contentPadding": {
 			"type": "string",
-			"default": "var(--wp--preset--spacing--50)"
+			"default": "var:preset|spacing|50"
 		}
 	},
 	"schemaMetadata": {

--- a/src/blocks/grid/block.json
+++ b/src/blocks/grid/block.json
@@ -106,12 +106,12 @@
 			"type": "object",
 			"default": {
 				"spacing": {
-					"blockGap": "var(--wp--preset--spacing--50)",
+					"blockGap": "var:preset|spacing|50",
 					"padding": {
-						"top": "var(--wp--preset--spacing--50)",
-						"bottom": "var(--wp--preset--spacing--50)",
-						"left": "var(--wp--preset--spacing--30)",
-						"right": "var(--wp--preset--spacing--30)"
+						"top": "var:preset|spacing|50",
+						"bottom": "var:preset|spacing|50",
+						"left": "var:preset|spacing|30",
+						"right": "var:preset|spacing|30"
 					}
 				}
 			}

--- a/src/blocks/row/block.json
+++ b/src/blocks/row/block.json
@@ -103,12 +103,12 @@
 			"default": {
 				"spacing": {
 					"padding": {
-						"top": "var(--wp--preset--spacing--50)",
-						"bottom": "var(--wp--preset--spacing--50)",
-						"left": "var(--wp--preset--spacing--30)",
-						"right": "var(--wp--preset--spacing--30)"
+						"top": "var:preset|spacing|50",
+						"bottom": "var:preset|spacing|50",
+						"left": "var:preset|spacing|30",
+						"right": "var:preset|spacing|30"
 					},
-					"blockGap": "var(--wp--preset--spacing--30)"
+					"blockGap": "var:preset|spacing|30"
 				}
 			}
 		},

--- a/src/blocks/section/block.json
+++ b/src/blocks/section/block.json
@@ -101,10 +101,10 @@
 			"default": {
 				"spacing": {
 					"padding": {
-						"top": "var(--wp--preset--spacing--50)",
-						"bottom": "var(--wp--preset--spacing--50)",
-						"left": "var(--wp--preset--spacing--30)",
-						"right": "var(--wp--preset--spacing--30)"
+						"top": "var:preset|spacing|50",
+						"bottom": "var:preset|spacing|50",
+						"left": "var:preset|spacing|30",
+						"right": "var:preset|spacing|30"
 					}
 				}
 			}
@@ -230,7 +230,7 @@
 	},
 	"example": {
 		"attributes": {
-			"gap": "var(--wp--preset--spacing--50)"
+			"gap": "var:preset|spacing|50"
 		},
 		"innerBlocks": [
 			{


### PR DESCRIPTION
## Description
Updates spacing variable syntax across block configuration files from the legacy CSS custom property format to the new WordPress preset variable format. This change standardizes how preset spacing values are referenced in block defaults.

## Type of Change
- [x] Code refactoring

## Changes Made
- Updated `blockGap` spacing variables in grid, row, and section blocks from `var(--wp--preset--spacing--*)` to `var:preset|spacing|*` format
- Updated padding spacing variables (top, bottom, left, right) in grid, row, and section blocks to use new format
- Updated `contentPadding` default in fifty-fifty block to use new format
- Updated example `gap` attribute in section block to use new format

## Testing
- [x] No console errors
- [x] No PHP errors

## Checklist
- [x] My code follows the WordPress Coding Standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

## Additional Notes
This is a straightforward refactoring that updates variable syntax across block configuration files. The changes maintain functional equivalence while adopting the standardized preset variable format used by WordPress.

https://claude.ai/code/session_01RVg6s9moRc3NrwSFk4b7SL