### PR TITLE
feat(image-accordion): inline image upload and click-to-expand editor UX

### DIFF
--- a/src/blocks/image-accordion-item/block.json
+++ b/src/blocks/image-accordion-item/block.json
@@ -87,9 +87,9 @@
 		},
 		"background": {
 			"backgroundImage": true,
-			"backgroundSize": true,
+			"backgroundSize": false,
 			"backgroundPosition": true,
-			"backgroundRepeat": true,
+			"backgroundRepeat": false,
 			"__experimentalDefaultControls": {
 				"backgroundImage": true
 			}

--- a/src/blocks/image-accordion-item/edit.js
+++ b/src/blocks/image-accordion-item/edit.js
@@ -3,9 +3,12 @@ import {
 	useBlockProps,
 	useInnerBlocksProps,
 	InspectorControls,
+	BlockControls,
+	MediaReplaceFlow,
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
-import { PanelBody, SelectControl } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { PanelBody, SelectControl, ToolbarGroup } from '@wordpress/components';
 import classnames from 'classnames';
 import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
 
@@ -13,8 +16,44 @@ export default function ImageAccordionItemEdit({
 	attributes,
 	setAttributes,
 	context,
+	clientId,
+	isSelected,
 }) {
-	const { uniqueId, verticalAlignment, horizontalAlignment } = attributes;
+	const { uniqueId, verticalAlignment, horizontalAlignment, style } =
+		attributes;
+
+	// Expand when this item (or any of its inner blocks) is selected so the
+	// inline toolbar and content editing stay stable — hover-based expansion
+	// collapsed the item when the cursor moved to the toolbar.
+	const hasChildSelected = useSelect(
+		(select) =>
+			select('core/block-editor').hasSelectedInnerBlock(clientId, true),
+		[clientId]
+	);
+	const isExpanded = isSelected || hasChildSelected;
+
+	const backgroundImage = style?.background?.backgroundImage;
+	const mediaUrl = backgroundImage?.url || '';
+	const mediaId = backgroundImage?.id;
+
+	const onSelectMedia = (media) => {
+		if (!media?.url) {
+			return;
+		}
+		setAttributes({
+			style: {
+				...(style || {}),
+				background: {
+					...(style?.background || {}),
+					backgroundImage: {
+						url: media.url,
+						id: media.id,
+						source: 'file',
+					},
+				},
+			},
+		});
+	};
 
 	// Get context from parent accordion
 	const enableOverlay =
@@ -40,6 +79,7 @@ export default function ImageAccordionItemEdit({
 	// Declaratively calculate classes
 	const itemClasses = classnames('dsgo-image-accordion-item', {
 		'dsgo-image-accordion-item--has-overlay': enableOverlay,
+		'is-expanded': isExpanded,
 	});
 
 	// Apply overlay and alignment as inline styles
@@ -89,6 +129,23 @@ export default function ImageAccordionItemEdit({
 
 	return (
 		<>
+			<BlockControls group="other">
+				<ToolbarGroup>
+					<MediaReplaceFlow
+						mediaId={mediaId}
+						mediaURL={mediaUrl}
+						allowedTypes={['image']}
+						accept="image/*"
+						onSelect={onSelectMedia}
+						name={
+							mediaUrl
+								? __('Replace', 'designsetgo')
+								: __('Add image', 'designsetgo')
+						}
+					/>
+				</ToolbarGroup>
+			</BlockControls>
+
 			<InspectorControls>
 				<PanelBody
 					title={__('Content Alignment', 'designsetgo')}

--- a/src/blocks/image-accordion-item/edit.js
+++ b/src/blocks/image-accordion-item/edit.js
@@ -55,6 +55,18 @@ export default function ImageAccordionItemEdit({
 		});
 	};
 
+	const onRemoveMedia = () => {
+		setAttributes({
+			style: {
+				...(style || {}),
+				background: {
+					...(style?.background || {}),
+					backgroundImage: undefined,
+				},
+			},
+		});
+	};
+
 	// Get context from parent accordion
 	const enableOverlay =
 		context['designsetgo/imageAccordion/enableOverlay'] !== undefined
@@ -137,6 +149,7 @@ export default function ImageAccordionItemEdit({
 						allowedTypes={['image']}
 						accept="image/*"
 						onSelect={onSelectMedia}
+						onReset={mediaUrl ? onRemoveMedia : undefined}
 						name={
 							mediaUrl
 								? __('Replace', 'designsetgo')

--- a/src/blocks/image-accordion-item/editor.scss
+++ b/src/blocks/image-accordion-item/editor.scss
@@ -11,10 +11,11 @@
 	overflow: hidden;
 	min-height: 200px;
 
-	// Background image handling (WordPress adds this automatically)
-	background-size: cover;
+	// Background image must always cover the item regardless of what the Styles
+	// panel sets inline — allowing `auto`/`contain` breaks the accordion layout.
+	background-size: cover !important;
 	background-position: center;
-	background-repeat: no-repeat;
+	background-repeat: no-repeat !important;
 
 	// Overlay (pseudo-element) - same as frontend
 	&--has-overlay::before {
@@ -54,24 +55,6 @@
 		a {
 			text-decoration: underline;
 		}
-	}
-
-	// Editor-specific: Show placeholder when no background image
-	&:not([style*="background-image"])::after {
-		content: 'Add background image in Styles panel →';
-		position: absolute;
-		top: 50%;
-		left: 50%;
-		transform: translate(-50%, -50%);
-		background: rgba(0, 0, 0, 0.8);
-		color: #fff;
-		padding: 12px 20px;
-		border-radius: 8px;
-		font-size: 14px;
-		text-align: center;
-		z-index: 3;
-		pointer-events: none;
-		white-space: nowrap;
 	}
 
 	// Border for better visibility in editor

--- a/src/blocks/image-accordion-item/style.scss
+++ b/src/blocks/image-accordion-item/style.scss
@@ -14,10 +14,11 @@
 	// Smooth transition on flex property
 	transition: flex var(--transition-duration, 0.5s) cubic-bezier(0.4, 0, 0.2, 1);
 
-	// Background image handling (WordPress adds this automatically)
-	background-size: cover;
+	// Background image must always cover the item regardless of what the Styles
+	// panel sets inline — allowing `auto`/`contain` breaks the accordion layout.
+	background-size: cover !important;
 	background-position: center;
-	background-repeat: no-repeat;
+	background-repeat: no-repeat !important;
 
 	// Overlay (pseudo-element)
 	&--has-overlay::before {

--- a/src/blocks/image-accordion/editor.scss
+++ b/src/blocks/image-accordion/editor.scss
@@ -18,13 +18,11 @@
 	}
 
 	.dsgo-image-accordion-item {
-		position: relative;
+		// Higher-specificity baseline so the is-expanded override below beats
+		// the `flex: 1` set on the item in its own editor.scss. All other
+		// base properties live on the item itself.
 		flex: 1;
-		overflow: hidden;
-		transition: flex var(--transition-duration, 0.5s) cubic-bezier(0.4, 0, 0.2, 1);
 
-		// Bump specificity so the is-expanded rule from style.scss wins over
-		// the editor's `flex: 1` baseline above.
 		&.is-expanded {
 			flex: var(--expanded-ratio, 3);
 		}

--- a/src/blocks/image-accordion/editor.scss
+++ b/src/blocks/image-accordion/editor.scss
@@ -4,9 +4,11 @@
  * Editor-specific styles only - main styles in style.scss
  */
 
-// Editor: Enable hover animations
+// Editor layout — expansion is driven by block selection (see edit.js), not
+// hover. Hovering previously conflicted with inline-toolbar interactions
+// because moving to the toolbar collapsed the item.
 .editor-styles-wrapper .dsgo-image-accordion {
-	// Items container needs to be flex for hover to work
+
 	.dsgo-image-accordion__items {
 		display: flex;
 		flex-direction: row;
@@ -15,39 +17,16 @@
 		height: 500px; // Fixed height for editor preview
 	}
 
-	// Each item
 	.dsgo-image-accordion-item {
 		position: relative;
 		flex: 1;
 		overflow: hidden;
 		transition: flex var(--transition-duration, 0.5s) cubic-bezier(0.4, 0, 0.2, 1);
 
-		// Hover: expand this item, keep siblings normal size
-		&:hover {
+		// Bump specificity so the is-expanded rule from style.scss wins over
+		// the editor's `flex: 1` baseline above.
+		&.is-expanded {
 			flex: var(--expanded-ratio, 3);
-
-			// Reduce overlay on hover
-			&.dsgo-image-accordion-item--has-overlay::before {
-				opacity: var(--dsgo-overlay-opacity-expanded, 0.2);
-			}
-
-			// Increase content opacity on hover
-			.dsgo-image-accordion-item__content {
-				opacity: 1;
-			}
-
-			// Siblings stay normal size
-			~ .dsgo-image-accordion-item {
-				flex: 1;
-
-				&.dsgo-image-accordion-item--has-overlay::before {
-					opacity: calc(var(--dsgo-overlay-opacity, 0.4) + 0.2);
-				}
-
-				.dsgo-image-accordion-item__content {
-					opacity: 0.7;
-				}
-			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a **MediaReplaceFlow** button to the image-accordion-item block toolbar so users can add/replace the background image without opening the Styles panel. Writes to the same `style.background.backgroundImage` attribute, so both controls stay in sync.
- Replaces hover-to-expand in the editor with **selection-driven expansion**: clicking an item (or any of its inner blocks) expands it. Hover was colliding with the inline toolbar — moving the cursor to the toolbar collapsed the item, which then jumped the toolbar out from under the cursor.
- Removes the "Add background image in Styles panel →" placeholder badge that was covering every item.
- Forces `background-size: cover` and `background-repeat: no-repeat` via `!important` so values set in the Styles panel (e.g. `auto`) can't break the accordion layout — this was making the image appear as a small square in the expanded item.

## Test plan

- [ ] Insert an Image Accordion; each item shows no placeholder badge
- [ ] Select an item → item expands, siblings shrink; toolbar stays stable while mousing to it
- [ ] Click a child heading/paragraph inside an item → parent item stays expanded
- [ ] Click "Add image" in the toolbar → popover shows Upload / Open Media Library
- [ ] Pick an image → it fills the full item (cover), overlay covers the full item
- [ ] Toolbar label changes from "Add image" to "Replace" once an image is set
- [ ] Changing background size in the Styles panel still renders as cover on both editor and frontend
- [ ] Frontend behavior unchanged — hover still expands, overlay still covers

🤖 Generated with [Claude Code](https://claude.com/claude-code)