### PR TITLE
fix: enable slider navigation buttons in block editor

### DIFF
--- a/src/blocks/slider/edit.js
+++ b/src/blocks/slider/edit.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
 import {
 	useBlockProps,
@@ -1120,7 +1120,11 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 								onClick={() => scrollToSlideIndex(i)}
 							>
 								<span className="screen-reader-text">
-									{`${__('Slide', 'designsetgo')} ${i + 1}`}
+									{sprintf(
+										/* translators: %d: slide number */
+										__('Slide %d', 'designsetgo'),
+										i + 1
+									)}
 								</span>
 							</button>
 						))}

--- a/src/blocks/slider/edit.js
+++ b/src/blocks/slider/edit.js
@@ -19,6 +19,7 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import classnames from 'classnames';
 import {
 	encodeColorValue,
@@ -72,6 +73,12 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 	// Get theme color palette and gradient settings
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
 	const requiresSingleSlideEffect = SINGLE_SLIDE_EFFECTS.includes(effect);
+
+	// Get actual slide count for dynamic dot navigation
+	const slideCount = useSelect(
+		(select) => select('core/block-editor').getBlockCount(clientId),
+		[clientId]
+	);
 
 	useEffect(() => {
 		if (
@@ -1105,33 +1112,18 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 
 				{showDots && (
 					<div className="dsgo-slider__dots dsgo-slider__dots--editor-only">
-						<button
-							type="button"
-							className="dsgo-slider__dot"
-							onClick={() => scrollToSlideIndex(0)}
-						>
-							<span className="screen-reader-text">
-								{__('Slide 1', 'designsetgo')}
-							</span>
-						</button>
-						<button
-							type="button"
-							className="dsgo-slider__dot"
-							onClick={() => scrollToSlideIndex(1)}
-						>
-							<span className="screen-reader-text">
-								{__('Slide 2', 'designsetgo')}
-							</span>
-						</button>
-						<button
-							type="button"
-							className="dsgo-slider__dot"
-							onClick={() => scrollToSlideIndex(2)}
-						>
-							<span className="screen-reader-text">
-								{__('Slide 3', 'designsetgo')}
-							</span>
-						</button>
+						{Array.from({ length: slideCount }, (_, i) => (
+							<button
+								key={i}
+								type="button"
+								className="dsgo-slider__dot"
+								onClick={() => scrollToSlideIndex(i)}
+							>
+								<span className="screen-reader-text">
+									{`${__('Slide', 'designsetgo')} ${i + 1}`}
+								</span>
+							</button>
+						))}
 					</div>
 				)}
 			</div>

--- a/src/blocks/slider/editor.scss
+++ b/src/blocks/slider/editor.scss
@@ -80,6 +80,7 @@
 
 		.dsgo-slider__arrow {
 			cursor: pointer;
+			pointer-events: auto;
 		}
 	}
 
@@ -87,6 +88,7 @@
 
 		.dsgo-slider__dot {
 			cursor: pointer;
+			pointer-events: auto;
 		}
 	}
 


### PR DESCRIPTION
## Summary
- **Arrow/dot buttons unclickable in editor**: `style.scss` sets `pointer-events: none` on `.dsgo-slider__arrows--editor-only` and `.dsgo-slider__dots--editor-only` containers. `editor.scss` added `cursor: pointer` to child buttons but never re-enabled `pointer-events: auto` — so clicks were still blocked by the parent
- **Dot navigation hardcoded to 3 slides**: Editor always rendered exactly 3 dot buttons regardless of actual slide count. Now uses `useSelect` with `getBlockCount` to dynamically generate the correct number of dots

## Context
User reported that slider navigation buttons work on the published frontend but not in the block editor. The frontend `view.js` builds its own navigation dynamically and removes the editor-only elements, so it was unaffected.

## Test plan
- [ ] Add a slider block with 2+ slides — verify arrow buttons scroll between slides in editor
- [ ] Add 4+ slides — verify dot count matches actual slide count
- [ ] Remove slides — verify dots update dynamically
- [ ] Publish and verify frontend navigation still works correctly
- [ ] Test fade and zoom effects in editor
- [ ] `npm run build` passes
- [ ] `npm run lint:js` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)