### PR TITLE
feat: Enable Claude bot to approve/request-changes on PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -80,14 +80,5 @@ jobs:
             Be thorough - a shallow review that misses real issues is worse than no review.
             If you find NO issues, explain what you checked and why the code is correct.
 
-            ## Final Verdict
-            After completing your review, submit a formal PR review:
-            - If you find NO Critical or High severity issues, APPROVE the PR:
-              `gh pr review ${{ github.event.pull_request.number }} --approve --body "your summary"`
-            - If you find any Critical or High severity issues, REQUEST CHANGES:
-              `gh pr review ${{ github.event.pull_request.number }} --request-changes --body "your summary"`
-            - If you only find Medium/Low issues worth noting but nothing blocking, COMMENT:
-              `gh pr review ${{ github.event.pull_request.number }} --comment --body "your summary"`
-
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Read,Grep,Glob"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -80,5 +80,14 @@ jobs:
             Be thorough - a shallow review that misses real issues is worse than no review.
             If you find NO issues, explain what you checked and why the code is correct.
 
+            ## Final Verdict
+            After completing your review, submit a formal PR review:
+            - If you find NO Critical or High severity issues, APPROVE the PR:
+              `gh pr review ${{ github.event.pull_request.number }} --approve --body "your summary"`
+            - If you find any Critical or High severity issues, REQUEST CHANGES:
+              `gh pr review ${{ github.event.pull_request.number }} --request-changes --body "your summary"`
+            - If you only find Medium/Low issues worth noting but nothing blocking, COMMENT:
+              `gh pr review ${{ github.event.pull_request.number }} --comment --body "your summary"`
+
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Read,Grep,Glob"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,11 +15,12 @@ jobs:
   claude-review:
     if: |
       github.event.issue.pull_request &&
-      (
-        (github.event_name == 'issue_comment' &&
-         (contains(github.event.comment.body, '@claude review') ||
-          contains(github.event.comment.body, '/review')))
-      )
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR') &&
+      (github.event_name == 'issue_comment' &&
+       (contains(github.event.comment.body, '@claude review') ||
+        contains(github.event.comment.body, '/review')))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -99,8 +99,17 @@ jobs:
             Be thorough - a shallow review that misses real issues is worse than no review.
             If you find NO issues, explain what you checked and why the code is correct.
 
+            ## Final Verdict
+            After completing your review, submit a formal PR review:
+            - If you find NO Critical or High severity issues, APPROVE the PR:
+              `gh pr review ${{ github.event.issue.number }} --approve --body "your summary"`
+            - If you find any Critical or High severity issues, REQUEST CHANGES:
+              `gh pr review ${{ github.event.issue.number }} --request-changes --body "your summary"`
+            - If you only find Medium/Low issues worth noting but nothing blocking, COMMENT:
+              `gh pr review ${{ github.event.issue.number }} --comment --body "your summary"`
+
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Read,Grep,Glob"
 
   # Handle general @claude mentions (not review requests)
   claude:


### PR DESCRIPTION
## Summary
- Adds formal PR review verdicts (approve/request-changes/comment) to both auto-review and on-demand review workflows
- Adds `gh pr review` to allowed tools in both workflows
- Review decisions based on issue severity: no Critical/High = approve, Critical/High = request changes, Medium/Low only = comment

## Test plan
- [ ] Open a test PR and verify the auto-review workflow submits a formal review verdict
- [ ] Comment `@claude review` on a PR and verify the on-demand review also submits a verdict
- [ ] Verify branch protection rules accept/count the bot's approval as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)