### PR TITLE
fix: handle non-JSON responses in form submission

### DIFF
--- a/includes/blocks/class-loader.php
+++ b/includes/blocks/class-loader.php
@@ -180,6 +180,15 @@ class Loader {
 			);
 		}
 
+		// Form Builder block has translatable frontend strings.
+		if ( wp_script_is( 'designsetgo-form-builder-view-script', 'registered' ) ) {
+			wp_set_script_translations(
+				'designsetgo-form-builder-view-script',
+				'designsetgo',
+				DESIGNSETGO_PATH . 'languages'
+			);
+		}
+
 		// Scroll Slides block has translatable frontend strings.
 		if ( wp_script_is( 'designsetgo-scroll-slides-view-script', 'registered' ) ) {
 			wp_set_script_translations(

--- a/src/blocks/form-builder/view.js
+++ b/src/blocks/form-builder/view.js
@@ -241,6 +241,19 @@ function initFormBuilder() {
 					}),
 				});
 
+				// Check for non-JSON responses (e.g. hosting WAF returning HTML error pages)
+				const contentType = response.headers.get('content-type') || '';
+				if (!contentType.includes('application/json')) {
+					if (response.status === 429) {
+						throw new Error(
+							'Too many requests. Please wait a moment and try again.'
+						);
+					}
+					throw new Error(
+						'The server returned an unexpected response. Please try again later.'
+					);
+				}
+
 				const result = await response.json();
 
 				if (result.success) {

--- a/src/blocks/form-builder/view.js
+++ b/src/blocks/form-builder/view.js
@@ -6,6 +6,8 @@
  * @since 1.0.0
  */
 
+import { __ } from '@wordpress/i18n';
+
 /* global designsetgoForm, dsgoIntegrations */
 
 // Track Turnstile script loading state
@@ -246,11 +248,17 @@ function initFormBuilder() {
 				if (!contentType.includes('application/json')) {
 					if (response.status === 429) {
 						throw new Error(
-							'Too many requests. Please wait a moment and try again.'
+							__(
+								'Too many requests. Please wait a moment and try again.',
+								'designsetgo'
+							)
 						);
 					}
 					throw new Error(
-						'The server returned an unexpected response. Please try again later.'
+						__(
+							'The server returned an unexpected response. Please try again later.',
+							'designsetgo'
+						)
 					);
 				}
 

--- a/src/blocks/form-phone-field/view.js
+++ b/src/blocks/form-phone-field/view.js
@@ -107,11 +107,12 @@ function initPhoneFields() {
 
 		// Handle paste event
 		input.addEventListener('paste', function (e) {
-			e.preventDefault();
 			const clipboard = e.clipboardData || window.clipboardData;
 			if (!clipboard) {
+				// Can't access clipboard data — allow default browser paste as fallback
 				return;
 			}
+			e.preventDefault();
 			const pastedText = clipboard.getData('text');
 			const formattedValue = formatPhoneNumber(pastedText, phoneFormat);
 			e.target.value = formattedValue;

--- a/src/blocks/form-phone-field/view.js
+++ b/src/blocks/form-phone-field/view.js
@@ -108,9 +108,11 @@ function initPhoneFields() {
 		// Handle paste event
 		input.addEventListener('paste', function (e) {
 			e.preventDefault();
-			const pastedText = (
-				e.clipboardData || window.clipboardData
-			).getData('text');
+			const clipboard = e.clipboardData || window.clipboardData;
+			if (!clipboard) {
+				return;
+			}
+			const pastedText = clipboard.getData('text');
 			const formattedValue = formatPhoneNumber(pastedText, phoneFormat);
 			e.target.value = formattedValue;
 		});


### PR DESCRIPTION
## Summary
- **Form submission**: Check response content-type before parsing as JSON. When hosting WAFs (e.g. GoDaddy) return HTML error pages (429 Too Many Requests), users now see a clear message instead of "Unexpected token '<' is not valid JSON"
- **Phone field paste**: Guard against undefined `clipboardData` in paste handler, which can crash when browser extensions (e.g. LastPass) interfere with clipboard events

## Context
Reported by a user on wordpress.org with two forms on a GoDaddy-hosted site. GoDaddy's infrastructure (`native-ui.js`, `tccl-tti.min.js`) wraps `window.fetch` for telemetry, and their WAF rate-limits `/wp-json/` requests — returning HTML instead of JSON. Our plugin only fires one fetch per submission, so the 429 is a hosting environment issue, but we should handle it gracefully.

## Test plan
- [ ] Submit form on a site that returns JSON normally — verify success flow unchanged
- [ ] Simulate non-JSON response (e.g. block REST API) — verify user-friendly error message appears
- [ ] Test phone field paste with and without clipboard data available
- [ ] `npm run build` passes
- [ ] `npm run lint:js` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)