### PR TITLE
fix: slider editor navigation fails in iframed editor

### DIFF
--- a/src/blocks/slider/edit.js
+++ b/src/blocks/slider/edit.js
@@ -74,7 +74,7 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
 	const requiresSingleSlideEffect = SINGLE_SLIDE_EFFECTS.includes(effect);
 
-	const blockRef = useRef();
+	const blockRef = useRef(null);
 
 	// Get actual slide count for dynamic dot navigation
 	const slideCount = useSelect(
@@ -118,7 +118,10 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 		}
 
 		const slideWidth = slide.offsetWidth;
-		const gapValue = parseFloat(window.getComputedStyle(track).gap) || 0;
+		const gapValue =
+			parseFloat(
+				track.ownerDocument.defaultView.getComputedStyle(track).gap
+			) || 0;
 		const scrollAmount = slideWidth + gapValue;
 
 		track.scrollBy({
@@ -139,7 +142,10 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 		}
 
 		const slideWidth = slide.offsetWidth;
-		const gapValue = parseFloat(window.getComputedStyle(track).gap) || 0;
+		const gapValue =
+			parseFloat(
+				track.ownerDocument.defaultView.getComputedStyle(track).gap
+			) || 0;
 		const scrollPosition = index * (slideWidth + gapValue);
 
 		track.scrollTo({

--- a/src/blocks/slider/edit.js
+++ b/src/blocks/slider/edit.js
@@ -1,5 +1,5 @@
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import {
 	useBlockProps,
 	useInnerBlocksProps,
@@ -74,6 +74,8 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
 	const requiresSingleSlideEffect = SINGLE_SLIDE_EFFECTS.includes(effect);
 
+	const blockRef = useRef();
+
 	// Get actual slide count for dynamic dot navigation
 	const slideCount = useSelect(
 		(select) => select('core/block-editor').getBlockCount(clientId),
@@ -103,11 +105,9 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 		setAttributes,
 	]);
 
-	// Editor navigation: scroll the track without state management
+	// Editor navigation: scroll the track using a ref (works inside iframed editor)
 	const scrollToSlide = (direction) => {
-		const track = document.querySelector(
-			`[data-block="${clientId}"] .dsgo-slider__track`
-		);
+		const track = blockRef.current?.querySelector('.dsgo-slider__track');
 		if (!track) {
 			return;
 		}
@@ -128,9 +128,7 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 	};
 
 	const scrollToSlideIndex = (index) => {
-		const track = document.querySelector(
-			`[data-block="${clientId}"] .dsgo-slider__track`
-		);
+		const track = blockRef.current?.querySelector('.dsgo-slider__track');
 		if (!track) {
 			return;
 		}
@@ -215,6 +213,7 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 	// Block wrapper props
 	// Data attributes for JavaScript configuration and CSS selectors (match save.js)
 	const blockProps = useBlockProps({
+		ref: blockRef,
 		className: sliderClasses,
 		style: customStyles,
 		'data-slides-per-view': effectiveSlidesPerView,


### PR DESCRIPTION
## Summary
- Slider arrow/dot buttons were clickable (pointer-events fix from #341) but scrolling never happened
- Root cause: `scrollToSlide()` and `scrollToSlideIndex()` used `document.querySelector()` which searches the **main document**, but WordPress 6.x+ renders block content inside an iframe — the track element lives in a different DOM tree
- Fix: use `useRef()` attached to the block wrapper via `useBlockProps({ ref: blockRef })`, then query within `blockRef.current` instead of `document`

## Test plan
- [ ] Add a slider block with 3+ slides in the editor
- [ ] Click the next arrow — slides should scroll
- [ ] Click the prev arrow — slides should scroll back
- [ ] Click a dot — should jump to that slide
- [ ] Publish and verify frontend navigation still works
- [ ] `npm run build` passes
- [ ] `npm run lint:js` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)