### PR TITLE
chore(deps): ignore phpunit advisory PKSA-5jz8-6tcw-pbk4 to unblock CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,11 @@
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true,
       "phpstan/extension-installer": true
+    },
+    "audit": {
+      "ignore": {
+        "PKSA-5jz8-6tcw-pbk4": "phpunit/phpunit advisory GHSA-qrr6-mg7r-m243 — argument injection via newline in PHP INI values forwarded to child processes. Only impacts PHPUnit's subprocess invocation in dev/CI; not reachable in production. Affected range covers all phpunit ^9 releases; revisit when phpunit ^10/^11 upgrade lands."
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

A new PHPUnit advisory ([GHSA-qrr6-mg7r-m243](https://github.com/advisories/GHSA-qrr6-mg7r-m243), Composer ID `PKSA-5jz8-6tcw-pbk4`) was published at **2026-04-18T00:59:28Z** flagging argument injection via newline in PHP INI values forwarded to child processes. The affected range `<=12.5.21` covers the entire `phpunit/phpunit ^9` line we currently depend on (9.6.34), so Composer's audit started flagging it on every PR opened after that timestamp — which is breaking CI.

This change adds an explicit `config.audit.ignore` entry to `composer.json` with a rationale comment, so `composer install` / `composer audit` stop tripping on the advisory. Independent verification:

- PR #350 (merged 2026-04-16T23:10Z, pre-advisory) — full CI green
- PR #352 (opened 2026-04-18T03:24Z, post-advisory) — every PHP/WP/E2E job red, all rooted in the same composer step

The advisory is only reachable through PHPUnit's own subprocess invocation in dev/CI; it is not a runtime risk to the plugin or its users.

## Why ignore instead of upgrade

Upgrading to `phpunit ^10` or `^11` is the proper fix but is non-trivial: it requires bumping `yoast/phpunit-polyfills` to `^3`, re-validating the WordPress integration test suite (which still pins to PHPUnit 9 expectations in places), and a separate review pass. That work belongs in a dedicated PR; this change is the minimal unblock.

## Test plan

- [ ] CI on this PR passes (`composer install` no longer trips audit; `composer audit` reports the advisory as ignored, exit 0)
- [ ] Local: `composer audit` exits 0 with the advisory listed under "ignored"
- [ ] Once merged, rerun CI on #352 (schema fix) — those failures should clear
- [ ] Follow-up: open a separate PR to upgrade `phpunit/phpunit` to `^10` or `^11` and remove this ignore

## Related

Unblocks #352 (and any other PR opened after the advisory landed).