### PR TITLE
feat: expose plugin settings via the Abilities API

### DIFF
--- a/includes/abilities/class-abilities-registry.php
+++ b/includes/abilities/class-abilities-registry.php
@@ -110,6 +110,7 @@ class Abilities_Registry {
 		$this->load_abilities_from_directory( $base_path . '/inserters' );
 		$this->load_abilities_from_directory( $base_path . '/configurators' );
 		$this->load_abilities_from_directory( $base_path . '/generators' );
+		$this->load_abilities_from_directory( $base_path . '/settings' );
 	}
 
 	/**
@@ -150,6 +151,7 @@ class Abilities_Registry {
 			'inserters'     => 'DesignSetGo\\Abilities\\Inserters\\',
 			'configurators' => 'DesignSetGo\\Abilities\\Configurators\\',
 			'generators'    => 'DesignSetGo\\Abilities\\Generators\\',
+			'settings'      => 'DesignSetGo\\Abilities\\Settings\\',
 		);
 
 		foreach ( $directories as $dir => $namespace ) {
@@ -267,6 +269,14 @@ class Abilities_Registry {
 			array(
 				'label'       => __( 'Blocks', 'designsetgo' ),
 				'description' => __( 'Abilities for inserting and configuring blocks', 'designsetgo' ),
+			)
+		);
+
+		wp_register_ability_category(
+			'settings',
+			array(
+				'label'       => __( 'Settings', 'designsetgo' ),
+				'description' => __( 'Abilities for reading and updating DesignSetGo plugin settings', 'designsetgo' ),
 			)
 		);
 	}

--- a/includes/abilities/info/class-list-abilities.php
+++ b/includes/abilities/info/class-list-abilities.php
@@ -69,7 +69,7 @@ class List_Abilities extends Abstract_Ability {
 				'category' => array(
 					'type'        => 'string',
 					'description' => __( 'Filter by ability category', 'designsetgo' ),
-					'enum'        => array( 'all', 'inserter', 'configurator', 'info' ),
+					'enum'        => array( 'all', 'inserter', 'configurator', 'info', 'settings' ),
 					'default'     => 'all',
 				),
 				'search'   => array(
@@ -240,13 +240,27 @@ class List_Abilities extends Abstract_Ability {
 	 * - insert-*, add-* → inserter
 	 * - configure-*, apply-*, batch-*, delete-*, update-* → configurator
 	 * - list-*, get-*, find-* → info
+	 * - *-settings → settings (takes precedence over the prefix rules)
 	 *
 	 * @param string $name Ability name (e.g., 'designsetgo/add-block').
-	 * @return string Category: inserter, configurator, or info.
+	 * @return string Category: inserter, configurator, info, or settings.
 	 */
 	private function infer_category( string $name ): string {
 		// Remove namespace prefix.
 		$short_name = str_replace( 'designsetgo/', '', $name );
+
+		// Suffix-based overrides run first so names like "update-settings"
+		// aren't mis-bucketed as configurators.
+		$suffix_map = array(
+			'-settings' => 'settings',
+		);
+
+		foreach ( $suffix_map as $suffix => $category ) {
+			$suffix_len = strlen( $suffix );
+			if ( strlen( $short_name ) >= $suffix_len && 0 === substr_compare( $short_name, $suffix, -$suffix_len ) ) {
+				return $category;
+			}
+		}
 
 		$prefix_map = array(
 			'insert-'    => 'inserter',

--- a/includes/abilities/settings/class-get-settings.php
+++ b/includes/abilities/settings/class-get-settings.php
@@ -89,12 +89,10 @@ class Get_Settings extends Abstract_Ability {
 	/**
 	 * Execute the ability.
 	 *
-	 * @param array<string, mixed> $input Unused.
+	 * @param array<string, mixed> $_input Unused — settings reads take no parameters.
 	 * @return array<string, mixed>
 	 */
-	public function execute( array $input ): array {
-		unset( $input );
-
+	public function execute( array $_input ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
 		return Settings::get_settings();
 	}
 }

--- a/includes/abilities/settings/class-get-settings.php
+++ b/includes/abilities/settings/class-get-settings.php
@@ -16,6 +16,7 @@ namespace DesignSetGo\Abilities\Settings;
 
 use DesignSetGo\Abilities\Abstract_Ability;
 use DesignSetGo\Admin\Settings;
+use DesignSetGo\Admin\Settings_Schema;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -46,7 +47,7 @@ class Get_Settings extends Abstract_Ability {
 			'description'         => __( 'Returns the current DesignSetGo plugin settings merged with defaults, including enabled blocks/extensions, performance, forms, animations, sticky header, draft mode, integrations, and llms.txt configuration.', 'designsetgo' ),
 			'category'            => 'settings',
 			'input_schema'        => $this->get_input_schema(),
-			'output_schema'       => Settings::get_json_schema(),
+			'output_schema'       => Settings_Schema::get(),
 			'permission_callback' => array( $this, 'check_permission_callback' ),
 			'show_in_rest'        => true,
 			'keywords'            => array( 'settings', 'config', 'options', 'preferences' ),

--- a/includes/abilities/settings/class-get-settings.php
+++ b/includes/abilities/settings/class-get-settings.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Get Settings Ability.
+ *
+ * Returns the current DesignSetGo plugin settings merged with defaults.
+ * Mirrors the GET /designsetgo/v1/settings REST endpoint so consumers of
+ * the WordPress Abilities API (MCP servers, AI agents) can read plugin
+ * configuration without knowing the plugin's REST surface.
+ *
+ * @package DesignSetGo
+ * @subpackage Abilities
+ * @since 2.1.0
+ */
+
+namespace DesignSetGo\Abilities\Settings;
+
+use DesignSetGo\Abilities\Abstract_Ability;
+use DesignSetGo\Admin\Settings;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Get Settings ability class.
+ */
+class Get_Settings extends Abstract_Ability {
+
+	/**
+	 * Get ability name.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'designsetgo/get-settings';
+	}
+
+	/**
+	 * Get ability configuration.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_config(): array {
+		return array(
+			'label'               => __( 'Get DesignSetGo Settings', 'designsetgo' ),
+			'description'         => __( 'Returns the current DesignSetGo plugin settings merged with defaults, including enabled blocks/extensions, performance, forms, animations, sticky header, draft mode, integrations, and llms.txt configuration.', 'designsetgo' ),
+			'category'            => 'settings',
+			'input_schema'        => $this->get_input_schema(),
+			'output_schema'       => Settings::get_json_schema(),
+			'permission_callback' => array( $this, 'check_permission_callback' ),
+			'show_in_rest'        => true,
+			'keywords'            => array( 'settings', 'config', 'options', 'preferences' ),
+			'annotations'         => array(
+				'readonly'     => true,
+				'idempotent'   => true,
+				'instructions' => 'Call this before update-settings to see current values. Results include secrets (API keys) since the caller has already been authorized via manage_options.',
+			),
+		);
+	}
+
+	/**
+	 * Get input schema.
+	 *
+	 * Settings reads take no parameters. Consumers that only want a single
+	 * group should pick the group from the returned object.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_input_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => new \stdClass(),
+			'additionalProperties' => false,
+		);
+	}
+
+	/**
+	 * Permission callback.
+	 *
+	 * Mirrors the REST endpoint — only site administrators can read
+	 * settings because the payload includes integration secrets.
+	 *
+	 * @return bool
+	 */
+	public function check_permission_callback(): bool {
+		return $this->check_permission( 'manage_options' );
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string, mixed> $input Unused.
+	 * @return array<string, mixed>
+	 */
+	public function execute( array $input ): array {
+		unset( $input );
+
+		return Settings::get_settings();
+	}
+}

--- a/includes/abilities/settings/class-update-settings.php
+++ b/includes/abilities/settings/class-update-settings.php
@@ -20,6 +20,7 @@ namespace DesignSetGo\Abilities\Settings;
 
 use DesignSetGo\Abilities\Abstract_Ability;
 use DesignSetGo\Admin\Settings;
+use DesignSetGo\Admin\Settings_Schema;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -49,7 +50,7 @@ class Update_Settings extends Abstract_Ability {
 			'label'               => __( 'Update DesignSetGo Settings', 'designsetgo' ),
 			'description'         => __( 'Applies a partial update to DesignSetGo plugin settings. Only the keys provided are changed; all other settings are preserved. Nested groups are merged field-by-field — sending { "forms": { "retention_days": 60 } } updates just that field.', 'designsetgo' ),
 			'category'            => 'settings',
-			'input_schema'        => Settings::get_json_schema(),
+			'input_schema'        => Settings_Schema::get(),
 			'output_schema'       => $this->get_output_schema(),
 			'permission_callback' => array( $this, 'check_permission_callback' ),
 			'show_in_rest'        => true,
@@ -75,7 +76,7 @@ class Update_Settings extends Abstract_Ability {
 					'description' => __( 'Whether the update was applied.', 'designsetgo' ),
 				),
 				'settings' => array_merge(
-					Settings::get_json_schema(),
+					Settings_Schema::get(),
 					array( 'description' => __( 'The full settings object after the update has been applied.', 'designsetgo' ) )
 				),
 			),

--- a/includes/abilities/settings/class-update-settings.php
+++ b/includes/abilities/settings/class-update-settings.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Update Settings Ability.
+ *
+ * Applies a partial update to DesignSetGo plugin settings. Only the keys
+ * provided in input are modified — all other settings are preserved.
+ * Nested groups are merged field-by-field, so sending
+ * { "forms": { "retention_days": 60 } } updates only that field without
+ * resetting the rest of the forms group.
+ *
+ * Mirrors the POST /designsetgo/v1/settings REST endpoint and shares the
+ * same sanitization pipeline via Settings::update_settings().
+ *
+ * @package DesignSetGo
+ * @subpackage Abilities
+ * @since 2.1.0
+ */
+
+namespace DesignSetGo\Abilities\Settings;
+
+use DesignSetGo\Abilities\Abstract_Ability;
+use DesignSetGo\Admin\Settings;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Update Settings ability class.
+ */
+class Update_Settings extends Abstract_Ability {
+
+	/**
+	 * Get ability name.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'designsetgo/update-settings';
+	}
+
+	/**
+	 * Get ability configuration.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_config(): array {
+		return array(
+			'label'               => __( 'Update DesignSetGo Settings', 'designsetgo' ),
+			'description'         => __( 'Applies a partial update to DesignSetGo plugin settings. Only the keys provided are changed; all other settings are preserved. Nested groups are merged field-by-field — sending { "forms": { "retention_days": 60 } } updates just that field.', 'designsetgo' ),
+			'category'            => 'settings',
+			'input_schema'        => Settings::get_json_schema(),
+			'output_schema'       => $this->get_output_schema(),
+			'permission_callback' => array( $this, 'check_permission_callback' ),
+			'show_in_rest'        => true,
+			'keywords'            => array( 'settings', 'config', 'configure', 'preferences', 'options' ),
+			'annotations'         => array(
+				'idempotent'   => true,
+				'instructions' => 'Call get-settings first to see current values. Submit only the keys you want to change — omitted keys remain untouched. Empty arrays for enabled_blocks or enabled_extensions mean "all enabled".',
+			),
+		);
+	}
+
+	/**
+	 * Get output schema.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_output_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'success'  => array(
+					'type'        => 'boolean',
+					'description' => __( 'Whether the update was applied.', 'designsetgo' ),
+				),
+				'settings' => array_merge(
+					Settings::get_json_schema(),
+					array( 'description' => __( 'The full settings object after the update has been applied.', 'designsetgo' ) )
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission callback.
+	 *
+	 * Settings writes require the same capability as the REST endpoint
+	 * (manage_options). Ability invocations do not need the X-WP-Nonce
+	 * check that the REST endpoint enforces — the Abilities API handles
+	 * authentication at the transport layer (REST or MCP).
+	 *
+	 * @return bool
+	 */
+	public function check_permission_callback(): bool {
+		return $this->check_permission( 'manage_options' );
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string, mixed> $input Partial settings to apply.
+	 * @return array<string, mixed>
+	 */
+	public function execute( array $input ): array {
+		$updated = Settings::update_settings( $input );
+
+		return $this->success(
+			array(
+				'settings' => $updated,
+			)
+		);
+	}
+}

--- a/includes/abilities/settings/class-update-settings.php
+++ b/includes/abilities/settings/class-update-settings.php
@@ -56,7 +56,7 @@ class Update_Settings extends Abstract_Ability {
 			'keywords'            => array( 'settings', 'config', 'configure', 'preferences', 'options' ),
 			'annotations'         => array(
 				'idempotent'   => true,
-				'instructions' => 'Call get-settings first to see current values. Submit only the keys you want to change — omitted keys remain untouched. Empty arrays for enabled_blocks or enabled_extensions mean "all enabled".',
+				'instructions' => 'Call get-settings first to see current values. Submit only the keys you want to change — omitted keys remain untouched. Empty arrays for enabled_blocks or enabled_extensions mean "all enabled". To replace a list field (enabled_blocks, enabled_extensions, excluded_blocks) entirely, fetch the current value first and resubmit the full desired array — lists are merged positionally (by index), not replaced wholesale.',
 			),
 		);
 	}

--- a/includes/admin/class-settings-schema.php
+++ b/includes/admin/class-settings-schema.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Settings JSON Schema.
+ *
+ * Describes the shape of the DesignSetGo plugin settings object for the
+ * Abilities API (get-settings, update-settings). Separated from Settings
+ * so that the already-large class-settings.php does not have to grow
+ * every time a new setting key is added.
+ *
+ * The schema mirrors the structure produced by Settings::get_defaults()
+ * and sanitized by Settings::sanitize_settings(). Keep all three in sync —
+ * a key missing from this schema is invisible to Abilities API clients
+ * even if it is otherwise valid.
+ *
+ * @package DesignSetGo
+ * @subpackage Admin
+ * @since 2.1.0
+ */
+
+namespace DesignSetGo\Admin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Settings_Schema class.
+ *
+ * Hosts the JSON Schema for the settings payload in one place so it can
+ * be consumed by the Abilities API without adding bulk to Settings.
+ */
+class Settings_Schema {
+
+	/**
+	 * Get the JSON Schema describing the settings object.
+	 *
+	 * @return array JSON Schema for the settings object.
+	 */
+	public static function get(): array {
+		return array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => array(
+				'enabled_blocks'     => array(
+					'type'        => 'array',
+					'items'       => array( 'type' => 'string' ),
+					'description' => __( 'Enabled block names. Empty array means all blocks are enabled.', 'designsetgo' ),
+				),
+				'enabled_extensions' => array(
+					'type'        => 'array',
+					'items'       => array( 'type' => 'string' ),
+					'description' => __( 'Enabled extension names. Empty array means all extensions are enabled.', 'designsetgo' ),
+				),
+				'excluded_blocks'    => array(
+					'type'        => 'array',
+					'items'       => array( 'type' => 'string' ),
+					'description' => __( 'Block name patterns excluded from configuration (supports wildcards like "plugin/*").', 'designsetgo' ),
+				),
+				'performance'        => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'conditional_loading' => array( 'type' => 'boolean' ),
+						'cache_duration'      => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+					),
+				),
+				'forms'              => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'enable_honeypot'      => array( 'type' => 'boolean' ),
+						'enable_rate_limiting' => array( 'type' => 'boolean' ),
+						'enable_email_logging' => array( 'type' => 'boolean' ),
+						'retention_days'       => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+					),
+				),
+				'animations'         => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'enable_animations'              => array( 'type' => 'boolean' ),
+						'default_duration'               => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'default_easing'                 => array( 'type' => 'string' ),
+						'respect_prefers_reduced_motion' => array( 'type' => 'boolean' ),
+						'default_icon_button_hover'      => array( 'type' => 'string' ),
+					),
+				),
+				'security'           => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'log_ip_addresses' => array( 'type' => 'boolean' ),
+						'log_user_agents'  => array( 'type' => 'boolean' ),
+						'log_referrers'    => array( 'type' => 'boolean' ),
+					),
+				),
+				'integrations'       => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'google_maps_api_key'  => array( 'type' => 'string' ),
+						'turnstile_site_key'   => array( 'type' => 'string' ),
+						'turnstile_secret_key' => array( 'type' => 'string' ),
+					),
+				),
+				'sticky_header'      => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'enable'                    => array( 'type' => 'boolean' ),
+						'custom_selector'           => array( 'type' => 'string' ),
+						'z_index'                   => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'shadow_on_scroll'          => array( 'type' => 'boolean' ),
+						'shadow_size'               => array( 'type' => 'string' ),
+						'shrink_on_scroll'          => array( 'type' => 'boolean' ),
+						'shrink_amount'             => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'mobile_enabled'            => array( 'type' => 'boolean' ),
+						'mobile_breakpoint'         => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'transition_speed'          => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'scroll_threshold'          => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'hide_on_scroll_down'       => array( 'type' => 'boolean' ),
+						'background_on_scroll'      => array( 'type' => 'boolean' ),
+						'background_scroll_color'   => array(
+							'type'        => 'string',
+							'description' => __( 'Hex color (e.g. "#ffffff") or empty string.', 'designsetgo' ),
+						),
+						'background_scroll_opacity' => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+							'maximum' => 100,
+						),
+						'text_scroll_color'         => array(
+							'type'        => 'string',
+							'description' => __( 'Hex color (e.g. "#000000") or empty string.', 'designsetgo' ),
+						),
+					),
+				),
+				'draft_mode'         => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'enable'                 => array( 'type' => 'boolean' ),
+						'show_page_list_actions' => array( 'type' => 'boolean' ),
+						'show_page_list_column'  => array( 'type' => 'boolean' ),
+						'show_frontend_preview'  => array( 'type' => 'boolean' ),
+						'auto_save_enabled'      => array( 'type' => 'boolean' ),
+						'auto_save_interval'     => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+					),
+				),
+				'llms_txt'           => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'enable'            => array( 'type' => 'boolean' ),
+						'post_types'        => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+						'description'       => array( 'type' => 'string' ),
+						'generate_full_txt' => array( 'type' => 'boolean' ),
+					),
+				),
+			),
+		);
+	}
+}

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -41,10 +41,11 @@ class Settings {
 	 * Get default settings
 	 *
 	 * Source of truth for the settings structure. When adding or removing
-	 * a setting key here, keep get_json_schema() and get_sanitization_schema()
-	 * in sync — each of the three methods describes the same shape and
-	 * omissions silently hide keys from either the Abilities API surface
-	 * (get_json_schema) or the sanitization pipeline (get_sanitization_schema).
+	 * a setting key here, keep Settings_Schema::get() and
+	 * get_sanitization_schema() in sync — each of the three descriptions
+	 * covers the same shape and omissions silently hide keys from either
+	 * the Abilities API surface (Settings_Schema) or the sanitization
+	 * pipeline (get_sanitization_schema).
 	 *
 	 * @return array Default settings.
 	 */
@@ -577,183 +578,14 @@ class Settings {
 	}
 
 	/**
-	 * Get the JSON Schema describing the settings object.
-	 *
-	 * Used by the Abilities API (get-settings, update-settings) to describe
-	 * the full shape of the settings payload to AI agents and MCP clients.
-	 * The schema mirrors the structure produced by get_defaults() and
-	 * sanitized by sanitize_settings().
-	 *
-	 * Keep in sync with get_defaults() and get_sanitization_schema() — a
-	 * key missing from this schema is invisible to Abilities API clients
-	 * even if it is otherwise valid.
-	 *
-	 * @return array JSON Schema for the settings object.
-	 */
-	public static function get_json_schema(): array {
-		return array(
-			'type'                 => 'object',
-			'additionalProperties' => false,
-			'properties'           => array(
-				'enabled_blocks'     => array(
-					'type'        => 'array',
-					'items'       => array( 'type' => 'string' ),
-					'description' => __( 'Enabled block names. Empty array means all blocks are enabled.', 'designsetgo' ),
-				),
-				'enabled_extensions' => array(
-					'type'        => 'array',
-					'items'       => array( 'type' => 'string' ),
-					'description' => __( 'Enabled extension names. Empty array means all extensions are enabled.', 'designsetgo' ),
-				),
-				'excluded_blocks'    => array(
-					'type'        => 'array',
-					'items'       => array( 'type' => 'string' ),
-					'description' => __( 'Block name patterns excluded from configuration (supports wildcards like "plugin/*").', 'designsetgo' ),
-				),
-				'performance'        => array(
-					'type'                 => 'object',
-					'additionalProperties' => false,
-					'properties'           => array(
-						'conditional_loading' => array( 'type' => 'boolean' ),
-						'cache_duration'      => array(
-							'type'    => 'integer',
-							'minimum' => 0,
-						),
-					),
-				),
-				'forms'              => array(
-					'type'                 => 'object',
-					'additionalProperties' => false,
-					'properties'           => array(
-						'enable_honeypot'      => array( 'type' => 'boolean' ),
-						'enable_rate_limiting' => array( 'type' => 'boolean' ),
-						'enable_email_logging' => array( 'type' => 'boolean' ),
-						'retention_days'       => array(
-							'type'    => 'integer',
-							'minimum' => 0,
-						),
-					),
-				),
-				'animations'         => array(
-					'type'                 => 'object',
-					'additionalProperties' => false,
-					'properties'           => array(
-						'enable_animations'              => array( 'type' => 'boolean' ),
-						'default_duration'               => array(
-							'type'    => 'integer',
-							'minimum' => 0,
-						),
-						'default_easing'                 => array( 'type' => 'string' ),
-						'respect_prefers_reduced_motion' => array( 'type' => 'boolean' ),
-						'default_icon_button_hover'      => array( 'type' => 'string' ),
-					),
-				),
-				'security'           => array(
-					'type'                 => 'object',
-					'additionalProperties' => false,
-					'properties'           => array(
-						'log_ip_addresses' => array( 'type' => 'boolean' ),
-						'log_user_agents'  => array( 'type' => 'boolean' ),
-						'log_referrers'    => array( 'type' => 'boolean' ),
-					),
-				),
-				'integrations'       => array(
-					'type'                 => 'object',
-					'additionalProperties' => false,
-					'properties'           => array(
-						'google_maps_api_key'  => array( 'type' => 'string' ),
-						'turnstile_site_key'   => array( 'type' => 'string' ),
-						'turnstile_secret_key' => array( 'type' => 'string' ),
-					),
-				),
-				'sticky_header'      => array(
-					'type'                 => 'object',
-					'additionalProperties' => false,
-					'properties'           => array(
-						'enable'                    => array( 'type' => 'boolean' ),
-						'custom_selector'           => array( 'type' => 'string' ),
-						'z_index'                   => array(
-							'type'    => 'integer',
-							'minimum' => 0,
-						),
-						'shadow_on_scroll'          => array( 'type' => 'boolean' ),
-						'shadow_size'               => array( 'type' => 'string' ),
-						'shrink_on_scroll'          => array( 'type' => 'boolean' ),
-						'shrink_amount'             => array(
-							'type'    => 'integer',
-							'minimum' => 0,
-						),
-						'mobile_enabled'            => array( 'type' => 'boolean' ),
-						'mobile_breakpoint'         => array(
-							'type'    => 'integer',
-							'minimum' => 0,
-						),
-						'transition_speed'          => array(
-							'type'    => 'integer',
-							'minimum' => 0,
-						),
-						'scroll_threshold'          => array(
-							'type'    => 'integer',
-							'minimum' => 0,
-						),
-						'hide_on_scroll_down'       => array( 'type' => 'boolean' ),
-						'background_on_scroll'      => array( 'type' => 'boolean' ),
-						'background_scroll_color'   => array(
-							'type'        => 'string',
-							'description' => __( 'Hex color (e.g. "#ffffff") or empty string.', 'designsetgo' ),
-						),
-						'background_scroll_opacity' => array(
-							'type'    => 'integer',
-							'minimum' => 0,
-							'maximum' => 100,
-						),
-						'text_scroll_color'         => array(
-							'type'        => 'string',
-							'description' => __( 'Hex color (e.g. "#000000") or empty string.', 'designsetgo' ),
-						),
-					),
-				),
-				'draft_mode'         => array(
-					'type'                 => 'object',
-					'additionalProperties' => false,
-					'properties'           => array(
-						'enable'                 => array( 'type' => 'boolean' ),
-						'show_page_list_actions' => array( 'type' => 'boolean' ),
-						'show_page_list_column'  => array( 'type' => 'boolean' ),
-						'show_frontend_preview'  => array( 'type' => 'boolean' ),
-						'auto_save_enabled'      => array( 'type' => 'boolean' ),
-						'auto_save_interval'     => array(
-							'type'    => 'integer',
-							'minimum' => 0,
-						),
-					),
-				),
-				'llms_txt'           => array(
-					'type'                 => 'object',
-					'additionalProperties' => false,
-					'properties'           => array(
-						'enable'            => array( 'type' => 'boolean' ),
-						'post_types'        => array(
-							'type'  => 'array',
-							'items' => array( 'type' => 'string' ),
-						),
-						'description'       => array( 'type' => 'string' ),
-						'generate_full_txt' => array( 'type' => 'boolean' ),
-					),
-				),
-			),
-		);
-	}
-
-	/**
 	 * Get the sanitization schema for settings fields.
 	 *
 	 * Maps each setting key to its sanitizer type. The defaults are sourced
 	 * from get_defaults() so there is a single source of truth.
 	 *
-	 * Keep in sync with get_defaults() and get_json_schema() — a key missing
-	 * from this schema is silently dropped by sanitize_settings() even if
-	 * the client sends it.
+	 * Keep in sync with get_defaults() and Settings_Schema::get() — a key
+	 * missing from this schema is silently dropped by sanitize_settings()
+	 * even if the client sends it.
 	 *
 	 * Supported sanitizer types:
 	 * - 'bool'       — Cast to boolean.
@@ -906,8 +738,8 @@ class Settings {
 				continue;
 			}
 
-			$group_defaults    = $defaults[ $key ] ?? array();
-			$sanitized[ $key ] = array();
+			$group_defaults = $defaults[ $key ] ?? array();
+			$group_values   = array();
 
 			foreach ( $field_schema as $field_key => $sanitizer ) {
 				// Only sanitize fields that were actually submitted.
@@ -919,11 +751,20 @@ class Settings {
 
 				$default = $group_defaults[ $field_key ] ?? null;
 
-				$sanitized[ $key ][ $field_key ] = self::sanitize_value(
+				$group_values[ $field_key ] = self::sanitize_value(
 					$settings[ $key ][ $field_key ],
 					$sanitizer,
 					$default
 				);
+			}
+
+			// Skip groups where no fields were actually submitted. Persisting
+			// an empty array for a nested group would suppress the group's
+			// defaults on subsequent get_settings() reads because wp_parse_args
+			// is not recursive — a fresh install would then see e.g.
+			// integrations => [] instead of the default shape.
+			if ( ! empty( $group_values ) ) {
+				$sanitized[ $key ] = $group_values;
 			}
 		}
 

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -92,9 +92,9 @@ class Settings {
 				'log_referrers'    => false,
 			),
 			'integrations'       => array(
-				'google_maps_api_key'    => '',
-				'turnstile_site_key'     => '',
-				'turnstile_secret_key'   => '',
+				'google_maps_api_key'  => '',
+				'turnstile_site_key'   => '',
+				'turnstile_secret_key' => '',
 			),
 			'sticky_header'      => array(
 				'enable'                    => true,
@@ -123,9 +123,9 @@ class Settings {
 				'auto_save_interval'     => 60,
 			),
 			'llms_txt'           => array(
-				'enable'           => false,
-				'post_types'       => array( 'page', 'post' ),
-				'description'      => '',
+				'enable'            => false,
+				'post_types'        => array( 'page', 'post' ),
+				'description'       => '',
 				'generate_full_txt' => false,
 			),
 		);
@@ -287,8 +287,8 @@ class Settings {
 			return self::$cached_settings;
 		}
 
-		$saved_settings       = get_option( self::OPTION_NAME, array() );
-		$defaults             = self::get_defaults();
+		$saved_settings        = get_option( self::OPTION_NAME, array() );
+		$defaults              = self::get_defaults();
 		self::$cached_settings = wp_parse_args( $saved_settings, $defaults );
 
 		return self::$cached_settings;
@@ -470,24 +470,35 @@ class Settings {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function update_settings_endpoint( $request ) {
-		$new_settings = $request->get_json_params();
+		return rest_ensure_response(
+			array(
+				'success'  => true,
+				'settings' => self::update_settings( (array) $request->get_json_params() ),
+			)
+		);
+	}
 
-		// Sanitize only the incoming keys.
-		$sanitized = $this->sanitize_settings( $new_settings );
+	/**
+	 * Apply a partial settings update.
+	 *
+	 * Sanitizes only keys present in $input, merges with existing saved
+	 * settings so unsubmitted keys are preserved, persists, and invalidates
+	 * the cache. Shared between the REST endpoint and the Abilities API
+	 * update-settings ability so sanitization stays centralized.
+	 *
+	 * @param array $input Raw settings to apply (partial, nested).
+	 * @return array Current settings after the update.
+	 */
+	public static function update_settings( array $input ): array {
+		$sanitized = self::sanitize_settings( $input );
 
-		// Merge with existing saved settings so unsubmitted keys are preserved.
 		$existing = get_option( self::OPTION_NAME, array() );
 		$merged   = array_replace_recursive( $existing, $sanitized );
 
 		update_option( self::OPTION_NAME, $merged );
 		self::invalidate_cache();
 
-		return rest_ensure_response(
-			array(
-				'success'  => true,
-				'settings' => self::get_settings(),
-			)
-		);
+		return self::get_settings();
 	}
 
 	/**
@@ -554,6 +565,171 @@ class Settings {
 	}
 
 	/**
+	 * Get the JSON Schema describing the settings object.
+	 *
+	 * Used by the Abilities API (get-settings, update-settings) to describe
+	 * the full shape of the settings payload to AI agents and MCP clients.
+	 * The schema mirrors the structure produced by get_defaults() and
+	 * sanitized by sanitize_settings().
+	 *
+	 * @return array JSON Schema for the settings object.
+	 */
+	public static function get_json_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => array(
+				'enabled_blocks'     => array(
+					'type'        => 'array',
+					'items'       => array( 'type' => 'string' ),
+					'description' => __( 'Enabled block names. Empty array means all blocks are enabled.', 'designsetgo' ),
+				),
+				'enabled_extensions' => array(
+					'type'        => 'array',
+					'items'       => array( 'type' => 'string' ),
+					'description' => __( 'Enabled extension names. Empty array means all extensions are enabled.', 'designsetgo' ),
+				),
+				'excluded_blocks'    => array(
+					'type'        => 'array',
+					'items'       => array( 'type' => 'string' ),
+					'description' => __( 'Block name patterns excluded from configuration (supports wildcards like "plugin/*").', 'designsetgo' ),
+				),
+				'performance'        => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'conditional_loading' => array( 'type' => 'boolean' ),
+						'cache_duration'      => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+					),
+				),
+				'forms'              => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'enable_honeypot'      => array( 'type' => 'boolean' ),
+						'enable_rate_limiting' => array( 'type' => 'boolean' ),
+						'enable_email_logging' => array( 'type' => 'boolean' ),
+						'retention_days'       => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+					),
+				),
+				'animations'         => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'enable_animations'              => array( 'type' => 'boolean' ),
+						'default_duration'               => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'default_easing'                 => array( 'type' => 'string' ),
+						'respect_prefers_reduced_motion' => array( 'type' => 'boolean' ),
+						'default_icon_button_hover'      => array( 'type' => 'string' ),
+					),
+				),
+				'security'           => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'log_ip_addresses' => array( 'type' => 'boolean' ),
+						'log_user_agents'  => array( 'type' => 'boolean' ),
+						'log_referrers'    => array( 'type' => 'boolean' ),
+					),
+				),
+				'integrations'       => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'google_maps_api_key'  => array( 'type' => 'string' ),
+						'turnstile_site_key'   => array( 'type' => 'string' ),
+						'turnstile_secret_key' => array( 'type' => 'string' ),
+					),
+				),
+				'sticky_header'      => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'enable'                    => array( 'type' => 'boolean' ),
+						'custom_selector'           => array( 'type' => 'string' ),
+						'z_index'                   => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'shadow_on_scroll'          => array( 'type' => 'boolean' ),
+						'shadow_size'               => array( 'type' => 'string' ),
+						'shrink_on_scroll'          => array( 'type' => 'boolean' ),
+						'shrink_amount'             => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'mobile_enabled'            => array( 'type' => 'boolean' ),
+						'mobile_breakpoint'         => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'transition_speed'          => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'scroll_threshold'          => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'hide_on_scroll_down'       => array( 'type' => 'boolean' ),
+						'background_on_scroll'      => array( 'type' => 'boolean' ),
+						'background_scroll_color'   => array(
+							'type'        => 'string',
+							'description' => __( 'Hex color (e.g. "#ffffff") or empty string.', 'designsetgo' ),
+						),
+						'background_scroll_opacity' => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+							'maximum' => 100,
+						),
+						'text_scroll_color'         => array(
+							'type'        => 'string',
+							'description' => __( 'Hex color (e.g. "#000000") or empty string.', 'designsetgo' ),
+						),
+					),
+				),
+				'draft_mode'         => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'enable'                 => array( 'type' => 'boolean' ),
+						'show_page_list_actions' => array( 'type' => 'boolean' ),
+						'show_page_list_column'  => array( 'type' => 'boolean' ),
+						'show_frontend_preview'  => array( 'type' => 'boolean' ),
+						'auto_save_enabled'      => array( 'type' => 'boolean' ),
+						'auto_save_interval'     => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+					),
+				),
+				'llms_txt'           => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'enable'            => array( 'type' => 'boolean' ),
+						'post_types'        => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+						'description'       => array( 'type' => 'string' ),
+						'generate_full_txt' => array( 'type' => 'boolean' ),
+					),
+				),
+			),
+		);
+	}
+
+	/**
 	 * Get the sanitization schema for settings fields.
 	 *
 	 * Maps each setting key to its sanitizer type. The defaults are sourced
@@ -599,9 +775,9 @@ class Settings {
 				'log_referrers'    => 'bool',
 			),
 			'integrations'       => array(
-				'google_maps_api_key'    => 'text',
-				'turnstile_site_key'     => 'text',
-				'turnstile_secret_key'   => 'text',
+				'google_maps_api_key'  => 'text',
+				'turnstile_site_key'   => 'text',
+				'turnstile_secret_key' => 'text',
 			),
 			'sticky_header'      => array(
 				'enable'                    => 'bool',
@@ -630,9 +806,9 @@ class Settings {
 				'auto_save_interval'     => 'absint',
 			),
 			'llms_txt'           => array(
-				'enable'           => 'bool',
-				'post_types'       => 'key_list',
-				'description'      => 'textarea',
+				'enable'            => 'bool',
+				'post_types'        => 'key_list',
+				'description'       => 'textarea',
 				'generate_full_txt' => 'bool',
 			),
 		);
@@ -684,7 +860,7 @@ class Settings {
 	 * @param array $settings Settings to sanitize.
 	 * @return array Sanitized settings.
 	 */
