### PR TITLE
feat: add admin-ajax.php fallback for rate-limited REST API

### DIFF
--- a/includes/abilities/class-form-field-html-generator.php
+++ b/includes/abilities/class-form-field-html-generator.php
@@ -458,7 +458,7 @@ class Form_Field_Html_Generator {
 		if ( $help_text ) {
 			$html .= ' aria-describedby="' . esc_attr( $field_id ) . '-help"';
 		}
-		$html .= ' data-field-type="phone"/>';
+		$html .= ' data-field-type="tel"/>';
 
 		$html .= self::generate_help_text( $field_id, $help_text );
 		$html .= '</div>';

--- a/includes/blocks/class-form-handler.php
+++ b/includes/blocks/class-form-handler.php
@@ -405,11 +405,11 @@ class Form_Handler {
 			);
 		}
 
-		$request->set_param( 'formId', isset( $data['formId'] ) ? $data['formId'] : '' );
+		$request->set_param( 'formId', isset( $data['formId'] ) ? sanitize_text_field( $data['formId'] ) : '' );
 		$request->set_param( 'fields', isset( $data['fields'] ) ? $data['fields'] : array() );
 		$request->set_param( 'honeypot', isset( $data['honeypot'] ) ? $data['honeypot'] : '' );
 		$request->set_param( 'timestamp', isset( $data['timestamp'] ) ? $data['timestamp'] : '' );
-		$request->set_param( 'turnstile_token', isset( $data['turnstile_token'] ) ? $data['turnstile_token'] : '' );
+		$request->set_param( 'turnstile_token', isset( $data['turnstile_token'] ) ? sanitize_text_field( $data['turnstile_token'] ) : '' );
 
 		$result = $this->handle_form_submission( $request );
 
@@ -434,29 +434,42 @@ class Form_Handler {
 	public function handle_post_submission() {
 		// Verify nonce.
 		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'designsetgo_form_submit' ) ) {
-			wp_die( esc_html__( 'Security verification failed.', 'designsetgo' ), 403 );
+			wp_die( esc_html__( 'Security verification failed.', 'designsetgo' ), '', array( 'response' => 403 ) );
 		}
 
 		$referer = wp_get_referer();
 		if ( ! $referer ) {
-			wp_die( esc_html__( 'Invalid form submission.', 'designsetgo' ), 400 );
+			wp_die( esc_html__( 'Invalid form submission.', 'designsetgo' ), '', array( 'response' => 400 ) );
 		}
 
 		// Build fields array from POST data.
 		$form_id = isset( $_POST['dsg_form_id'] ) ? sanitize_text_field( wp_unslash( $_POST['dsg_form_id'] ) ) : '';
 		$fields  = array();
 
