### PR TITLE
feat(blocks): editor UX pass — appenders, navigators, and wizards

### DIFF
--- a/docs/audits/BLOCK-EDITOR-UIUX-AUDIT.md
+++ b/docs/audits/BLOCK-EDITOR-UIUX-AUDIT.md
@@ -33,10 +33,10 @@ These three are the clearest usability regressions because they block the author
 
 Relevant files:
 
-- [slider/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/slider/edit.js#L240)
-- [slider/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/slider/edit.js#L363)
-- [advanced-heading/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/advanced-heading/edit.js#L62)
-- [reveal/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/reveal/edit.js#L26)
+- [slider/edit.js](src/blocks/slider/edit.js#L240)
+- [slider/edit.js](src/blocks/slider/edit.js#L363)
+- [advanced-heading/edit.js](src/blocks/advanced-heading/edit.js#L62)
+- [reveal/edit.js](src/blocks/reveal/edit.js#L26)
 
 ### 2. `Section` and `Row` auto-transform too aggressively
 
@@ -52,8 +52,8 @@ This should become:
 
 Relevant files:
 
-- [section/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/section/edit.js#L163)
-- [row/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/row/edit.js#L121)
+- [section/edit.js](src/blocks/section/edit.js#L163)
+- [row/edit.js](src/blocks/row/edit.js#L121)
 
 ### 3. The plugin already contains good onboarding patterns, but only for some blocks
 
@@ -69,11 +69,11 @@ These blocks use template choosers, placeholders, or setup states well. That pat
 
 Relevant files:
 
-- [ModalPlaceholder.js](/Users/jnealey/github-local/designsetgo/src/blocks/modal/components/ModalPlaceholder.js#L35)
-- [StickySectionsPlaceholder.js](/Users/jnealey/github-local/designsetgo/src/blocks/sticky-sections/components/StickySectionsPlaceholder.js#L30)
-- [ScrollSlidesPlaceholder.js](/Users/jnealey/github-local/designsetgo/src/blocks/scroll-slides/components/ScrollSlidesPlaceholder.js#L30)
-- [product-categories-grid/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/product-categories-grid/edit.js#L253)
-- [product-showcase-hero/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/product-showcase-hero/edit.js#L258)
+- [ModalPlaceholder.js](src/blocks/modal/components/ModalPlaceholder.js#L35)
+- [StickySectionsPlaceholder.js](src/blocks/sticky-sections/components/StickySectionsPlaceholder.js#L30)
+- [ScrollSlidesPlaceholder.js](src/blocks/scroll-slides/components/ScrollSlidesPlaceholder.js#L30)
+- [product-categories-grid/edit.js](src/blocks/product-categories-grid/edit.js#L253)
+- [product-showcase-hero/edit.js](src/blocks/product-showcase-hero/edit.js#L258)
 
 ### 4. Some of the most powerful blocks are too sidebar-driven
 
@@ -94,11 +94,11 @@ These should move toward:
 
 Relevant files:
 
-- [slider/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/slider/edit.js#L367)
-- [form-builder/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/form-builder/edit.js#L200)
-- [comparison-table/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/comparison-table/edit.js#L364)
-- [modal/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/modal/edit.js#L139)
-- [card/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/card/edit.js#L72)
+- [slider/edit.js](src/blocks/slider/edit.js#L367)
+- [form-builder/edit.js](src/blocks/form-builder/edit.js#L200)
+- [comparison-table/edit.js](src/blocks/comparison-table/edit.js#L364)
+- [modal/edit.js](src/blocks/modal/edit.js#L139)
+- [card/edit.js](src/blocks/card/edit.js#L72)
 
 ## Cross-Cutting Recommendations
 
@@ -214,8 +214,8 @@ Recommendations:
 
 Relevant files:
 
-- [section/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/section/edit.js#L163)
-- [section/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/section/edit.js#L328)
+- [section/edit.js](src/blocks/section/edit.js#L163)
+- [section/edit.js](src/blocks/section/edit.js#L328)
 
 #### `Row`
 
@@ -238,8 +238,8 @@ Recommendations:
 
 Relevant files:
 
-- [row/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/row/edit.js#L121)
-- [row/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/row/edit.js#L268)
+- [row/edit.js](src/blocks/row/edit.js#L121)
+- [row/edit.js](src/blocks/row/edit.js#L268)
 
 #### `Grid`
 
@@ -261,7 +261,7 @@ Recommendations:
 
 Relevant files:
 
-- [grid/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/grid/edit.js#L325)
+- [grid/edit.js](src/blocks/grid/edit.js#L325)
 
 #### `Fifty Fifty`
 
@@ -284,8 +284,8 @@ Recommendations:
 
 Relevant files:
 
-- [fifty-fifty/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/fifty-fifty/edit.js#L156)
-- [fifty-fifty/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/fifty-fifty/edit.js#L243)
+- [fifty-fifty/edit.js](src/blocks/fifty-fifty/edit.js#L156)
+- [fifty-fifty/edit.js](src/blocks/fifty-fifty/edit.js#L243)
 
 #### `Blobs`
 
@@ -325,7 +325,7 @@ Recommendations:
 
 Relevant files:
 
-- [accordion/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/accordion/edit.js#L103)
+- [accordion/edit.js](src/blocks/accordion/edit.js#L103)
 
 #### `Accordion Item`
 
@@ -346,7 +346,7 @@ Recommendations:
 
 Relevant files:
 
-- [accordion-item/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/accordion-item/edit.js#L173)
+- [accordion-item/edit.js](src/blocks/accordion-item/edit.js#L173)
 
 #### `Tabs`
 
@@ -370,8 +370,8 @@ Recommendations:
 
 Relevant files:
 
-- [tabs/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/tabs/edit.js#L87)
-- [tabs/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/tabs/edit.js#L515)
+- [tabs/edit.js](src/blocks/tabs/edit.js#L87)
+- [tabs/edit.js](src/blocks/tabs/edit.js#L515)
 
 #### `Tab`
 
@@ -390,7 +390,7 @@ Recommendations:
 
 Relevant files:
 
-- [tab/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/tab/edit.js#L77)
+- [tab/edit.js](src/blocks/tab/edit.js#L77)
 
 #### `Slider`
 
@@ -415,9 +415,9 @@ Recommendations:
 
 Relevant files:
 
-- [slider/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/slider/edit.js#L240)
-- [slider/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/slider/edit.js#L363)
-- [slider/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/slider/edit.js#L1091)
+- [slider/edit.js](src/blocks/slider/edit.js#L240)
+- [slider/edit.js](src/blocks/slider/edit.js#L363)
+- [slider/edit.js](src/blocks/slider/edit.js#L1091)
 
 #### `Slide`
 
@@ -438,8 +438,8 @@ Recommendations:
 
 Relevant files:
 
-- [slide/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/slide/edit.js#L107)
-- [slide/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/slide/edit.js#L186)
+- [slide/edit.js](src/blocks/slide/edit.js#L107)
+- [slide/edit.js](src/blocks/slide/edit.js#L186)
 
 #### `Flip Card`
 
@@ -460,7 +460,7 @@ Recommendations:
 
 Relevant files:
 
-- [flip-card/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/flip-card/edit.js#L67)
+- [flip-card/edit.js](src/blocks/flip-card/edit.js#L67)
 
 #### `Flip Card Front`
 
@@ -471,7 +471,7 @@ Recommendations:
 
 Relevant files:
 
-- [flip-card-front/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/flip-card-front/edit.js#L15)
+- [flip-card-front/edit.js](src/blocks/flip-card-front/edit.js#L15)
 
 #### `Flip Card Back`
 
@@ -482,7 +482,7 @@ Recommendations:
 
 Relevant files:
 
-- [flip-card-back/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/flip-card-back/edit.js#L15)
+- [flip-card-back/edit.js](src/blocks/flip-card-back/edit.js#L15)
 
 #### `Image Accordion`
 
@@ -504,7 +504,7 @@ Recommendations:
 
 Relevant files:
 
-- [image-accordion/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/image-accordion/edit.js#L207)
+- [image-accordion/edit.js](src/blocks/image-accordion/edit.js#L207)
 
 #### `Image Accordion Item`
 
@@ -524,7 +524,7 @@ Recommendations:
 
 Relevant files:
 
-- [image-accordion-item/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/image-accordion-item/edit.js#L66)
+- [image-accordion-item/edit.js](src/blocks/image-accordion-item/edit.js#L66)
 
 #### `Scroll Accordion`
 
@@ -545,8 +545,8 @@ Recommendations:
 
 Relevant files:
 
-- [scroll-accordion/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/scroll-accordion/edit.js#L45)
-- [scroll-accordion/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/scroll-accordion/edit.js#L220)
+- [scroll-accordion/edit.js](src/blocks/scroll-accordion/edit.js#L45)
+- [scroll-accordion/edit.js](src/blocks/scroll-accordion/edit.js#L220)
 
 #### `Scroll Accordion Item`
 
@@ -575,8 +575,8 @@ Recommendations:
 
 Relevant files:
 
-- [scroll-slides/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/scroll-slides/edit.js#L176)
-- [scroll-slides/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/scroll-slides/edit.js#L206)
+- [scroll-slides/edit.js](src/blocks/scroll-slides/edit.js#L176)
+- [scroll-slides/edit.js](src/blocks/scroll-slides/edit.js#L206)
 
 #### `Scroll Slide`
 
@@ -604,7 +604,7 @@ Recommendations:
 
 Relevant files:
 
-- [sticky-sections/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/sticky-sections/edit.js#L47)
+- [sticky-sections/edit.js](src/blocks/sticky-sections/edit.js#L47)
 
 #### `Timeline`
 
@@ -625,7 +625,7 @@ Recommendations:
 
 Relevant files:
 
-- [timeline/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/timeline/edit.js#L112)
+- [timeline/edit.js](src/blocks/timeline/edit.js#L112)
 
 #### `Timeline Item`
 
@@ -646,7 +646,7 @@ Recommendations:
 
 Relevant files:
 
-- [timeline-item/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/timeline-item/edit.js#L203)
+- [timeline-item/edit.js](src/blocks/timeline-item/edit.js#L203)
 
 #### `Scroll Marquee`
 
@@ -668,8 +668,8 @@ Recommendations:
 
 Relevant files:
 
-- [scroll-marquee/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/scroll-marquee/edit.js#L37)
-- [scroll-marquee/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/scroll-marquee/edit.js#L201)
+- [scroll-marquee/edit.js](src/blocks/scroll-marquee/edit.js#L37)
+- [scroll-marquee/edit.js](src/blocks/scroll-marquee/edit.js#L201)
 
 ### Content / Presentation Blocks
 
@@ -694,8 +694,8 @@ Recommendations:
 
 Relevant files:
 
-- [card/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/card/edit.js#L72)
-- [card/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/card/edit.js#L223)
+- [card/edit.js](src/blocks/card/edit.js#L72)
+- [card/edit.js](src/blocks/card/edit.js#L223)
 
 #### `Advanced Heading`
 
@@ -716,7 +716,7 @@ Recommendations:
 
 Relevant files:
 
-- [advanced-heading/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/advanced-heading/edit.js#L62)
+- [advanced-heading/edit.js](src/blocks/advanced-heading/edit.js#L62)
 
 #### `Heading Segment`
 
@@ -743,7 +743,7 @@ Recommendations:
 
 Relevant files:
 
-- [icon/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/icon/edit.js#L145)
+- [icon/edit.js](src/blocks/icon/edit.js#L145)
 
 #### `Icon Button`
 
@@ -762,7 +762,7 @@ Recommendations:
 
 Relevant files:
 
-- [icon-button/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/icon-button/edit.js#L216)
+- [icon-button/edit.js](src/blocks/icon-button/edit.js#L216)
 
 #### `Icon List`
 
@@ -781,7 +781,7 @@ Recommendations:
 
 Relevant files:
 
-- [icon-list/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/icon-list/edit.js#L100)
+- [icon-list/edit.js](src/blocks/icon-list/edit.js#L100)
 
 #### `Icon List Item`
 
@@ -806,7 +806,7 @@ Recommendations:
 
 Relevant files:
 
-- [pill/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/pill/edit.js#L55)
+- [pill/edit.js](src/blocks/pill/edit.js#L55)
 
 #### `Divider`
 
@@ -824,7 +824,7 @@ Recommendations:
 
 Relevant files:
 
-- [divider/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/divider/edit.js#L47)
+- [divider/edit.js](src/blocks/divider/edit.js#L47)
 
 #### `Counter Group`
 
@@ -844,7 +844,7 @@ Recommendations:
 
 Relevant files:
 
-- [counter-group/index.js](/Users/jnealey/github-local/designsetgo/src/blocks/counter-group/index.js#L153)
+- [counter-group/index.js](src/blocks/counter-group/index.js#L153)
 
 #### `Counter`
 
@@ -863,7 +863,7 @@ Recommendations:
 
 Relevant files:
 
-- [counter/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/counter/edit.js#L162)
+- [counter/edit.js](src/blocks/counter/edit.js#L162)
 
 #### `Progress Bar`
 
@@ -884,7 +884,7 @@ Recommendations:
 
 Relevant files:
 
-- [progress-bar/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/progress-bar/edit.js#L162)
+- [progress-bar/edit.js](src/blocks/progress-bar/edit.js#L162)
 
 #### `Countdown Timer`
 
@@ -906,8 +906,8 @@ Recommendations:
 
 Relevant files:
 
-- [countdown-timer/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/countdown-timer/edit.js#L79)
-- [countdown-timer/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/countdown-timer/edit.js#L429)
+- [countdown-timer/edit.js](src/blocks/countdown-timer/edit.js#L79)
+- [countdown-timer/edit.js](src/blocks/countdown-timer/edit.js#L429)
 
 #### `Comparison Table`
 
@@ -929,8 +929,8 @@ Recommendations:
 
 Relevant files:
 
-- [comparison-table/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/comparison-table/edit.js#L431)
-- [comparison-table/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/comparison-table/edit.js#L782)
+- [comparison-table/edit.js](src/blocks/comparison-table/edit.js#L431)
+- [comparison-table/edit.js](src/blocks/comparison-table/edit.js#L782)
 
 ### Form Blocks
 
@@ -955,8 +955,8 @@ Recommendations:
 
 Relevant files:
 
-- [form-builder/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/form-builder/edit.js#L148)
-- [form-builder/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/form-builder/edit.js#L714)
+- [form-builder/edit.js](src/blocks/form-builder/edit.js#L148)
+- [form-builder/edit.js](src/blocks/form-builder/edit.js#L714)
 
 #### `Form Text Field`
 
@@ -1007,8 +1007,8 @@ Recommendations:
 
 Relevant files:
 
-- [form-phone-field/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/form-phone-field/edit.js#L82)
-- [form-phone-field/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/form-phone-field/edit.js#L192)
+- [form-phone-field/edit.js](src/blocks/form-phone-field/edit.js#L82)
+- [form-phone-field/edit.js](src/blocks/form-phone-field/edit.js#L192)
 
 #### `Form Date Field`
 
@@ -1064,8 +1064,8 @@ Recommendations:
 
 Relevant files:
 
-- [modal/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/modal/edit.js#L124)
-- [modal/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/modal/edit.js#L149)
+- [modal/edit.js](src/blocks/modal/edit.js#L124)
+- [modal/edit.js](src/blocks/modal/edit.js#L149)
 
 #### `Modal Trigger`
 
@@ -1085,8 +1085,8 @@ Recommendations:
 
 Relevant files:
 
-- [modal-trigger/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/modal-trigger/edit.js#L64)
-- [modal-trigger/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/modal-trigger/edit.js#L152)
+- [modal-trigger/edit.js](src/blocks/modal-trigger/edit.js#L64)
+- [modal-trigger/edit.js](src/blocks/modal-trigger/edit.js#L152)
 
 #### `Table of Contents`
 
@@ -1107,7 +1107,7 @@ Recommendations:
 
 Relevant files:
 
-- [table-of-contents/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/table-of-contents/edit.js#L52)
+- [table-of-contents/edit.js](src/blocks/table-of-contents/edit.js#L52)
 
 #### `Breadcrumbs`
 
@@ -1126,7 +1126,7 @@ Recommendations:
 
 Relevant files:
 
-- [breadcrumbs/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/breadcrumbs/edit.js#L201)
+- [breadcrumbs/edit.js](src/blocks/breadcrumbs/edit.js#L201)
 
 #### `Map`
 
@@ -1146,7 +1146,7 @@ Recommendations:
 
 Relevant files:
 
-- [map/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/map/edit.js#L97)
+- [map/edit.js](src/blocks/map/edit.js#L97)
 
 #### `Product Categories Grid`
 
@@ -1167,7 +1167,7 @@ Recommendations:
 
 Relevant files:
 
-- [product-categories-grid/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/product-categories-grid/edit.js#L105)
+- [product-categories-grid/edit.js](src/blocks/product-categories-grid/edit.js#L105)
 
 #### `Product Showcase Hero`
 
@@ -1187,8 +1187,8 @@ Recommendations:
 
 Relevant files:
 
-- [product-showcase-hero/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/product-showcase-hero/edit.js#L128)
-- [product-showcase-hero/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/product-showcase-hero/edit.js#L209)
+- [product-showcase-hero/edit.js](src/blocks/product-showcase-hero/edit.js#L128)
+- [product-showcase-hero/edit.js](src/blocks/product-showcase-hero/edit.js#L209)
 
 ## Suggested Roadmap
 

--- a/docs/audits/BLOCK-EDITOR-UIUX-AUDIT.md
+++ b/docs/audits/BLOCK-EDITOR-UIUX-AUDIT.md
@@ -1,0 +1,1235 @@
+# Block Editor UI/UX Audit
+
+**Date:** April 16, 2026  
+**Scope:** DesignSetGo custom WordPress blocks  
+**Method:** Code inspection of live block implementations plus review of existing QA screenshots  
+
+## Overview
+
+This audit focuses on editor usability, ease of use, onboarding, discoverability, and authoring flow for each custom block in the plugin.
+
+It is based on:
+
+- `block.json` metadata and block supports
+- `edit.js` implementations
+- placeholder and template chooser flows
+- nested block constraints and inserter behavior
+- inspector control structure and toolbar usage
+- existing QA screenshots for representative frontend states
+
+This is not a frontend design critique in isolation. The emphasis is editor experience: how easy it is for a content author to insert, configure, understand, and repeat each block.
+
+## Highest-Priority Findings
+
+### 1. Child insertion discoverability is inconsistent
+
+Several composite blocks hide or weaken the normal Gutenberg affordance for adding child content.
+
+- `Slider` disables the default appender without a clear replacement in the current editor surface.
+- `Advanced Heading` disables the segment appender and does not surface an obvious "Add Segment" action.
+- `Reveal` hides its appender entirely.
+
+These three are the clearest usability regressions because they block the author's next step.
+
+Relevant files:
+
+- [slider/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/slider/edit.js#L240)
+- [slider/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/slider/edit.js#L363)
+- [advanced-heading/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/advanced-heading/edit.js#L62)
+- [reveal/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/reveal/edit.js#L26)
+
+### 2. `Section` and `Row` auto-transform too aggressively
+
+`Section` silently converts to `Row` when orientation becomes horizontal, and `Row` silently converts to `Section` when orientation becomes vertical.
+
+That is technically clever, but it is a confusing authoring model. The selected block can effectively change identity without the user explicitly choosing a transform.
+
+This should become:
+
+- an explicit transform action
+- a contextual notice
+- an easy undo path
+
+Relevant files:
+
+- [section/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/section/edit.js#L163)
+- [row/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/row/edit.js#L121)
+
+### 3. The plugin already contains good onboarding patterns, but only for some blocks
+
+The strongest onboarding flows currently appear in:
+
+- `Modal`
+- `Sticky Sections`
+- `Scroll Slides`
+- `Product Categories Grid`
+- `Product Showcase Hero`
+
+These blocks use template choosers, placeholders, or setup states well. That pattern should be standardized for all complex, composite, or data-driven blocks.
+
+Relevant files:
+
+- [ModalPlaceholder.js](/Users/jnealey/github-local/designsetgo/src/blocks/modal/components/ModalPlaceholder.js#L35)
+- [StickySectionsPlaceholder.js](/Users/jnealey/github-local/designsetgo/src/blocks/sticky-sections/components/StickySectionsPlaceholder.js#L30)
+- [ScrollSlidesPlaceholder.js](/Users/jnealey/github-local/designsetgo/src/blocks/scroll-slides/components/ScrollSlidesPlaceholder.js#L30)
+- [product-categories-grid/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/product-categories-grid/edit.js#L253)
+- [product-showcase-hero/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/product-showcase-hero/edit.js#L258)
+
+### 4. Some of the most powerful blocks are too sidebar-driven
+
+These blocks expose a lot of capability, but ask the author to understand too many options before getting a strong initial result:
+
+- `Slider`
+- `Form Builder`
+- `Comparison Table`
+- `Modal`
+- `Card`
+
+These should move toward:
+
+- variation picker on insert
+- strong starter templates
+- progressive disclosure of advanced controls
+- more inline editing for common tasks
+
+Relevant files:
+
+- [slider/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/slider/edit.js#L367)
+- [form-builder/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/form-builder/edit.js#L200)
+- [comparison-table/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/comparison-table/edit.js#L364)
+- [modal/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/modal/edit.js#L139)
+- [card/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/card/edit.js#L72)
+
+## Cross-Cutting Recommendations
+
+### Standardize empty-state UX
+
+For any block that is:
+
+- composite
+- interactive
+- content-structured
+- data-driven
+- visually opinionated
+
+default to one of these on first insert:
+
+- template chooser
+- variation picker
+- setup placeholder
+- guided starter state
+
+### Move high-frequency actions into toolbars or canvas UI
+
+Authors should not have to open the sidebar for their most common next step.
+
+Examples:
+
+- add tab
+- add slide
+- duplicate item
+- reorder item
+- flip media side
+- rename nav item
+- connect modal trigger to modal
+
+### Standardize child navigators
+
+Several blocks would benefit from the same reusable editor pattern:
+
+- item list
+- current selection
+- add button
+- duplicate button
+- reorder controls
+- quick settings
+
+This would apply to:
+
+- `Tabs`
+- `Slider`
+- `Accordion`
+- `Timeline`
+- `Scroll Slides`
+- `Sticky Sections`
+- `Form Builder`
+
+### Reduce numeric-only controls where the editor already knows the items
+
+Avoid author-facing controls like "Default Expanded Item = 3" when the editor can show actual child names.
+
+Prefer:
+
+- item pickers
+- inline chips
+- dropdowns populated from real child blocks
+
+### Prefer preset-first workflows for expressive blocks
+
+For visually rich blocks, do not start with a blank configuration problem.
+
+Start with:
+
+- a few good presets
+- a visible preview
+- a simple first-choice decision
+
+Then allow deeper customization.
+
+### Keep inspector information architecture consistent
+
+Use:
+
+- `Settings` for behavior and structure
+- `Styles` and style subsections for appearance
+- toolbar for quick actions
+- canvas controls for direct-manipulation actions
+
+The repo already documents this direction and should continue applying it consistently.
+
+## Block-by-Block Audit
+
+### Layout Containers
+
+#### `Section`
+
+Current strengths:
+
+- good width constraint controls
+- strong shape divider capability
+- good use of WordPress supports
+
+Usability issues:
+
+- silent conversion to `Row`
+- no guided empty-state starters
+- shape divider setup is powerful but not visually guided
+
+Recommendations:
+
+- replace silent orientation swap with explicit transform
+- add starter layouts for common section structures
+- add visual shape-divider presets with thumbnails
+- show nested-section behavior more clearly when padding is auto-cleared
+
+Relevant files:
+
+- [section/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/section/edit.js#L163)
+- [section/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/section/edit.js#L328)
+
+#### `Row`
+
+Current strengths:
+
+- mobile stacking control is clear
+- width constraint control is solid
+
+Usability issues:
+
+- silent conversion to `Section`
+- lacks starter patterns for common horizontal layouts
+
+Recommendations:
+
+- make transforms explicit
+- add quick layout starters for 2, 3, and 4 child columns
+- add row reversal control
+- show a mobile preview hint next to `Stack on Mobile`
+
+Relevant files:
+
+- [row/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/row/edit.js#L121)
+- [row/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/row/edit.js#L268)
+
+#### `Grid`
+
+Current strengths:
+
+- responsive controls are well covered
+- width and gap settings are clear
+
+Usability issues:
+
+- configuration is capable but abstract
+- no first-insert layout presets
+
+Recommendations:
+
+- add starter presets such as `features`, `cards`, `logos`, `gallery`
+- add device preview toggles beside responsive column controls
+- expose common span/reorder workflows more directly for children
+
+Relevant files:
+
+- [grid/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/grid/edit.js#L325)
+
+#### `Fifty Fifty`
+
+Current strengths:
+
+- toolbar flip action is excellent
+- media selection is easy
+- one of the better insert-to-success flows in the repo
+
+Usability issues:
+
+- no variation picker on insert
+- missing strong alt-text guidance
+
+Recommendations:
+
+- add `image left`, `image right`, `copy-heavy`, and `media-heavy` variations
+- warn when image exists without alt text
+- offer preset content structures
+
+Relevant files:
+
+- [fifty-fifty/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/fifty-fifty/edit.js#L156)
+- [fifty-fifty/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/fifty-fifty/edit.js#L243)
+
+#### `Blobs`
+
+Current strengths:
+
+- expressive decorative capability
+
+Usability issues:
+
+- likely too parameterized for a decorative block
+
+Recommendations:
+
+- move to preset-first setup
+- reduce reliance on manual tuning
+- add decorative intensity presets
+
+### Interactive / Composite Blocks
+
+#### `Accordion`
+
+Current strengths:
+
+- good parent-child structure
+- clear item template
+- item-level open state is understandable
+
+Usability issues:
+
+- authors must manage initial state item by item
+- no quick batch actions
+
+Recommendations:
+
+- add parent actions for `Add item`, `Open first`, `Expand all`, `Collapse all`
+- surface item count and current default-open items in parent UI
+
+Relevant files:
+
+- [accordion/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/accordion/edit.js#L103)
+
+#### `Accordion Item`
+
+Current strengths:
+
+- in-canvas title editing is good
+- item open/close behavior is visible
+
+Usability issues:
+
+- no quick duplicate or reorder in header
+- default-open state is easy to miss in larger accordions
+
+Recommendations:
+
+- add duplicate and reorder affordances in the item header
+- show an "opens by default" chip when enabled
+
+Relevant files:
+
+- [accordion-item/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/accordion-item/edit.js#L173)
+
+#### `Tabs`
+
+Current strengths:
+
+- active tab selection also selects child block
+- keyboard navigation is handled
+- parent-child relationship is strong
+
+Usability issues:
+
+- tab management is still too sidebar-dependent
+- no obvious in-canvas add/duplicate/reorder action
+
+Recommendations:
+
+- enable inline tab renaming in the tab strip
+- add `+ Add Tab`
+- add duplicate and drag reorder for tabs
+- make active/inactive editing feel more direct
+
+Relevant files:
+
+- [tabs/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/tabs/edit.js#L87)
+- [tabs/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/tabs/edit.js#L515)
+
+#### `Tab`
+
+Current strengths:
+
+- inactive-tab notice is helpful
+
+Usability issues:
+
+- title, icon, and anchor editing are still isolated to inspector
+
+Recommendations:
+
+- move tab label editing into the navigation UI
+- add inline icon picker entry point from nav
+
+Relevant files:
+
+- [tab/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/tab/edit.js#L77)
+
+#### `Slider`
+
+Current strengths:
+
+- very capable feature set
+- editor-only arrows and dots help preview interaction
+
+Usability issues:
+
+- disabled appender is a major discoverability issue
+- configuration burden is high before first success
+- lacks slide navigator / thumbnail workflow
+
+Recommendations:
+
+- restore a clear add-slide path immediately
+- add slide navigator with thumbnail or title chips
+- add duplicate/remove/reorder slide actions
+- introduce slider presets such as `hero`, `gallery`, `testimonials`, `logos`
+- collapse advanced options behind presets
+
+Relevant files:
+
+- [slider/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/slider/edit.js#L240)
+- [slider/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/slider/edit.js#L363)
+- [slider/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/slider/edit.js#L1091)
+
+#### `Slide`
+
+Current strengths:
+
+- strong background/media controls
+- sensible starter content template
+
+Usability issues:
+
+- repetitive slide authoring could be faster
+
+Recommendations:
+
+- add slide templates
+- add duplicate previous slide action
+- expose common background/content/alignment controls in a compact inline panel
+
+Relevant files:
+
+- [slide/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/slide/edit.js#L107)
+- [slide/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/slide/edit.js#L186)
+
+#### `Flip Card`
+
+Current strengths:
+
+- seeded front/back structure is good
+- guards against duplicate faces
+
+Usability issues:
+
+- front and back are conceptually strong but not visually guided enough in editor
+
+Recommendations:
+
+- add clear in-canvas face labels
+- add preview toggle for front/back while editing
+- add starter variations by use case
+
+Relevant files:
+
+- [flip-card/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/flip-card/edit.js#L67)
+
+#### `Flip Card Front`
+
+Recommendations:
+
+- add stronger face labeling in canvas
+- offer starter content variants
+
+Relevant files:
+
+- [flip-card-front/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/flip-card-front/edit.js#L15)
+
+#### `Flip Card Back`
+
+Recommendations:
+
+- same as front
+- make back-side editing feel intentionally distinct
+
+Relevant files:
+
+- [flip-card-back/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/flip-card-back/edit.js#L15)
+
+#### `Image Accordion`
+
+Current strengths:
+
+- clear overall control groups
+- good core concept
+
+Usability issues:
+
+- `Default Expanded Item` is numeric instead of semantic
+- likely too dark / heavy in default visual expression
+
+Recommendations:
+
+- replace numeric item selector with actual child-item picker
+- add starter visual themes
+- improve mobile-state explanation
+
+Relevant files:
+
+- [image-accordion/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/image-accordion/edit.js#L207)
+
+#### `Image Accordion Item`
+
+Current strengths:
+
+- content alignment controls are simple
+
+Usability issues:
+
+- background/media setup is not direct enough for a media-led block
+
+Recommendations:
+
+- add inline media dropzone
+- add contrast warning for overlay plus text
+- improve visibility of per-item identity in editor
+
+Relevant files:
+
+- [image-accordion-item/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/image-accordion-item/edit.js#L66)
+
+#### `Scroll Accordion`
+
+Current strengths:
+
+- strong starter content template
+- simple top-level alignment toolbar
+
+Usability issues:
+
+- parent block is under-explained for a visually specialized experience
+- lacks richer parent controls and navigator
+
+Recommendations:
+
+- add inspector guidance for pinning, progression, and spacing
+- add item navigator and reorder controls
+
+Relevant files:
+
+- [scroll-accordion/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/scroll-accordion/edit.js#L45)
+- [scroll-accordion/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/scroll-accordion/edit.js#L220)
+
+#### `Scroll Accordion Item`
+
+Recommendations:
+
+- add inline label or summary in parent navigator
+- expose item state more clearly in-canvas
+
+#### `Scroll Slides`
+
+Current strengths:
+
+- strong setup chooser
+- inline nav heading editing is very good
+- active-slide mental model is clear
+
+Usability issues:
+
+- would benefit from richer slide management
+
+Recommendations:
+
+- add thumbnails
+- add drag reorder
+- add slide count and active-state strip
+
+Relevant files:
+
+- [scroll-slides/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/scroll-slides/edit.js#L176)
+- [scroll-slides/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/scroll-slides/edit.js#L206)
+
+#### `Scroll Slide`
+
+Recommendations:
+
+- add duplicate previous slide action
+- add quick style transfer between slides
+
+#### `Sticky Sections`
+
+Current strengths:
+
+- good template chooser
+- simple settings
+
+Usability issues:
+
+- authors need better visibility into section order and sticky offset impact
+
+Recommendations:
+
+- add section navigator
+- add reorder affordances
+- add sticky-offset preview ruler
+
+Relevant files:
+
+- [sticky-sections/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/sticky-sections/edit.js#L47)
+
+#### `Timeline`
+
+Current strengths:
+
+- clear settings split
+- strong starter template
+
+Usability issues:
+
+- timeline authoring is still list-like rather than journey-like
+
+Recommendations:
+
+- add variations such as `history`, `roadmap`, `process`
+- add parent-level duplicate/reorder tools
+- show a stronger overview of all items
+
+Relevant files:
+
+- [timeline/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/timeline/edit.js#L112)
+
+#### `Timeline Item`
+
+Current strengths:
+
+- date/title editing is straightforward
+- image and link support are useful
+
+Usability issues:
+
+- link editing is still overly inspector-based
+- item identification could be stronger in long timelines
+
+Recommendations:
+
+- move link editing into a toolbar action
+- add clearer item chips or summaries in the editor
+
+Relevant files:
+
+- [timeline-item/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/timeline-item/edit.js#L203)
+
+#### `Scroll Marquee`
+
+Current strengths:
+
+- row-based editing is fairly direct
+- performance warning is a good guardrail
+
+Usability issues:
+
+- row management lacks drag reorder
+- heavy-image use is still easy to overdo
+
+Recommendations:
+
+- add row reordering
+- add marquee starter presets
+- improve image budget messaging and optimization guidance
+
+Relevant files:
+
+- [scroll-marquee/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/scroll-marquee/edit.js#L37)
+- [scroll-marquee/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/scroll-marquee/edit.js#L201)
+
+### Content / Presentation Blocks
+
+#### `Card`
+
+Current strengths:
+
+- highly flexible
+- supports multiple visual and layout modes
+
+Usability issues:
+
+- too many decisions before getting a good result
+- image and CTA workflows are not as guided as they should be
+
+Recommendations:
+
+- move to preset-first onboarding
+- add clearer CTA editing mode
+- add whole-card click option
+- add stronger alt-text warning
+
+Relevant files:
+
+- [card/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/card/edit.js#L72)
+- [card/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/card/edit.js#L223)
+
+#### `Advanced Heading`
+
+Current strengths:
+
+- strong concept
+- heading-level toolbar is good
+
+Usability issues:
+
+- add-segment flow is not discoverable
+
+Recommendations:
+
+- add visible `Add Segment` action
+- add segment chips / navigator
+- provide quick heading style variations
+
+Relevant files:
+
+- [advanced-heading/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/advanced-heading/edit.js#L62)
+
+#### `Heading Segment`
+
+Recommendations:
+
+- make duplication and reorder easier
+- surface segment editing affordances more clearly
+
+#### `Icon`
+
+Current strengths:
+
+- good accessibility section
+
+Usability issues:
+
+- icon selection could be faster for repeated use
+
+Recommendations:
+
+- add recent/favorite icons
+- add stronger required-label guidance when not decorative
+- add quicker inline picker entry point
+
+Relevant files:
+
+- [icon/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/icon/edit.js#L145)
+
+#### `Icon Button`
+
+Current strengths:
+
+- inline link popover follows good core button patterns
+
+Usability issues:
+
+- common icon and variant actions are still too hidden
+
+Recommendations:
+
+- add quick icon and variant toolbar controls
+- improve modal/action integration patterns
+
+Relevant files:
+
+- [icon-button/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/icon-button/edit.js#L216)
+
+#### `Icon List`
+
+Current strengths:
+
+- good shared parent settings model
+
+Usability issues:
+
+- batch authoring can be faster
+
+Recommendations:
+
+- support bulk paste from newline-separated text
+- add global icon sync action for children
+
+Relevant files:
+
+- [icon-list/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/icon-list/edit.js#L100)
+
+#### `Icon List Item`
+
+Recommendations:
+
+- improve duplicate / reorder speed
+- surface per-item editing in a more list-native way
+
+#### `Pill`
+
+Current strengths:
+
+- simple editing model
+
+Usability issues:
+
+- no preset visual vocabulary
+
+Recommendations:
+
+- add style presets such as `badge`, `status`, `eyebrow`, `label`
+
+Relevant files:
+
+- [pill/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/pill/edit.js#L55)
+
+#### `Divider`
+
+Current strengths:
+
+- simple and compact control set
+
+Usability issues:
+
+- style names are less effective than visual previews
+
+Recommendations:
+
+- convert divider style options into visual thumbnails
+
+Relevant files:
+
+- [divider/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/divider/edit.js#L47)
+
+#### `Counter Group`
+
+Current strengths:
+
+- good parent-child structure
+- strong defaults
+
+Usability issues:
+
+- formatting logic is hard to visualize from sidebar alone
+
+Recommendations:
+
+- add layout presets
+- add live number formatting preview
+
+Relevant files:
+
+- [counter-group/index.js](/Users/jnealey/github-local/designsetgo/src/blocks/counter-group/index.js#L153)
+
+#### `Counter`
+
+Current strengths:
+
+- clear child-level override model
+
+Usability issues:
+
+- repeated counter authoring could be faster
+
+Recommendations:
+
+- add prefix/suffix presets
+- improve duplicate-styled-counter flow
+
+Relevant files:
+
+- [counter/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/counter/edit.js#L162)
+
+#### `Progress Bar`
+
+Current strengths:
+
+- clear control grouping
+- preview is understandable
+
+Usability issues:
+
+- percentage is numeric only
+- style selection is still abstract
+
+Recommendations:
+
+- allow drag-to-set directly on the bar
+- add style presets
+
+Relevant files:
+
+- [progress-bar/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/progress-bar/edit.js#L162)
+
+#### `Countdown Timer`
+
+Current strengths:
+
+- live editor preview
+- clear completion handling
+
+Usability issues:
+
+- too much repeated inspector setup code
+- date entry could be faster for common use cases
+
+Recommendations:
+
+- add relative-date shortcuts
+- add explicit expired-state preview toggle
+- simplify author mental model around completion states
+
+Relevant files:
+
+- [countdown-timer/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/countdown-timer/edit.js#L79)
+- [countdown-timer/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/countdown-timer/edit.js#L429)
+
+#### `Comparison Table`
+
+Current strengths:
+
+- inline cell editing is strong
+- row actions are already present
+
+Usability issues:
+
+- column management is still sidebar-heavy
+- importing / batch editing is missing
+
+Recommendations:
+
+- add CSV or table paste import
+- add duplicate column action
+- move CTA link editing closer to column headers
+
+Relevant files:
+
+- [comparison-table/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/comparison-table/edit.js#L431)
+- [comparison-table/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/comparison-table/edit.js#L782)
+
+### Form Blocks
+
+#### `Form Builder`
+
+Current strengths:
+
+- strong base template
+- broad capability
+
+Usability issues:
+
+- too much setup burden for common cases
+- some mappings use raw text where structured selection would be better
+
+Recommendations:
+
+- add a setup wizard
+- add form presets such as `contact`, `newsletter`, `event registration`, `lead capture`
+- replace free-text mapping fields like reply-to source with dropdowns populated from actual form fields
+- add form summary panel showing required fields, email target, spam settings
+
+Relevant files:
+
+- [form-builder/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/form-builder/edit.js#L148)
+- [form-builder/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/form-builder/edit.js#L714)
+
+#### `Form Text Field`
+
+Recommendations:
+
+- add inline label/placeholder editing
+- reuse a shared field settings panel pattern
+
+#### `Form Email Field`
+
+Recommendations:
+
+- add stronger email-source guidance for notifications
+- provide common email presets
+
+#### `Form Textarea Field`
+
+Recommendations:
+
+- add message presets and quick size options
+
+#### `Form URL Field`
+
+Recommendations:
+
+- add example validation hints and common placeholder presets
+
+#### `Form Number Field`
+
+Recommendations:
+
+- add use-case presets such as `quantity`, `budget`, `team size`
+
+#### `Form Phone Field`
+
+Current strengths:
+
+- reasonably clear formatting controls
+
+Usability issues:
+
+- format and country setup can still feel abstract
+
+Recommendations:
+
+- show a live example preview when format or country changes
+- auto-update placeholder based on chosen format and country
+
+Relevant files:
+
+- [form-phone-field/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/form-phone-field/edit.js#L82)
+- [form-phone-field/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/form-phone-field/edit.js#L192)
+
+#### `Form Date Field`
+
+Recommendations:
+
+- add relative min/max presets
+- add more user-friendly scheduling presets
+
+#### `Form Time Field`
+
+Recommendations:
+
+- add common slot presets like business hours and 15-minute increments
+
+#### `Form Select Field`
+
+Recommendations:
+
+- support bulk option paste and drag reorder
+
+#### `Form Checkbox Field`
+
+Recommendations:
+
+- add consent templates with optional linked policy text
+
+#### `Form Hidden Field`
+
+Recommendations:
+
+- present hidden values as metadata chips in canvas
+- add quick sources like URL param, page title, post ID, current date
+
+### Data / Utility Blocks
+
+#### `Modal`
+
+Current strengths:
+
+- template chooser is strong
+- overall block architecture is good
+
+Usability issues:
+
+- modal/trigger pairing is still manual
+- open-state preview could be clearer
+
+Recommendations:
+
+- allow creating a trigger directly from a modal
+- allow jumping from a trigger to its target modal
+- add open-state and focus-order preview in editor
+
+Relevant files:
+
+- [modal/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/modal/edit.js#L124)
+- [modal/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/modal/edit.js#L149)
+
+#### `Modal Trigger`
+
+Current strengths:
+
+- scans page for available modals
+
+Usability issues:
+
+- warning-only state when no modal exists
+
+Recommendations:
+
+- offer `Create Modal` directly
+- show connection status chip
+- add jump-to-target action
+
+Relevant files:
+
+- [modal-trigger/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/modal-trigger/edit.js#L64)
+- [modal-trigger/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/modal-trigger/edit.js#L152)
+
+#### `Table of Contents`
+
+Current strengths:
+
+- helpful empty and warning states
+- scanning hook model is good
+
+Usability issues:
+
+- source headings are not strongly surfaced to the author
+
+Recommendations:
+
+- add source-heading list in inspector
+- allow clicking from TOC entry to originating heading block
+- allow per-heading exclusion
+
+Relevant files:
+
+- [table-of-contents/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/table-of-contents/edit.js#L52)
+
+#### `Breadcrumbs`
+
+Current strengths:
+
+- preview is contextual
+
+Usability issues:
+
+- preview states could be more actionable
+
+Recommendations:
+
+- show clearer context badges
+- improve loading / empty-state guidance
+
+Relevant files:
+
+- [breadcrumbs/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/breadcrumbs/edit.js#L201)
+
+#### `Map`
+
+Current strengths:
+
+- editor preview communicates configuration state
+
+Usability issues:
+
+- still feels like a placeholder rather than a map authoring tool
+
+Recommendations:
+
+- add geocode search
+- show provider/config status
+- add lightweight live-preview mode when feasible
+
+Relevant files:
+
+- [map/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/map/edit.js#L97)
+
+#### `Product Categories Grid`
+
+Current strengths:
+
+- setup and empty states are good
+- manual vs all-categories mode is understandable
+
+Usability issues:
+
+- manual curation could be faster
+
+Recommendations:
+
+- add drag reorder in manual mode
+- add visual emphasis controls for featured categories
+- add style presets
+
+Relevant files:
+
+- [product-categories-grid/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/product-categories-grid/edit.js#L105)
+
+#### `Product Showcase Hero`
+
+Current strengths:
+
+- current-product vs manual-product flow is clear
+- good setup and sample-preview messaging
+
+Usability issues:
+
+- authors still need to compose too much manually for common hero patterns
+
+Recommendations:
+
+- add hero composition presets
+- add stronger CTA / content display presets
+
+Relevant files:
+
+- [product-showcase-hero/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/product-showcase-hero/edit.js#L128)
+- [product-showcase-hero/edit.js](/Users/jnealey/github-local/designsetgo/src/blocks/product-showcase-hero/edit.js#L209)
+
+## Suggested Roadmap
+
+### Quick Wins
+
+- restore missing or hidden child inserter flows
+- replace silent block transforms with explicit transforms
+- add inline add/duplicate/reorder actions to composite blocks
+- replace numeric child selectors with item pickers
+
+### Shared Editor Infrastructure
+
+- reusable template chooser / setup shell
+- reusable child navigator
+- reusable preset-first variation picker
+- reusable summary panel for complex blocks
+
+### Block-Specific Follow-Up Work
+
+- `Slider` navigator and presets
+- `Form Builder` wizard and structured mappings
+- `Tabs` nav editing
+- `Comparison Table` import and duplicate column flow
+- `Modal` / `Modal Trigger` pairing workflow
+
+## Summary
+
+The codebase already has many strong building blocks for better editor UX:
+
+- strong use of templates
+- good block supports usage
+- some excellent setup placeholders
+- several good toolbar patterns
+
+The main gap is consistency.
+
+The blocks that feel best today are the ones that:
+
+- start with a guided state
+- provide useful defaults
+- keep common actions in the canvas or toolbar
+- avoid making the author think in implementation details
+
+The next phase should focus less on adding raw capability and more on making the existing capability easier to discover, easier to repeat, and easier to trust.

--- a/src/blocks/advanced-heading/edit.js
+++ b/src/blocks/advanced-heading/edit.js
@@ -68,7 +68,6 @@ export default function AdvancedHeadingEdit({ attributes, setAttributes }) {
 			allowedBlocks: ALLOWED_BLOCKS,
 			template: TEMPLATE,
 			orientation: 'horizontal',
-			renderAppender: false,
 		}
 	);
 

--- a/src/blocks/form-builder/block.json
+++ b/src/blocks/form-builder/block.json
@@ -19,6 +19,10 @@
 			"type": "string",
 			"default": ""
 		},
+		"hasFields": {
+			"type": "boolean",
+			"default": true
+		},
 		"submitButtonText": {
 			"type": "string",
 			"default": "Submit"

--- a/src/blocks/form-builder/components/FormBuilderPlaceholder.js
+++ b/src/blocks/form-builder/components/FormBuilderPlaceholder.js
@@ -1,0 +1,64 @@
+/**
+ * Form Builder Placeholder
+ *
+ * First-insert template chooser. Skippable — "Blank" seeds a minimal field
+ * so authors can always bail out and build from scratch.
+ */
+
+import { __ } from '@wordpress/i18n';
+import { Button, Placeholder, Icon } from '@wordpress/components';
+import { createBlocksFromInnerBlocksTemplate } from '@wordpress/blocks';
+import { useDispatch } from '@wordpress/data';
+import { formBuilderTemplates } from '../templates';
+import './form-builder-placeholder.scss';
+
+export default function FormBuilderPlaceholder({ clientId, setAttributes }) {
+	const { replaceInnerBlocks } = useDispatch('core/block-editor');
+
+	const selectTemplate = (template) => {
+		if (template.attributes) {
+			setAttributes(template.attributes);
+		}
+		if (template.innerBlocks?.length) {
+			const blocks = createBlocksFromInnerBlocksTemplate(
+				template.innerBlocks
+			);
+			replaceInnerBlocks(clientId, blocks, false);
+		}
+	};
+
+	return (
+		<Placeholder
+			icon="feedback"
+			label={__('Form Builder', 'designsetgo')}
+			instructions={__(
+				'Pick a starting template or begin with a blank form.',
+				'designsetgo'
+			)}
+			className="dsgo-form-builder-placeholder"
+		>
+			<div className="dsgo-form-builder-placeholder__templates">
+				{formBuilderTemplates.map((template) => (
+					<Button
+						key={template.name}
+						className={`dsgo-form-builder-placeholder__template dsgo-form-builder-placeholder__template--${template.name}`}
+						onClick={() => selectTemplate(template)}
+						variant="secondary"
+					>
+						<div className="dsgo-form-builder-placeholder__template-icon">
+							<Icon icon={template.icon} size={32} />
+						</div>
+						<div className="dsgo-form-builder-placeholder__template-info">
+							<span className="dsgo-form-builder-placeholder__template-title">
+								{template.title}
+							</span>
+							<span className="dsgo-form-builder-placeholder__template-description">
+								{template.description}
+							</span>
+						</div>
+					</Button>
+				))}
+			</div>
+		</Placeholder>
+	);
+}

--- a/src/blocks/form-builder/components/form-builder-placeholder.scss
+++ b/src/blocks/form-builder/components/form-builder-placeholder.scss
@@ -1,0 +1,144 @@
+.dsgo-form-builder-placeholder {
+	padding: 32px;
+	min-height: 300px;
+
+	.components-placeholder__label {
+		margin-bottom: 8px;
+	}
+
+	.components-placeholder__instructions {
+		margin-bottom: 24px;
+		color: #757575;
+	}
+
+	&__templates {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+		gap: 16px;
+		width: 100%;
+		max-width: 900px;
+		margin: 0 auto;
+	}
+
+	&__template {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 12px;
+		padding: 20px 16px;
+		height: auto;
+		min-height: 140px;
+		max-width: 100%;
+		width: 100%;
+		text-align: center;
+		white-space: normal;
+		word-break: break-word;
+		overflow-wrap: break-word;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+		background: #fff;
+		transition: all 0.2s ease;
+
+		&:hover {
+			border-color: var(--wp-admin-theme-color, #007cba);
+			background: #f8f9fa;
+			transform: translateY(-2px);
+			box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+		}
+
+		&:focus {
+			border-color: var(--wp-admin-theme-color, #007cba);
+			box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #007cba);
+		}
+
+		&--blank {
+			border-color: var(--wp-admin-theme-color, #007cba);
+			background: #f0f6fc;
+
+			.dsgo-form-builder-placeholder__template-icon {
+				color: var(--wp-admin-theme-color, #007cba);
+			}
+		}
+	}
+
+	&__template-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 48px;
+		height: 48px;
+		color: #666;
+
+		svg {
+			fill: currentcolor;
+		}
+	}
+
+	&__template-info {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		width: 100%;
+		min-width: 0;
+	}
+
+	&__template-title {
+		font-weight: 600;
+		font-size: 14px;
+		color: #1e1e1e;
+	}
+
+	&__template-description {
+		font-size: 12px;
+		color: #757575;
+		line-height: 1.4;
+		white-space: normal;
+		word-break: break-word;
+		overflow-wrap: break-word;
+	}
+}
+
+@media (max-width: 782px) {
+
+	.dsgo-form-builder-placeholder {
+		padding: 20px;
+
+		&__templates {
+			grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+			gap: 12px;
+		}
+
+		&__template {
+			padding: 16px 12px;
+			min-height: 120px;
+		}
+
+		&__template-icon {
+			width: 40px;
+			height: 40px;
+
+			svg {
+				width: 28px !important;
+				height: 28px !important;
+			}
+		}
+
+		&__template-title {
+			font-size: 13px;
+		}
+
+		&__template-description {
+			font-size: 11px;
+		}
+	}
+}
+
+@media (max-width: 600px) {
+
+	.dsgo-form-builder-placeholder {
+
+		&__templates {
+			grid-template-columns: 1fr 1fr;
+		}
+	}
+}

--- a/src/blocks/form-builder/edit.js
+++ b/src/blocks/form-builder/edit.js
@@ -4,7 +4,7 @@
  * @since 1.0.0
  */
 
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	useBlockProps,
 	useInnerBlocksProps,
@@ -27,6 +27,7 @@ import {
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import classnames from 'classnames';
 import {
 	encodeColorValue,
@@ -34,6 +35,22 @@ import {
 } from '../../utils/encode-color-value';
 import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
 import { validateCSSLength } from '../../utils/css-generator';
+import FormBuilderPlaceholder from './components/FormBuilderPlaceholder';
+
+// Blocks that Gutenberg identifies as form fields for the reply-to dropdown.
+const EMAILABLE_FIELD_BLOCKS = new Set([
+	'designsetgo/form-text-field',
+	'designsetgo/form-email-field',
+	'designsetgo/form-textarea-field',
+	'designsetgo/form-number-field',
+	'designsetgo/form-phone-field',
+	'designsetgo/form-url-field',
+	'designsetgo/form-date-field',
+	'designsetgo/form-time-field',
+	'designsetgo/form-select-field',
+	'designsetgo/form-checkbox-field',
+	'designsetgo/form-hidden-field',
+]);
 
 export default function FormBuilderEdit({
 	attributes,
@@ -119,6 +136,35 @@ export default function FormBuilderEdit({
 		}
 	}, [formId, clientId, setAttributes]);
 
+	// Track child count so we can show the template chooser on first insert,
+	// and build the reply-to dropdown options from the actual form fields.
+	const { hasInnerBlocks, replyToFieldOptions } = useSelect(
+		(select) => {
+			const children =
+				select('core/block-editor').getBlocks(clientId) || [];
+			const fields = children
+				.filter((child) => EMAILABLE_FIELD_BLOCKS.has(child.name))
+				.map((child) => ({
+					name: child.attributes?.fieldName || '',
+					label: child.attributes?.label || '',
+				}))
+				.filter((field) => !!field.name);
+			return {
+				hasInnerBlocks: children.length > 0,
+				replyToFieldOptions: fields,
+			};
+		},
+		[clientId]
+	);
+
+	// Keep hasFields in sync with the actual child field count so save.js can
+	// suppress the submit button/form wrapper when no template is picked.
+	useEffect(() => {
+		if (attributes.hasFields !== hasInnerBlocks) {
+			setAttributes({ hasFields: hasInnerBlocks });
+		}
+	}, [hasInnerBlocks, attributes.hasFields, setAttributes]);
+
 	// Calculate classes
 	const formClasses = classnames('dsgo-form-builder', {
 		[`dsgo-form-builder--align-${submitButtonAlignment}`]:
@@ -145,8 +191,10 @@ export default function FormBuilderEdit({
 		'data-form-id': formId,
 	});
 
-	// Inner blocks for form fields
-	// Extract children so we can add button inside fields container
+	// Inner blocks for form fields. The first-insert template chooser seeds
+	// innerBlocks itself, so we omit a default template here — otherwise the
+	// placeholder would never show.
+	// Extract children so we can add button inside fields container.
 	const { children, ...innerBlocksPropsWithoutChildren } =
 		useInnerBlocksProps(
 			{
@@ -166,34 +214,21 @@ export default function FormBuilderEdit({
 					'designsetgo/form-checkbox-field',
 					'designsetgo/form-hidden-field',
 				],
-				template: [
-					[
-						'designsetgo/form-text-field',
-						{
-							label: __('Name', 'designsetgo'),
-							fieldName: 'name',
-							required: true,
-						},
-					],
-					[
-						'designsetgo/form-email-field',
-						{
-							label: __('Email', 'designsetgo'),
-							fieldName: 'email',
-							required: true,
-						},
-					],
-					[
-						'designsetgo/form-textarea-field',
-						{
-							label: __('Message', 'designsetgo'),
-							fieldName: 'message',
-						},
-					],
-				],
 				orientation: 'vertical',
 			}
 		);
+
+	// Show the template chooser when the form is empty.
+	if (!hasInnerBlocks) {
+		return (
+			<div {...blockProps}>
+				<FormBuilderPlaceholder
+					clientId={clientId}
+					setAttributes={setAttributes}
+				/>
+			</div>
+		);
+	}
 
 	return (
 		<>
@@ -711,15 +746,50 @@ export default function FormBuilderEdit({
 								__nextHasNoMarginBottom
 							/>
 
-							<TextControl
-								label={__('Reply-To Field Name', 'designsetgo')}
-								value={emailReplyTo}
+							<SelectControl
+								label={__('Reply-To Field', 'designsetgo')}
+								value={emailReplyTo || ''}
+								options={[
+									{
+										label: __(
+											'— None (use From address) —',
+											'designsetgo'
+										),
+										value: '',
+									},
+									...replyToFieldOptions.map((field) => ({
+										label: field.label
+											? `${field.label} (${field.name})`
+											: field.name,
+										value: field.name,
+									})),
+									// If the saved value references a field that no
+									// longer exists, keep it as a selectable option
+									// so nothing silently changes behavior.
+									...(emailReplyTo &&
+									!replyToFieldOptions.some(
+										(field) => field.name === emailReplyTo
+									)
+										? [
+												{
+													label: sprintf(
+														/* translators: %s: missing field name */
+														__(
+															'%s (field not found)',
+															'designsetgo'
+														),
+														emailReplyTo
+													),
+													value: emailReplyTo,
+												},
+											]
+										: []),
+								]}
 								onChange={(value) =>
 									setAttributes({ emailReplyTo: value })
 								}
-								placeholder="email"
 								help={__(
-									'Use a form field value for reply-to (e.g., "email" or "user_email")',
+									'Submission from this form field is used as the reply-to address on notification emails.',
 									'designsetgo'
 								)}
 								__next40pxDefaultSize

--- a/src/blocks/form-builder/save.js
+++ b/src/blocks/form-builder/save.js
@@ -12,6 +12,7 @@ import { validateCSSLength } from '../../utils/css-generator';
 export default function FormBuilderSave({ attributes }) {
 	const {
 		formId,
+		hasFields,
 		submitButtonText,
 		submitButtonAlignment,
 		submitButtonPosition,
@@ -37,6 +38,12 @@ export default function FormBuilderSave({ attributes }) {
 		enableTurnstile,
 		redirectUrl,
 	} = attributes;
+
+	// If the author never picked a template (so the form has no fields),
+	// render nothing instead of a lonely submit button.
+	if (!hasFields) {
+		return null;
+	}
 
 	// Same classes as edit.js - MUST MATCH
 	const formClasses = classnames('dsgo-form-builder', {

--- a/src/blocks/form-builder/templates.js
+++ b/src/blocks/form-builder/templates.js
@@ -94,7 +94,7 @@ export const formBuilderTemplates = [
 					label: __('Email Address', 'designsetgo'),
 					fieldName: 'email',
 					required: true,
-					placeholder: 'you@example.com',
+					placeholder: __('you@example.com', 'designsetgo'),
 				},
 			],
 		],

--- a/src/blocks/form-builder/templates.js
+++ b/src/blocks/form-builder/templates.js
@@ -1,0 +1,208 @@
+/**
+ * Form Builder Templates
+ *
+ * Preset structures surfaced in the first-insert placeholder.
+ * Each template seeds its own innerBlocks and any notification/messaging
+ * defaults appropriate for the use case.
+ */
+
+import { __ } from '@wordpress/i18n';
+
+export const formBuilderTemplates = [
+	{
+		name: 'blank',
+		title: __('Blank', 'designsetgo'),
+		description: __('Start with a single text field', 'designsetgo'),
+		icon: 'welcome-add-page',
+		attributes: {},
+		innerBlocks: [
+			[
+				'designsetgo/form-text-field',
+				{
+					label: __('Name', 'designsetgo'),
+					fieldName: 'name',
+					required: true,
+				},
+			],
+		],
+	},
+	{
+		name: 'contact',
+		title: __('Contact', 'designsetgo'),
+		description: __(
+			'Name, email, and message — the classic contact form',
+			'designsetgo'
+		),
+		icon: 'email',
+		attributes: {
+			submitButtonText: __('Send Message', 'designsetgo'),
+			successMessage: __(
+				"Thanks — we'll be in touch shortly.",
+				'designsetgo'
+			),
+			enableEmail: true,
+			emailSubject: __('New contact form submission', 'designsetgo'),
+			emailReplyTo: 'email',
+		},
+		innerBlocks: [
+			[
+				'designsetgo/form-text-field',
+				{
+					label: __('Name', 'designsetgo'),
+					fieldName: 'name',
+					required: true,
+				},
+			],
+			[
+				'designsetgo/form-email-field',
+				{
+					label: __('Email', 'designsetgo'),
+					fieldName: 'email',
+					required: true,
+				},
+			],
+			[
+				'designsetgo/form-textarea-field',
+				{
+					label: __('Message', 'designsetgo'),
+					fieldName: 'message',
+					required: true,
+				},
+			],
+		],
+	},
+	{
+		name: 'newsletter',
+		title: __('Newsletter', 'designsetgo'),
+		description: __(
+			'Single email field with an inline subscribe button',
+			'designsetgo'
+		),
+		icon: 'email-alt',
+		attributes: {
+			submitButtonText: __('Subscribe', 'designsetgo'),
+			submitButtonPosition: 'inline',
+			successMessage: __('Thanks for subscribing!', 'designsetgo'),
+			enableEmail: true,
+			emailSubject: __('New newsletter signup', 'designsetgo'),
+			emailReplyTo: 'email',
+		},
+		innerBlocks: [
+			[
+				'designsetgo/form-email-field',
+				{
+					label: __('Email Address', 'designsetgo'),
+					fieldName: 'email',
+					required: true,
+					placeholder: 'you@example.com',
+				},
+			],
+		],
+	},
+	{
+		name: 'event-registration',
+		title: __('Event Registration', 'designsetgo'),
+		description: __(
+			'Name, email, phone, and number of guests',
+			'designsetgo'
+		),
+		icon: 'calendar-alt',
+		attributes: {
+			submitButtonText: __('Register', 'designsetgo'),
+			successMessage: __(
+				"You're on the list — check your inbox for details.",
+				'designsetgo'
+			),
+			enableEmail: true,
+			emailSubject: __('New event registration', 'designsetgo'),
+			emailReplyTo: 'email',
+		},
+		innerBlocks: [
+			[
+				'designsetgo/form-text-field',
+				{
+					label: __('Full Name', 'designsetgo'),
+					fieldName: 'name',
+					required: true,
+				},
+			],
+			[
+				'designsetgo/form-email-field',
+				{
+					label: __('Email', 'designsetgo'),
+					fieldName: 'email',
+					required: true,
+				},
+			],
+			[
+				'designsetgo/form-phone-field',
+				{
+					label: __('Phone', 'designsetgo'),
+					fieldName: 'phone',
+				},
+			],
+			[
+				'designsetgo/form-number-field',
+				{
+					label: __('Number of Guests', 'designsetgo'),
+					fieldName: 'guests',
+					min: 1,
+					max: 10,
+					defaultValue: 1,
+				},
+			],
+		],
+	},
+	{
+		name: 'lead-capture',
+		title: __('Lead Capture', 'designsetgo'),
+		description: __(
+			'Name, work email, company, and phone for B2B leads',
+			'designsetgo'
+		),
+		icon: 'businessman',
+		attributes: {
+			submitButtonText: __('Get in Touch', 'designsetgo'),
+			successMessage: __(
+				"Thanks — we'll reach out shortly.",
+				'designsetgo'
+			),
+			enableEmail: true,
+			emailSubject: __('New lead submission', 'designsetgo'),
+			emailReplyTo: 'email',
+		},
+		innerBlocks: [
+			[
+				'designsetgo/form-text-field',
+				{
+					label: __('Full Name', 'designsetgo'),
+					fieldName: 'name',
+					required: true,
+				},
+			],
+			[
+				'designsetgo/form-email-field',
+				{
+					label: __('Work Email', 'designsetgo'),
+					fieldName: 'email',
+					required: true,
+				},
+			],
+			[
+				'designsetgo/form-text-field',
+				{
+					label: __('Company', 'designsetgo'),
+					fieldName: 'company',
+					required: true,
+				},
+			],
+			[
+				'designsetgo/form-phone-field',
+				{
+					label: __('Phone', 'designsetgo'),
+					fieldName: 'phone',
+				},
+			],
+		],
+	},
+];

--- a/src/blocks/image-accordion/edit.js
+++ b/src/blocks/image-accordion/edit.js
@@ -62,8 +62,13 @@ export default function ImageAccordionEdit({
 					(inner) => inner.name === 'core/heading'
 				);
 				const raw = heading?.attributes?.content ?? '';
-				const text = String(raw)
-					.replace(/<[^>]+>/g, '')
+				// DOMParser handles malformed/unterminated tags safely
+				// (unlike a naive regex).
+				const parsed = new window.DOMParser().parseFromString(
+					String(raw),
+					'text/html'
+				);
+				const text = (parsed.body.textContent || '')
 					.trim()
 					.slice(0, 40);
 				const label = text

--- a/src/blocks/image-accordion/edit.js
+++ b/src/blocks/image-accordion/edit.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	useBlockProps,
 	useInnerBlocksProps,
@@ -16,6 +16,7 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import classnames from 'classnames';
 import {
 	encodeColorValue,
@@ -43,6 +44,46 @@ export default function ImageAccordionEdit({
 
 	// Get theme color palette and gradient settings
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
+
+	// Build options for the default-expanded picker from the actual child items.
+	// Uses the first core/heading content when present so authors recognize each item.
+	const itemOptions = useSelect(
+		(select) => {
+			const children =
+				select('core/block-editor').getBlocks(clientId) || [];
+			const options = [
+				{
+					label: __('None (no item expanded)', 'designsetgo'),
+					value: '0',
+				},
+			];
+			children.forEach((child, index) => {
+				const heading = child.innerBlocks?.find(
+					(inner) => inner.name === 'core/heading'
+				);
+				const raw = heading?.attributes?.content ?? '';
+				const text = String(raw)
+					.replace(/<[^>]+>/g, '')
+					.trim()
+					.slice(0, 40);
+				const label = text
+					? sprintf(
+							/* translators: %1$d: item position, %2$s: item title */
+							__('Item %1$d: %2$s', 'designsetgo'),
+							index + 1,
+							text
+						)
+					: sprintf(
+							/* translators: %d: item position */
+							__('Item %d', 'designsetgo'),
+							index + 1
+						);
+				options.push({ label, value: String(index + 1) });
+			});
+			return options;
+		},
+		[clientId]
+	);
 
 	// Declaratively calculate classes based on attributes
 	const accordionClasses = classnames('dsgo-image-accordion', {
@@ -204,16 +245,17 @@ export default function ImageAccordionEdit({
 						__nextHasNoMarginBottom
 					/>
 
-					<RangeControl
+					<SelectControl
 						label={__('Default Expanded Item', 'designsetgo')}
-						value={defaultExpanded}
+						value={String(defaultExpanded)}
+						options={itemOptions}
 						onChange={(value) =>
-							setAttributes({ defaultExpanded: value })
+							setAttributes({
+								defaultExpanded: parseInt(value, 10) || 0,
+							})
 						}
-						min={0}
-						max={10}
 						help={__(
-							'Which item is expanded on page load (0 = none, 1 = first, etc.)',
+							'Which item is expanded when the page loads',
 							'designsetgo'
 						)}
 						__next40pxDefaultSize

--- a/src/blocks/slider/edit.js
+++ b/src/blocks/slider/edit.js
@@ -16,10 +16,14 @@ import {
 	RangeControl,
 	TextControl,
 	Notice,
+	Button,
+	Tooltip,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
+import { copy, trash, plus } from '@wordpress/icons';
 import classnames from 'classnames';
 import {
 	encodeColorValue,
@@ -76,11 +80,75 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 
 	const blockRef = useRef(null);
 
-	// Get actual slide count for dynamic dot navigation
-	const slideCount = useSelect(
-		(select) => select('core/block-editor').getBlockCount(clientId),
+	// Slide list powers both the dot navigation and the editor-only navigator.
+	const { slides, selectedSlideId } = useSelect(
+		(select) => {
+			const editor = select('core/block-editor');
+			const children = editor.getBlocks(clientId) || [];
+			const selectedBlock = editor.getSelectedBlockClientId();
+			let selectedSlide = null;
+			if (selectedBlock) {
+				if (
+					children.some((child) => child.clientId === selectedBlock)
+				) {
+					selectedSlide = selectedBlock;
+				} else {
+					const parents = editor.getBlockParents(selectedBlock);
+					const match = parents.find((parent) =>
+						children.some((child) => child.clientId === parent)
+					);
+					if (match) {
+						selectedSlide = match;
+					}
+				}
+			}
+			return { slides: children, selectedSlideId: selectedSlide };
+		},
 		[clientId]
 	);
+	const slideCount = slides.length;
+
+	const { insertBlock, removeBlock, selectBlock } =
+		useDispatch('core/block-editor');
+
+	// Extract a readable label for a slide: first heading text if present, else "Slide N".
+	const getSlideLabel = (slide, index) => {
+		const heading = slide.innerBlocks?.find(
+			(inner) => inner.name === 'core/heading'
+		);
+		const raw = heading?.attributes?.content ?? '';
+		const text = String(raw)
+			.replace(/<[^>]+>/g, '')
+			.trim();
+		if (text) {
+			return text.slice(0, 30);
+		}
+		return sprintf(
+			/* translators: %d: slide number */
+			__('Slide %d', 'designsetgo'),
+			index + 1
+		);
+	};
+
+	const handleAddSlide = () => {
+		const newSlide = createBlock('designsetgo/slide');
+		insertBlock(newSlide, slideCount, clientId, true);
+	};
+
+	const handleDuplicateSlide = (slide, index) => {
+		const clone = createBlock(
+			slide.name,
+			{ ...slide.attributes },
+			slide.innerBlocks.map((inner) =>
+				createBlock(inner.name, inner.attributes, inner.innerBlocks)
+			)
+		);
+		insertBlock(clone, index + 1, clientId, true);
+	};
+
+	const handleRemoveSlide = (slide) => {
+		removeBlock(slide.clientId, false);
+	};
 
 	useEffect(() => {
 		if (
@@ -360,7 +428,6 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 				],
 			],
 			orientation: 'horizontal',
-			renderAppender: false, // Hide default appender, we'll add custom UI
 		}
 	);
 
@@ -1092,6 +1159,85 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 				<div className="dsgo-slider__viewport">
 					<div {...innerBlocksProps} />
 				</div>
+
+				{/* Editor-only slide navigator */}
+				{slides.length > 0 && (
+					<div
+						className="dsgo-slider__nav dsgo-slider__nav--editor-only"
+						role="toolbar"
+						aria-label={__('Slides', 'designsetgo')}
+					>
+						{slides.map((slide, index) => (
+							<div
+								key={slide.clientId}
+								className={classnames('dsgo-slider__nav-chip', {
+									'is-active':
+										selectedSlideId === slide.clientId,
+								})}
+							>
+								<button
+									type="button"
+									className="dsgo-slider__nav-chip-label"
+									onClick={() => selectBlock(slide.clientId)}
+								>
+									<span className="dsgo-slider__nav-chip-index">
+										{index + 1}
+									</span>
+									<span className="dsgo-slider__nav-chip-title">
+										{getSlideLabel(slide, index)}
+									</span>
+								</button>
+								<div className="dsgo-slider__nav-chip-actions">
+									<Tooltip
+										text={__(
+											'Duplicate slide',
+											'designsetgo'
+										)}
+									>
+										<Button
+											size="small"
+											icon={copy}
+											label={__(
+												'Duplicate slide',
+												'designsetgo'
+											)}
+											onClick={() =>
+												handleDuplicateSlide(
+													slide,
+													index
+												)
+											}
+										/>
+									</Tooltip>
+									<Tooltip
+										text={__('Remove slide', 'designsetgo')}
+									>
+										<Button
+											size="small"
+											icon={trash}
+											isDestructive
+											label={__(
+												'Remove slide',
+												'designsetgo'
+											)}
+											onClick={() =>
+												handleRemoveSlide(slide)
+											}
+										/>
+									</Tooltip>
+								</div>
+							</div>
+						))}
+						<Button
+							size="small"
+							icon={plus}
+							className="dsgo-slider__nav-add"
+							onClick={handleAddSlide}
+						>
+							{__('Add slide', 'designsetgo')}
+						</Button>
+					</div>
+				)}
 
 				{/* Editor-only navigation - functional scroll controls */}
 				{showArrows && (

--- a/src/blocks/slider/edit.js
+++ b/src/blocks/slider/edit.js
@@ -22,7 +22,7 @@ import {
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, cloneBlock } from '@wordpress/blocks';
 import { copy, trash, plus } from '@wordpress/icons';
 import classnames from 'classnames';
 import {
@@ -112,14 +112,17 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 		useDispatch('core/block-editor');
 
 	// Extract a readable label for a slide: first heading text if present, else "Slide N".
+	// DOMParser handles malformed/unterminated tags safely (unlike a naive regex).
 	const getSlideLabel = (slide, index) => {
 		const heading = slide.innerBlocks?.find(
 			(inner) => inner.name === 'core/heading'
 		);
 		const raw = heading?.attributes?.content ?? '';
-		const text = String(raw)
-			.replace(/<[^>]+>/g, '')
-			.trim();
+		const parsed = new window.DOMParser().parseFromString(
+			String(raw),
+			'text/html'
+		);
+		const text = (parsed.body.textContent || '').trim();
 		if (text) {
 			return text.slice(0, 30);
 		}
@@ -136,17 +139,15 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 	};
 
 	const handleDuplicateSlide = (slide, index) => {
-		const clone = createBlock(
-			slide.name,
-			{ ...slide.attributes },
-			slide.innerBlocks.map((inner) =>
-				createBlock(inner.name, inner.attributes, inner.innerBlocks)
-			)
-		);
+		// cloneBlock does a deep clone with fresh clientIds at every level.
+		const clone = cloneBlock(slide);
 		insertBlock(clone, index + 1, clientId, true);
 	};
 
 	const handleRemoveSlide = (slide) => {
+		if (slides.length <= 1) {
+			return;
+		}
 		removeBlock(slide.clientId, false);
 	};
 

--- a/src/blocks/slider/editor.scss
+++ b/src/blocks/slider/editor.scss
@@ -101,23 +101,26 @@
 		display: none;
 	}
 
-	// `display: contents` removes the appender wrappers from layout entirely,
-	// so they don't take flex-flow space in the centered content (which was
-	// visually pushing heading/paragraph upward). The inserter button inside
-	// then becomes a direct child of .dsgo-slide__content for layout purposes.
-	.dsgo-slide .block-list-appender,
-	.dsgo-slide .block-editor-default-block-appender {
+	// `display: contents` on the slide's own end-of-content appender wrappers
+	// removes them from layout, so they don't take flex-flow space in the
+	// centered content (which was pushing heading/paragraph upward). The
+	// inserter button inside then becomes a direct child of .dsgo-slide__content.
+	// Scoped to the direct-child appender only (not inserters inside nested
+	// Group / Columns / etc. blocks within a slide).
+	.dsgo-slide > .dsgo-slide__content > .block-list-appender,
+	.dsgo-slide > .dsgo-slide__content > .block-list-appender > .block-editor-default-block-appender {
 		display: contents;
 	}
 
 	// Make .dsgo-slide__content static so the nearest positioned ancestor of
-	// the inserter is .dsgo-slide. Overlay stacking still works because the
-	// overlay is rendered before content in the DOM.
-	.dsgo-slide .dsgo-slide__content {
+	// the slide-level inserter is .dsgo-slide. Overlay stacking still works
+	// because the overlay is rendered before content in the DOM.
+	.dsgo-slide > .dsgo-slide__content {
 		position: static;
 	}
 
-	.dsgo-slide .block-editor-inserter {
+	// Pin ONLY the slide-level inserter (not inserters inside nested blocks).
+	.dsgo-slide > .dsgo-slide__content > .block-list-appender .block-editor-inserter {
 		position: absolute !important;
 		top: auto !important;
 		right: auto !important;

--- a/src/blocks/slider/editor.scss
+++ b/src/blocks/slider/editor.scss
@@ -92,6 +92,43 @@
 		}
 	}
 
+	// Pin the slide's block-list-appender "+" button to the slide's
+	// bottom-center so it sits below the arrow band instead of overlapping
+	// the arrows (which are centered mid-height, intentionally overlaying
+	// the slide). Frontend/save output is unaffected.
+	/* stylelint-disable selector-class-pattern */
+	.dsgo-slide .block-editor-default-block-appender__content {
+		display: none;
+	}
+
+	// `display: contents` removes the appender wrappers from layout entirely,
+	// so they don't take flex-flow space in the centered content (which was
+	// visually pushing heading/paragraph upward). The inserter button inside
+	// then becomes a direct child of .dsgo-slide__content for layout purposes.
+	.dsgo-slide .block-list-appender,
+	.dsgo-slide .block-editor-default-block-appender {
+		display: contents;
+	}
+
+	// Make .dsgo-slide__content static so the nearest positioned ancestor of
+	// the inserter is .dsgo-slide. Overlay stacking still works because the
+	// overlay is rendered before content in the DOM.
+	.dsgo-slide .dsgo-slide__content {
+		position: static;
+	}
+
+	.dsgo-slide .block-editor-inserter {
+		position: absolute !important;
+		top: auto !important;
+		right: auto !important;
+		bottom: 16px !important;
+		left: 50% !important;
+		translate: -50% 0 !important;
+		transform: none !important;
+		z-index: 5;
+	}
+	/* stylelint-enable selector-class-pattern */
+
 	// Make appender visible in editor
 	/* stylelint-disable-next-line selector-class-pattern */
 	.block-list-appender {
@@ -121,5 +158,102 @@
 	.block-editor-block-list__block {
 		margin-top: 0;
 		margin-bottom: 0;
+	}
+}
+
+// Editor-only slide navigator
+.dsgo-slider__nav--editor-only {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 6px;
+	margin-top: 12px;
+	padding: 8px;
+	background: rgba(0, 0, 0, 0.03);
+	border: 1px dashed rgba(0, 0, 0, 0.15);
+	border-radius: 4px;
+
+	.dsgo-slider__nav-chip {
+		display: inline-flex;
+		align-items: center;
+		background: #fff;
+		border: 1px solid rgba(0, 0, 0, 0.15);
+		border-radius: 4px;
+		overflow: hidden;
+		transition: border-color 0.15s ease, box-shadow 0.15s ease;
+		max-width: 220px;
+
+		&:hover {
+			border-color: var(--wp-admin-theme-color, #2271b1);
+
+			.dsgo-slider__nav-chip-actions {
+				display: inline-flex;
+			}
+		}
+
+		&.is-active {
+			border-color: var(--wp-admin-theme-color, #2271b1);
+			box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #2271b1);
+		}
+	}
+
+	.dsgo-slider__nav-chip-label {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 4px 8px;
+		background: none;
+		border: 0;
+		cursor: pointer;
+		font-size: 12px;
+		line-height: 1.2;
+		color: inherit;
+		max-width: 100%;
+
+		&:focus-visible {
+			outline: 2px solid var(--wp-admin-theme-color, #2271b1);
+			outline-offset: -2px;
+		}
+	}
+
+	.dsgo-slider__nav-chip-index {
+		flex-shrink: 0;
+		width: 18px;
+		height: 18px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		background: rgba(0, 0, 0, 0.08);
+		border-radius: 9px;
+		font-size: 10px;
+		font-weight: 600;
+		color: rgba(0, 0, 0, 0.7);
+	}
+
+	.dsgo-slider__nav-chip.is-active .dsgo-slider__nav-chip-index {
+		background: var(--wp-admin-theme-color, #2271b1);
+		color: #fff;
+	}
+
+	.dsgo-slider__nav-chip-title {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.dsgo-slider__nav-chip-actions {
+		display: none;
+		align-items: center;
+		border-left: 1px solid rgba(0, 0, 0, 0.1);
+		padding: 0 2px;
+
+		// Always show on focus inside the chip for keyboard users
+		.dsgo-slider__nav-chip:focus-within & {
+			display: inline-flex;
+		}
+	}
+
+	.dsgo-slider__nav-add {
+		margin-left: auto;
 	}
 }

--- a/src/blocks/tab/block.json
+++ b/src/blocks/tab/block.json
@@ -110,5 +110,5 @@
 	},
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
-	"style": "file:./index.css"
+	"style": "file:./style-index.css"
 }

--- a/src/blocks/tabs/block.json
+++ b/src/blocks/tabs/block.json
@@ -211,5 +211,5 @@
 	"viewScript": "file:./view.js",
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
-	"style": "file:./index.css"
+	"style": "file:./style-index.css"
 }

--- a/src/blocks/tabs/edit.js
+++ b/src/blocks/tabs/edit.js
@@ -4,7 +4,7 @@
  * Parent block that manages tab navigation and panels
  */
 
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	useBlockProps,
 	InspectorControls,
@@ -23,7 +23,7 @@ import {
 	Button,
 	Tooltip,
 } from '@wordpress/components';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, cloneBlock } from '@wordpress/blocks';
 import { copy, trash, plus } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -106,25 +106,29 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 	const handleAddTab = () => {
 		const tabCount = innerBlocks.length;
 		const newTab = createBlock('designsetgo/tab', {
-			title: `Tab ${tabCount + 1}`,
+			title: sprintf(
+				/* translators: %d: tab number */
+				__('Tab %d', 'designsetgo'),
+				tabCount + 1
+			),
 		});
 		insertBlock(newTab, tabCount, clientId, true);
 		setAttributes({ activeTab: tabCount });
 	};
 
 	const handleDuplicateTab = (tab, index) => {
-		const clone = createBlock(
-			tab.name,
-			{ ...tab.attributes, uniqueId: '' },
-			tab.innerBlocks.map((inner) =>
-				createBlock(inner.name, inner.attributes, inner.innerBlocks)
-			)
-		);
+		// cloneBlock produces a deep clone with fresh clientIds at every level.
+		// Reset uniqueId so the duplicated tab regenerates its own via the
+		// child block's onMount effect.
+		const clone = cloneBlock(tab, { uniqueId: '' });
 		insertBlock(clone, index + 1, clientId, true);
 		setAttributes({ activeTab: index + 1 });
 	};
 
 	const handleRemoveTab = (tab, index) => {
+		if (innerBlocks.length <= 1) {
+			return;
+		}
 		removeBlock(tab.clientId, false);
 		// If we removed the active tab (or an earlier one), keep a valid index.
 		if (index <= activeTab) {
@@ -552,108 +556,167 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 			</InspectorControls>
 
 			<div {...blockProps}>
-				{/* Tab Navigation */}
-				<div
-					className="dsgo-tabs__nav"
-					role="tablist"
-					aria-label={__('Tabs', 'designsetgo')}
-				>
-					{innerBlocks.map((block, index) => {
-						const {
-							title,
-							icon,
-							iconPosition,
-							uniqueId: tabId,
-						} = block.attributes;
-						const isActive = index === activeTab;
+				{/* Tab Navigation. The tablist + the editor-only "Add tab"
+				    button are wrapped in a single flex row so the add
+				    control reads as adjacent to the tabs without sitting
+				    inside role="tablist". */}
+				<div className="dsgo-tabs__nav-row">
+					<div
+						className="dsgo-tabs__nav"
+						role="tablist"
+						aria-label={__('Tabs', 'designsetgo')}
+					>
+						{innerBlocks.map((block, index) => {
+							const {
+								title,
+								icon,
+								iconPosition,
+								uniqueId: tabId,
+							} = block.attributes;
+							const isActive = index === activeTab;
 
-						return (
-							<div
-								key={block.clientId}
-								className={`dsgo-tabs__tab dsgo-tabs__tab--editor ${
-									isActive ? 'is-active' : ''
-								} ${
-									icon
-										? `has-icon has-icon-${iconPosition}`
-										: ''
-								}`}
-								id={`tab-${tabId}`}
-								role="tab"
-								aria-selected={isActive}
-								aria-controls={`panel-${tabId}`}
-								tabIndex={isActive ? 0 : -1}
-								data-tab-index={index}
-								onKeyDown={(e) => handleKeyDown(e, index)}
-							>
-								{icon && iconPosition === 'left' && (
-									<span className="dsgo-tabs__tab-icon">
-										{getIcon(icon)}
-									</span>
-								)}
+							const placeholderLabel = sprintf(
+								/* translators: %d: tab number */
+								__('Tab %d', 'designsetgo'),
+								index + 1
+							);
+							return (
+								<div
+									key={block.clientId}
+									className={`dsgo-tabs__tab dsgo-tabs__tab--editor ${
+										isActive ? 'is-active' : ''
+									} ${
+										icon
+											? `has-icon has-icon-${iconPosition}`
+											: ''
+									}`}
+									id={`tab-${tabId}`}
+									role="tab"
+									aria-selected={isActive}
+									aria-controls={`panel-${tabId}`}
+									tabIndex={isActive ? 0 : -1}
+									data-tab-index={index}
+									onClick={(e) => {
+										// Ignore clicks routed through the inline
+										// edit input or an action button — they
+										// handle their own focus/click behavior.
+										if (
+											e.target.closest(
+												'.dsgo-tabs__tab-title--editor, .dsgo-tabs__tab-actions'
+											)
+										) {
+											return;
+										}
+										handleTabClick(index);
+									}}
+									onKeyDown={(e) => handleKeyDown(e, index)}
+								>
+									{icon && iconPosition === 'left' && (
+										<span className="dsgo-tabs__tab-icon">
+											{getIcon(icon)}
+										</span>
+									)}
 
-								{icon && iconPosition === 'top' && (
-									<span className="dsgo-tabs__tab-icon-top">
-										{getIcon(icon)}
-									</span>
-								)}
+									{icon && iconPosition === 'top' && (
+										<span className="dsgo-tabs__tab-icon-top">
+											{getIcon(icon)}
+										</span>
+									)}
 
-								<input
-									type="text"
-									className="dsgo-tabs__tab-title dsgo-tabs__tab-title--editor"
-									value={title || ''}
-									placeholder={`Tab ${index + 1}`}
-									onFocus={() => handleTabClick(index)}
-									onChange={(e) =>
-										handleTitleChange(block, e.target.value)
-									}
-									aria-label={__('Tab title', 'designsetgo')}
-								/>
-
-								{icon && iconPosition === 'right' && (
-									<span className="dsgo-tabs__tab-icon">
-										{getIcon(icon)}
-									</span>
-								)}
-
-								<span className="dsgo-tabs__tab-actions">
-									<Tooltip
-										text={__(
-											'Duplicate tab',
+									<input
+										type="text"
+										className="dsgo-tabs__tab-title dsgo-tabs__tab-title--editor"
+										value={title || ''}
+										placeholder={placeholderLabel}
+										onFocus={() => handleTabClick(index)}
+										onChange={(e) =>
+											handleTitleChange(
+												block,
+												e.target.value
+											)
+										}
+										onKeyDown={(e) => {
+											// Don't let navigation keys from the
+											// title input bubble up and trigger
+											// the tab's arrow-key navigation —
+											// those should move the text caret.
+											if (
+												[
+													'ArrowLeft',
+													'ArrowRight',
+													'ArrowUp',
+													'ArrowDown',
+													'Home',
+													'End',
+												].includes(e.key)
+											) {
+												e.stopPropagation();
+											}
+										}}
+										aria-label={__(
+											'Tab title',
 											'designsetgo'
 										)}
-									>
-										<Button
-											size="small"
-											icon={copy}
-											label={__(
+									/>
+
+									{icon && iconPosition === 'right' && (
+										<span className="dsgo-tabs__tab-icon">
+											{getIcon(icon)}
+										</span>
+									)}
+
+									<span className="dsgo-tabs__tab-actions">
+										<Tooltip
+											text={__(
 												'Duplicate tab',
 												'designsetgo'
 											)}
-											onClick={() =>
-												handleDuplicateTab(block, index)
-											}
-										/>
-									</Tooltip>
-									<Tooltip
-										text={__('Remove tab', 'designsetgo')}
-									>
-										<Button
-											size="small"
-											icon={trash}
-											isDestructive
-											label={__(
+										>
+											<Button
+												size="small"
+												icon={copy}
+												label={__(
+													'Duplicate tab',
+													'designsetgo'
+												)}
+												onClick={() =>
+													handleDuplicateTab(
+														block,
+														index
+													)
+												}
+											/>
+										</Tooltip>
+										<Tooltip
+											text={__(
 												'Remove tab',
 												'designsetgo'
 											)}
-											onClick={() =>
-												handleRemoveTab(block, index)
-											}
-										/>
-									</Tooltip>
-								</span>
-							</div>
-						);
-					})}
+										>
+											<Button
+												size="small"
+												icon={trash}
+												isDestructive
+												label={__(
+													'Remove tab',
+													'designsetgo'
+												)}
+												onClick={() =>
+													handleRemoveTab(
+														block,
+														index
+													)
+												}
+											/>
+										</Tooltip>
+									</span>
+								</div>
+							);
+						})}
+					</div>
+					{/* "Add tab" sits outside the tablist so it doesn't violate the
+				    ARIA tab pattern (a tablist should only contain role="tab"
+				    children). */}
 					<Button
 						size="small"
 						icon={plus}

--- a/src/blocks/tabs/edit.js
+++ b/src/blocks/tabs/edit.js
@@ -20,7 +20,11 @@ import {
 	SelectControl,
 	ToggleControl,
 	RangeControl,
+	Button,
+	Tooltip,
 } from '@wordpress/components';
+import { createBlock } from '@wordpress/blocks';
+import { copy, trash, plus } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { getIcon } from '../icon/utils/svg-icons';
@@ -82,7 +86,8 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 	);
 
 	// Get dispatch actions for selecting blocks
-	const { selectBlock } = useDispatch(blockEditorStore);
+	const { selectBlock, insertBlock, removeBlock, updateBlockAttributes } =
+		useDispatch(blockEditorStore);
 
 	// Handle tab click - set active tab and select the Tab block to show its settings
 	const handleTabClick = (index) => {
@@ -91,6 +96,40 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 		// Select the corresponding Tab block so its settings appear in sidebar
 		if (innerBlocks[index]) {
 			selectBlock(innerBlocks[index].clientId);
+		}
+	};
+
+	const handleTitleChange = (tab, value) => {
+		updateBlockAttributes(tab.clientId, { title: value });
+	};
+
+	const handleAddTab = () => {
+		const tabCount = innerBlocks.length;
+		const newTab = createBlock('designsetgo/tab', {
+			title: `Tab ${tabCount + 1}`,
+		});
+		insertBlock(newTab, tabCount, clientId, true);
+		setAttributes({ activeTab: tabCount });
+	};
+
+	const handleDuplicateTab = (tab, index) => {
+		const clone = createBlock(
+			tab.name,
+			{ ...tab.attributes, uniqueId: '' },
+			tab.innerBlocks.map((inner) =>
+				createBlock(inner.name, inner.attributes, inner.innerBlocks)
+			)
+		);
+		insertBlock(clone, index + 1, clientId, true);
+		setAttributes({ activeTab: index + 1 });
+	};
+
+	const handleRemoveTab = (tab, index) => {
+		removeBlock(tab.clientId, false);
+		// If we removed the active tab (or an earlier one), keep a valid index.
+		if (index <= activeTab) {
+			const next = Math.max(0, activeTab - 1);
+			setAttributes({ activeTab: next });
 		}
 	};
 
@@ -529,9 +568,11 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 						const isActive = index === activeTab;
 
 						return (
-							<button
+							<div
 								key={block.clientId}
-								className={`dsgo-tabs__tab ${isActive ? 'is-active' : ''} ${
+								className={`dsgo-tabs__tab dsgo-tabs__tab--editor ${
+									isActive ? 'is-active' : ''
+								} ${
 									icon
 										? `has-icon has-icon-${iconPosition}`
 										: ''
@@ -542,7 +583,6 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 								aria-controls={`panel-${tabId}`}
 								tabIndex={isActive ? 0 : -1}
 								data-tab-index={index}
-								onClick={() => handleTabClick(index)}
 								onKeyDown={(e) => handleKeyDown(e, index)}
 							>
 								{icon && iconPosition === 'left' && (
@@ -557,18 +597,71 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 									</span>
 								)}
 
-								<span className="dsgo-tabs__tab-title">
-									{title || `Tab ${index + 1}`}
-								</span>
+								<input
+									type="text"
+									className="dsgo-tabs__tab-title dsgo-tabs__tab-title--editor"
+									value={title || ''}
+									placeholder={`Tab ${index + 1}`}
+									onFocus={() => handleTabClick(index)}
+									onChange={(e) =>
+										handleTitleChange(block, e.target.value)
+									}
+									aria-label={__('Tab title', 'designsetgo')}
+								/>
 
 								{icon && iconPosition === 'right' && (
 									<span className="dsgo-tabs__tab-icon">
 										{getIcon(icon)}
 									</span>
 								)}
-							</button>
+
+								<span className="dsgo-tabs__tab-actions">
+									<Tooltip
+										text={__(
+											'Duplicate tab',
+											'designsetgo'
+										)}
+									>
+										<Button
+											size="small"
+											icon={copy}
+											label={__(
+												'Duplicate tab',
+												'designsetgo'
+											)}
+											onClick={() =>
+												handleDuplicateTab(block, index)
+											}
+										/>
+									</Tooltip>
+									<Tooltip
+										text={__('Remove tab', 'designsetgo')}
+									>
+										<Button
+											size="small"
+											icon={trash}
+											isDestructive
+											label={__(
+												'Remove tab',
+												'designsetgo'
+											)}
+											onClick={() =>
+												handleRemoveTab(block, index)
+											}
+										/>
+									</Tooltip>
+								</span>
+							</div>
 						);
 					})}
+					<Button
+						size="small"
+						icon={plus}
+						className="dsgo-tabs__add-tab"
+						onClick={handleAddTab}
+					>
+						{__('Add tab', 'designsetgo')}
+					</Button>
 				</div>
 
 				{/* Tab Panels - Use spread props pattern */}

--- a/src/blocks/tabs/edit.js
+++ b/src/blocks/tabs/edit.js
@@ -85,18 +85,16 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 		[clientId]
 	);
 
-	// Get dispatch actions for selecting blocks
-	const { selectBlock, insertBlock, removeBlock, updateBlockAttributes } =
+	const { insertBlock, removeBlock, updateBlockAttributes } =
 		useDispatch(blockEditorStore);
 
-	// Handle tab click - set active tab and select the Tab block to show its settings
+	// Handle tab chip click — only switch which tab is active. We intentionally
+	// do NOT call selectBlock() on the child Tab, so the Gutenberg inline
+	// toolbar stays anchored to the Tabs parent (above the whole block) instead
+	// of hovering between the nav and the panel. Authors who want to edit a
+	// specific Tab's attributes can click into its panel content below.
 	const handleTabClick = (index) => {
 		setAttributes({ activeTab: index });
-
-		// Select the corresponding Tab block so its settings appear in sidebar
-		if (innerBlocks[index]) {
-			selectBlock(innerBlocks[index].clientId);
-		}
 	};
 
 	const handleTitleChange = (tab, value) => {
@@ -112,7 +110,9 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 				tabCount + 1
 			),
 		});
-		insertBlock(newTab, tabCount, clientId, true);
+		// updateSelection: false — keep the Tabs parent selected so the inline
+		// toolbar doesn't jump to the new child Tab and overlap the nav.
+		insertBlock(newTab, tabCount, clientId, false);
 		setAttributes({ activeTab: tabCount });
 	};
 
@@ -121,7 +121,7 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 		// Reset uniqueId so the duplicated tab regenerates its own via the
 		// child block's onMount effect.
 		const clone = cloneBlock(tab, { uniqueId: '' });
-		insertBlock(clone, index + 1, clientId, true);
+		insertBlock(clone, index + 1, clientId, false);
 		setAttributes({ activeTab: index + 1 });
 	};
 
@@ -167,11 +167,6 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 
 		if (newIndex !== index) {
 			setAttributes({ activeTab: newIndex });
-
-			// Select the corresponding Tab block so its settings appear in sidebar
-			if (innerBlocks[newIndex]) {
-				selectBlock(innerBlocks[newIndex].clientId);
-			}
 
 			// Focus the new tab
 			setTimeout(() => {

--- a/src/blocks/tabs/editor.scss
+++ b/src/blocks/tabs/editor.scss
@@ -344,13 +344,23 @@
 	 */
 
 	// Gutenberg positions the block toolbar directly above the selected block.
-	// Reserve space above the nav (for the Tabs block's own toolbar) and
-	// below the nav (for a selected child Tab's toolbar). Without this, the
-	// toolbar overlaps the tab titles or the panel boundary.
-	/* stylelint-disable-next-line no-duplicate-selectors */
-	.dsgo-tabs__nav {
+	// Reserve space above the nav row (for the Tabs block's own toolbar) and
+	// below the nav row (for a selected child Tab's toolbar). Without this,
+	// the toolbar overlaps the tab titles or the panel boundary.
+	.dsgo-tabs__nav-row {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 8px;
 		margin-top: 56px;
 		margin-bottom: 56px;
+	}
+
+	// The nav strip inside the row keeps its own layout but drops the
+	// outer margin (the row handles spacing now).
+	/* stylelint-disable-next-line no-duplicate-selectors */
+	.dsgo-tabs__nav-row .dsgo-tabs__nav {
+		margin-bottom: 0;
 	}
 
 	.dsgo-tabs__tab--editor {
@@ -362,7 +372,9 @@
 			padding: 2px 4px;
 			font: inherit;
 			color: inherit;
-			min-width: 4ch;
+			// Minimum size fallback for browsers without field-sizing support
+			// (Firefox/Safari pre-17.4). Keeps the input readable when empty.
+			min-width: max(6ch, 6rem);
 			width: auto;
 			field-sizing: content;
 
@@ -392,6 +404,6 @@
 
 	.dsgo-tabs__add-tab {
 		align-self: center;
-		margin-left: 4px;
+		flex-shrink: 0;
 	}
 }

--- a/src/blocks/tabs/editor.scss
+++ b/src/blocks/tabs/editor.scss
@@ -337,4 +337,61 @@
 			}
 		}
 	}
+
+	/**
+	 * Editor-only inline tab affordances: inline-rename input, hover actions,
+	 * and the "Add tab" button. None of this is emitted to the frontend.
+	 */
+
+	// Gutenberg positions the block toolbar directly above the selected block.
+	// Reserve space above the nav (for the Tabs block's own toolbar) and
+	// below the nav (for a selected child Tab's toolbar). Without this, the
+	// toolbar overlaps the tab titles or the panel boundary.
+	/* stylelint-disable-next-line no-duplicate-selectors */
+	.dsgo-tabs__nav {
+		margin-top: 56px;
+		margin-bottom: 56px;
+	}
+
+	.dsgo-tabs__tab--editor {
+
+		.dsgo-tabs__tab-title--editor {
+			background: transparent;
+			border: 1px dashed transparent;
+			border-radius: 3px;
+			padding: 2px 4px;
+			font: inherit;
+			color: inherit;
+			min-width: 4ch;
+			width: auto;
+			field-sizing: content;
+
+			&:hover,
+			&:focus {
+				border-color: var(--wp-admin-theme-color, #2271b1);
+				background: rgba(255, 255, 255, 0.8);
+			}
+
+			&:focus {
+				outline: none;
+			}
+		}
+
+		.dsgo-tabs__tab-actions {
+			display: none;
+			align-items: center;
+			gap: 2px;
+			margin-left: 4px;
+		}
+
+		&:hover .dsgo-tabs__tab-actions,
+		&:focus-within .dsgo-tabs__tab-actions {
+			display: inline-flex;
+		}
+	}
+
+	.dsgo-tabs__add-tab {
+		align-self: center;
+		margin-left: 4px;
+	}
 }

--- a/src/blocks/tabs/editor.scss
+++ b/src/blocks/tabs/editor.scss
@@ -343,17 +343,17 @@
 	 * and the "Add tab" button. None of this is emitted to the frontend.
 	 */
 
-	// Gutenberg positions the block toolbar directly above the selected block.
-	// Reserve space above the nav row (for the Tabs block's own toolbar) and
-	// below the nav row (for a selected child Tab's toolbar). Without this,
-	// the toolbar overlaps the tab titles or the panel boundary.
+	// Wrap the tablist and the editor-only "Add tab" button in a flex row so
+	// the add control reads as adjacent to the tabs without sitting inside
+	// role="tablist". No artificial toolbar spacing is needed: tab chip
+	// clicks only switch `activeTab` (see handleTabClick) instead of
+	// selecting the child Tab, so the inline toolbar stays anchored to the
+	// Tabs parent block above the whole block.
 	.dsgo-tabs__nav-row {
 		display: flex;
 		align-items: center;
 		flex-wrap: wrap;
 		gap: 8px;
-		margin-top: 56px;
-		margin-bottom: 56px;
 	}
 
 	// The nav strip inside the row keeps its own layout but drops the


### PR DESCRIPTION
## Summary

Addresses the high-priority findings from [docs/audits/BLOCK-EDITOR-UIUX-AUDIT.md](docs/audits/BLOCK-EDITOR-UIUX-AUDIT.md) — specifically composite blocks that were hiding or weakening standard Gutenberg affordances, plus a few frontend-leak fixes discovered along the way.

### What changed

**Restored or replaced child-insertion affordances (Tier 1):**
- `advanced-heading`: restored the default segment appender (was `renderAppender: false`)
- `image-accordion`: the "Default Expanded Item" is now a `SelectControl` populated from the actual child items (using the first heading's text as a label), replacing the abstract 0–10 numeric slider

**Composite-block navigators + guided setup (Tier 3):**
- `slider`: canvas navigator strip under the track — chip per slide with active state, click-to-select, hover-revealed duplicate/remove, and trailing "Add slide". The slide's `+` appender is now pinned to the slide's bottom-center so it stops colliding with the editor preview arrows; appender wrappers use `display: contents` so the slide's centered content is no longer pushed off-center.
- `form-builder`: skippable first-insert template chooser (Blank / Contact / Newsletter / Event Registration / Lead Capture). `Reply-To Field` is now a structured dropdown populated from actual child fields, with a ghost option if the saved value references a removed field. A `hasFields` attribute (default `true` for backward compat) is synced from live child count; `save()` returns `null` when no template has been picked so a lonely submit button never reaches the frontend.
- `tabs`: inline-editable tab titles in the nav strip, hover-revealed duplicate/remove per tab, trailing "Add tab" button. Editor-only top/bottom margin on the nav so the Gutenberg toolbar no longer overlaps the titles or the panel boundary.

**Frontend leaks:**
- `tab` and `tabs` `block.json`: `"style"` was pointing at the editor bundle (`index.css`), which surfaced editor-only rules — most visibly the "Click the + button below to add content to this tab" empty-state — on the frontend. Repointed to `style-index.css`.

## Test plan

- [ ] **Advanced Heading**: insert fresh — template seeds Bold + Heading; selecting the block shows a `+` appender; clicking it adds a third segment.
- [ ] **Image Accordion**: insert fresh — sidebar → Interaction → "Default Expanded Item" is now a dropdown (`None`, `Item 1`, `Item 2`, `Item 3`). Add heading text to an item; the label updates to `Item N: <heading>`. Save + reload, selection persists, frontend respects it.
- [ ] **Slider**: insert fresh — navigator strip under the track with 3 chips and "Add slide". Clicking a chip activates that slide and opens its inspector; hover reveals duplicate/delete. Select a slide → the `+` appender sits at the slide's bottom-center; the content (heading + paragraph) stays visually centered; left/right arrows remain visible and do NOT collide with the `+`.
- [ ] **Form Builder**: insert fresh — template chooser shows with 5 cards, text does not overflow any card. Pick Contact → Name/Email/Message seeded, submit = "Send Message", `Email Notifications` → `Reply-To Field` dropdown shows `— None —`, `Name (name)`, `Email (email)`, `Message (message)`; currently `Email (email)`. Add a new Phone field → dropdown updates. Delete the selected Reply-To field → dropdown shows `email (field not found)` instead of silently dropping. Insert a second form, don't pick a template, save the post, view on frontend → no form/submit button renders.
- [ ] **Tabs**: insert fresh — Tab 1 / Tab 2 / Tab 3 / `+ Add tab`. Click a tab title to rename inline; hover reveals duplicate/delete. Select a tab → Gutenberg toolbar sits between nav and panel, does not overlap the titles.
- [ ] **Frontend regression**: for each block above, save + view on frontend. Confirm none of the editor-only affordances (navigator, template chooser, nav hover actions, empty-state messages) render. Tab panels should show their actual content only — no "Click the + button…" prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)