### PR TITLE
fix(forms): apply block.json defaults when reading form attrs server-side

### DIFF
--- a/includes/blocks/class-form-handler.php
+++ b/includes/blocks/class-form-handler.php
@@ -940,7 +940,9 @@ class Form_Handler {
 	 */
 	private function get_form_block_attributes( $form_id ) {
 		// Check transient cache first to avoid LIKE queries on every submission.
-		$cache_key = 'dsgo_form_attrs_' . md5( $form_id );
+		// v2 prefix invalidates older caches that were stored before block-type
+		// defaults were merged into parsed attributes.
+		$cache_key = 'dsgo_form_attrs_v2_' . md5( $form_id );
 		$cached    = get_transient( $cache_key );
 
 		if ( false !== $cached ) {
@@ -996,7 +998,12 @@ class Form_Handler {
 				isset( $block['attrs']['formId'] ) &&
 				$block['attrs']['formId'] === $form_id
 			) {
-				return $block['attrs'];
+				// parse_blocks() returns only the attributes that were serialized into
+				// the block comment. The editor omits attributes that equal their
+				// declared default, so booleans like `enableEmail` (default true) and
+				// similar may be missing here. Merge in the block-type defaults so
+				// server-side consumers see the same attribute set the editor does.
+				return $this->apply_form_block_defaults( $block['attrs'] );
 			}
 
 			if ( ! empty( $block['innerBlocks'] ) ) {
@@ -1008,6 +1015,34 @@ class Form_Handler {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Merge registered block-type attribute defaults into a parsed attributes array.
+	 *
+	 * @param array $attrs Parsed block attributes from parse_blocks().
+	 * @return array Attributes with block.json defaults filled in for missing keys.
+	 */
+	private function apply_form_block_defaults( $attrs ) {
+		if ( ! class_exists( '\WP_Block_Type_Registry' ) ) {
+			return $attrs;
+		}
+
+		$block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'designsetgo/form-builder' );
+		if ( ! $block_type || ! is_array( $block_type->attributes ) ) {
+			return $attrs;
+		}
+
+		foreach ( $block_type->attributes as $key => $schema ) {
+			if ( array_key_exists( $key, $attrs ) ) {
+				continue;
+			}
+			if ( is_array( $schema ) && array_key_exists( 'default', $schema ) ) {
+				$attrs[ $key ] = $schema['default'];
+			}
+		}
+
+		return $attrs;
 	}
 
 	/**
@@ -1192,7 +1227,7 @@ class Form_Handler {
 				'designsetgo/form-builder' === $block['blockName'] &&
 				isset( $block['attrs']['formId'] )
 			) {
-				delete_transient( 'dsgo_form_attrs_' . md5( $block['attrs']['formId'] ) );
+				delete_transient( 'dsgo_form_attrs_v2_' . md5( $block['attrs']['formId'] ) );
 				delete_transient( 'dsgo_form_field_types_' . md5( $block['attrs']['formId'] ) );
 			}
 

--- a/tests/phpunit/form-handler-test.php
+++ b/tests/phpunit/form-handler-test.php
@@ -502,6 +502,47 @@ class Test_Form_Handler extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that block.json defaults are merged into parsed attributes.
+	 *
+	 * parse_blocks() only returns attributes serialized into the block comment.
+	 * The editor omits attributes whose value equals the block.json default, so
+	 * server-side consumers must merge defaults back in. Regression guard for
+	 * the "emails never send" bug where enableEmail (default true) was absent
+	 * from $block_attrs and the empty() guard bailed before wp_mail().
+	 */
+	public function test_get_form_block_attributes_merges_block_json_defaults() {
+		$form_id = 'defaults1';
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_title'   => 'Test Defaults Form',
+				// Bare formId only — no enableEmail, no emailSubject, etc.
+				'post_content' => '<!-- wp:designsetgo/form-builder {"formId":"' . $form_id . '"} --><div class="wp-block-designsetgo-form-builder"></div><!-- /wp:designsetgo/form-builder -->',
+			)
+		);
+
+		$this->assertNotWPError( $post_id );
+		delete_transient( 'dsgo_form_attrs_v2_' . md5( $form_id ) );
+
+		$attrs = $this->call_private_method( 'get_form_block_attributes', array( $form_id ) );
+
+		$this->assertNotNull( $attrs );
+		$this->assertArrayHasKey( 'enableEmail', $attrs, 'enableEmail default must be filled in when absent from block comment' );
+		$this->assertTrue( $attrs['enableEmail'], 'enableEmail default per block.json is true' );
+		$this->assertArrayHasKey( 'emailSubject', $attrs );
+		$this->assertEquals( 'New Form Submission', $attrs['emailSubject'] );
+		$this->assertArrayHasKey( 'enableHoneypot', $attrs );
+		$this->assertTrue( $attrs['enableHoneypot'] );
+		$this->assertArrayHasKey( 'enableTurnstile', $attrs );
+		$this->assertFalse( $attrs['enableTurnstile'], 'false defaults must also be filled in (not just truthy ones)' );
+
+		// Cleanup.
+		wp_delete_post( $post_id, true );
+		delete_transient( 'dsgo_form_attrs_v2_' . md5( $form_id ) );
+	}
+
+	/**
 	 * Test get_form_block_attributes returns null for non-existent form.
 	 */
 	public function test_get_form_block_attributes_returns_null_for_missing() {
@@ -519,13 +560,16 @@ class Test_Form_Handler extends WP_UnitTestCase {
 	public function test_client_email_params_are_ignored() {
 		$form_id = 'noemail1';
 
-		// Create form WITHOUT email enabled.
+		// Create form with email explicitly disabled. enableEmail must be set to
+		// false on the block because its block.json default is true, and
+		// apply_form_block_defaults() now fills the default in server-side when
+		// the attribute is omitted from the serialized block comment.
 		$post_id = wp_insert_post(
 			array(
 				'post_type'    => 'page',
 				'post_status'  => 'publish',
 				'post_title'   => 'Test No Email Form',
-				'post_content' => '<!-- wp:designsetgo/form-builder {"formId":"' . $form_id . '"} --><div class="wp-block-designsetgo-form-builder"></div><!-- /wp:designsetgo/form-builder -->',
+				'post_content' => '<!-- wp:designsetgo/form-builder {"formId":"' . $form_id . '","enableEmail":false} --><div class="wp-block-designsetgo-form-builder"></div><!-- /wp:designsetgo/form-builder -->',
 			)
 		);
 
@@ -555,7 +599,7 @@ class Test_Form_Handler extends WP_UnitTestCase {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertTrue( $data['success'] );
 
-		// Email should NOT have been sent (enableEmail is not set in block attrs).
+		// Email should NOT have been sent (enableEmail is explicitly false in block attrs).
 		$email_sent = get_post_meta( $data['submissionId'], '_dsg_email_sent', true );
 		$this->assertEmpty( $email_sent, 'Email must not be sent when enableEmail is false in block attributes' );
 

--- a/tests/phpunit/form-handler-test.php
+++ b/tests/phpunit/form-handler-test.php
@@ -487,7 +487,7 @@ class Test_Form_Handler extends WP_UnitTestCase {
 		$this->assertNotWPError( $post_id );
 
 		// Clear any cached transient from the insert.
-		delete_transient( 'dsgo_form_attrs_' . md5( $form_id ) );
+		delete_transient( 'dsgo_form_attrs_v2_' . md5( $form_id ) );
 
 		$attrs = $this->call_private_method( 'get_form_block_attributes', array( $form_id ) );
 
@@ -498,7 +498,7 @@ class Test_Form_Handler extends WP_UnitTestCase {
 
 		// Cleanup.
 		wp_delete_post( $post_id, true );
-		delete_transient( 'dsgo_form_attrs_' . md5( $form_id ) );
+		delete_transient( 'dsgo_form_attrs_v2_' . md5( $form_id ) );
 	}
 
 	/**
@@ -530,7 +530,7 @@ class Test_Form_Handler extends WP_UnitTestCase {
 		);
 
 		$this->assertNotWPError( $post_id );
-		delete_transient( 'dsgo_form_attrs_' . md5( $form_id ) );
+		delete_transient( 'dsgo_form_attrs_v2_' . md5( $form_id ) );
 
 		// Submit with client-supplied email params (should be ignored by server).
 		$request = new WP_REST_Request( 'POST', '/designsetgo/v1/form/submit' );
@@ -562,7 +562,7 @@ class Test_Form_Handler extends WP_UnitTestCase {
 		// Cleanup.
 		wp_delete_post( $post_id, true );
 		wp_delete_post( $data['submissionId'], true );
-		delete_transient( 'dsgo_form_attrs_' . md5( $form_id ) );
+		delete_transient( 'dsgo_form_attrs_v2_' . md5( $form_id ) );
 	}
 
 	/**
@@ -642,7 +642,7 @@ class Test_Form_Handler extends WP_UnitTestCase {
 	 */
 	public function test_form_block_attributes_are_cached() {
 		$form_id   = 'cachetest';
-		$cache_key = 'dsgo_form_attrs_' . md5( $form_id );
+		$cache_key = 'dsgo_form_attrs_v2_' . md5( $form_id );
 
 		// Seed the transient cache directly.
 		$fake_attrs = array(


### PR DESCRIPTION
## Summary

Contact form submissions on production silently stopped sending admin-notification emails. Every submission recorded `_dsg_email_sent` as missing (`—` in the admin list), meaning `wp_mail()` was never called.

**Root cause:** `parse_blocks()` only returns attributes that were serialized into the block comment, and the editor omits any attribute equal to its declared default. `enableEmail` defaults to `true` in [src/blocks/form-builder/block.json](../blob/main/src/blocks/form-builder/block.json#L132-L134), so the key was absent from `$block_attrs` for any form left at default settings. The guard in [class-form-handler.php:699](../blob/main/includes/blocks/class-form-handler.php#L699) — `empty( $block_attrs['enableEmail'] )` — returned early, before `wp_mail()` or any meta write. Introduced by #240 (server-side email config); client-side code previously relied on React attribute defaults, so the regression only manifested on the server.

## Fix

- Merge registered block-type defaults into parsed attributes inside `find_form_block_attributes()` via a new `apply_form_block_defaults()` helper. All three server-side consumers (rate-limit at line 249, Turnstile check, email notification at line 697) now see the same attribute set the editor does.
- Fully-qualified `\WP_Block_Type_Registry` to avoid namespace resolution in `DesignSetGo\Blocks`.
- Bumped the form-attrs transient cache prefix to `dsgo_form_attrs_v2_` so stale pre-fix caches are invalidated automatically on deploy (no manual transient flush required). Updated `invalidate_form_block_transients()` and the corresponding test references.

## Test plan

- [x] `php -l` clean on modified files
- [x] `composer run lint` passes (79/79)
- [x] Manual end-to-end verification on designsetgoblocks.com — submission #2036 recorded `_dsg_email_sent=yes` with `To: justnealey@gmail.com` and `wp_mail()` returned true (confirmed in admin submission detail)
- [ ] Run `tests/phpunit/form-handler-test.php` in CI (cache-key assertions updated to v2 prefix)
- [ ] Smoke check a form with `enableEmail` explicitly toggled off still skips sending (backward-compat path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)