### PR TITLE
Fix icon button height in fifty-fifty layout context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "designsetgo",
-  "version": "2.0.26",
+  "version": "2.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "designsetgo",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@wordpress/block-editor": "^14.0.0",

--- a/src/blocks/icon-button/editor.scss
+++ b/src/blocks/icon-button/editor.scss
@@ -67,14 +67,16 @@
 }
 
 // CRITICAL: Prevent button from stretching vertically in stretch contexts (editor-only)
-// When a section is inside a grid or slide, the parent's stretch/height cascades through
-// the section's flex layout, and WordPress applies height: 100% to wp-element-button
-// elements in layout contexts. This resets the button element's height.
+// When a section is inside a grid, slide, or fifty-fifty, the parent's stretch/height
+// cascades through the section's flex layout, and WordPress applies height: 100% to
+// wp-element-button elements in layout contexts. This resets the button element's height.
 // Grid: align-items: stretch cascades through section flex layout.
 // Slide: height: 100% + flex: 1 on .dsgo-slide__content cascades similarly.
+// Fifty-fifty: min-height on grid container + flex column content cascades to child blocks.
 // No frontend equivalent needed - frontend has no [data-block] wrappers and doesn't
 // inherit height: 100% from WordPress's editor layout system.
 .dsgo-grid .dsgo-icon-button,
-.dsgo-slide .dsgo-icon-button {
+.dsgo-slide .dsgo-icon-button,
+.dsgo-fifty-fifty .dsgo-icon-button {
 	height: auto !important;
 }


### PR DESCRIPTION
## Description
Extends the editor-only CSS fix for icon button vertical stretching to include the fifty-fifty block layout. The fifty-fifty block's grid container with `min-height` and flex column content was causing icon buttons to stretch vertically, similar to the existing issues with grid and slide layouts.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Added `.dsgo-fifty-fifty .dsgo-icon-button` selector to the existing height reset rule in `src/blocks/icon-button/editor.scss`
- Updated the comment documentation to explain how fifty-fifty layout cascades height to child blocks
- Clarified the comment structure for better readability

## Testing
- [x] No testing needed (CSS-only fix for editor layout context)
- Existing editor layout behavior unaffected
- No frontend changes required

## Additional Notes
This is an editor-only fix that prevents unintended vertical stretching of icon buttons within fifty-fifty block layouts, consistent with the existing handling for grid and slide layouts.

https://claude.ai/code/session_01JigjhesKREe9aybasreqbQ