### PR TITLE
Add mobile responsive stacking for icon list grid layout

### DIFF
--- a/src/blocks/icon-list/editor.scss
+++ b/src/blocks/icon-list/editor.scss
@@ -24,4 +24,15 @@
 			}
 		}
 	}
+
+	// Stack grid to single column on mobile for editor/frontend parity
+	&.dsgo-icon-list--grid {
+
+		@media (max-width: 600px) {
+
+			.dsgo-icon-list__items {
+				grid-template-columns: 1fr !important;
+			}
+		}
+	}
 }

--- a/src/blocks/icon-list/style.scss
+++ b/src/blocks/icon-list/style.scss
@@ -45,5 +45,13 @@
 		.dsgo-icon-list__items {
 			// display: grid and grid-template-columns applied via inline styles
 		}
+
+		// Stack to single column on mobile (≤ 600px)
+		@media (max-width: 600px) {
+
+			.dsgo-icon-list__items {
+				grid-template-columns: 1fr !important;
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Description
Add responsive behavior to the icon list block's grid layout to stack items into a single column on mobile devices (≤ 600px). This ensures visual consistency between the editor and frontend, and improves mobile usability by preventing cramped grid layouts on small screens.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Added mobile media query (max-width: 600px) to `src/blocks/icon-list/editor.scss` to stack grid items to single column in the editor
- Added mobile media query (max-width: 600px) to `src/blocks/icon-list/style.scss` to stack grid items to single column on the frontend
- Both implementations use `grid-template-columns: 1fr !important` to override inline styles and ensure single-column layout on mobile

## Testing
- [x] Tested in WordPress editor
- [x] Tested on frontend
- [x] Tested responsive behavior (mobile/tablet/desktop)
- [x] No console errors

## Checklist
- [x] My code follows the WordPress Coding Standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

## Additional Notes
The `!important` flag is necessary to override inline grid-template-columns styles applied by the block's column settings. The 600px breakpoint aligns with common mobile device widths and provides a clear threshold for the responsive behavior.

https://claude.ai/code/session_01CHh1QRqQtsEgRLRbCRDLYB