### PR TITLE
fix: stop setting default colors on sticky header and allow clearing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
 
       - name: Stop wp-env
         if: always()
-        run: npx wp-env stop
+        run: npx @wordpress/env stop
 
       - name: Upload E2E test artifacts
         uses: actions/upload-artifact@v4
@@ -363,32 +363,32 @@ jobs:
 
       - name: Check WordPress version
         run: |
-          npx wp-env run cli wp core version
-          npx wp-env run cli wp plugin list
+          npx @wordpress/env run cli wp core version
+          npx @wordpress/env run cli wp plugin list
 
       - name: Run PHP tests in WordPress environment
         run: |
-          npx wp-env run tests-cli --env-cwd=wp-content/plugins/designsetgo vendor/bin/phpunit
+          npx @wordpress/env run tests-cli --env-cwd=wp-content/plugins/designsetgo vendor/bin/phpunit
 
       - name: Check plugin lifecycle (activate → deactivate → delete)
         run: |
           echo "=== Activate ==="
-          npx wp-env run cli wp plugin activate designsetgo
-          npx wp-env run cli wp plugin list --status=active | grep designsetgo
+          npx @wordpress/env run cli wp plugin activate designsetgo
+          npx @wordpress/env run cli wp plugin list --status=active | grep designsetgo
 
           echo "=== Deactivate ==="
-          npx wp-env run cli wp plugin deactivate designsetgo
-          npx wp-env run cli wp plugin list --status=inactive | grep designsetgo
+          npx @wordpress/env run cli wp plugin deactivate designsetgo
+          npx @wordpress/env run cli wp plugin list --status=inactive | grep designsetgo
 
           echo "=== Re-activate for dev environment ==="
-          npx wp-env run cli wp plugin activate designsetgo
+          npx @wordpress/env run cli wp plugin activate designsetgo
 
           echo "=== Delete on tests environment (runs uninstall.php) ==="
-          npx wp-env run tests-cli wp plugin deactivate designsetgo
-          npx wp-env run tests-cli wp plugin delete designsetgo
+          npx @wordpress/env run tests-cli wp plugin deactivate designsetgo
+          npx @wordpress/env run tests-cli wp plugin delete designsetgo
 
           echo "=== Verify deleted ==="
-          if npx wp-env run tests-cli wp plugin list 2>&1 | grep -q designsetgo; then
+          if npx @wordpress/env run tests-cli wp plugin list 2>&1 | grep -q designsetgo; then
             echo "❌ Plugin still present after delete"
             exit 1
           fi
@@ -396,4 +396,4 @@ jobs:
 
       - name: Stop wp-env
         if: always()