-	private function sanitize_settings( $settings ): array {
+	public static function sanitize_settings( array $settings ): array {
 		$sanitized = array();
 		$defaults  = self::get_defaults();
 		$schema    = self::get_sanitization_schema();

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -40,6 +40,12 @@ class Settings {
 	/**
 	 * Get default settings
 	 *
+	 * Source of truth for the settings structure. When adding or removing
+	 * a setting key here, keep get_json_schema() and get_sanitization_schema()
+	 * in sync — each of the three methods describes the same shape and
+	 * omissions silently hide keys from either the Abilities API surface
+	 * (get_json_schema) or the sanitization pipeline (get_sanitization_schema).
+	 *
 	 * @return array Default settings.
 	 */
 	public static function get_defaults() {
@@ -486,6 +492,12 @@ class Settings {
 	 * the cache. Shared between the REST endpoint and the Abilities API
 	 * update-settings ability so sanitization stays centralized.
 	 *
+	 * IMPORTANT: This method does not perform any authorization. Callers
+	 * are responsible for verifying that the current user is allowed to
+	 * mutate plugin settings (e.g. current_user_can( 'manage_options' ))
+	 * before invoking it. The REST endpoint and update-settings ability
+	 * both gate on manage_options before calling through.
+	 *
 	 * @param array $input Raw settings to apply (partial, nested).
 	 * @return array Current settings after the update.
 	 */
@@ -571,6 +583,10 @@ class Settings {
 	 * the full shape of the settings payload to AI agents and MCP clients.
 	 * The schema mirrors the structure produced by get_defaults() and
 	 * sanitized by sanitize_settings().
+	 *
+	 * Keep in sync with get_defaults() and get_sanitization_schema() — a
+	 * key missing from this schema is invisible to Abilities API clients
+	 * even if it is otherwise valid.
 	 *
 	 * @return array JSON Schema for the settings object.
 	 */
@@ -734,6 +750,10 @@ class Settings {
 	 *
 	 * Maps each setting key to its sanitizer type. The defaults are sourced
 	 * from get_defaults() so there is a single source of truth.
+	 *
+	 * Keep in sync with get_defaults() and get_json_schema() — a key missing
+	 * from this schema is silently dropped by sanitize_settings() even if
+	 * the client sends it.
 	 *
 	 * Supported sanitizer types:
 	 * - 'bool'       — Cast to boolean.

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -491,6 +491,7 @@ class Plugin {
 		require_once DESIGNSETGO_PATH . 'includes/patterns/class-loader.php';
 		require_once DESIGNSETGO_PATH . 'includes/admin/class-global-styles.php';
 		require_once DESIGNSETGO_PATH . 'includes/admin/class-settings.php';
+		require_once DESIGNSETGO_PATH . 'includes/admin/class-settings-schema.php';
 		require_once DESIGNSETGO_PATH . 'includes/admin/class-block-manager.php';
 		require_once DESIGNSETGO_PATH . 'includes/admin/class-gdpr-compliance.php';
 		require_once DESIGNSETGO_PATH . 'includes/admin/class-admin-menu.php';

--- a/tests/phpunit/settings-abilities-test.php
+++ b/tests/phpunit/settings-abilities-test.php
@@ -1,0 +1,260 @@
+<?php
+/**
+ * Tests for the Settings abilities (designsetgo/get-settings,
+ * designsetgo/update-settings) and the shared Settings::update_settings()
+ * pipeline they rely on.
+ *
+ * Covers:
+ * - permission enforcement (manage_options required)
+ * - partial update semantics (nested merge preserves omitted keys)
+ * - empty-object edge case so groups aren't accidentally reset
+ *
+ * @package DesignSetGo
+ * @subpackage Tests
+ */
+
+use DesignSetGo\Abilities\Settings\Get_Settings;
+use DesignSetGo\Abilities\Settings\Update_Settings;
+use DesignSetGo\Admin\Settings;
+
+/**
+ * Settings abilities test class.
+ */
+class Settings_Abilities_Test extends WP_UnitTestCase {
+
+	/**
+	 * Administrator user ID (meets manage_options).
+	 *
+	 * @var int
+	 */
+	private int $admin_id;
+
+	/**
+	 * Subscriber user ID (lacks manage_options).
+	 *
+	 * @var int
+	 */
+	private int $subscriber_id;
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->admin_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		delete_option( Settings::OPTION_NAME );
+		Settings::invalidate_cache();
+
+		wp_set_current_user( $this->admin_id );
+	}
+
+	/**
+	 * Reset any cached state that could leak between tests.
+	 */
+	public function tear_down(): void {
+		delete_option( Settings::OPTION_NAME );
+		Settings::invalidate_cache();
+		parent::tear_down();
+	}
+
+	// -------------------------------------------------------------------------
+	// Permission enforcement
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Administrators can read settings.
+	 */
+	public function test_get_settings_permission_granted_for_admin(): void {
+		wp_set_current_user( $this->admin_id );
+		$ability = new Get_Settings();
+		$this->assertTrue( $ability->check_permission_callback() );
+	}
+
+	/**
+	 * Subscribers cannot read settings.
+	 */
+	public function test_get_settings_permission_denied_for_subscriber(): void {
+		wp_set_current_user( $this->subscriber_id );
+		$ability = new Get_Settings();
+		$this->assertFalse( $ability->check_permission_callback() );
+	}
+
+	/**
+	 * Anonymous users cannot read settings.
+	 */
+	public function test_get_settings_permission_denied_for_anonymous(): void {
+		wp_set_current_user( 0 );
+		$ability = new Get_Settings();
+		$this->assertFalse( $ability->check_permission_callback() );
+	}
+
+	/**
+	 * Administrators can update settings.
+	 */
+	public function test_update_settings_permission_granted_for_admin(): void {
+		wp_set_current_user( $this->admin_id );
+		$ability = new Update_Settings();
+		$this->assertTrue( $ability->check_permission_callback() );
+	}
+
+	/**
+	 * Subscribers cannot update settings.
+	 */
+	public function test_update_settings_permission_denied_for_subscriber(): void {
+		wp_set_current_user( $this->subscriber_id );
+		$ability = new Update_Settings();
+		$this->assertFalse( $ability->check_permission_callback() );
+	}
+
+	// -------------------------------------------------------------------------
+	// get-settings execution
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Returns the expected top-level setting groups.
+	 */
+	public function test_get_settings_returns_full_settings_structure(): void {
+		$ability = new Get_Settings();
+		$result  = $ability->execute( array() );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'forms', $result );
+		$this->assertArrayHasKey( 'integrations', $result );
+		$this->assertArrayHasKey( 'animations', $result );
+		$this->assertArrayHasKey( 'draft_mode', $result );
+		$this->assertArrayHasKey( 'llms_txt', $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// Partial update semantics — nested merge preserves omitted keys
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Updating a single nested field preserves all other fields in the group.
+	 */
+	public function test_partial_nested_update_preserves_sibling_fields(): void {
+		// Seed a non-default value across multiple fields in the forms group.
+		update_option(
+			Settings::OPTION_NAME,
+			array(
+				'forms' => array(
+					'enable_honeypot' => false,
+					'retention_days'  => 90,
+				),
+			)
+		);
+		Settings::invalidate_cache();
+
+		$ability = new Update_Settings();
+		$ability->execute(
+			array(
+				'forms' => array( 'retention_days' => 120 ),
+			)
+		);
+
+		$saved = Settings::get_settings();
+		$this->assertSame( 120, $saved['forms']['retention_days'], 'Submitted field should update.' );
+		$this->assertFalse( $saved['forms']['enable_honeypot'], 'Omitted sibling field should be preserved.' );
+	}
+
+	/**
+	 * Updating one group leaves other groups untouched.
+	 */
+	public function test_update_one_group_does_not_affect_other_groups(): void {
+		update_option(
+			Settings::OPTION_NAME,
+			array(
+				'integrations' => array(
+					'google_maps_api_key'  => 'SEEDED-MAPS-KEY',
+					'turnstile_site_key'   => 'SEEDED-SITE-KEY',
+					'turnstile_secret_key' => 'SEEDED-SECRET',
+				),
+			)
+		);
+		Settings::invalidate_cache();
+
+		$ability = new Update_Settings();
+		$ability->execute(
+			array(
+				'forms' => array( 'retention_days' => 7 ),
+			)
+		);
+
+		$saved = Settings::get_settings();
+		$this->assertSame( 'SEEDED-MAPS-KEY', $saved['integrations']['google_maps_api_key'] );
+		$this->assertSame( 'SEEDED-SITE-KEY', $saved['integrations']['turnstile_site_key'] );
+		$this->assertSame( 'SEEDED-SECRET', $saved['integrations']['turnstile_secret_key'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Empty-object edge case
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Submitting an empty nested group is a no-op — the group is not reset.
+	 *
+	 * Regression coverage for the bug where `{ "integrations": {} }` on a
+	 * fresh install would persist `integrations => []`, and subsequent
+	 * get_settings() would lose the defaults for that group because
+	 * wp_parse_args is not recursive.
+	 */
+	public function test_empty_nested_group_does_not_reset_existing_values(): void {
+		update_option(
+			Settings::OPTION_NAME,
+			array(
+				'integrations' => array(
+					'google_maps_api_key' => 'SEEDED-MAPS-KEY',
+				),
+			)
+		);
+		Settings::invalidate_cache();
+
+		$ability = new Update_Settings();
+		$ability->execute( array( 'integrations' => array() ) );
+
+		$saved = Settings::get_settings();
+		$this->assertSame(
+			'SEEDED-MAPS-KEY',
+			$saved['integrations']['google_maps_api_key'],
+			'Empty group payload must not clear existing values.'
+		);
+	}
+
+	/**
+	 * On a fresh install (no prior saved option), submitting an empty nested
+	 * group must not suppress the defaults for that group.
+	 */
+	public function test_empty_group_on_fresh_install_keeps_defaults(): void {
+		delete_option( Settings::OPTION_NAME );
+		Settings::invalidate_cache();
+
+		$ability = new Update_Settings();
+		$ability->execute( array( 'integrations' => array() ) );
+
+		$saved = Settings::get_settings();
+		$this->assertArrayHasKey( 'google_maps_api_key', $saved['integrations'] );
+		$this->assertArrayHasKey( 'turnstile_site_key', $saved['integrations'] );
+		$this->assertArrayHasKey( 'turnstile_secret_key', $saved['integrations'] );
+	}
+
+	/**
+	 * Submitting an empty top-level object is a total no-op.
+	 */
+	public function test_empty_top_level_object_is_noop(): void {
+		update_option(
+			Settings::OPTION_NAME,
+			array(
+				'forms' => array( 'retention_days' => 45 ),
+			)
+		);
+		Settings::invalidate_cache();
+
+		$ability = new Update_Settings();
+		$ability->execute( array() );
+
+		$saved = Settings::get_settings();
+		$this->assertSame( 45, $saved['forms']['retention_days'] );
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `designsetgo/get-settings` and `designsetgo/update-settings` abilities so MCP servers and AI agents can read and mutate plugin configuration via the WordPress Abilities API instead of bespoke REST calls.
- Introduces a new `settings` ability category and auto-discovers classes under `includes/abilities/settings/` (matches the existing `info/`, `inserters/`, `configurators/` pattern).
- Centralizes the settings JSON Schema and partial-update pipeline on `Settings` so the REST endpoint and both abilities share one source of truth — no behavioral change for REST consumers.

## Context

This is **Phase 1** of the multi-repo plan to let plugins own their ability surface:

| Repo | Change |
| --- | --- |
| **designsetgo** (this PR) | Registers `designsetgo/get-settings` + `designsetgo/update-settings`. |
| `mcp-adapter-initializer` | Widen `get_exposed_abilities()` with a `gd_mcp_exposed_abilities` filter so plugins opt-in without editing that repo. |
| `site-designer-api` | Add `designsetgoTools.ts` + adapter method calling the two abilities. |

Level 2 architecture (plugin-owned abilities + allowlist) — the other two repos are out of scope for this PR.

## Changes

**New files**
- `includes/abilities/settings/class-get-settings.php` — readonly, idempotent. `manage_options` required.
- `includes/abilities/settings/class-update-settings.php` — idempotent partial update. `manage_options` required. Same merge semantics as the REST endpoint (nested groups merged field-by-field; omitted keys preserved).

**Modified files**
- `includes/admin/class-settings.php`
  - `Settings::get_json_schema()` — new, shared between both abilities.
  - `Settings::update_settings()` — new static helper encapsulating sanitize → merge → persist → invalidate.
  - `sanitize_settings()` → `public static` so abilities can reuse it. The REST endpoint routes through `update_settings()` — no behavior change.
- `includes/abilities/class-abilities-registry.php` — registers the `settings` category and wires `settings/` into the auto-discovery loader + namespace map.
- `includes/abilities/info/class-list-abilities.php` — adds a suffix-based `-settings → settings` rule (runs before the prefix rules so `update-settings` isn't misbucketed as a configurator). Extends the `category` filter enum.

## Security notes

- Both abilities require `manage_options` (matches REST endpoint).
- `get-settings` returns integration secrets (Turnstile keys, etc.) in its payload — same behavior as today's REST endpoint. Documented in the ability's `instructions` annotation so agents know the caller was already authorized.
- No nonce check inside the ability — Abilities API authenticates at the transport layer (REST or MCP). The existing REST endpoint still enforces its nonce path unchanged.

## Test plan

- [ ] `composer lint` — phpcs passes
- [ ] `vendor/bin/phpstan analyse --memory-limit=1G` — passes
- [ ] Via REST: `GET /wp-json/wp/v2/abilities/designsetgo%2Fget-settings/run` returns the merged settings object for an admin user
- [ ] Via REST: `POST /wp-json/wp/v2/abilities/designsetgo%2Fupdate-settings/run` with `{ "forms": { "retention_days": 60 } }` updates only that field
- [ ] `list-abilities` now exposes `settings` as a filterable category and bucketizes the two new abilities into it
- [ ] Non-admin user gets a permission error from both abilities
- [ ] Existing `POST /designsetgo/v1/settings` REST endpoint still behaves identically (now routes through `Settings::update_settings()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)