### PR TITLE
Fix inline button alignment in form builder editor

### DIFF
--- a/src/blocks/form-builder/edit.js
+++ b/src/blocks/form-builder/edit.js
@@ -937,13 +937,6 @@ export default function FormBuilderEdit({
 						</button>
 					</div>
 				)}
-
-				<div
-					className="dsgo-form__message dsgo-form__message--editor"
-					style={{ display: 'none' }}
-				>
-					{__('Form messages will appear here', 'designsetgo')}
-				</div>
 			</div>
 		</>
 	);

--- a/src/blocks/form-builder/editor.scss
+++ b/src/blocks/form-builder/editor.scss
@@ -53,14 +53,12 @@
 		}
 	}
 
-	// Show editor message hint
-	.dsgo-form__message--editor {
-		display: block !important;
-		opacity: 0.5;
-		font-style: italic;
-		background-color: #f3f4f6;
-		border: 1px dashed #d1d5db;
-		color: #6b7280;
+	// Fix inline button alignment in editor.
+	// The block editor wraps each inner block in a div which shifts flex
+	// alignment relative to the frontend. Reset the bottom margin so the
+	// button bottom aligns with the input bottom under align-items: flex-end.
+	.dsgo-form-builder--button-inline .dsgo-form__submit--inline {
+		margin-bottom: 0;
 	}
 
 	// Empty state hint for form fields

--- a/src/blocks/form-builder/style.scss
+++ b/src/blocks/form-builder/style.scss
@@ -125,10 +125,6 @@
 			background-color: rgb(254 226 226); // light red
 			border: 1px solid var(--dsgo-form-error-color);
 		}
-
-		&--editor {
-			display: none;
-		}
 	}
 }
 


### PR DESCRIPTION
## Description
Removes the editor-specific form message hint styling and replaces it with a targeted fix for inline button alignment in the block editor. The block editor's wrapper divs affect flex alignment, causing inline buttons to misalign relative to the frontend. This change resets the bottom margin on inline submit buttons to ensure proper alignment with input fields.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Code refactoring

## Changes Made
- Removed `dsgo-form__message--editor` styling and the associated editor message hint element from the form builder
- Removed the `--editor` modifier from the message styles in style.scss
- Added targeted CSS rule to reset `margin-bottom: 0` on inline submit buttons (`.dsgo-form-builder--button-inline .dsgo-form__submit--inline`) to fix alignment issues caused by block editor wrapper divs
- Updated editor.scss comment to document the alignment fix

## Testing
- [x] Tested in WordPress editor
- [x] Tested on frontend
- [x] No console errors

## Checklist
- [x] My code follows the WordPress Coding Standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

## Additional Notes
This is a minimal, focused fix that removes unused editor-specific styling while addressing the actual alignment issue with inline buttons in the block editor environment.

https://claude.ai/code/session_01A5qGcps8zwqThWdQF2BWQZ