-        run: npx wp-env stop
+        run: npx @wordpress/env stop

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -109,10 +109,10 @@ class Settings {
 				'transition_speed'          => 300,
 				'scroll_threshold'          => 50,
 				'hide_on_scroll_down'       => false,
-				'background_on_scroll'      => true,
-				'background_scroll_color'   => '#ffffff',
+				'background_on_scroll'      => false,
+				'background_scroll_color'   => '',
 				'background_scroll_opacity' => 100,
-				'text_scroll_color'         => '#000000',
+				'text_scroll_color'         => '',
 			),
 			'draft_mode'         => array(
 				'enable'                 => true,

--- a/src/admin/components/ColorDropdownControl.js
+++ b/src/admin/components/ColorDropdownControl.js
@@ -34,7 +34,7 @@ const ColorDropdownControl = ({
 					className="designsetgo-color-dropdown__toggle"
 					aria-expanded={isOpen}
 				>
-					<ColorIndicator colorValue={value || defaultValue} />
+					<ColorIndicator colorValue={value} />
 					<span>{label}</span>
 				</Button>
 			)}
@@ -46,7 +46,7 @@ const ColorDropdownControl = ({
 						</p>
 					)}
 					<ColorPalette
-						value={value || defaultValue}
+						value={value}
 						onChange={(color) => onChange(color || '')}
 						colors={colors}
 						clearable

--- a/src/admin/components/ColorDropdownControl.js
+++ b/src/admin/components/ColorDropdownControl.js
@@ -14,14 +14,7 @@ import {
 	Button,
 } from '@wordpress/components';
 
-const ColorDropdownControl = ({
-	label,
-	value,
-	defaultValue,
-	onChange,
-	colors,
-	help,
-}) => {
+const ColorDropdownControl = ({ label, value, onChange, colors, help }) => {
 	return (
 		<Dropdown
 			className="designsetgo-color-dropdown"

--- a/src/admin/components/settings-panels/StickyHeaderPanel.js
+++ b/src/admin/components/settings-panels/StickyHeaderPanel.js
@@ -286,7 +286,6 @@ const StickyHeaderPanel = ({ settings, updateSetting }) => {
 												settings?.sticky_header
 													?.background_scroll_color
 											}
-											defaultValue="#ffffff"
 											onChange={(color) =>
 												updateSetting(
 													'sticky_header',
@@ -344,7 +343,6 @@ const StickyHeaderPanel = ({ settings, updateSetting }) => {
 												settings?.sticky_header
 													?.text_scroll_color
 											}
-											defaultValue="#000000"
 											onChange={(color) =>
 												updateSetting(
 													'sticky_header',

--- a/src/utils/sticky-header.js
+++ b/src/utils/sticky-header.js
@@ -182,24 +182,40 @@ import './sticky-header.scss';
 			settings.backgroundOnScroll ||
 			header.classList.contains('dsgo-sticky-bg-on-scroll');
 
-		if (needsBgVars && settings.backgroundScrollColor) {
-			const opacity = settings.backgroundScrollOpacity / 100;
-			// Convert hex to rgba if needed
-			let bgColor = settings.backgroundScrollColor;
-			if (bgColor.startsWith('#')) {
-				const r = parseInt(bgColor.slice(1, 3), 16);
-				const g = parseInt(bgColor.slice(3, 5), 16);
-				const b = parseInt(bgColor.slice(5, 7), 16);
-				bgColor = `rgba(${r}, ${g}, ${b}, ${opacity})`;
+		if (needsBgVars) {
+			if (settings.backgroundScrollColor) {
+				const opacity = settings.backgroundScrollOpacity / 100;
+				// Convert hex to rgba if needed
+				let bgColor = settings.backgroundScrollColor;
+				if (bgColor.startsWith('#')) {
+					const r = parseInt(bgColor.slice(1, 3), 16);
+					const g = parseInt(bgColor.slice(3, 5), 16);
+					const b = parseInt(bgColor.slice(5, 7), 16);
+					bgColor = `rgba(${r}, ${g}, ${b}, ${opacity})`;
+				}
+				header.style.setProperty(
+					'--dsgo-sticky-scroll-bg-color',
+					bgColor
+				);
+			} else {
+				// No color set — override CSS fallback so no background applies
+				header.style.setProperty(
+					'--dsgo-sticky-scroll-bg-color',
+					'transparent'
+				);
 			}
-			header.style.setProperty('--dsgo-sticky-scroll-bg-color', bgColor);
-		}
 
-		if (needsBgVars && settings.textScrollColor) {
-			header.style.setProperty(
-				'--dsgo-sticky-scroll-text-color',
-				settings.textScrollColor
-			);
+			if (settings.textScrollColor) {
+				header.style.setProperty(
+					'--dsgo-sticky-scroll-text-color',
+					settings.textScrollColor
+				);
+			} else {
+				header.style.setProperty(
+					'--dsgo-sticky-scroll-text-color',
+					'inherit'
+				);
+			}
 		}
 	}
 

--- a/src/utils/sticky-header.js
+++ b/src/utils/sticky-header.js
@@ -32,10 +32,10 @@ import './sticky-header.scss';
 		transitionSpeed: 300,
 		scrollThreshold: 50,
 		hideOnScrollDown: false,
-		backgroundOnScroll: true,
-		backgroundScrollColor: '#ffffff',
+		backgroundOnScroll: false,
+		backgroundScrollColor: '',
 		backgroundScrollOpacity: 100,
-		textScrollColor: '#000000',
+		textScrollColor: '',
 	};
 
 	// Early exit if sticky header is disabled


### PR DESCRIPTION
## Summary
- Sticky header background/text colors were hardcoded to `#ffffff`/`#000000` by default and `background_on_scroll` was enabled by default — users got colors applied without explicitly choosing them
- Clicking "Clear" on the color picker reverted to the default color instead of actually clearing, because `ColorDropdownControl` fell back to `defaultValue` when value was empty
- Changed all three defaults to off/empty so colors are opt-in, and removed the `defaultValue` fallback so clearing works as expected

## Test plan
- [ ] Fresh install: verify sticky header does not apply background/text color on scroll by default
- [ ] Enable "Background Color on Scroll", pick a color, then click Clear — verify it clears to no color (no swatch shown)
- [ ] Pick a color, save, reload settings — verify color persists
- [ ] Existing installs with colors already set should be unaffected (values are stored in DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)