+		// Read field type map (JSON mapping of field name => type).
+		$field_types = array();
+		if ( isset( $_POST['dsg_field_types'] ) ) {
+			$decoded = json_decode( sanitize_text_field( wp_unslash( $_POST['dsg_field_types'] ) ), true );
+			if ( is_array( $decoded ) ) {
+				$field_types = $decoded;
+			}
+		}
+
+		$system_fields = array( 'dsg_website', 'dsg_form_id', 'dsg_timestamp', 'dsg_turnstile_token', 'dsg_field_types', '_wpnonce', 'action' );
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above.
 		foreach ( $_POST as $key => $value ) {
 			// Skip system fields.
-			if ( in_array( $key, array( 'dsg_website', 'dsg_form_id', 'dsg_timestamp', 'dsg_turnstile_token', '_wpnonce', 'action' ), true ) ) {
+			if ( in_array( $key, $system_fields, true ) ) {
 				continue;
 			}
+
+			$field_type = isset( $field_types[ $key ] ) ? sanitize_text_field( $field_types[ $key ] ) : 'text';
 
 			$fields[] = array(
 				'name'  => $key,
 				'value' => sanitize_text_field( wp_unslash( $value ) ),
-				'type'  => 'text',
+				'type'  => $field_type,
 			);
 		}
 
@@ -646,10 +659,11 @@ class Form_Handler {
 			$handle,
 			'designsetgoForm',
 			array(
-				'nonce'     => wp_create_nonce( 'wp_rest' ),
-				'restUrl'   => rest_url( 'designsetgo/v1/form/submit' ),
-				'ajaxUrl'   => admin_url( 'admin-ajax.php' ),
-				'ajaxNonce' => wp_create_nonce( 'designsetgo_form_submit' ),
+				'nonce'        => wp_create_nonce( 'wp_rest' ),
+				'restUrl'      => rest_url( 'designsetgo/v1/form/submit' ),
+				'ajaxUrl'      => admin_url( 'admin-ajax.php' ),
+				'adminPostUrl' => admin_url( 'admin-post.php' ),
+				'ajaxNonce'    => wp_create_nonce( 'designsetgo_form_submit' ),
 			)
 		);
 

--- a/includes/blocks/class-form-handler.php
+++ b/includes/blocks/class-form-handler.php
@@ -245,6 +245,12 @@ class Form_Handler {
 		$timestamp     = $request->get_param( 'timestamp' );
 		$form_settings = $this->get_form_settings();
 
+		// Look up per-block attributes for rate limiting and Turnstile enforcement.
+		$block_attrs      = $this->get_form_block_attributes( $form_id );
+		$rate_limit_count = isset( $block_attrs['rateLimitCount'] ) ? absint( $block_attrs['rateLimitCount'] ) : 3;
+		$rate_limit_window = isset( $block_attrs['rateLimitWindow'] ) ? absint( $block_attrs['rateLimitWindow'] ) : 60;
+		$turnstile_required = ! empty( $block_attrs['enableTurnstile'] );
+
 		// Honeypot spam check (only if enabled in settings).
 		if ( $form_settings['enable_honeypot'] ) {
 			$honeypot_check = $this->security->check_honeypot( $honeypot, $form_id );
@@ -260,17 +266,24 @@ class Form_Handler {
 		}
 
 		// Rate limiting check (only if enabled in settings).
-		// Note: We only CHECK here, not increment. Increment happens after successful submission.
+		// Uses per-block rateLimitCount/rateLimitWindow attributes as defaults for the filter.
 		if ( $form_settings['enable_rate_limiting'] ) {
-			$rate_limit_check = $this->security->check_rate_limit( $form_id );
+			$rate_limit_check = $this->security->check_rate_limit( $form_id, $rate_limit_count );
 			if ( is_wp_error( $rate_limit_check ) ) {
 				return $rate_limit_check;
 			}
 		}
 
-		// Turnstile verification (if token provided).
-		// Graceful degradation: If no token, skip verification (form submitted without Turnstile or widget failed).
+		// Turnstile verification.
+		// If the block requires Turnstile, reject submissions without a valid token.
 		$turnstile_token = $request->get_param( 'turnstile_token' );
+		if ( $turnstile_required && empty( $turnstile_token ) ) {
+			return new WP_Error(
+				'turnstile_required',
+				__( 'Security verification is required. Please complete the challenge and try again.', 'designsetgo' ),
+				array( 'status' => 403 )
+			);
+		}
 		if ( ! empty( $turnstile_token ) ) {
 			$turnstile_result = $this->security->verify_turnstile( $turnstile_token );
 			if ( is_wp_error( $turnstile_result ) ) {
@@ -288,15 +301,19 @@ class Form_Handler {
 		}
 
 		// Sanitize and validate all fields.
+		$form_field_types = $this->get_form_field_types( $form_id );
 		$sanitized_fields = array();
 		foreach ( $fields as $field ) {
 			if ( ! isset( $field['name'] ) || ! isset( $field['value'] ) ) {
 				continue;
 			}
 
-			$field_name  = sanitize_text_field( $field['name'] );
-			$field_value = $field['value'];
-			$field_type  = isset( $field['type'] ) ? sanitize_text_field( $field['type'] ) : 'text';
+			$field_name          = sanitize_text_field( $field['name'] );
+			$field_value         = $field['value'];
+			$submitted_field_type = isset( $field['type'] ) ? sanitize_text_field( $field['type'] ) : 'text';
+			$field_type          = isset( $form_field_types[ $field_name ] )
+				? $form_field_types[ $field_name ]
+				: $submitted_field_type;
 
 			// Type-specific validation.
 			$validation_result = $this->validate_field( $field_value, $field_type );
@@ -341,7 +358,7 @@ class Form_Handler {
 
 		// Increment rate limit counter ONLY after successful submission.
 		if ( $form_settings['enable_rate_limiting'] ) {
-			$this->security->increment_rate_limit( $form_id );
+			$this->security->increment_rate_limit( $form_id, $rate_limit_window );
 		}
 
 		// Trigger action hook for email notifications, integrations, etc.
@@ -430,7 +447,7 @@ class Form_Handler {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above.
 		foreach ( $_POST as $key => $value ) {
 			// Skip system fields.
-			if ( in_array( $key, array( 'dsg_website', 'dsg_form_id', 'dsg_timestamp', '_wpnonce', 'action' ), true ) ) {
+			if ( in_array( $key, array( 'dsg_website', 'dsg_form_id', 'dsg_timestamp', 'dsg_turnstile_token', '_wpnonce', 'action' ), true ) ) {
 				continue;
 			}
 
@@ -446,14 +463,26 @@ class Form_Handler {
 		$request->set_param( 'fields', $fields );
 		$request->set_param( 'honeypot', isset( $_POST['dsg_website'] ) ? sanitize_text_field( wp_unslash( $_POST['dsg_website'] ) ) : '' );
 		$request->set_param( 'timestamp', isset( $_POST['dsg_timestamp'] ) ? sanitize_text_field( wp_unslash( $_POST['dsg_timestamp'] ) ) : '' );
-		$request->set_param( 'turnstile_token', '' );
+		$request->set_param( 'turnstile_token', isset( $_POST['dsg_turnstile_token'] ) ? sanitize_text_field( wp_unslash( $_POST['dsg_turnstile_token'] ) ) : '' );
 
 		$result = $this->handle_form_submission( $request );
 
 		if ( is_wp_error( $result ) ) {
-			$redirect = add_query_arg( 'dsgo_form_error', '1', $referer );
+			$redirect = add_query_arg(
+				array(
+					'dsgo_form_status' => 'error',
+					'dsgo_form_id'     => $form_id,
+				),
+				$referer
+			);
 		} else {
-			$redirect = add_query_arg( 'dsgo_form_success', '1', $referer );
+			$redirect = add_query_arg(
+				array(
+					'dsgo_form_status' => 'success',
+					'dsgo_form_id'     => $form_id,
+				),
+				$referer
+			);
 		}
 
 		wp_safe_redirect( $redirect );
@@ -966,6 +995,160 @@ class Form_Handler {
 	}
 
 	/**
+	 * Look up server-defined field types for a form by form ID.
+	 *
+	 * Uses parsed block content so validation/sanitization does not rely on
+	 * client-supplied field types.
+	 *
+	 * @param string $form_id Form identifier to look up.
+	 * @return array<string, string> Field types keyed by field name.
+	 */
+	private function get_form_field_types( $form_id ) {
+		$cache_key = 'dsgo_form_field_types_' . md5( $form_id );
+		$cached    = get_transient( $cache_key );
+
+		if ( false !== $cached && is_array( $cached ) ) {
+			return $cached;
+		}
+
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Cached via transient above.
+		$posts = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT ID, post_content FROM {$wpdb->posts}
+				WHERE post_content LIKE %s
+				AND post_content LIKE %s
+				AND post_status IN ('publish', 'private')
+				LIMIT 5",
+				'%' . $wpdb->esc_like( 'designsetgo/form-builder' ) . '%',
+				'%' . $wpdb->esc_like( '"formId":"' . $form_id . '"' ) . '%'
+			)
+		);
+
+		if ( empty( $posts ) ) {
+			return array();
+		}
+
+		foreach ( $posts as $post ) {
+			$blocks      = parse_blocks( $post->post_content );
+			$field_types = $this->find_form_field_types( $blocks, $form_id );
+
+			if ( ! empty( $field_types ) ) {
+				set_transient( $cache_key, $field_types, HOUR_IN_SECONDS );
+				return $field_types;
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Recursively search parsed blocks for a form-builder block and extract field types.
+	 *
+	 * @param array  $blocks  Parsed blocks array.
+	 * @param string $form_id Form identifier to match.
+	 * @return array<string, string> Field types keyed by field name.
+	 */
+	private function find_form_field_types( $blocks, $form_id ) {
+		foreach ( $blocks as $block ) {
+			if (
+				'designsetgo/form-builder' === $block['blockName'] &&
+				isset( $block['attrs']['formId'] ) &&
+				$block['attrs']['formId'] === $form_id
+			) {
+				return $this->extract_field_types_from_blocks(
+					isset( $block['innerBlocks'] ) ? $block['innerBlocks'] : array()
+				);
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$result = $this->find_form_field_types( $block['innerBlocks'], $form_id );
+				if ( ! empty( $result ) ) {
+					return $result;
+				}
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Extract field types from a form block's inner blocks.
+	 *
+	 * @param array $blocks Parsed inner blocks.
+	 * @return array<string, string> Field types keyed by field name.
+	 */
+	private function extract_field_types_from_blocks( $blocks ) {
+		$field_types = array();
+
+		foreach ( $blocks as $block ) {
+			$block_name = isset( $block['blockName'] ) ? $block['blockName'] : '';
+			$field_name = isset( $block['attrs']['fieldName'] ) ? sanitize_text_field( $block['attrs']['fieldName'] ) : '';
+			$field_type = $this->map_block_name_to_field_type( $block_name );
+
+			if ( $field_name && $field_type ) {
+				$field_types[ $field_name ] = $field_type;
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$field_types = array_merge(
+					$field_types,
+					$this->extract_field_types_from_blocks( $block['innerBlocks'] )
+				);
+			}
+		}
+
+		return $field_types;
+	}
+
+	/**
+	 * Map form field block names to server-side field types.
+	 *
+	 * @param string $block_name Block name.
+	 * @return string|null Server-side field type, or null when unsupported.
+	 */
+	private function map_block_name_to_field_type( $block_name ) {
+		switch ( $block_name ) {
+			case 'designsetgo/form-text-field':
+				return 'text';
+
+			case 'designsetgo/form-email-field':
+				return 'email';
+
+			case 'designsetgo/form-textarea-field':
+				return 'textarea';
+
+			case 'designsetgo/form-number-field':
+				return 'number';
+
+			case 'designsetgo/form-phone-field':
+				return 'tel';
+
+			case 'designsetgo/form-url-field':
+				return 'url';
+
+			case 'designsetgo/form-date-field':
+				return 'date';
+
+			case 'designsetgo/form-time-field':
+				return 'time';
+
+			case 'designsetgo/form-select-field':
+				return 'select';
+
+			case 'designsetgo/form-checkbox-field':
+				return 'checkbox';
+
+			case 'designsetgo/form-hidden-field':
+				return 'hidden';
+
+			default:
+				return null;
+		}
+	}
+
+	/**
 	 * Clear cached form block attributes when a post is saved.
 	 *
 	 * Hooked to save_post to ensure email config changes take effect immediately.
@@ -994,6 +1177,7 @@ class Form_Handler {
 				isset( $block['attrs']['formId'] )
 			) {
 				delete_transient( 'dsgo_form_attrs_' . md5( $block['attrs']['formId'] ) );
+				delete_transient( 'dsgo_form_field_types_' . md5( $block['attrs']['formId'] ) );
 			}
 
 			if ( ! empty( $block['innerBlocks'] ) ) {

--- a/includes/blocks/class-form-handler.php
+++ b/includes/blocks/class-form-handler.php
@@ -391,10 +391,12 @@ class Form_Handler {
 		$request = new \WP_REST_Request( 'POST' );
 		$request->set_header( 'Content-Type', 'application/json' );
 
-		// Map POST params to REST request params.
+		// Read JSON form data from the form_data POST field (form-encoded).
+		// Form-encoded is used because some hosts (GoDaddy/Cloudflare) block
+		// application/json POST requests with 429 errors.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by handle_form_submission.
-		$raw_body = file_get_contents( 'php://input' );
-		$data     = json_decode( $raw_body, true );
+		$raw_data = isset( $_POST['form_data'] ) ? wp_unslash( $_POST['form_data'] ) : '';
+		$data     = json_decode( $raw_data, true );
 
 		if ( ! is_array( $data ) ) {
 			wp_send_json_error(

--- a/includes/blocks/class-form-handler.php
+++ b/includes/blocks/class-form-handler.php
@@ -107,6 +107,14 @@ class Form_Handler {
 		add_action( 'rest_api_init', array( $this, 'register_rest_endpoint' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'localize_form_script' ) );
 
+		// Admin-ajax fallback for hosts that rate-limit /wp-json/ (e.g. Cloudflare/GoDaddy).
+		add_action( 'wp_ajax_designsetgo_form_submit', array( $this, 'handle_ajax_submission' ) );
+		add_action( 'wp_ajax_nopriv_designsetgo_form_submit', array( $this, 'handle_ajax_submission' ) );
+
+		// Non-AJAX form POST handler.
+		add_action( 'admin_post_designsetgo_form_submit', array( $this, 'handle_post_submission' ) );
+		add_action( 'admin_post_nopriv_designsetgo_form_submit', array( $this, 'handle_post_submission' ) );
+
 		// Register cron callback (scheduling handled by activation hook).
 		add_action( 'designsetgo_cleanup_old_submissions', array( $this, 'cleanup_old_submissions' ) );
 
@@ -350,6 +358,109 @@ class Form_Handler {
 	}
 
 	/**
+	 * Handle form submission via admin-ajax.php (fallback for rate-limited REST API).
+	 *
+	 * Wraps the REST handler by building a WP_REST_Request from $_POST data.
+	 */
+	public function handle_ajax_submission() {
+		// Verify nonce.
+		if ( ! check_ajax_referer( 'designsetgo_form_submit', '_ajax_nonce', false ) ) {
+			wp_send_json_error(
+				array( 'message' => __( 'Security verification failed. Please refresh the page and try again.', 'designsetgo' ) ),
+				403
+			);
+		}
+
+		$request = new \WP_REST_Request( 'POST' );
+		$request->set_header( 'Content-Type', 'application/json' );
+
+		// Map POST params to REST request params.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by handle_form_submission.
+		$raw_body = file_get_contents( 'php://input' );
+		$data     = json_decode( $raw_body, true );
+
+		if ( ! is_array( $data ) ) {
+			wp_send_json_error(
+				array( 'message' => __( 'Invalid request data.', 'designsetgo' ) ),
+				400
+			);
+		}
+
+		$request->set_param( 'formId', isset( $data['formId'] ) ? $data['formId'] : '' );
+		$request->set_param( 'fields', isset( $data['fields'] ) ? $data['fields'] : array() );
+		$request->set_param( 'honeypot', isset( $data['honeypot'] ) ? $data['honeypot'] : '' );
+		$request->set_param( 'timestamp', isset( $data['timestamp'] ) ? $data['timestamp'] : '' );
+		$request->set_param( 'turnstile_token', isset( $data['turnstile_token'] ) ? $data['turnstile_token'] : '' );
+
+		$result = $this->handle_form_submission( $request );
+
+		if ( is_wp_error( $result ) ) {
+			$status = $result->get_error_data() && isset( $result->get_error_data()['status'] )
+				? $result->get_error_data()['status']
+				: 400;
+			wp_send_json_error(
+				array( 'message' => $result->get_error_message() ),
+				$status
+			);
+		}
+
+		wp_send_json_success( $result->get_data() );
+	}
+
+	/**
+	 * Handle non-AJAX form submission via admin_post.
+	 *
+	 * Processes standard form POST and redirects back with a status query param.
+	 */
+	public function handle_post_submission() {
+		// Verify nonce.
+		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'designsetgo_form_submit' ) ) {
+			wp_die( esc_html__( 'Security verification failed.', 'designsetgo' ), 403 );
+		}
+
+		$referer = wp_get_referer();
+		if ( ! $referer ) {
+			wp_die( esc_html__( 'Invalid form submission.', 'designsetgo' ), 400 );
+		}
+
+		// Build fields array from POST data.
+		$form_id = isset( $_POST['dsg_form_id'] ) ? sanitize_text_field( wp_unslash( $_POST['dsg_form_id'] ) ) : '';
+		$fields  = array();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above.
+		foreach ( $_POST as $key => $value ) {
+			// Skip system fields.
+			if ( in_array( $key, array( 'dsg_website', 'dsg_form_id', 'dsg_timestamp', '_wpnonce', 'action' ), true ) ) {
+				continue;
+			}
+
+			$fields[] = array(
+				'name'  => $key,
+				'value' => sanitize_text_field( wp_unslash( $value ) ),
+				'type'  => 'text',
+			);
+		}
+
+		$request = new \WP_REST_Request( 'POST' );
+		$request->set_param( 'formId', $form_id );
+		$request->set_param( 'fields', $fields );
+		$request->set_param( 'honeypot', isset( $_POST['dsg_website'] ) ? sanitize_text_field( wp_unslash( $_POST['dsg_website'] ) ) : '' );
+		$request->set_param( 'timestamp', isset( $_POST['dsg_timestamp'] ) ? sanitize_text_field( wp_unslash( $_POST['dsg_timestamp'] ) ) : '' );
+		$request->set_param( 'turnstile_token', '' );
+
+		$result = $this->handle_form_submission( $request );
+
+		if ( is_wp_error( $result ) ) {
+			$redirect = add_query_arg( 'dsgo_form_error', '1', $referer );
+		} else {
+			$redirect = add_query_arg( 'dsgo_form_success', '1', $referer );
+		}
+
+		wp_safe_redirect( $redirect );
+		exit;
+	}
+
+	/**
 	 * Validate field based on type.
 	 *
 	 * @param mixed  $value Field value.
@@ -504,8 +615,10 @@ class Form_Handler {
 			$handle,
 			'designsetgoForm',
 			array(
-				'nonce'   => wp_create_nonce( 'wp_rest' ),
-				'restUrl' => rest_url( 'designsetgo/v1/form/submit' ),
+				'nonce'     => wp_create_nonce( 'wp_rest' ),
+				'restUrl'   => rest_url( 'designsetgo/v1/form/submit' ),
+				'ajaxUrl'   => admin_url( 'admin-ajax.php' ),
+				'ajaxNonce' => wp_create_nonce( 'designsetgo_form_submit' ),
 			)
 		);
 

--- a/includes/blocks/class-form-security.php
+++ b/includes/blocks/class-form-security.php
@@ -77,15 +77,16 @@ class Form_Security {
 	/**
 	 * Check rate limiting for form submissions.
 	 *
-	 * @param string $form_id Form ID.
+	 * @param string $form_id   Form ID.
+	 * @param int    $block_max Max submissions from block attributes. Default 3.
 	 * @return true|WP_Error True if allowed, WP_Error if rate limited.
 	 */
-	public function check_rate_limit( string $form_id ) {
+	public function check_rate_limit( string $form_id, int $block_max = 3 ) {
 		$ip_address = $this->get_client_ip();
 		$key        = 'form_submit_' . $form_id . '_' . md5( $ip_address );
 		$count      = get_transient( $key );
 
-		$max_submissions = apply_filters( 'designsetgo_form_rate_limit_count', 3, $form_id );
+		$max_submissions = apply_filters( 'designsetgo_form_rate_limit_count', $block_max, $form_id );
 
 		if ( false !== $count && $count >= $max_submissions ) {
 			do_action( 'designsetgo_form_rate_limit_exceeded', $form_id, $ip_address, $count, $max_submissions );
@@ -103,14 +104,15 @@ class Form_Security {
 	/**
 	 * Increment rate limit counter after successful submission.
 	 *
-	 * @param string $form_id Form ID.
+	 * @param string $form_id      Form ID.
+	 * @param int    $block_window Time window in seconds from block attributes. Default 60.
 	 */
-	public function increment_rate_limit( string $form_id ): void {
+	public function increment_rate_limit( string $form_id, int $block_window = 60 ): void {
 		$ip_address = $this->get_client_ip();
 		$key        = 'form_submit_' . $form_id . '_' . md5( $ip_address );
 		$count      = get_transient( $key );
 
-		$time_window = apply_filters( 'designsetgo_form_rate_limit_window', 60, $form_id );
+		$time_window = apply_filters( 'designsetgo_form_rate_limit_window', $block_window, $form_id );
 
 		if ( false === $count ) {
 			set_transient( $key, 1, $time_window );

--- a/src/blocks/form-builder/edit.js
+++ b/src/blocks/form-builder/edit.js
@@ -162,7 +162,7 @@ export default function FormBuilderEdit({
 					'designsetgo/form-date-field',
 					'designsetgo/form-time-field',
 					'designsetgo/form-select-field',
-					'designsetgo/form-checkbox',
+					'designsetgo/form-checkbox-field',
 					'designsetgo/form-hidden-field',
 				],
 				template: [

--- a/src/blocks/form-builder/edit.js
+++ b/src/blocks/form-builder/edit.js
@@ -17,6 +17,7 @@ import {
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
+	Notice,
 	TextControl,
 	TextareaControl,
 	ToggleControl,
@@ -639,6 +640,16 @@ export default function FormBuilderEdit({
 
 					{enableEmail && (
 						<>
+							<Notice
+								status="info"
+								isDismissible={false}
+								className="dsgo-form__smtp-notice"
+							>
+								{__(
+									'Emails are sent using wp_mail(). For reliable delivery, consider using an SMTP plugin like WP Mail SMTP.',
+									'designsetgo'
+								)}
+							</Notice>
 							<TextControl
 								label={__('Recipient Email', 'designsetgo')}
 								value={emailTo}

--- a/src/blocks/form-builder/style.scss
+++ b/src/blocks/form-builder/style.scss
@@ -101,7 +101,7 @@
 				border-radius: 50%;
 				border-top-color: transparent;
 				animation: dsgo-form-spinner 0.6s linear infinite;
-				color: var(--dsgo-form-submit-color);
+				color: inherit;
 			}
 		}
 	}

--- a/src/blocks/form-builder/view.js
+++ b/src/blocks/form-builder/view.js
@@ -174,37 +174,40 @@ function initFormBuilder() {
 		}
 
 		const formId = formContainer.getAttribute('data-form-id');
+		const successMessage = formContainer.getAttribute(
+			'data-success-message'
+		);
+		const errorMessage = formContainer.getAttribute('data-error-message');
 
-		// Check if AJAX is enabled
-		const ajaxEnabled =
-			formContainer.getAttribute('data-ajax-submit') === 'true';
-
-		// Non-AJAX: set up standard form POST to admin_post
-		if (!ajaxEnabled) {
+		function ensureNativePostFields() {
 			formElement.action = designsetgoForm.ajaxUrl.replace(
 				'admin-ajax.php',
 				'admin-post.php'
 			);
+			formElement.method = 'post';
 
-			// Add required hidden fields for admin_post handler
-			const actionField = document.createElement('input');
-			actionField.type = 'hidden';
-			actionField.name = 'action';
+			let actionField = formElement.querySelector('input[name="action"]');
+			if (!actionField) {
+				actionField = document.createElement('input');
+				actionField.type = 'hidden';
+				actionField.name = 'action';
+				formElement.appendChild(actionField);
+			}
 			actionField.value = 'designsetgo_form_submit';
-			formElement.appendChild(actionField);
 
-			const nonceField = document.createElement('input');
-			nonceField.type = 'hidden';
-			nonceField.name = '_wpnonce';
+			let nonceField = formElement.querySelector(
+				'input[name="_wpnonce"]'
+			);
+			if (!nonceField) {
+				nonceField = document.createElement('input');
+				nonceField.type = 'hidden';
+				nonceField.name = '_wpnonce';
+				formElement.appendChild(nonceField);
+			}
 			nonceField.value = designsetgoForm.ajaxNonce;
-			formElement.appendChild(nonceField);
+		}
 
-			// Set timestamp on submit
-			formElement.addEventListener('submit', function () {
-				timestampField.value = Date.now();
-			});
-
-			// Check for success/error query params after redirect
+		function showRedirectStatus() {
 			const params = new URLSearchParams(window.location.search);
 			const status = params.get('dsgo_form_status');
 			const statusFormId = params.get('dsgo_form_id');
@@ -216,33 +219,76 @@ function initFormBuilder() {
 			) {
 				showMessage(
 					messageContainer,
-					formContainer.getAttribute('data-success-message') ||
+					successMessage ||
 						__('Form submitted successfully!', 'designsetgo'),
 					'success'
 				);
 				formElement.reset();
-			} else if (
+				return true;
+			}
+
+			if (
 				matchesCurrentForm &&
 				(params.has('dsgo_form_error') || status === 'error')
 			) {
 				showMessage(
 					messageContainer,
-					formContainer.getAttribute('data-error-message') ||
+					errorMessage ||
 						__(
 							'An error occurred. Please try again.',
 							'designsetgo'
 						),
 					'error'
 				);
+				return true;
 			}
+
+			return false;
+		}
+
+		function markTransportBlocked(key) {
+			try {
+				sessionStorage.setItem(key, '1');
+			} catch {
+				// sessionStorage may be unavailable
+			}
+		}
+
+		function isTransportBlocked(key) {
+			try {
+				return sessionStorage.getItem(key) === '1';
+			} catch {
+				return false;
+			}
+		}
+
+		function submitViaNativePost() {
+			ensureNativePostFields();
+			timestampField.value = Date.now();
+			if (turnstileTokenField) {
+				turnstileTokenField.value = turnstileToken || '';
+			}
+			window.HTMLFormElement.prototype.submit.call(formElement);
+		}
+
+		showRedirectStatus();
+
+		// Check if AJAX is enabled
+		const ajaxEnabled =
+			formContainer.getAttribute('data-ajax-submit') === 'true';
+
+		// Non-AJAX: set up standard form POST to admin_post
+		if (!ajaxEnabled) {
+			ensureNativePostFields();
+
+			// Set timestamp on submit
+			formElement.addEventListener('submit', function () {
+				timestampField.value = Date.now();
+			});
 
 			return;
 		}
 
-		const successMessage = formContainer.getAttribute(
-			'data-success-message'
-		);
-		const errorMessage = formContainer.getAttribute('data-error-message');
 		const redirectUrl = formContainer.getAttribute('data-redirect-url');
 
 		// Handle form submission
@@ -323,9 +369,15 @@ function initFormBuilder() {
 				const useAjax =
 					designsetgoForm.ajaxUrl && designsetgoForm.ajaxNonce;
 				const restBlocked =
-					useAjax &&
-					typeof sessionStorage !== 'undefined' &&
-					sessionStorage.getItem('dsgo_rest_blocked') === '1';
+					useAjax && isTransportBlocked('dsgo_rest_blocked');
+				const ajaxBlocked =
+					useAjax && isTransportBlocked('dsgo_ajax_blocked');
+
+				if (ajaxBlocked) {
+					redirecting = true;
+					submitViaNativePost();
+					return;
+				}
 
 				if (!restBlocked) {
 					// Try REST API first
@@ -342,11 +394,7 @@ function initFormBuilder() {
 						result = await restResponse.json();
 					} else if (restResponse.status === 429 && useAjax) {
 						// Remember that REST is blocked for this session
-						try {
-							sessionStorage.setItem('dsgo_rest_blocked', '1');
-						} catch {
-							// sessionStorage may be unavailable
-						}
+						markTransportBlocked('dsgo_rest_blocked');
 						// Fall through to admin-ajax below
 					} else {
 						// Non-429 error from REST API
@@ -384,6 +432,13 @@ function initFormBuilder() {
 					});
 
 					if (!ajaxResponse.ok) {
+						if (ajaxResponse.status === 429) {
+							markTransportBlocked('dsgo_ajax_blocked');
+							redirecting = true;
+							submitViaNativePost();
+							return;
+						}
+
 						let ajaxMessage;
 						try {
 							const ajaxError = await ajaxResponse.json();

--- a/src/blocks/form-builder/view.js
+++ b/src/blocks/form-builder/view.js
@@ -180,10 +180,7 @@ function initFormBuilder() {
 		const errorMessage = formContainer.getAttribute('data-error-message');
 
 		function ensureNativePostFields() {
-			formElement.action = designsetgoForm.ajaxUrl.replace(
-				'admin-ajax.php',
-				'admin-post.php'
-			);
+			formElement.action = designsetgoForm.adminPostUrl;
 			formElement.method = 'post';
 
 			let actionField = formElement.querySelector('input[name="action"]');
@@ -194,6 +191,7 @@ function initFormBuilder() {
 				formElement.appendChild(actionField);
 			}
 			actionField.value = 'designsetgo_form_submit';
+			actionField.defaultValue = actionField.value;
 
 			let nonceField = formElement.querySelector(
 				'input[name="_wpnonce"]'
@@ -205,6 +203,7 @@ function initFormBuilder() {
 				formElement.appendChild(nonceField);
 			}
 			nonceField.value = designsetgoForm.ajaxNonce;
+			nonceField.defaultValue = nonceField.value;
 		}
 
 		function showRedirectStatus() {
@@ -212,6 +211,7 @@ function initFormBuilder() {
 			const status = params.get('dsgo_form_status');
 			const statusFormId = params.get('dsgo_form_id');
 			const matchesCurrentForm = !statusFormId || statusFormId === formId;
+			let shown = false;
 
 			if (
 				matchesCurrentForm &&
@@ -224,10 +224,8 @@ function initFormBuilder() {
 					'success'
 				);
 				formElement.reset();
-				return true;
-			}
-
-			if (
+				shown = true;
+			} else if (
 				matchesCurrentForm &&
 				(params.has('dsgo_form_error') || status === 'error')
 			) {
@@ -240,10 +238,20 @@ function initFormBuilder() {
 						),
 					'error'
 				);
-				return true;
+				shown = true;
 			}
 
-			return false;
+			// Strip form status params from URL to prevent stale messages on refresh
+			if (shown) {
+				const cleanUrl = new URL(window.location.href);
+				cleanUrl.searchParams.delete('dsgo_form_success');
+				cleanUrl.searchParams.delete('dsgo_form_error');
+				cleanUrl.searchParams.delete('dsgo_form_status');
+				cleanUrl.searchParams.delete('dsgo_form_id');
+				window.history.replaceState(null, '', cleanUrl.href);
+			}
+
+			return shown;
 		}
 
 		function markTransportBlocked(key) {
@@ -268,6 +276,25 @@ function initFormBuilder() {
 			if (turnstileTokenField) {
 				turnstileTokenField.value = turnstileToken || '';
 			}
+
+			// Build field type map so server can validate/sanitize correctly
+			const typeMap = {};
+			formElement.querySelectorAll('[data-field-type]').forEach((el) => {
+				if (el.name) {
+					typeMap[el.name] = el.getAttribute('data-field-type');
+				}
+			});
+			let typeMapField = formElement.querySelector(
+				'input[name="dsg_field_types"]'
+			);
+			if (!typeMapField) {
+				typeMapField = document.createElement('input');
+				typeMapField.type = 'hidden';
+				typeMapField.name = 'dsg_field_types';
+				formElement.appendChild(typeMapField);
+			}
+			typeMapField.value = JSON.stringify(typeMap);
+
 			window.HTMLFormElement.prototype.submit.call(formElement);
 		}
 

--- a/src/blocks/form-builder/view.js
+++ b/src/blocks/form-builder/view.js
@@ -8,7 +8,7 @@
 
 import { __ } from '@wordpress/i18n';
 
-/* global designsetgoForm, dsgoIntegrations */
+/* global designsetgoForm, dsgoIntegrations, sessionStorage */
 
 // Track Turnstile script loading state
 let turnstileScriptLoaded = false;
@@ -313,36 +313,69 @@ function initFormBuilder() {
 					turnstile_token: turnstileToken || '',
 				});
 
-				// Try REST API first, fall back to admin-ajax.php if rate-limited.
 				let result;
-				const restResponse = await fetch(designsetgoForm.restUrl, {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-						'X-WP-Nonce': designsetgoForm.nonce,
-					},
-					body: requestBody,
-				});
 
-				if (restResponse.status === 429) {
-					// REST API rate-limited (common on Cloudflare/GoDaddy).
-					// Retry via admin-ajax.php which is rarely rate-limited.
-					const ajaxUrl = new URL(designsetgoForm.ajaxUrl);
-					ajaxUrl.searchParams.set(
-						'action',
-						'designsetgo_form_submit'
-					);
-					ajaxUrl.searchParams.set(
-						'_ajax_nonce',
-						designsetgoForm.ajaxNonce
-					);
+				// Submit via admin-ajax (form-encoded) or REST API.
+				// Some hosts (GoDaddy/Cloudflare) block JSON POSTs entirely,
+				// so we use admin-ajax as primary when available, with REST
+				// as fallback. sessionStorage remembers if REST failed before
+				// to avoid wasting the rate limit window on a doomed request.
+				const useAjax =
+					designsetgoForm.ajaxUrl && designsetgoForm.ajaxNonce;
+				const restBlocked =
+					useAjax &&
+					typeof sessionStorage !== 'undefined' &&
+					sessionStorage.getItem('dsgo_rest_blocked') === '1';
 
-					// Use form-encoded POST — GoDaddy's gateway blocks
-					// application/json POSTs but allows form-encoded.
+				if (!restBlocked) {
+					// Try REST API first
+					const restResponse = await fetch(designsetgoForm.restUrl, {
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							'X-WP-Nonce': designsetgoForm.nonce,
+						},
+						body: requestBody,
+					});
+
+					if (restResponse.ok) {
+						result = await restResponse.json();
+					} else if (restResponse.status === 429 && useAjax) {
+						// Remember that REST is blocked for this session
+						try {
+							sessionStorage.setItem('dsgo_rest_blocked', '1');
+						} catch {
+							// sessionStorage may be unavailable
+						}
+						// Fall through to admin-ajax below
+					} else {
+						// Non-429 error from REST API
+						let serverMessage;
+						try {
+							const errorData = await restResponse.json();
+							serverMessage = errorData.message;
+						} catch {
+							// Response body isn't valid JSON
+						}
+
+						throw new Error(
+							serverMessage ||
+								__(
+									'The server returned an unexpected response. Please try again later.',
+									'designsetgo'
+								)
+						);
+					}
+				}
+
+				// Admin-ajax fallback (or primary if REST was blocked)
+				if (!result && useAjax) {
 					const ajaxBody = new URLSearchParams();
+					ajaxBody.set('action', 'designsetgo_form_submit');
+					ajaxBody.set('_ajax_nonce', designsetgoForm.ajaxNonce);
 					ajaxBody.set('form_data', requestBody);
 
-					const ajaxResponse = await fetch(ajaxUrl.href, {
+					const ajaxResponse = await fetch(designsetgoForm.ajaxUrl, {
 						method: 'POST',
 						headers: {
 							'Content-Type': 'application/x-www-form-urlencoded',
@@ -357,7 +390,7 @@ function initFormBuilder() {
 							ajaxMessage =
 								ajaxError.data?.message || ajaxError.message;
 						} catch {
-							// Non-JSON response from admin-ajax
+							// Non-JSON response
 						}
 
 						throw new Error(
@@ -370,27 +403,8 @@ function initFormBuilder() {
 					}
 
 					const ajaxResult = await ajaxResponse.json();
-					// wp_send_json_success wraps data in { success: true, data: {...} }
+					// wp_send_json_success wraps in { success, data }
 					result = ajaxResult.data;
-				} else if (!restResponse.ok) {
-					// Non-429 error from REST API
-					let serverMessage;
-					try {
-						const errorData = await restResponse.json();
-						serverMessage = errorData.message;
-					} catch {
-						// Response body isn't valid JSON (e.g. HTML from WAF)
-					}
-
-					throw new Error(
-						serverMessage ||
-							__(
-								'The server returned an unexpected response. Please try again later.',
-								'designsetgo'
-							)
-					);
-				} else {
-					result = await restResponse.json();
 				}
 
 				if (result.success) {

--- a/src/blocks/form-builder/view.js
+++ b/src/blocks/form-builder/view.js
@@ -337,12 +337,17 @@ function initFormBuilder() {
 						designsetgoForm.ajaxNonce
 					);
 
+					// Use form-encoded POST — GoDaddy's gateway blocks
+					// application/json POSTs but allows form-encoded.
+					const ajaxBody = new URLSearchParams();
+					ajaxBody.set('form_data', requestBody);
+
 					const ajaxResponse = await fetch(ajaxUrl.href, {
 						method: 'POST',
 						headers: {
-							'Content-Type': 'application/json',
+							'Content-Type': 'application/x-www-form-urlencoded',
 						},
-						body: requestBody,
+						body: ajaxBody.toString(),
 					});
 
 					if (!ajaxResponse.ok) {

--- a/src/blocks/form-builder/view.js
+++ b/src/blocks/form-builder/view.js
@@ -155,12 +155,57 @@ function initFormBuilder() {
 		const ajaxEnabled =
 			formContainer.getAttribute('data-ajax-submit') === 'true';
 
-		// If AJAX is not enabled, use standard form submission
+		// Non-AJAX: set up standard form POST to admin_post
 		if (!ajaxEnabled) {
+			formElement.action = designsetgoForm.ajaxUrl.replace(
+				'admin-ajax.php',
+				'admin-post.php'
+			);
+
+			// Add required hidden fields for admin_post handler
+			const actionField = document.createElement('input');
+			actionField.type = 'hidden';
+			actionField.name = 'action';
+			actionField.value = 'designsetgo_form_submit';
+			formElement.appendChild(actionField);
+
+			const nonceField = document.createElement('input');
+			nonceField.type = 'hidden';
+			nonceField.name = '_wpnonce';
+			nonceField.value = designsetgoForm.ajaxNonce;
+			formElement.appendChild(nonceField);
+
+			// Set timestamp on submit
+			formElement.addEventListener('submit', function () {
+				timestampField.value = Date.now();
+			});
+
+			// Check for success/error query params after redirect
+			const params = new URLSearchParams(window.location.search);
+			if (params.has('dsgo_form_success')) {
+				showMessage(
+					messageContainer,
+					formContainer.getAttribute('data-success-message') ||
+						__('Form submitted successfully!', 'designsetgo'),
+					'success'
+				);
+				formElement.reset();
+			} else if (params.has('dsgo_form_error')) {
+				showMessage(
+					messageContainer,
+					formContainer.getAttribute('data-error-message') ||
+						__(
+							'An error occurred. Please try again.',
+							'designsetgo'
+						),
+					'error'
+				);
+			}
+
 			return;
 		}
 
-		// Get form settings from data attributes (only if AJAX enabled)
+		// Get form settings from data attributes (AJAX-only)
 		const formId = formContainer.getAttribute('data-form-id');
 		const successMessage = formContainer.getAttribute(
 			'data-success-message'
@@ -226,40 +271,74 @@ function initFormBuilder() {
 			let redirecting = false;
 
 			try {
-				// Make AJAX request to WordPress REST API
-				const response = await fetch(designsetgoForm.restUrl, {
+				const requestBody = JSON.stringify({
+					formId,
+					fields,
+					honeypot: honeypot || '',
+					timestamp: timestamp || Date.now(),
+					// Include Turnstile token if available (graceful degradation: empty if failed)
+					turnstile_token: turnstileToken || '',
+				});
+
+				// Try REST API first, fall back to admin-ajax.php if rate-limited.
+				let result;
+				const restResponse = await fetch(designsetgoForm.restUrl, {
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',
 						'X-WP-Nonce': designsetgoForm.nonce,
 					},
-					body: JSON.stringify({
-						formId,
-						fields,
-						honeypot: honeypot || '',
-						timestamp: timestamp || Date.now(),
-						// Include Turnstile token if available (graceful degradation: empty if failed)
-						turnstile_token: turnstileToken || '',
-					}),
+					body: requestBody,
 				});
 
-				// Handle non-OK responses before parsing JSON.
-				// Some hosts (e.g. Cloudflare/GoDaddy) return HTML error pages
-				// with content-type: application/json, so we can't rely on headers alone.
-				if (!response.ok) {
-					if (response.status === 429) {
+				if (restResponse.status === 429) {
+					// REST API rate-limited (common on Cloudflare/GoDaddy).
+					// Retry via admin-ajax.php which is rarely rate-limited.
+					const ajaxUrl = new URL(designsetgoForm.ajaxUrl);
+					ajaxUrl.searchParams.set(
+						'action',
+						'designsetgo_form_submit'
+					);
+					ajaxUrl.searchParams.set(
+						'_ajax_nonce',
+						designsetgoForm.ajaxNonce
+					);
+
+					const ajaxResponse = await fetch(ajaxUrl.href, {
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+						},
+						body: requestBody,
+					});
+
+					if (!ajaxResponse.ok) {
+						let ajaxMessage;
+						try {
+							const ajaxError = await ajaxResponse.json();
+							ajaxMessage =
+								ajaxError.data?.message || ajaxError.message;
+						} catch {
+							// Non-JSON response from admin-ajax
+						}
+
 						throw new Error(
-							__(
-								'Too many requests. Please wait a moment and try again.',
-								'designsetgo'
-							)
+							ajaxMessage ||
+								__(
+									'The server returned an unexpected response. Please try again later.',
+									'designsetgo'
+								)
 						);
 					}
 
-					// Try to parse error JSON from WordPress REST API
+					const ajaxResult = await ajaxResponse.json();
+					// wp_send_json_success wraps data in { success: true, data: {...} }
+					result = ajaxResult.data;
+				} else if (!restResponse.ok) {
+					// Non-429 error from REST API
 					let serverMessage;
 					try {
-						const errorData = await response.json();
+						const errorData = await restResponse.json();
 						serverMessage = errorData.message;
 					} catch {
 						// Response body isn't valid JSON (e.g. HTML from WAF)
@@ -272,9 +351,9 @@ function initFormBuilder() {
 								'designsetgo'
 							)
 					);
+				} else {
+					result = await restResponse.json();
 				}
-
-				const result = await response.json();
 
 				if (result.success) {
 					// Fire custom event for tracking/analytics

--- a/src/blocks/form-builder/view.js
+++ b/src/blocks/form-builder/view.js
@@ -105,6 +105,14 @@ function initFormBuilder() {
 			typeof dsgoIntegrations !== 'undefined'
 				? dsgoIntegrations.turnstileSiteKey
 				: null;
+		let turnstileTokenField = null;
+
+		if (turnstileEnabled) {
+			turnstileTokenField = document.createElement('input');
+			turnstileTokenField.type = 'hidden';
+			turnstileTokenField.name = 'dsg_turnstile_token';
+			formElement.appendChild(turnstileTokenField);
+		}
 
 		// Initialize Turnstile if enabled
 		if (turnstileEnabled && turnstileContainer && turnstileSiteKey) {
@@ -123,9 +131,15 @@ function initFormBuilder() {
 							// Mode (managed/non-interactive/invisible) is configured in Cloudflare dashboard
 							callback: (token) => {
 								turnstileToken = token;
+								if (turnstileTokenField) {
+									turnstileTokenField.value = token;
+								}
 							},
 							'expired-callback': () => {
 								turnstileToken = null;
+								if (turnstileTokenField) {
+									turnstileTokenField.value = '';
+								}
 								// Reset widget for new token
 								if (
 									turnstileWidgetId !== null &&
@@ -135,6 +149,10 @@ function initFormBuilder() {
 								}
 							},
 							'error-callback': () => {
+								turnstileToken = null;
+								if (turnstileTokenField) {
+									turnstileTokenField.value = '';
+								}
 								// Graceful degradation - form will submit without Turnstile token
 								// eslint-disable-next-line no-console -- Log for debugging
 								console.warn(
@@ -145,11 +163,17 @@ function initFormBuilder() {
 					);
 				})
 				.catch((error) => {
+					turnstileToken = null;
+					if (turnstileTokenField) {
+						turnstileTokenField.value = '';
+					}
 					// Graceful degradation - form will submit without Turnstile token
 					// eslint-disable-next-line no-console -- Log for debugging
 					console.warn('Turnstile failed to load:', error.message);
 				});
 		}
+
+		const formId = formContainer.getAttribute('data-form-id');
 
 		// Check if AJAX is enabled
 		const ajaxEnabled =
@@ -182,7 +206,14 @@ function initFormBuilder() {
 
 			// Check for success/error query params after redirect
 			const params = new URLSearchParams(window.location.search);
-			if (params.has('dsgo_form_success')) {
+			const status = params.get('dsgo_form_status');
+			const statusFormId = params.get('dsgo_form_id');
+			const matchesCurrentForm = !statusFormId || statusFormId === formId;
+
+			if (
+				matchesCurrentForm &&
+				(params.has('dsgo_form_success') || status === 'success')
+			) {
 				showMessage(
 					messageContainer,
 					formContainer.getAttribute('data-success-message') ||
@@ -190,7 +221,10 @@ function initFormBuilder() {
 					'success'
 				);
 				formElement.reset();
-			} else if (params.has('dsgo_form_error')) {
+			} else if (
+				matchesCurrentForm &&
+				(params.has('dsgo_form_error') || status === 'error')
+			) {
 				showMessage(
 					messageContainer,
 					formContainer.getAttribute('data-error-message') ||
@@ -205,8 +239,6 @@ function initFormBuilder() {
 			return;
 		}
 
-		// Get form settings from data attributes (AJAX-only)
-		const formId = formContainer.getAttribute('data-form-id');
 		const successMessage = formContainer.getAttribute(
 			'data-success-message'
 		);
@@ -244,7 +276,8 @@ function initFormBuilder() {
 				if (
 					name === 'dsg_website' ||
 					name === 'dsg_form_id' ||
-					name === 'dsg_timestamp'
+					name === 'dsg_timestamp' ||
+					name === 'dsg_turnstile_token'
 				) {
 					continue;
 				}
@@ -383,6 +416,13 @@ function initFormBuilder() {
 
 					// Reset form
 					formElement.reset();
+					turnstileToken = null;
+					if (turnstileTokenField) {
+						turnstileTokenField.value = '';
+					}
+					if (turnstileWidgetId !== null && window.turnstile) {
+						window.turnstile.reset(turnstileWidgetId);
+					}
 
 					// Scroll to message if not visible
 					if (!isElementInViewport(messageContainer)) {

--- a/tests/phpunit/form-handler-test.php
+++ b/tests/phpunit/form-handler-test.php
@@ -566,6 +566,78 @@ class Test_Form_Handler extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_form_field_types reads server-side field definitions.
+	 */
+	public function test_get_form_field_types_finds_known_fields() {
+		$form_id = 'fieldtypes1';
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_title'   => 'Test Field Types Form',
+				'post_content' => '<!-- wp:designsetgo/form-builder {"formId":"' . $form_id . '"} --><div class="wp-block-designsetgo-form-builder"><!-- wp:designsetgo/form-email-field {"fieldName":"email"} /--><!-- wp:designsetgo/form-textarea-field {"fieldName":"message"} /--><!-- wp:designsetgo/form-phone-field {"fieldName":"phone"} /--><!-- wp:designsetgo/form-checkbox-field {"fieldName":"consent"} /--></div><!-- /wp:designsetgo/form-builder -->',
+			)
+		);
+
+		$this->assertNotWPError( $post_id );
+		delete_transient( 'dsgo_form_field_types_' . md5( $form_id ) );
+
+		$field_types = $this->call_private_method( 'get_form_field_types', array( $form_id ) );
+
+		$this->assertEquals(
+			array(
+				'email'   => 'email',
+				'message' => 'textarea',
+				'phone'   => 'tel',
+				'consent' => 'checkbox',
+			),
+			$field_types
+		);
+
+		wp_delete_post( $post_id, true );
+		delete_transient( 'dsgo_form_field_types_' . md5( $form_id ) );
+	}
+
+	/**
+	 * Test server-side field definitions override client-supplied field types.
+	 */
+	public function test_server_field_types_override_client_types() {
+		$form_id = 'typedoverride1';
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_title'   => 'Typed Override Form',
+				'post_content' => '<!-- wp:designsetgo/form-builder {"formId":"' . $form_id . '"} --><div class="wp-block-designsetgo-form-builder"><!-- wp:designsetgo/form-email-field {"fieldName":"email"} /--></div><!-- /wp:designsetgo/form-builder -->',
+			)
+		);
+
+		$this->assertNotWPError( $post_id );
+		delete_transient( 'dsgo_form_field_types_' . md5( $form_id ) );
+
+		$request = new WP_REST_Request( 'POST', '/designsetgo/v1/form/submit' );
+		$request->set_body_params(
+			array(
+				'formId' => $form_id,
+				'fields' => array(
+					array(
+						'name'  => 'email',
+						'value' => 'not-an-email',
+						'type'  => 'text',
+					),
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+
+		wp_delete_post( $post_id, true );
+		delete_transient( 'dsgo_form_field_types_' . md5( $form_id ) );
+	}
+
+	/**
 	 * Test get_form_block_attributes uses transient cache.
 	 */
 	public function test_form_block_attributes_are_cached() {


### PR DESCRIPTION
## What Changed
This PR hardens the form submission fallback paths for hosts that rate-limit or otherwise interfere with the REST API.

It now:
- falls back from the REST endpoint to `admin-ajax.php` when the REST request is rate-limited
- supports non-AJAX form submission through `admin-post.php`
- preserves Turnstile verification across both AJAX and non-AJAX submission paths
- scopes redirect-based success and error messaging to the form that was actually submitted
- aligns generated phone field metadata with the runtime validator by using `tel`
- adds PHPUnit coverage for server-side field type resolution and client type spoofing protection

## Why
Some environments were blocking or rate-limiting `/wp-json/`, which made otherwise valid forms fail. The fallback path fixed the transport problem, but it still had edge cases:
- non-AJAX submissions were not carrying the Turnstile token
- redirect-based messaging could affect every form on the page instead of the submitted one
- phone field metadata was inconsistent between generated HTML and the main form runtime
- the server needed explicit test coverage proving that saved form definitions win over client-submitted field types

## Impact
Users get a more reliable form experience on restrictive hosts, and form validation/security behavior is now more consistent across transport modes.

For developers:
- non-AJAX submissions now pass the Turnstile token through the standard handler
- form status redirects include the form id so multi-form pages behave correctly
- server-side validation continues to rely on the saved form definition rather than trusting client field types

## Validation
I validated this with:
- `npm run lint:js`
- `composer run-script lint`
- `npm run build`

Full PHPUnit execution is still blocked locally because the WordPress test suite is only configured through `wp-env`, and `wp-env` could not run in this shell because Docker is not running.
