### PR TITLE
feat(flip-card): consolidate front/back into flip-card-face (Theme 2)

### DIFF
--- a/.claude/claude.md
+++ b/.claude/claude.md
@@ -33,9 +33,13 @@ Before adding a pattern to a block, check `src/hooks/` and `src/components/share
 - `<DsgoBlockPlaceholder>` — first-insert wizard for compound blocks.
 - `<DsgoChildToolbar>` — Add/Duplicate/Move/Remove for child blocks of compound parents.
 
-### Variation vs New Block
+### Variations vs. new blocks
 
-If a new block differs from an existing one only by 1–3 attributes **and shares the same `save()` output structure**, register a `block.json` variation, not a new block. The `save()` constraint is the technical blocker: variations cannot carry differing markup, so differing output forces a new block + deprecations.
+Before registering a new block, check whether the idea fits a variation on an existing one. **If a new block would differ from an existing block only by 1–3 attributes and share the same `save()` output structure, register a variation (`registerBlockVariation`), not a new block.** The shared-`save()` constraint is the real technical gate: variations cannot carry differing markup, so differing output always forces a separate block + deprecations.
+
+When in doubt prefer variations — they have no migration cost, no deprecation debt, and stay invisible to `save()` validation. Reach for a new block only when markup, inner-block structure, or block-level behaviour actually differs.
+
+For sibling blocks that already exist and meet the "1–3 attribute difference + shared save" rule (e.g. `flip-card-front` / `flip-card-back` → `flip-card-face` with a `side` attribute), consolidate via a new block + `inserter: false` on the legacy names + `transforms.to` on each legacy block pointing to the new one. Keep the legacy blocks registered so existing content keeps rendering.
 
 ### Inspector IA (Theme 3)
 

--- a/.claude/skills/add-block/SKILL.md
+++ b/.claude/skills/add-block/SKILL.md
@@ -8,6 +8,17 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash(mkdir *), Bash(npm run *)
 
 Create a new Gutenberg block following WordPress best practices.
 
+## Pre-flight: Variation check
+
+Before scaffolding a new block, run this check:
+
+1. Search existing blocks (`src/blocks/*`) for anything conceptually similar.
+2. Ask: would the new block differ from an existing one only by 1–3 attributes **and share the same `save()` output structure**?
+3. If yes → register a **variation** via `registerBlockVariation`, not a new block. Variations have no migration cost and no deprecation debt.
+4. If the save markup or inner-block structure actually differs → a new block is justified. Proceed.
+
+See the "Variations vs. new blocks" section in `.claude/claude.md` for rationale and the consolidation pattern for sibling blocks.
+
 ## Ask the User For
 
 - **Block name** (e.g., "accordion", "testimonial-slider")

--- a/.claude/skills/add-pattern/references/block-catalog.md
+++ b/.claude/skills/add-pattern/references/block-catalog.md
@@ -328,8 +328,8 @@ Key attributes:
   flipEffect ("horizontal"|"vertical"|"diagonal")
   flipDuration (string)
 
-Children: designsetgo/flip-card-front, designsetgo/flip-card-back
-  Both accept InnerBlocks
+Children: designsetgo/flip-card-face (required side attribute: "front" or "back")
+  Each face accepts InnerBlocks. Insert two faces, one with side="front" and one with side="back".
 ```
 
 ### designsetgo/image-accordion

--- a/docs/blocks/FLIP-CARD.md
+++ b/docs/blocks/FLIP-CARD.md
@@ -16,7 +16,7 @@ The **Flip Card Block** adds a layer of interactivity and surprise to your websi
     *   Add a **Heading** (Name) and **Paragraph** (Role).
     *   *Style*: Set a white background and add a subtle shadow.
 3.  **Edit Back**:
-    *   Select the second **Flip Card Face** (Side = Back — already set by the template). Add a **Paragraph** (Bio).
+    *   Select the second **Flip Card Face** (Side = back — already set by the template). Add a **Paragraph** (Bio).
     *   Add an **Icon Group** or **Buttons** for social links (LinkedIn, Twitter).
     *   *Style*: Set a colored background (e.g., Brand Blue) and white text to make it distinct from the front.
 4.  **Settings**:

--- a/docs/blocks/FLIP-CARD.md
+++ b/docs/blocks/FLIP-CARD.md
@@ -12,11 +12,11 @@ The **Flip Card Block** adds a layer of interactivity and surprise to your websi
 
 1.  **Insert Block**: Add the **Flip Card** block.
 2.  **Edit Front**:
-    *   Inside the **Flip Card Front** area, add an **Image** block (Team Photo).
+    *   Select the first **Flip Card Face** (Side = Front). Add an **Image** block (Team Photo).
     *   Add a **Heading** (Name) and **Paragraph** (Role).
     *   *Style*: Set a white background and add a subtle shadow.
 3.  **Edit Back**:
-    *   Inside the **Flip Card Back** area, add a **Paragraph** (Bio).
+    *   Select the second **Flip Card Face** and switch the **Side** attribute to `Back`. Add a **Paragraph** (Bio).
     *   Add an **Icon Group** or **Buttons** for social links (LinkedIn, Twitter).
     *   *Style*: Set a colored background (e.g., Brand Blue) and white text to make it distinct from the front.
 4.  **Settings**:
@@ -84,10 +84,10 @@ Front shows "Before" state; Back shows "After".
 
 *   **DOM Structure**:
     ```html
-    <div class="designsetgo-flip-card">
-      <div class="designsetgo-flip-card-inner">
-        <div class="designsetgo-flip-card-front">...</div>
-        <div class="designsetgo-flip-card-back">...</div>
+    <div class="wp-block-designsetgo-flip-card dsgo-flip-card">
+      <div class="dsgo-flip-card__container">
+        <div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__front">...</div>
+        <div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__back">...</div>
       </div>
     </div>
     ```

--- a/docs/blocks/FLIP-CARD.md
+++ b/docs/blocks/FLIP-CARD.md
@@ -16,7 +16,7 @@ The **Flip Card Block** adds a layer of interactivity and surprise to your websi
     *   Add a **Heading** (Name) and **Paragraph** (Role).
     *   *Style*: Set a white background and add a subtle shadow.
 3.  **Edit Back**:
-    *   Select the second **Flip Card Face** and switch the **Side** attribute to `Back`. Add a **Paragraph** (Bio).
+    *   Select the second **Flip Card Face** (Side = Back — already set by the template). Add a **Paragraph** (Bio).
     *   Add an **Icon Group** or **Buttons** for social links (LinkedIn, Twitter).
     *   *Style*: Set a colored background (e.g., Brand Blue) and white text to make it distinct from the front.
 4.  **Settings**:

--- a/includes/abilities/class-block-inserter.php
+++ b/includes/abilities/class-block-inserter.php
@@ -448,7 +448,7 @@ class Block_Inserter {
 					'closing' => '</div>',
 				);
 
-			// Legacy — consolidated into designsetgo/flip-card-face in 2.0.52.
+			// Legacy — consolidated into designsetgo/flip-card-face in 2.0.51.
 			// Kept so the inserter ability can still emit existing content
 			// until it is transformed to the new block.
 			case 'designsetgo/flip-card-front':

--- a/includes/abilities/class-block-inserter.php
+++ b/includes/abilities/class-block-inserter.php
@@ -441,6 +441,16 @@ class Block_Inserter {
 					'closing' => '</div></div>',
 				);
 
+			case 'designsetgo/flip-card-face':
+				$side = isset( $attributes['side'] ) && 'back' === $attributes['side'] ? 'back' : 'front';
+				return array(
+					'opening' => '<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__' . esc_attr( $side ) . '">',
+					'closing' => '</div>',
+				);
+
+			// Legacy — consolidated into designsetgo/flip-card-face in 2.0.52.
+			// Kept so the inserter ability can still emit existing content
+			// until it is transformed to the new block.
 			case 'designsetgo/flip-card-front':
 				return array(
 					'opening' => '<div class="wp-block-designsetgo-flip-card-front dsgo-flip-card__face dsgo-flip-card__front">',

--- a/includes/admin/blocks-registry-i18n.php
+++ b/includes/admin/blocks-registry-i18n.php
@@ -73,10 +73,8 @@ __( 'Individual slide within Scroll Slides', 'designsetgo' );
 // Interactive Blocks.
 __( 'Flip Card', 'designsetgo' );
 __( '3D flip card container', 'designsetgo' );
-__( 'Flip Card Front', 'designsetgo' );
-__( 'Front face of flip card', 'designsetgo' );
-__( 'Flip Card Back', 'designsetgo' );
-__( 'Back face of flip card', 'designsetgo' );
+__( 'Flip Card Face', 'designsetgo' );
+__( 'Front or back face of a flip card', 'designsetgo' );
 __( 'Slider', 'designsetgo' );
 __( 'Modern carousel with effects', 'designsetgo' );
 __( 'Slide', 'designsetgo' );

--- a/includes/admin/blocks-registry.json
+++ b/includes/admin/blocks-registry.json
@@ -145,15 +145,9 @@
 				"performance": "high"
 			},
 			{
-				"name": "designsetgo/flip-card-front",
-				"title": "Flip Card Front",
-				"description": "Front face of flip card",
-				"performance": "high"
-			},
-			{
-				"name": "designsetgo/flip-card-back",
-				"title": "Flip Card Back",
-				"description": "Back face of flip card",
+				"name": "designsetgo/flip-card-face",
+				"title": "Flip Card Face",
+				"description": "Front or back face of a flip card",
 				"performance": "high"
 			},
 			{

--- a/includes/extension-configs/background-video.php
+++ b/includes/extension-configs/background-video.php
@@ -14,6 +14,7 @@ return array(
 		'designsetgo/row',
 		'designsetgo/grid',
 		'designsetgo/flip-card',
+		'designsetgo/flip-card-face',
 		'designsetgo/flip-card-front',
 		'designsetgo/flip-card-back',
 		'designsetgo/accordion',

--- a/includes/extension-configs/vertical-parallax.php
+++ b/includes/extension-configs/vertical-parallax.php
@@ -23,6 +23,7 @@ return array(
 		'designsetgo/grid',
 		// DesignSetGo visual blocks.
 		'designsetgo/flip-card',
+		'designsetgo/flip-card-face',
 		'designsetgo/flip-card-front',
 		'designsetgo/flip-card-back',
 		'designsetgo/icon',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "designsetgo",
-  "version": "2.0.50",
+  "version": "2.0.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "designsetgo",
-      "version": "2.0.50",
+      "version": "2.0.51",
+      "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@wordpress/block-editor": "^14.0.0",

--- a/patterns/features/features-flip-card-grid.php
+++ b/patterns/features/features-flip-card-grid.php
@@ -30,8 +30,8 @@ return array(
 
 <!-- wp:designsetgo/grid {"style":{"spacing":{"blockGap":"var:preset|spacing|30","padding":{"top":"0","bottom":"0","left":"0","right":"0"}}}} -->
 <div class="wp-block-designsetgo-grid alignfull dsgo-grid dsgo-grid-cols-3 dsgo-grid-cols-tablet-2 dsgo-grid-cols-mobile-1 dsgo-no-width-constraint" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><div class="dsgo-grid__inner" style="display:grid;grid-template-columns:repeat(3, 1fr);align-items:stretch;row-gap:var(--wp--preset--spacing--30);column-gap:var(--wp--preset--spacing--30)"><!-- wp:designsetgo/flip-card -->
-<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-front {"className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"},"color":{"gradient":"linear-gradient(135deg,rgb(139,92,246) 0%,rgb(79,70,229) 100%)"}}} -->
-<div class="wp-block-designsetgo-flip-card-front dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:16px;background:linear-gradient(135deg,rgb(139,92,246) 0%,rgb(79,70,229) 100%);padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:designsetgo/icon {"icon":"chart","iconSize":56,"style":{"color":{"text":"#ffffff"}}} -->
+<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-face {"side":"front","className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"},"color":{"gradient":"linear-gradient(135deg,rgb(139,92,246) 0%,rgb(79,70,229) 100%)"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:16px;background:linear-gradient(135deg,rgb(139,92,246) 0%,rgb(79,70,229) 100%);padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:designsetgo/icon {"icon":"chart","iconSize":56,"style":{"color":{"text":"#ffffff"}}} -->
 <div class="wp-block-designsetgo-icon dsgo-icon has-text-color" style="color:#ffffff;display:flex;align-items:center;justify-content:center"><div class="dsgo-icon__wrapper dsgo-lazy-icon" style="width:56px;height:56px;display:inline-flex;align-items:center;justify-content:center;border-radius:inherit" data-icon-name="chart" data-icon-style="filled" data-icon-stroke-width="1.5" role="img" aria-label="Chart"></div></div>
 <!-- /wp:designsetgo/icon -->
 
@@ -42,10 +42,10 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"color":{"text":"rgba(255,255,255,0.8)"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:rgba(255,255,255,0.8);margin-top:var(--wp--preset--spacing--10)">Hover to learn more</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-front -->
+<!-- /wp:designsetgo/flip-card-face -->
 
-<!-- wp:designsetgo/flip-card-back {"className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"}}} -->
-<div class="wp-block-designsetgo-flip-card-back dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+<!-- wp:designsetgo/flip-card-face {"side":"back","className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
 <h3 class="wp-block-heading has-medium-font-size">Real-time Analytics</h3>
 <!-- /wp:heading -->
 
@@ -56,12 +56,12 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}},"color":{"text":"#8b5cf6"},"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:#8b5cf6;margin-top:var(--wp--preset--spacing--20);font-style:normal;font-weight:600">Learn more →</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-back --></div></div>
+<!-- /wp:designsetgo/flip-card-face --></div></div>
 <!-- /wp:designsetgo/flip-card -->
 
 <!-- wp:designsetgo/flip-card -->
-<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-front {"className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"},"color":{"gradient":"linear-gradient(135deg,rgb(6,182,212) 0%,rgb(59,130,246) 100%)"}}} -->
-<div class="wp-block-designsetgo-flip-card-front dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:16px;background:linear-gradient(135deg,rgb(6,182,212) 0%,rgb(59,130,246) 100%);padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:designsetgo/icon {"icon":"users","iconSize":56,"style":{"color":{"text":"#ffffff"}}} -->
+<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-face {"side":"front","className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"},"color":{"gradient":"linear-gradient(135deg,rgb(6,182,212) 0%,rgb(59,130,246) 100%)"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:16px;background:linear-gradient(135deg,rgb(6,182,212) 0%,rgb(59,130,246) 100%);padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:designsetgo/icon {"icon":"users","iconSize":56,"style":{"color":{"text":"#ffffff"}}} -->
 <div class="wp-block-designsetgo-icon dsgo-icon has-text-color" style="color:#ffffff;display:flex;align-items:center;justify-content:center"><div class="dsgo-icon__wrapper dsgo-lazy-icon" style="width:56px;height:56px;display:inline-flex;align-items:center;justify-content:center;border-radius:inherit" data-icon-name="users" data-icon-style="filled" data-icon-stroke-width="1.5" role="img" aria-label="Users"></div></div>
 <!-- /wp:designsetgo/icon -->
 
@@ -72,10 +72,10 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"color":{"text":"rgba(255,255,255,0.8)"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:rgba(255,255,255,0.8);margin-top:var(--wp--preset--spacing--10)">Hover to learn more</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-front -->
+<!-- /wp:designsetgo/flip-card-face -->
 
-<!-- wp:designsetgo/flip-card-back {"className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"}}} -->
-<div class="wp-block-designsetgo-flip-card-back dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+<!-- wp:designsetgo/flip-card-face {"side":"back","className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
 <h3 class="wp-block-heading has-medium-font-size">Team Collaboration</h3>
 <!-- /wp:heading -->
 
@@ -86,12 +86,12 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}},"color":{"text":"#ec4899"},"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:#ec4899;margin-top:var(--wp--preset--spacing--20);font-style:normal;font-weight:600">Learn more →</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-back --></div></div>
+<!-- /wp:designsetgo/flip-card-face --></div></div>
 <!-- /wp:designsetgo/flip-card -->
 
 <!-- wp:designsetgo/flip-card -->
-<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-front {"className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"},"color":{"gradient":"linear-gradient(135deg,rgb(236,72,153) 0%,rgb(239,68,68) 100%)"}}} -->
-<div class="wp-block-designsetgo-flip-card-front dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:16px;background:linear-gradient(135deg,rgb(236,72,153) 0%,rgb(239,68,68) 100%);padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:designsetgo/icon {"icon":"lightning","iconSize":56,"style":{"color":{"text":"#ffffff"}}} -->
+<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-face {"side":"front","className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"},"color":{"gradient":"linear-gradient(135deg,rgb(236,72,153) 0%,rgb(239,68,68) 100%)"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:16px;background:linear-gradient(135deg,rgb(236,72,153) 0%,rgb(239,68,68) 100%);padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:designsetgo/icon {"icon":"lightning","iconSize":56,"style":{"color":{"text":"#ffffff"}}} -->
 <div class="wp-block-designsetgo-icon dsgo-icon has-text-color" style="color:#ffffff;display:flex;align-items:center;justify-content:center"><div class="dsgo-icon__wrapper dsgo-lazy-icon" style="width:56px;height:56px;display:inline-flex;align-items:center;justify-content:center;border-radius:inherit" data-icon-name="lightning" data-icon-style="filled" data-icon-stroke-width="1.5" role="img" aria-label="Lightning"></div></div>
 <!-- /wp:designsetgo/icon -->
 
@@ -102,10 +102,10 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"color":{"text":"rgba(255,255,255,0.8)"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:rgba(255,255,255,0.8);margin-top:var(--wp--preset--spacing--10)">Hover to learn more</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-front -->
+<!-- /wp:designsetgo/flip-card-face -->
 
-<!-- wp:designsetgo/flip-card-back {"className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"}}} -->
-<div class="wp-block-designsetgo-flip-card-back dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+<!-- wp:designsetgo/flip-card-face {"side":"back","className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
 <h3 class="wp-block-heading has-medium-font-size">Automation</h3>
 <!-- /wp:heading -->
 
@@ -116,7 +116,7 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}},"color":{"text":"#ec4899"},"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:#ec4899;margin-top:var(--wp--preset--spacing--20);font-style:normal;font-weight:600">Learn more →</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-back --></div></div>
+<!-- /wp:designsetgo/flip-card-face --></div></div>
 <!-- /wp:designsetgo/flip-card --></div></div>
 <!-- /wp:designsetgo/grid --></div></div>
 <!-- /wp:designsetgo/section -->',

--- a/patterns/features/features-flip-card-services.php
+++ b/patterns/features/features-flip-card-services.php
@@ -26,8 +26,8 @@ return array(
 
 <!-- wp:designsetgo/grid {"style":{"spacing":{"blockGap":"var:preset|spacing|30","padding":{"top":"0","bottom":"0","left":"0","right":"0"}}}} -->
 <div class="wp-block-designsetgo-grid alignfull dsgo-grid dsgo-grid-cols-3 dsgo-grid-cols-tablet-2 dsgo-grid-cols-mobile-1 dsgo-no-width-constraint" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><div class="dsgo-grid__inner" style="display:grid;grid-template-columns:repeat(3, 1fr);align-items:stretch;row-gap:var(--wp--preset--spacing--30);column-gap:var(--wp--preset--spacing--30)"><!-- wp:designsetgo/flip-card -->
-<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-front {"className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"border":{"radius":"0"},"color":{"gradient":"linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%)"}}} -->
-<div class="wp-block-designsetgo-flip-card-front dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:0;background:linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%);padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40)"><!-- wp:designsetgo/icon {"icon":"home","style":{"color":{"text":"#d4af37"}},"dsgoAnimationEnabled":true,"dsgoEntranceAnimation":"zoomIn","dsgoAnimationDuration":500} -->
+<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-face {"side":"front","className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"border":{"radius":"0"},"color":{"gradient":"linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%)"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:0;background:linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%);padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40)"><!-- wp:designsetgo/icon {"icon":"home","style":{"color":{"text":"#d4af37"}},"dsgoAnimationEnabled":true,"dsgoEntranceAnimation":"zoomIn","dsgoAnimationDuration":500} -->
 <div class="wp-block-designsetgo-icon dsgo-icon has-text-color has-dsgo-animation dsgo-animation-zoomIn" style="color:#d4af37;display:flex;align-items:center;justify-content:center" data-dsgo-animation-enabled="true" data-dsgo-entrance-animation="zoomIn" data-dsgo-animation-duration="500"><div class="dsgo-icon__wrapper dsgo-lazy-icon" style="width:48px;height:48px;display:inline-flex;align-items:center;justify-content:center;border-radius:inherit" data-icon-name="home" data-icon-style="filled" data-icon-stroke-width="1.5" role="img" aria-label="Home"></div></div>
 <!-- /wp:designsetgo/icon -->
 
@@ -38,10 +38,10 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"color":{"text":"rgba(255,255,255,0.6)"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:rgba(255,255,255,0.6);margin-top:var(--wp--preset--spacing--10)">Hover to learn more</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-front -->
+<!-- /wp:designsetgo/flip-card-face -->
 
-<!-- wp:designsetgo/flip-card-back {"className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"0"}}} -->
-<div class="wp-block-designsetgo-flip-card-back dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:0;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+<!-- wp:designsetgo/flip-card-face {"side":"back","className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"0"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:0;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
 <h3 class="wp-block-heading has-medium-font-size">Buyer Representation</h3>
 <!-- /wp:heading -->
 
@@ -52,12 +52,12 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|15"}},"color":{"text":"#d4af37"},"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:#d4af37;margin-top:var(--wp--preset--spacing--15);font-style:normal;font-weight:600">Learn more →</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-back --></div></div>
+<!-- /wp:designsetgo/flip-card-face --></div></div>
 <!-- /wp:designsetgo/flip-card -->
 
 <!-- wp:designsetgo/flip-card -->
-<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-front {"className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"border":{"radius":"0"},"color":{"gradient":"linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%)"}}} -->
-<div class="wp-block-designsetgo-flip-card-front dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:0;background:linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%);padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40)"><!-- wp:designsetgo/icon {"icon":"chart","style":{"color":{"text":"#d4af37"}},"dsgoAnimationEnabled":true,"dsgoEntranceAnimation":"zoomIn","dsgoAnimationDuration":500,"dsgoAnimationDelay":100} -->
+<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-face {"side":"front","className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"border":{"radius":"0"},"color":{"gradient":"linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%)"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:0;background:linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%);padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40)"><!-- wp:designsetgo/icon {"icon":"chart","style":{"color":{"text":"#d4af37"}},"dsgoAnimationEnabled":true,"dsgoEntranceAnimation":"zoomIn","dsgoAnimationDuration":500,"dsgoAnimationDelay":100} -->
 <div class="wp-block-designsetgo-icon dsgo-icon has-text-color has-dsgo-animation dsgo-animation-zoomIn" style="color:#d4af37;display:flex;align-items:center;justify-content:center" data-dsgo-animation-enabled="true" data-dsgo-entrance-animation="zoomIn" data-dsgo-animation-duration="500" data-dsgo-animation-delay="100"><div class="dsgo-icon__wrapper dsgo-lazy-icon" style="width:48px;height:48px;display:inline-flex;align-items:center;justify-content:center;border-radius:inherit" data-icon-name="chart" data-icon-style="filled" data-icon-stroke-width="1.5" role="img" aria-label="Chart"></div></div>
 <!-- /wp:designsetgo/icon -->
 
@@ -68,10 +68,10 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"color":{"text":"rgba(255,255,255,0.6)"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:rgba(255,255,255,0.6);margin-top:var(--wp--preset--spacing--10)">Hover to learn more</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-front -->
+<!-- /wp:designsetgo/flip-card-face -->
 
-<!-- wp:designsetgo/flip-card-back {"className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"0"}}} -->
-<div class="wp-block-designsetgo-flip-card-back dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:0;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+<!-- wp:designsetgo/flip-card-face {"side":"back","className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"0"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:0;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
 <h3 class="wp-block-heading has-medium-font-size">Property Valuation</h3>
 <!-- /wp:heading -->
 
@@ -82,12 +82,12 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|15"}},"color":{"text":"#d4af37"},"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:#d4af37;margin-top:var(--wp--preset--spacing--15);font-style:normal;font-weight:600">Learn more →</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-back --></div></div>
+<!-- /wp:designsetgo/flip-card-face --></div></div>
 <!-- /wp:designsetgo/flip-card -->
 
 <!-- wp:designsetgo/flip-card -->
-<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-front {"className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"border":{"radius":"0"},"color":{"gradient":"linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%)"}}} -->
-<div class="wp-block-designsetgo-flip-card-front dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:0;background:linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%);padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40)"><!-- wp:designsetgo/icon {"icon":"globe","style":{"color":{"text":"#d4af37"}},"dsgoAnimationEnabled":true,"dsgoEntranceAnimation":"zoomIn","dsgoAnimationDuration":500,"dsgoAnimationDelay":200} -->
+<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-face {"side":"front","className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"border":{"radius":"0"},"color":{"gradient":"linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%)"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:0;background:linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%);padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40)"><!-- wp:designsetgo/icon {"icon":"globe","style":{"color":{"text":"#d4af37"}},"dsgoAnimationEnabled":true,"dsgoEntranceAnimation":"zoomIn","dsgoAnimationDuration":500,"dsgoAnimationDelay":200} -->
 <div class="wp-block-designsetgo-icon dsgo-icon has-text-color has-dsgo-animation dsgo-animation-zoomIn" style="color:#d4af37;display:flex;align-items:center;justify-content:center" data-dsgo-animation-enabled="true" data-dsgo-entrance-animation="zoomIn" data-dsgo-animation-duration="500" data-dsgo-animation-delay="200"><div class="dsgo-icon__wrapper dsgo-lazy-icon" style="width:48px;height:48px;display:inline-flex;align-items:center;justify-content:center;border-radius:inherit" data-icon-name="globe" data-icon-style="filled" data-icon-stroke-width="1.5" role="img" aria-label="Globe"></div></div>
 <!-- /wp:designsetgo/icon -->
 
@@ -98,10 +98,10 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"color":{"text":"rgba(255,255,255,0.6)"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:rgba(255,255,255,0.6);margin-top:var(--wp--preset--spacing--10)">Hover to learn more</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-front -->
+<!-- /wp:designsetgo/flip-card-face -->
 
-<!-- wp:designsetgo/flip-card-back {"className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"0"}}} -->
-<div class="wp-block-designsetgo-flip-card-back dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:0;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+<!-- wp:designsetgo/flip-card-face {"side":"back","className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"0"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:0;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
 <h3 class="wp-block-heading has-medium-font-size">Global Reach</h3>
 <!-- /wp:heading -->
 
@@ -112,7 +112,7 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|15"}},"color":{"text":"#d4af37"},"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:#d4af37;margin-top:var(--wp--preset--spacing--15);font-style:normal;font-weight:600">Learn more →</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-back --></div></div>
+<!-- /wp:designsetgo/flip-card-face --></div></div>
 <!-- /wp:designsetgo/flip-card --></div></div>
 <!-- /wp:designsetgo/grid --></div></div>
 <!-- /wp:designsetgo/section -->',

--- a/patterns/homepage/homepage-luxury-realestate.php
+++ b/patterns/homepage/homepage-luxury-realestate.php
@@ -166,8 +166,8 @@ return array(
 
 <!-- wp:designsetgo/grid {"style":{"spacing":{"blockGap":"var:preset|spacing|30","padding":{"top":"0","bottom":"0","left":"0","right":"0"}}}} -->
 <div class="wp-block-designsetgo-grid alignfull dsgo-grid dsgo-grid-cols-3 dsgo-grid-cols-tablet-2 dsgo-grid-cols-mobile-1 dsgo-no-width-constraint" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><div class="dsgo-grid__inner" style="display:grid;grid-template-columns:repeat(3, 1fr);align-items:stretch;row-gap:var(--wp--preset--spacing--30);column-gap:var(--wp--preset--spacing--30)"><!-- wp:designsetgo/flip-card -->
-<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-front {"className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"border":{"radius":"0"},"color":{"gradient":"linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%)"}}} -->
-<div class="wp-block-designsetgo-flip-card-front dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:0;background:linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%);padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40)"><!-- wp:designsetgo/icon {"icon":"home","style":{"color":{"text":"#d4af37"}},"dsgoAnimationEnabled":true,"dsgoEntranceAnimation":"zoomIn","dsgoAnimationDuration":500} -->
+<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-face {"side":"front","className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"border":{"radius":"0"},"color":{"gradient":"linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%)"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:0;background:linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%);padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40)"><!-- wp:designsetgo/icon {"icon":"home","style":{"color":{"text":"#d4af37"}},"dsgoAnimationEnabled":true,"dsgoEntranceAnimation":"zoomIn","dsgoAnimationDuration":500} -->
 <div class="wp-block-designsetgo-icon dsgo-icon has-text-color has-dsgo-animation dsgo-animation-zoomIn" style="color:#d4af37;display:flex;align-items:center;justify-content:center" data-dsgo-animation-enabled="true" data-dsgo-entrance-animation="zoomIn" data-dsgo-animation-duration="500"><div class="dsgo-icon__wrapper dsgo-lazy-icon" style="width:48px;height:48px;display:inline-flex;align-items:center;justify-content:center;border-radius:inherit" data-icon-name="home" data-icon-style="filled" data-icon-stroke-width="1.5" role="img" aria-label="Home"></div></div>
 <!-- /wp:designsetgo/icon -->
 
@@ -178,10 +178,10 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"color":{"text":"rgba(255,255,255,0.6)"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:rgba(255,255,255,0.6);margin-top:var(--wp--preset--spacing--10)">Hover to learn more</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-front -->
+<!-- /wp:designsetgo/flip-card-face -->
 
-<!-- wp:designsetgo/flip-card-back {"className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"0"}}} -->
-<div class="wp-block-designsetgo-flip-card-back dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:0;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+<!-- wp:designsetgo/flip-card-face {"side":"back","className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"0"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:0;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
 <h3 class="wp-block-heading has-medium-font-size">Buyer Representation</h3>
 <!-- /wp:heading -->
 
@@ -192,12 +192,12 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|15"}},"color":{"text":"#d4af37"},"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:#d4af37;margin-top:var(--wp--preset--spacing--15);font-style:normal;font-weight:600">Learn more →</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-back --></div></div>
+<!-- /wp:designsetgo/flip-card-face --></div></div>
 <!-- /wp:designsetgo/flip-card -->
 
 <!-- wp:designsetgo/flip-card -->
-<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-front {"className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"border":{"radius":"0"},"color":{"gradient":"linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%)"}}} -->
-<div class="wp-block-designsetgo-flip-card-front dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:0;background:linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%);padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40)"><!-- wp:designsetgo/icon {"icon":"chart","style":{"color":{"text":"#d4af37"}},"dsgoAnimationEnabled":true,"dsgoEntranceAnimation":"zoomIn","dsgoAnimationDuration":500,"dsgoAnimationDelay":100} -->
+<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-face {"side":"front","className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"border":{"radius":"0"},"color":{"gradient":"linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%)"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:0;background:linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%);padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40)"><!-- wp:designsetgo/icon {"icon":"chart","style":{"color":{"text":"#d4af37"}},"dsgoAnimationEnabled":true,"dsgoEntranceAnimation":"zoomIn","dsgoAnimationDuration":500,"dsgoAnimationDelay":100} -->
 <div class="wp-block-designsetgo-icon dsgo-icon has-text-color has-dsgo-animation dsgo-animation-zoomIn" style="color:#d4af37;display:flex;align-items:center;justify-content:center" data-dsgo-animation-enabled="true" data-dsgo-entrance-animation="zoomIn" data-dsgo-animation-duration="500" data-dsgo-animation-delay="100"><div class="dsgo-icon__wrapper dsgo-lazy-icon" style="width:48px;height:48px;display:inline-flex;align-items:center;justify-content:center;border-radius:inherit" data-icon-name="chart" data-icon-style="filled" data-icon-stroke-width="1.5" role="img" aria-label="Chart"></div></div>
 <!-- /wp:designsetgo/icon -->
 
@@ -208,10 +208,10 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"color":{"text":"rgba(255,255,255,0.6)"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:rgba(255,255,255,0.6);margin-top:var(--wp--preset--spacing--10)">Hover to learn more</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-front -->
+<!-- /wp:designsetgo/flip-card-face -->
 
-<!-- wp:designsetgo/flip-card-back {"className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"0"}}} -->
-<div class="wp-block-designsetgo-flip-card-back dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:0;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+<!-- wp:designsetgo/flip-card-face {"side":"back","className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"0"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:0;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
 <h3 class="wp-block-heading has-medium-font-size">Property Valuation</h3>
 <!-- /wp:heading -->
 
@@ -222,12 +222,12 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|15"}},"color":{"text":"#d4af37"},"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:#d4af37;margin-top:var(--wp--preset--spacing--15);font-style:normal;font-weight:600">Learn more →</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-back --></div></div>
+<!-- /wp:designsetgo/flip-card-face --></div></div>
 <!-- /wp:designsetgo/flip-card -->
 
 <!-- wp:designsetgo/flip-card -->
-<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-front {"className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"border":{"radius":"0"},"color":{"gradient":"linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%)"}}} -->
-<div class="wp-block-designsetgo-flip-card-front dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:0;background:linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%);padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40)"><!-- wp:designsetgo/icon {"icon":"globe","style":{"color":{"text":"#d4af37"}},"dsgoAnimationEnabled":true,"dsgoEntranceAnimation":"zoomIn","dsgoAnimationDuration":500,"dsgoAnimationDelay":200} -->
+<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-face {"side":"front","className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"border":{"radius":"0"},"color":{"gradient":"linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%)"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:0;background:linear-gradient(135deg,rgb(15,23,42) 0%,rgb(30,41,59) 100%);padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40)"><!-- wp:designsetgo/icon {"icon":"globe","style":{"color":{"text":"#d4af37"}},"dsgoAnimationEnabled":true,"dsgoEntranceAnimation":"zoomIn","dsgoAnimationDuration":500,"dsgoAnimationDelay":200} -->
 <div class="wp-block-designsetgo-icon dsgo-icon has-text-color has-dsgo-animation dsgo-animation-zoomIn" style="color:#d4af37;display:flex;align-items:center;justify-content:center" data-dsgo-animation-enabled="true" data-dsgo-entrance-animation="zoomIn" data-dsgo-animation-duration="500" data-dsgo-animation-delay="200"><div class="dsgo-icon__wrapper dsgo-lazy-icon" style="width:48px;height:48px;display:inline-flex;align-items:center;justify-content:center;border-radius:inherit" data-icon-name="globe" data-icon-style="filled" data-icon-stroke-width="1.5" role="img" aria-label="Globe"></div></div>
 <!-- /wp:designsetgo/icon -->
 
@@ -238,10 +238,10 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"color":{"text":"rgba(255,255,255,0.6)"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:rgba(255,255,255,0.6);margin-top:var(--wp--preset--spacing--10)">Hover to learn more</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-front -->
+<!-- /wp:designsetgo/flip-card-face -->
 
-<!-- wp:designsetgo/flip-card-back {"className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"0"}}} -->
-<div class="wp-block-designsetgo-flip-card-back dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:0;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+<!-- wp:designsetgo/flip-card-face {"side":"back","className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"0"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:0;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
 <h3 class="wp-block-heading has-medium-font-size">Global Reach</h3>
 <!-- /wp:heading -->
 
@@ -252,7 +252,7 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|15"}},"color":{"text":"#d4af37"},"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:#d4af37;margin-top:var(--wp--preset--spacing--15);font-style:normal;font-weight:600">Learn more →</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-back --></div></div>
+<!-- /wp:designsetgo/flip-card-face --></div></div>
 <!-- /wp:designsetgo/flip-card --></div></div>
 <!-- /wp:designsetgo/grid --></div></div>
 <!-- /wp:designsetgo/section -->

--- a/patterns/homepage/homepage-modern-saas.php
+++ b/patterns/homepage/homepage-modern-saas.php
@@ -86,8 +86,8 @@ return array(
 
 <!-- wp:designsetgo/grid {"style":{"spacing":{"blockGap":"var:preset|spacing|30","padding":{"top":"0","bottom":"0","left":"0","right":"0"}}}} -->
 <div class="wp-block-designsetgo-grid alignfull dsgo-grid dsgo-grid-cols-3 dsgo-grid-cols-tablet-2 dsgo-grid-cols-mobile-1 dsgo-no-width-constraint" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><div class="dsgo-grid__inner" style="display:grid;grid-template-columns:repeat(3, 1fr);align-items:stretch;row-gap:var(--wp--preset--spacing--30);column-gap:var(--wp--preset--spacing--30)"><!-- wp:designsetgo/flip-card -->
-<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-front {"className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"},"color":{"gradient":"linear-gradient(135deg,rgb(139,92,246) 0%,rgb(79,70,229) 100%)"}}} -->
-<div class="wp-block-designsetgo-flip-card-front dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:16px;background:linear-gradient(135deg,rgb(139,92,246) 0%,rgb(79,70,229) 100%);padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:designsetgo/icon {"icon":"chart","iconSize":56,"style":{"color":{"text":"#ffffff"}}} -->
+<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-face {"side":"front","className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"},"color":{"gradient":"linear-gradient(135deg,rgb(139,92,246) 0%,rgb(79,70,229) 100%)"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:16px;background:linear-gradient(135deg,rgb(139,92,246) 0%,rgb(79,70,229) 100%);padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:designsetgo/icon {"icon":"chart","iconSize":56,"style":{"color":{"text":"#ffffff"}}} -->
 <div class="wp-block-designsetgo-icon dsgo-icon has-text-color" style="color:#ffffff;display:flex;align-items:center;justify-content:center"><div class="dsgo-icon__wrapper dsgo-lazy-icon" style="width:56px;height:56px;display:inline-flex;align-items:center;justify-content:center;border-radius:inherit" data-icon-name="chart" data-icon-style="filled" data-icon-stroke-width="1.5" role="img" aria-label="Chart"></div></div>
 <!-- /wp:designsetgo/icon -->
 
@@ -98,10 +98,10 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"color":{"text":"rgba(255,255,255,0.8)"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:rgba(255,255,255,0.8);margin-top:var(--wp--preset--spacing--10)">Hover to learn more</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-front -->
+<!-- /wp:designsetgo/flip-card-face -->
 
-<!-- wp:designsetgo/flip-card-back {"className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"}}} -->
-<div class="wp-block-designsetgo-flip-card-back dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+<!-- wp:designsetgo/flip-card-face {"side":"back","className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
 <h3 class="wp-block-heading has-medium-font-size">Real-time Analytics</h3>
 <!-- /wp:heading -->
 
@@ -112,12 +112,12 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}},"color":{"text":"#8b5cf6"},"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:#8b5cf6;margin-top:var(--wp--preset--spacing--20);font-style:normal;font-weight:600">Learn more →</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-back --></div></div>
+<!-- /wp:designsetgo/flip-card-face --></div></div>
 <!-- /wp:designsetgo/flip-card -->
 
 <!-- wp:designsetgo/flip-card -->
-<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-front {"className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"},"color":{"gradient":"linear-gradient(135deg,rgb(6,182,212) 0%,rgb(59,130,246) 100%)"}}} -->
-<div class="wp-block-designsetgo-flip-card-front dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:16px;background:linear-gradient(135deg,rgb(6,182,212) 0%,rgb(59,130,246) 100%);padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:designsetgo/icon {"icon":"users","iconSize":56,"style":{"color":{"text":"#ffffff"}}} -->
+<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-face {"side":"front","className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"},"color":{"gradient":"linear-gradient(135deg,rgb(6,182,212) 0%,rgb(59,130,246) 100%)"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:16px;background:linear-gradient(135deg,rgb(6,182,212) 0%,rgb(59,130,246) 100%);padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:designsetgo/icon {"icon":"users","iconSize":56,"style":{"color":{"text":"#ffffff"}}} -->
 <div class="wp-block-designsetgo-icon dsgo-icon has-text-color" style="color:#ffffff;display:flex;align-items:center;justify-content:center"><div class="dsgo-icon__wrapper dsgo-lazy-icon" style="width:56px;height:56px;display:inline-flex;align-items:center;justify-content:center;border-radius:inherit" data-icon-name="users" data-icon-style="filled" data-icon-stroke-width="1.5" role="img" aria-label="Users"></div></div>
 <!-- /wp:designsetgo/icon -->
 
@@ -128,10 +128,10 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"color":{"text":"rgba(255,255,255,0.8)"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:rgba(255,255,255,0.8);margin-top:var(--wp--preset--spacing--10)">Hover to learn more</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-front -->
+<!-- /wp:designsetgo/flip-card-face -->
 
-<!-- wp:designsetgo/flip-card-back {"className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"}}} -->
-<div class="wp-block-designsetgo-flip-card-back dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+<!-- wp:designsetgo/flip-card-face {"side":"back","className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
 <h3 class="wp-block-heading has-medium-font-size">Team Collaboration</h3>
 <!-- /wp:heading -->
 
@@ -142,12 +142,12 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}},"color":{"text":"#ec4899"},"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:#ec4899;margin-top:var(--wp--preset--spacing--20);font-style:normal;font-weight:600">Learn more →</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-back --></div></div>
+<!-- /wp:designsetgo/flip-card-face --></div></div>
 <!-- /wp:designsetgo/flip-card -->
 
 <!-- wp:designsetgo/flip-card -->
-<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-front {"className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"},"color":{"gradient":"linear-gradient(135deg,rgb(236,72,153) 0%,rgb(239,68,68) 100%)"}}} -->
-<div class="wp-block-designsetgo-flip-card-front dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:16px;background:linear-gradient(135deg,rgb(236,72,153) 0%,rgb(239,68,68) 100%);padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:designsetgo/icon {"icon":"lightning","iconSize":56,"style":{"color":{"text":"#ffffff"}}} -->
+<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-face {"side":"front","className":"dsgo-flip-card__face\u002d\u002dfront","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"},"color":{"gradient":"linear-gradient(135deg,rgb(236,72,153) 0%,rgb(239,68,68) 100%)"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__front dsgo-flip-card__face--front has-background" style="border-radius:16px;background:linear-gradient(135deg,rgb(236,72,153) 0%,rgb(239,68,68) 100%);padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:designsetgo/icon {"icon":"lightning","iconSize":56,"style":{"color":{"text":"#ffffff"}}} -->
 <div class="wp-block-designsetgo-icon dsgo-icon has-text-color" style="color:#ffffff;display:flex;align-items:center;justify-content:center"><div class="dsgo-icon__wrapper dsgo-lazy-icon" style="width:56px;height:56px;display:inline-flex;align-items:center;justify-content:center;border-radius:inherit" data-icon-name="lightning" data-icon-style="filled" data-icon-stroke-width="1.5" role="img" aria-label="Lightning"></div></div>
 <!-- /wp:designsetgo/icon -->
 
@@ -158,10 +158,10 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"color":{"text":"rgba(255,255,255,0.8)"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:rgba(255,255,255,0.8);margin-top:var(--wp--preset--spacing--10)">Hover to learn more</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-front -->
+<!-- /wp:designsetgo/flip-card-face -->
 
-<!-- wp:designsetgo/flip-card-back {"className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"}}} -->
-<div class="wp-block-designsetgo-flip-card-back dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+<!-- wp:designsetgo/flip-card-face {"side":"back","className":"dsgo-flip-card__face\u002d\u002dback","backgroundColor":"base-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"radius":"16px"}}} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__back dsgo-flip-card__face--back has-base-2-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
 <h3 class="wp-block-heading has-medium-font-size">Automation</h3>
 <!-- /wp:heading -->
 
@@ -172,7 +172,7 @@ return array(
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}},"color":{"text":"#ec4899"},"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"small"} -->
 <p class="has-text-color has-small-font-size" style="color:#ec4899;margin-top:var(--wp--preset--spacing--20);font-style:normal;font-weight:600">Learn more →</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-back --></div></div>
+<!-- /wp:designsetgo/flip-card-face --></div></div>
 <!-- /wp:designsetgo/flip-card --></div></div>
 <!-- /wp:designsetgo/grid --></div></div>
 <!-- /wp:designsetgo/section -->

--- a/patterns/team/team-flip-cards.php
+++ b/patterns/team/team-flip-cards.php
@@ -26,8 +26,8 @@ return array(
 
 <!-- wp:designsetgo/grid {"style":{"spacing":{"blockGap":"var:preset|spacing|40","padding":{"top":"0","bottom":"0","left":"0","right":"0"}}}} -->
 <div class="wp-block-designsetgo-grid alignfull dsgo-grid dsgo-grid-cols-3 dsgo-grid-cols-tablet-2 dsgo-grid-cols-mobile-1 dsgo-no-width-constraint" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><div class="dsgo-grid__inner" style="display:grid;grid-template-columns:repeat(3, 1fr);align-items:stretch;row-gap:var(--wp--preset--spacing--40);column-gap:var(--wp--preset--spacing--40)"><!-- wp:designsetgo/flip-card {"style":{"dimensions":{"minHeight":"350px"}}} -->
-<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="min-height:350px;--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-front {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"},"blockGap":"1rem"},"border":{"radius":"16px"}},"backgroundColor":"base"} -->
-<div class="wp-block-designsetgo-flip-card-front dsgo-flip-card__face dsgo-flip-card__front has-base-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:image {"width":"120px","height":"120px","scale":"cover","sizeSlug":"thumbnail","className":"is-style-rounded"} -->
+<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="min-height:350px;--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-face {"side":"front","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"},"blockGap":"1rem"},"border":{"radius":"16px"}},"backgroundColor":"base"} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__front has-base-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:image {"width":"120px","height":"120px","scale":"cover","sizeSlug":"thumbnail","className":"is-style-rounded"} -->
 <figure class="wp-block-image size-thumbnail is-resized is-style-rounded"><img src="https://i.pravatar.cc/200?img=68" alt="Chris Anderson" style="object-fit:cover;width:120px;height:120px"/></figure>
 <!-- /wp:image -->
 
@@ -38,10 +38,10 @@ return array(
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center">Product Manager</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-front -->
+<!-- /wp:designsetgo/flip-card-face -->
 
-<!-- wp:designsetgo/flip-card-back {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"},"blockGap":"1rem"},"border":{"radius":"16px"}},"backgroundColor":"contrast","textColor":"base"} -->
-<div class="wp-block-designsetgo-flip-card-back dsgo-flip-card__face dsgo-flip-card__back has-base-color has-contrast-background-color has-text-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:paragraph {"align":"center","fontSize":"medium"} -->
+<!-- wp:designsetgo/flip-card-face {"side":"back","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"},"blockGap":"1rem"},"border":{"radius":"16px"}},"backgroundColor":"contrast","textColor":"base"} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__back has-base-color has-contrast-background-color has-text-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:paragraph {"align":"center","fontSize":"medium"} -->
 <p class="has-text-align-center has-medium-font-size">Chris brings 10 years of product experience from leading tech companies. When not building products, you can find him hiking or playing guitar.</p>
 <!-- /wp:paragraph -->
 
@@ -50,12 +50,12 @@ return array(
 
 <!-- wp:social-link {"url":"#","service":"x"} /--></ul>
 <!-- /wp:social-links --></div>
-<!-- /wp:designsetgo/flip-card-back --></div></div>
+<!-- /wp:designsetgo/flip-card-face --></div></div>
 <!-- /wp:designsetgo/flip-card -->
 
 <!-- wp:designsetgo/flip-card {"style":{"dimensions":{"minHeight":"350px"}}} -->
-<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="min-height:350px;--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-front {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"},"blockGap":"1rem"},"border":{"radius":"16px"}},"backgroundColor":"base"} -->
-<div class="wp-block-designsetgo-flip-card-front dsgo-flip-card__face dsgo-flip-card__front has-base-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:image {"width":"120px","height":"120px","scale":"cover","sizeSlug":"thumbnail","className":"is-style-rounded"} -->
+<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="min-height:350px;--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-face {"side":"front","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"},"blockGap":"1rem"},"border":{"radius":"16px"}},"backgroundColor":"base"} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__front has-base-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:image {"width":"120px","height":"120px","scale":"cover","sizeSlug":"thumbnail","className":"is-style-rounded"} -->
 <figure class="wp-block-image size-thumbnail is-resized is-style-rounded"><img src="https://i.pravatar.cc/200?img=26" alt="Maria Santos" style="object-fit:cover;width:120px;height:120px"/></figure>
 <!-- /wp:image -->
 
@@ -66,10 +66,10 @@ return array(
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center">Lead Developer</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-front -->
+<!-- /wp:designsetgo/flip-card-face -->
 
-<!-- wp:designsetgo/flip-card-back {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"},"blockGap":"1rem"},"border":{"radius":"16px"}},"backgroundColor":"contrast","textColor":"base"} -->
-<div class="wp-block-designsetgo-flip-card-back dsgo-flip-card__face dsgo-flip-card__back has-base-color has-contrast-background-color has-text-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:paragraph {"align":"center","fontSize":"medium"} -->
+<!-- wp:designsetgo/flip-card-face {"side":"back","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"},"blockGap":"1rem"},"border":{"radius":"16px"}},"backgroundColor":"contrast","textColor":"base"} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__back has-base-color has-contrast-background-color has-text-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:paragraph {"align":"center","fontSize":"medium"} -->
 <p class="has-text-align-center has-medium-font-size">Maria is a React and WordPress expert who loves building accessible interfaces. She contributes to open source and mentors junior developers.</p>
 <!-- /wp:paragraph -->
 
@@ -78,12 +78,12 @@ return array(
 
 <!-- wp:social-link {"url":"#","service":"linkedin"} /--></ul>
 <!-- /wp:social-links --></div>
-<!-- /wp:designsetgo/flip-card-back --></div></div>
+<!-- /wp:designsetgo/flip-card-face --></div></div>
 <!-- /wp:designsetgo/flip-card -->
 
 <!-- wp:designsetgo/flip-card {"style":{"dimensions":{"minHeight":"350px"}}} -->
-<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="min-height:350px;--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-front {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"},"blockGap":"1rem"},"border":{"radius":"16px"}},"backgroundColor":"base"} -->
-<div class="wp-block-designsetgo-flip-card-front dsgo-flip-card__face dsgo-flip-card__front has-base-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:image {"width":"120px","height":"120px","scale":"cover","sizeSlug":"thumbnail","className":"is-style-rounded"} -->
+<div class="wp-block-designsetgo-flip-card dsgo-flip-card dsgo-flip-card--hover dsgo-flip-card--effect-flip dsgo-flip-card--horizontal" style="min-height:350px;--dsgo-flip-duration:0.6s;width:100%" data-flip-trigger="hover" data-flip-effect="flip" data-flip-direction="horizontal"><div class="dsgo-flip-card__container"><!-- wp:designsetgo/flip-card-face {"side":"front","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"},"blockGap":"1rem"},"border":{"radius":"16px"}},"backgroundColor":"base"} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__front has-base-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:image {"width":"120px","height":"120px","scale":"cover","sizeSlug":"thumbnail","className":"is-style-rounded"} -->
 <figure class="wp-block-image size-thumbnail is-resized is-style-rounded"><img src="https://i.pravatar.cc/200?img=59" alt="James Wright" style="object-fit:cover;width:120px;height:120px"/></figure>
 <!-- /wp:image -->
 
@@ -94,10 +94,10 @@ return array(
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center">UX Designer</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:designsetgo/flip-card-front -->
+<!-- /wp:designsetgo/flip-card-face -->
 
-<!-- wp:designsetgo/flip-card-back {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"},"blockGap":"1rem"},"border":{"radius":"16px"}},"backgroundColor":"contrast","textColor":"base"} -->
-<div class="wp-block-designsetgo-flip-card-back dsgo-flip-card__face dsgo-flip-card__back has-base-color has-contrast-background-color has-text-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:paragraph {"align":"center","fontSize":"medium"} -->
+<!-- wp:designsetgo/flip-card-face {"side":"back","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"},"blockGap":"1rem"},"border":{"radius":"16px"}},"backgroundColor":"contrast","textColor":"base"} -->
+<div class="wp-block-designsetgo-flip-card-face dsgo-flip-card__face dsgo-flip-card__back has-base-color has-contrast-background-color has-text-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:paragraph {"align":"center","fontSize":"medium"} -->
 <p class="has-text-align-center has-medium-font-size">James creates intuitive user experiences backed by research. He is passionate about accessibility and inclusive design practices.</p>
 <!-- /wp:paragraph -->
 
@@ -106,7 +106,7 @@ return array(
 
 <!-- wp:social-link {"url":"#","service":"linkedin"} /--></ul>
 <!-- /wp:social-links --></div>
-<!-- /wp:designsetgo/flip-card-back --></div></div>
+<!-- /wp:designsetgo/flip-card-face --></div></div>
 <!-- /wp:designsetgo/flip-card --></div></div>
 <!-- /wp:designsetgo/grid --></div></div>
 <!-- /wp:designsetgo/section -->',

--- a/src/blocks/flip-card-back/index.js
+++ b/src/blocks/flip-card-back/index.js
@@ -1,7 +1,7 @@
 /**
  * Flip Card Back Block Registration
  *
- * Deprecated in 2.0.52 in favour of designsetgo/flip-card-face. The block
+ * Deprecated in 2.0.51 in favour of designsetgo/flip-card-face. The block
  * stays registered with inserter:false so existing content keeps rendering;
  * the transforms.to entry lets editors one-click convert it to the new
  * consolidated block.

--- a/src/blocks/flip-card-face/block.json
+++ b/src/blocks/flip-card-face/block.json
@@ -1,26 +1,27 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
-	"name": "designsetgo/flip-card-back",
+	"name": "designsetgo/flip-card-face",
 	"version": "1.0.0",
-	"title": "Flip Card Back",
-	"category": "designsetgo",
+	"title": "Flip Card Face",
+	"category": "design",
 	"parent": [
 		"designsetgo/flip-card"
 	],
-	"description": "Back face of the flip card.",
+	"description": "A face of the flip card. Use the Side attribute to mark it as front or back.",
 	"keywords": [
 		"flip",
 		"card",
+		"face",
+		"front",
 		"back"
 	],
 	"textdomain": "designsetgo",
-	"icon": "id-alt",
 	"supports": {
 		"anchor": false,
 		"align": false,
 		"html": false,
-		"inserter": false,
+		"inserter": true,
 		"reusable": false,
 		"layout": {
 			"allowSwitching": false,
@@ -70,7 +71,16 @@
 			}
 		}
 	},
-	"attributes": {},
+	"attributes": {
+		"side": {
+			"type": "string",
+			"default": "front",
+			"enum": [
+				"front",
+				"back"
+			]
+		}
+	},
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
 	"style": "file:./style-index.css"

--- a/src/blocks/flip-card-face/edit.js
+++ b/src/blocks/flip-card-face/edit.js
@@ -17,6 +17,7 @@ import {
 } from '@wordpress/block-editor';
 import { Notice, PanelBody, SelectControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 
 export default function FlipCardFaceEdit({
 	attributes,
@@ -30,37 +31,70 @@ export default function FlipCardFaceEdit({
 	// front face renamed to back while a sibling already holds back) would
 	// break the flip animation. Track which side(s) siblings occupy so we
 	// can disable the matching option in the Side dropdown and fall back to
-	// a Notice if legacy content already violates the invariant.
-	const siblingSides = useSelect(
+	// a Notice if legacy content already violates the invariant. We split
+	// siblings by position — `earlier` siblings are the ones we treat as
+	// "already present" when deciding whether this face is a newly inserted
+	// duplicate, while `all` drives the inspector dropdown's occupied-side
+	// state (which must consider every sibling regardless of order).
+	const { earlierSiblingSides, allSiblingSides } = useSelect(
 		(select) => {
 			const { getBlockRootClientId, getBlock } =
 				select('core/block-editor');
 			const parentId = getBlockRootClientId(clientId);
 			if (!parentId) {
-				return [];
+				return { earlierSiblingSides: [], allSiblingSides: [] };
 			}
 			const siblings = getBlock(parentId)?.innerBlocks || [];
-			return siblings
-				.filter((sibling) => sibling.clientId !== clientId)
-				.map((sibling) => {
-					if (sibling.name === 'designsetgo/flip-card-face') {
-						return sibling.attributes?.side === 'back'
-							? 'back'
-							: 'front';
-					}
-					if (sibling.name === 'designsetgo/flip-card-front') {
-						return 'front';
-					}
-					if (sibling.name === 'designsetgo/flip-card-back') {
-						return 'back';
-					}
-					return null;
-				})
+			const toSide = (sibling) => {
+				if (sibling.name === 'designsetgo/flip-card-face') {
+					return sibling.attributes?.side === 'back'
+						? 'back'
+						: 'front';
+				}
+				if (sibling.name === 'designsetgo/flip-card-front') {
+					return 'front';
+				}
+				if (sibling.name === 'designsetgo/flip-card-back') {
+					return 'back';
+				}
+				return null;
+			};
+			const selfIndex = siblings.findIndex(
+				(sibling) => sibling.clientId === clientId
+			);
+			const earlier = siblings
+				.slice(0, selfIndex === -1 ? 0 : selfIndex)
+				.map(toSide)
 				.filter(Boolean);
+			const all = siblings
+				.filter((sibling) => sibling.clientId !== clientId)
+				.map(toSide)
+				.filter(Boolean);
+			return { earlierSiblingSides: earlier, allSiblingSides: all };
 		},
 		[clientId]
 	);
+	const siblingSides = allSiblingSides;
 	const hasDuplicateSide = siblingSides.includes(side);
+
+	// When an author deletes a face and inserts a replacement via the parent's
+	// inserter, the new block uses the block.json default `side: 'front'`. If
+	// an earlier sibling already occupies this face's side and the opposite
+	// side is free, flip *this* face so the parent keeps exactly one front
+	// and one back. Using *earlier* siblings (rather than all siblings) is
+	// the tie-breaker: without it, two faces with the same side would each
+	// try to switch in the same tick and the older face would usually win.
+	// Only auto-correct when the opposite side is actually available —
+	// otherwise leave the duplicate in place so the Notice guides the author.
+	useEffect(() => {
+		if (!earlierSiblingSides.includes(side)) {
+			return;
+		}
+		const oppositeSide = side === 'front' ? 'back' : 'front';
+		if (!siblingSides.includes(oppositeSide)) {
+			setAttributes({ side: oppositeSide });
+		}
+	}, [earlierSiblingSides, siblingSides, side, setAttributes]);
 
 	const blockProps = useBlockProps({
 		className: `dsgo-flip-card__face dsgo-flip-card__${side}`,

--- a/src/blocks/flip-card-face/edit.js
+++ b/src/blocks/flip-card-face/edit.js
@@ -6,7 +6,7 @@
  * flip card. Kept as a child-only block so it can only appear inside
  * designsetgo/flip-card.
  *
- * @since 2.0.52
+ * @since 2.0.51
  */
 
 import { __ } from '@wordpress/i18n';
@@ -28,26 +28,39 @@ export default function FlipCardFaceEdit({
 	// The parent flip-card's view script and stylesheet assume exactly one
 	// front face and one back face — a duplicate side (two fronts, or the
 	// front face renamed to back while a sibling already holds back) would
-	// break the flip animation. Warn authors before they ship broken markup.
-	const hasDuplicateSide = useSelect(
+	// break the flip animation. Track which side(s) siblings occupy so we
+	// can disable the matching option in the Side dropdown and fall back to
+	// a Notice if legacy content already violates the invariant.
+	const siblingSides = useSelect(
 		(select) => {
 			const { getBlockRootClientId, getBlock } =
 				select('core/block-editor');
 			const parentId = getBlockRootClientId(clientId);
 			if (!parentId) {
-				return false;
+				return [];
 			}
 			const siblings = getBlock(parentId)?.innerBlocks || [];
-			return siblings.some(
-				(sibling) =>
-					sibling.clientId !== clientId &&
-					(sibling.name === 'designsetgo/flip-card-face'
-						? sibling.attributes?.side === side
-						: sibling.name === `designsetgo/flip-card-${side}`)
-			);
+			return siblings
+				.filter((sibling) => sibling.clientId !== clientId)
+				.map((sibling) => {
+					if (sibling.name === 'designsetgo/flip-card-face') {
+						return sibling.attributes?.side === 'back'
+							? 'back'
+							: 'front';
+					}
+					if (sibling.name === 'designsetgo/flip-card-front') {
+						return 'front';
+					}
+					if (sibling.name === 'designsetgo/flip-card-back') {
+						return 'back';
+					}
+					return null;
+				})
+				.filter(Boolean);
 		},
-		[clientId, side]
+		[clientId]
 	);
+	const hasDuplicateSide = siblingSides.includes(side);
 
 	const blockProps = useBlockProps({
 		className: `dsgo-flip-card__face dsgo-flip-card__${side}`,
@@ -94,10 +107,16 @@ export default function FlipCardFaceEdit({
 							{
 								label: __('Front', 'designsetgo'),
 								value: 'front',
+								disabled:
+									side !== 'front' &&
+									siblingSides.includes('front'),
 							},
 							{
 								label: __('Back', 'designsetgo'),
 								value: 'back',
+								disabled:
+									side !== 'back' &&
+									siblingSides.includes('back'),
 							},
 						]}
 						onChange={(value) => setAttributes({ side: value })}

--- a/src/blocks/flip-card-face/edit.js
+++ b/src/blocks/flip-card-face/edit.js
@@ -15,15 +15,47 @@ import {
 	useInnerBlocksProps,
 	InspectorControls,
 } from '@wordpress/block-editor';
-import { PanelBody, SelectControl } from '@wordpress/components';
+import { Notice, PanelBody, SelectControl } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 
-export default function FlipCardFaceEdit({ attributes, setAttributes }) {
+export default function FlipCardFaceEdit({
+	attributes,
+	setAttributes,
+	clientId,
+}) {
 	const side = attributes.side === 'back' ? 'back' : 'front';
+
+	// The parent flip-card's view script and stylesheet assume exactly one
+	// front face and one back face — a duplicate side (two fronts, or the
+	// front face renamed to back while a sibling already holds back) would
+	// break the flip animation. Warn authors before they ship broken markup.
+	const hasDuplicateSide = useSelect(
+		(select) => {
+			const { getBlockRootClientId, getBlock } =
+				select('core/block-editor');
+			const parentId = getBlockRootClientId(clientId);
+			if (!parentId) {
+				return false;
+			}
+			const siblings = getBlock(parentId)?.innerBlocks || [];
+			return siblings.some(
+				(sibling) =>
+					sibling.clientId !== clientId &&
+					(sibling.name === 'designsetgo/flip-card-face'
+						? sibling.attributes?.side === side
+						: sibling.name === `designsetgo/flip-card-${side}`)
+			);
+		},
+		[clientId, side]
+	);
 
 	const blockProps = useBlockProps({
 		className: `dsgo-flip-card__face dsgo-flip-card__${side}`,
 	});
 
+	// Template is seeded once on first insertion; switching `side` later does
+	// not re-template, so a face relabelled "back" will still show the
+	// original "Front of Card" placeholder heading until the author edits it.
 	const innerBlocksProps = useInnerBlocksProps(blockProps, {
 		template: [
 			[
@@ -76,6 +108,19 @@ export default function FlipCardFaceEdit({ attributes, setAttributes }) {
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
 					/>
+					{hasDuplicateSide && (
+						<Notice status="warning" isDismissible={false}>
+							{side === 'back'
+								? __(
+										'Another face on this flip card is already set to Back. Change one of them to Front so the card can flip.',
+										'designsetgo'
+									)
+								: __(
+										'Another face on this flip card is already set to Front. Change one of them to Back so the card can flip.',
+										'designsetgo'
+									)}
+						</Notice>
+					)}
 				</PanelBody>
 			</InspectorControls>
 			<div {...innerBlocksProps} />

--- a/src/blocks/flip-card-face/edit.js
+++ b/src/blocks/flip-card-face/edit.js
@@ -1,0 +1,84 @@
+/**
+ * Flip Card Face - Edit Component
+ *
+ * Replaces the separate flip-card-front and flip-card-back blocks. The
+ * `side` attribute (front|back) controls placement inside the parent
+ * flip card. Kept as a child-only block so it can only appear inside
+ * designsetgo/flip-card.
+ *
+ * @since 2.0.52
+ */
+
+import { __ } from '@wordpress/i18n';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	InspectorControls,
+} from '@wordpress/block-editor';
+import { PanelBody, SelectControl } from '@wordpress/components';
+
+export default function FlipCardFaceEdit({ attributes, setAttributes }) {
+	const side = attributes.side === 'back' ? 'back' : 'front';
+
+	const blockProps = useBlockProps({
+		className: `dsgo-flip-card__face dsgo-flip-card__${side}`,
+	});
+
+	const innerBlocksProps = useInnerBlocksProps(blockProps, {
+		template: [
+			[
+				'core/heading',
+				{
+					content:
+						side === 'back'
+							? __('Back of Card', 'designsetgo')
+							: __('Front of Card', 'designsetgo'),
+					level: 2,
+					textAlign: 'center',
+				},
+			],
+			[
+				'core/paragraph',
+				{
+					content: __('Add any blocks you want here…', 'designsetgo'),
+					align: 'center',
+				},
+			],
+		],
+		templateLock: false,
+	});
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody
+					title={__('Face Settings', 'designsetgo')}
+					initialOpen={true}
+				>
+					<SelectControl
+						label={__('Side', 'designsetgo')}
+						value={side}
+						options={[
+							{
+								label: __('Front', 'designsetgo'),
+								value: 'front',
+							},
+							{
+								label: __('Back', 'designsetgo'),
+								value: 'back',
+							},
+						]}
+						onChange={(value) => setAttributes({ side: value })}
+						help={__(
+							'Choose whether this face shows on the front or back of the flip card.',
+							'designsetgo'
+						)}
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div {...innerBlocksProps} />
+		</>
+	);
+}

--- a/src/blocks/flip-card-face/editor.scss
+++ b/src/blocks/flip-card-face/editor.scss
@@ -1,0 +1,8 @@
+/**
+ * Flip Card Face - Editor Styles
+ *
+ * @since 2.0.52
+ */
+
+// Styles are inherited from parent flip-card block
+// This file is required for the build process

--- a/src/blocks/flip-card-face/editor.scss
+++ b/src/blocks/flip-card-face/editor.scss
@@ -1,7 +1,7 @@
 /**
  * Flip Card Face - Editor Styles
  *
- * @since 2.0.52
+ * @since 2.0.51
  */
 
 // Styles are inherited from parent flip-card block

--- a/src/blocks/flip-card-face/index.js
+++ b/src/blocks/flip-card-face/index.js
@@ -1,7 +1,7 @@
 /**
  * Flip Card Face Block Registration
  *
- * @since 2.0.52
+ * @since 2.0.51
  */
 
 import { registerBlockType, createBlock } from '@wordpress/blocks';

--- a/src/blocks/flip-card-face/index.js
+++ b/src/blocks/flip-card-face/index.js
@@ -1,12 +1,7 @@
 /**
- * Flip Card Back Block Registration
+ * Flip Card Face Block Registration
  *
- * Deprecated in 2.0.52 in favour of designsetgo/flip-card-face. The block
- * stays registered with inserter:false so existing content keeps rendering;
- * the transforms.to entry lets editors one-click convert it to the new
- * consolidated block.
- *
- * @since 1.0.0
+ * @since 2.0.52
  */
 
 import { registerBlockType, createBlock } from '@wordpress/blocks';
@@ -39,8 +34,6 @@ registerBlockType(metadata.name, {
 					stroke="currentColor"
 					strokeWidth="2"
 					fill="none"
-					strokeDasharray="3 3"
-					opacity="0.5"
 				/>
 				<circle cx="12" cy="12" r="3" fill="currentColor" />
 			</svg>
@@ -50,10 +43,20 @@ registerBlockType(metadata.name, {
 	edit,
 	save,
 	transforms: {
-		to: [
+		from: [
 			{
 				type: 'block',
-				blocks: ['designsetgo/flip-card-face'],
+				blocks: ['designsetgo/flip-card-front'],
+				transform: (attributes, innerBlocks) =>
+					createBlock(
+						'designsetgo/flip-card-face',
+						{ ...attributes, side: 'front' },
+						innerBlocks
+					),
+			},
+			{
+				type: 'block',
+				blocks: ['designsetgo/flip-card-back'],
 				transform: (attributes, innerBlocks) =>
 					createBlock(
 						'designsetgo/flip-card-face',

--- a/src/blocks/flip-card-face/index.js
+++ b/src/blocks/flip-card-face/index.js
@@ -42,6 +42,10 @@ registerBlockType(metadata.name, {
 	},
 	edit,
 	save,
+	// Spread preserves core-managed attrs (style, className, color, etc.)
+	// across the transform. flip-card-front / flip-card-back defined no
+	// custom attributes, so this is safe today — if either legacy block ever
+	// picks up a custom attribute, audit the spread before shipping.
 	transforms: {
 		from: [
 			{

--- a/src/blocks/flip-card-face/save.js
+++ b/src/blocks/flip-card-face/save.js
@@ -1,0 +1,19 @@
+/**
+ * Flip Card Face - Save Component
+ *
+ * @since 2.0.52
+ */
+
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+export default function FlipCardFaceSave({ attributes }) {
+	const side = attributes.side === 'back' ? 'back' : 'front';
+
+	const blockProps = useBlockProps.save({
+		className: `dsgo-flip-card__face dsgo-flip-card__${side}`,
+	});
+
+	const innerBlocksProps = useInnerBlocksProps.save(blockProps);
+
+	return <div {...innerBlocksProps} />;
+}

--- a/src/blocks/flip-card-face/save.js
+++ b/src/blocks/flip-card-face/save.js
@@ -1,7 +1,7 @@
 /**
  * Flip Card Face - Save Component
  *
- * @since 2.0.52
+ * @since 2.0.51
  */
 
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';

--- a/src/blocks/flip-card-face/style.scss
+++ b/src/blocks/flip-card-face/style.scss
@@ -1,7 +1,7 @@
 /**
  * Flip Card Face - Frontend Styles
  *
- * @since 2.0.52
+ * @since 2.0.51
  */
 
 // Styles are inherited from parent flip-card block

--- a/src/blocks/flip-card-face/style.scss
+++ b/src/blocks/flip-card-face/style.scss
@@ -1,0 +1,8 @@
+/**
+ * Flip Card Face - Frontend Styles
+ *
+ * @since 2.0.52
+ */
+
+// Styles are inherited from parent flip-card block
+// This file is required for the build process

--- a/src/blocks/flip-card-front/block.json
+++ b/src/blocks/flip-card-front/block.json
@@ -20,7 +20,7 @@
 		"anchor": false,
 		"align": false,
 		"html": false,
-		"inserter": true,
+		"inserter": false,
 		"reusable": false,
 		"layout": {
 			"allowSwitching": false,

--- a/src/blocks/flip-card-front/index.js
+++ b/src/blocks/flip-card-front/index.js
@@ -1,7 +1,7 @@
 /**
  * Flip Card Front Block Registration
  *
- * Deprecated in 2.0.52 in favour of designsetgo/flip-card-face. The block
+ * Deprecated in 2.0.51 in favour of designsetgo/flip-card-face. The block
  * stays registered with inserter:false so existing content keeps rendering;
  * the transforms.to entry lets editors one-click convert it to the new
  * consolidated block.

--- a/src/blocks/flip-card-front/index.js
+++ b/src/blocks/flip-card-front/index.js
@@ -1,10 +1,15 @@
 /**
  * Flip Card Front Block Registration
  *
+ * Deprecated in 2.0.52 in favour of designsetgo/flip-card-face. The block
+ * stays registered with inserter:false so existing content keeps rendering;
+ * the transforms.to entry lets editors one-click convert it to the new
+ * consolidated block.
+ *
  * @since 1.0.0
  */
 
-import { registerBlockType } from '@wordpress/blocks';
+import { registerBlockType, createBlock } from '@wordpress/blocks';
 
 import edit from './edit';
 import save from './save';
@@ -42,4 +47,18 @@ registerBlockType(metadata.name, {
 	},
 	edit,
 	save,
+	transforms: {
+		to: [
+			{
+				type: 'block',
+				blocks: ['designsetgo/flip-card-face'],
+				transform: (attributes, innerBlocks) =>
+					createBlock(
+						'designsetgo/flip-card-face',
+						{ ...attributes, side: 'front' },
+						innerBlocks
+					),
+			},
+		],
+	},
 });

--- a/src/blocks/flip-card/block.json
+++ b/src/blocks/flip-card/block.json
@@ -68,8 +68,9 @@
 		},
 		"innerBlocks": [
 			{
-				"name": "designsetgo/flip-card-front",
+				"name": "designsetgo/flip-card-face",
 				"attributes": {
+					"side": "front",
 					"style": {
 						"spacing": {
 							"padding": {
@@ -105,8 +106,9 @@
 				]
 			},
 			{
-				"name": "designsetgo/flip-card-back",
+				"name": "designsetgo/flip-card-face",
 				"attributes": {
+					"side": "back",
 					"style": {
 						"spacing": {
 							"padding": {

--- a/src/blocks/flip-card/edit.js
+++ b/src/blocks/flip-card/edit.js
@@ -25,8 +25,8 @@ import FlipCardPlaceholder from './components/FlipCardPlaceholder';
 /**
  * Flip Card Edit Component
  *
- * Uses a template with two child blocks (flip-card-front and flip-card-back).
- * Each child block can contain any blocks the user wants to add.
+ * Uses a template with two designsetgo/flip-card-face children (one per
+ * side). Each face can contain any blocks the author wants to add.
  *
  * @param {Object}   props               Component props
  * @param {Object}   props.attributes    Block attributes

--- a/src/blocks/flip-card/edit.js
+++ b/src/blocks/flip-card/edit.js
@@ -37,23 +37,31 @@ import FlipCardPlaceholder from './components/FlipCardPlaceholder';
 export default function FlipCardEdit({ attributes, setAttributes, clientId }) {
 	const { flipTrigger, flipEffect, flipDirection, flipDuration } = attributes;
 
-	// Determine which face blocks already exist to prevent duplicates and
-	// whether the card has been seeded yet (used to gate the placeholder).
+	// Cap child faces at two (one front + one back). designsetgo/flip-card-face
+	// is the canonical child block; flip-card-front / flip-card-back are
+	// legacy siblings kept for content already in the wild — they count
+	// toward the same two-face budget. `hasInnerBlocks` gates the first-
+	// insert placeholder (Theme 1).
 	const { allowedBlocks, hasInnerBlocks } = useSelect(
 		(select) => {
 			const { getBlock } = select(blockEditorStore);
 			const block = getBlock(clientId);
 			const children = block?.innerBlocks || [];
-			const childNames = children.map((child) => child.name);
-			const missing = [];
-			if (!childNames.includes('designsetgo/flip-card-front')) {
-				missing.push('designsetgo/flip-card-front');
-			}
-			if (!childNames.includes('designsetgo/flip-card-back')) {
-				missing.push('designsetgo/flip-card-back');
-			}
+			const legacyCount = children.filter(
+				(child) =>
+					child.name === 'designsetgo/flip-card-front' ||
+					child.name === 'designsetgo/flip-card-back'
+			).length;
+			const faceCount = children.filter(
+				(child) => child.name === 'designsetgo/flip-card-face'
+			).length;
+			// Empty array hides the inserter entirely — flip card is at capacity.
+			const allowed =
+				legacyCount + faceCount >= 2
+					? []
+					: ['designsetgo/flip-card-face'];
 			return {
-				allowedBlocks: missing,
+				allowedBlocks: allowed,
 				hasInnerBlocks: children.length > 0,
 			};
 		},
@@ -69,18 +77,22 @@ export default function FlipCardEdit({ attributes, setAttributes, clientId }) {
 		},
 	});
 
-	// Inner blocks configuration. Initial seeding (both faces) is handled by
-	// FlipCardPlaceholder so authors pick a starter layout instead of landing
-	// on two empty faces. templateLock is false so users can delete a face
-	// and re-add it; "Attempt Recovery" still works on validation errors.
-	// allowedBlocks is computed dynamically to only permit missing faces,
-	// preventing duplicate front or back blocks.
+	// Inner blocks configuration. Initial seeding is handled by
+	// FlipCardPlaceholder so authors pick a starter layout instead of
+	// landing on two empty faces. The `template` here is a safety net for
+	// "Attempt Recovery" on validation errors — it fires only when there
+	// are no children, which normally is caught by hasInnerBlocks above.
+	// templateLock is false so authors can delete a face and re-add it.
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'dsgo-flip-card__container',
 		},
 		{
 			allowedBlocks,
+			template: [
+				['designsetgo/flip-card-face', { side: 'front' }],
+				['designsetgo/flip-card-face', { side: 'back' }],
+			],
 			templateLock: false,
 			orientation: 'vertical',
 		}

--- a/src/blocks/flip-card/editor.scss
+++ b/src/blocks/flip-card/editor.scss
@@ -51,9 +51,14 @@
 			width: 100%;
 		}
 
-		// Both cards visible for editing
+		// Both cards visible for editing. Match both the legacy
+		// flip-card-front/back block wrappers and the new flip-card-face
+		// face classes (dsgo-flip-card__front / __back) so consolidated
+		// content authored via designsetgo/flip-card-face is editable.
 		&__container > .wp-block-designsetgo-flip-card-front,
-		&__container > .wp-block-designsetgo-flip-card-back {
+		&__container > .wp-block-designsetgo-flip-card-back,
+		&__container > .dsgo-flip-card__front,
+		&__container > .dsgo-flip-card__back {
 			box-sizing: border-box;
 			position: relative;
 			// CRITICAL: Override frontend opacity to show both cards in editor
@@ -78,14 +83,16 @@
 			}
 		}
 
-		&__container > .wp-block-designsetgo-flip-card-front {
+		&__container > .wp-block-designsetgo-flip-card-front,
+		&__container > .dsgo-flip-card__front {
 
 			&::before {
 				content: 'Front';
 			}
 		}
 
-		&__container > .wp-block-designsetgo-flip-card-back {
+		&__container > .wp-block-designsetgo-flip-card-back,
+		&__container > .dsgo-flip-card__back {
 
 			&::before {
 				content: 'Back';

--- a/src/blocks/flip-card/templates.js
+++ b/src/blocks/flip-card/templates.js
@@ -2,27 +2,36 @@
  * Flip Card Templates
  *
  * Starter layouts shown by FlipCardPlaceholder when the block is first
- * inserted. Every template seeds both flip-card-front and flip-card-back so
- * the card is immediately interactive — never a single-faced state.
+ * inserted. Every template seeds one front face and one back face so the
+ * card is immediately interactive — never a single-faced state.
+ *
+ * Children are `designsetgo/flip-card-face` (the consolidated block
+ * introduced in Theme 2) distinguished by the `side` attribute; the
+ * legacy flip-card-front / flip-card-back siblings remain registered
+ * with `inserter: false` for existing content but are not seeded here.
  */
 
 import { __ } from '@wordpress/i18n';
 
-// flip-card-front/back support `spacing.padding` but default to none, so
-// templates seed it explicitly — otherwise text sits flush against the card
-// edge on first insert. Authors can still adjust via Style → Padding.
+// Face children support `spacing.padding` but default to none, so templates
+// seed it explicitly — otherwise text sits flush against the card edge on
+// first insert. Authors can still adjust via Style → Padding.
 const facePadding = {
-	style: {
-		spacing: {
-			padding: {
-				top: '32px',
-				right: '32px',
-				bottom: '32px',
-				left: '32px',
-			},
+	spacing: {
+		padding: {
+			top: '32px',
+			right: '32px',
+			bottom: '32px',
+			left: '32px',
 		},
 	},
 };
+
+const face = (side, extra = {}, innerBlocks = []) => [
+	'designsetgo/flip-card-face',
+	{ side, style: { ...facePadding, ...(extra.style || {}) } },
+	innerBlocks,
+];
 
 const flipCardTemplates = [
 	{
@@ -31,10 +40,7 @@ const flipCardTemplates = [
 		description: __('Empty front and back to fill in', 'designsetgo'),
 		icon: 'welcome-add-page',
 		attributes: {},
-		innerBlocks: [
-			['designsetgo/flip-card-front', facePadding],
-			['designsetgo/flip-card-back', facePadding],
-		],
+		innerBlocks: [face('front'), face('back')],
 	},
 	{
 		name: 'feature',
@@ -46,36 +52,28 @@ const flipCardTemplates = [
 		icon: 'star-filled',
 		attributes: { flipTrigger: 'hover', flipEffect: 'flip' },
 		innerBlocks: [
-			[
-				'designsetgo/flip-card-front',
-				facePadding,
+			face('front', {}, [
 				[
-					[
-						'core/heading',
-						{
-							level: 3,
-							content: __('Feature title', 'designsetgo'),
-							textAlign: 'center',
-						},
-					],
+					'core/heading',
+					{
+						level: 3,
+						content: __('Feature title', 'designsetgo'),
+						textAlign: 'center',
+					},
 				],
-			],
-			[
-				'designsetgo/flip-card-back',
-				facePadding,
+			]),
+			face('back', {}, [
 				[
-					[
-						'core/paragraph',
-						{
-							content: __(
-								'Add a short description of the feature, the value it delivers, or how it works.',
-								'designsetgo'
-							),
-							align: 'center',
-						},
-					],
+					'core/paragraph',
+					{
+						content: __(
+							'Add a short description of the feature, the value it delivers, or how it works.',
+							'designsetgo'
+						),
+						align: 'center',
+					},
 				],
-			],
+			]),
 		],
 	},
 	{
@@ -85,44 +83,36 @@ const flipCardTemplates = [
 		icon: 'admin-users',
 		attributes: { flipTrigger: 'click', flipEffect: 'flip' },
 		innerBlocks: [
-			[
-				'designsetgo/flip-card-front',
-				facePadding,
+			face('front', {}, [
+				['core/image', { sizeSlug: 'medium' }],
 				[
-					['core/image', { sizeSlug: 'medium' }],
-					[
-						'core/heading',
-						{
-							level: 4,
-							content: __('Name', 'designsetgo'),
-							textAlign: 'center',
-						},
-					],
-					[
-						'core/paragraph',
-						{
-							content: __('Role / Title', 'designsetgo'),
-							align: 'center',
-						},
-					],
+					'core/heading',
+					{
+						level: 4,
+						content: __('Name', 'designsetgo'),
+						textAlign: 'center',
+					},
 				],
-			],
-			[
-				'designsetgo/flip-card-back',
-				facePadding,
 				[
-					[
-						'core/paragraph',
-						{
-							content: __(
-								'Short bio. Mention background, current focus, and how to get in touch.',
-								'designsetgo'
-							),
-							align: 'center',
-						},
-					],
+					'core/paragraph',
+					{
+						content: __('Role / Title', 'designsetgo'),
+						align: 'center',
+					},
 				],
-			],
+			]),
+			face('back', {}, [
+				[
+					'core/paragraph',
+					{
+						content: __(
+							'Short bio. Mention background, current focus, and how to get in touch.',
+							'designsetgo'
+						),
+						align: 'center',
+					},
+				],
+			]),
 		],
 	},
 	{
@@ -135,50 +125,42 @@ const flipCardTemplates = [
 		icon: 'megaphone',
 		attributes: { flipTrigger: 'hover', flipEffect: 'flip' },
 		innerBlocks: [
-			[
-				'designsetgo/flip-card-front',
-				facePadding,
+			face('front', {}, [
 				[
-					[
-						'core/heading',
-						{
-							level: 3,
-							content: __('Try it free', 'designsetgo'),
-							textAlign: 'center',
-						},
-					],
-					[
-						'core/paragraph',
-						{
-							content: __('Hover to learn more.', 'designsetgo'),
-							align: 'center',
-						},
-					],
+					'core/heading',
+					{
+						level: 3,
+						content: __('Try it free', 'designsetgo'),
+						textAlign: 'center',
+					},
 				],
-			],
-			[
-				'designsetgo/flip-card-back',
-				facePadding,
 				[
-					[
-						'core/paragraph',
-						{
-							content: __(
-								'No credit card required. Cancel anytime.',
-								'designsetgo'
-							),
-							align: 'center',
-						},
-					],
-					[
-						'designsetgo/icon-button',
-						{
-							text: __('Get started', 'designsetgo'),
-							align: 'center',
-						},
-					],
+					'core/paragraph',
+					{
+						content: __('Hover to learn more.', 'designsetgo'),
+						align: 'center',
+					},
 				],
-			],
+			]),
+			face('back', {}, [
+				[
+					'core/paragraph',
+					{
+						content: __(
+							'No credit card required. Cancel anytime.',
+							'designsetgo'
+						),
+						align: 'center',
+					},
+				],
+				[
+					'designsetgo/icon-button',
+					{
+						text: __('Get started', 'designsetgo'),
+						align: 'center',
+					},
+				],
+			]),
 		],
 	},
 ];

--- a/src/blocks/flip-card/templates.js
+++ b/src/blocks/flip-card/templates.js
@@ -29,9 +29,36 @@ const facePadding = {
 
 const face = (side, extra = {}, innerBlocks = []) => [
 	'designsetgo/flip-card-face',
-	{ side, style: { ...facePadding, ...(extra.style || {}) } },
+	{
+		side,
+		style: {
+			...facePadding,
+			...(extra.style || {}),
+		},
+	},
 	innerBlocks,
 ];
+
+// Theme-agnostic neutral colors for template starters. Hardcoded hex keeps
+// the faces visibly "card-like" on any theme; authors override via Style.
+// Palette matches the DesignSetGo wider system (slate-inspired neutrals).
+const neutralBack = {
+	style: {
+		color: {
+			background: '#f1f5f9',
+			text: '#0f172a',
+		},
+	},
+};
+
+const contrastBack = {
+	style: {
+		color: {
+			background: '#0f172a',
+			text: '#ffffff',
+		},
+	},
+};
 
 const flipCardTemplates = [
 	{
@@ -62,7 +89,7 @@ const flipCardTemplates = [
 					},
 				],
 			]),
-			face('back', {}, [
+			face('back', neutralBack, [
 				[
 					'core/paragraph',
 					{
@@ -142,7 +169,7 @@ const flipCardTemplates = [
 					},
 				],
 			]),
-			face('back', {}, [
+			face('back', contrastBack, [
 				[
 					'core/paragraph',
 					{

--- a/src/extensions/background-video/index.js
+++ b/src/extensions/background-video/index.js
@@ -22,6 +22,7 @@ const ALLOWED_BLOCKS = [
 	'designsetgo/row',
 	'designsetgo/grid',
 	'designsetgo/flip-card',
+	'designsetgo/flip-card-face',
 	'designsetgo/flip-card-front',
 	'designsetgo/flip-card-back',
 	'designsetgo/accordion',

--- a/src/extensions/vertical-scroll-parallax/constants.js
+++ b/src/extensions/vertical-scroll-parallax/constants.js
@@ -69,6 +69,7 @@ export const ALLOWED_BLOCKS = [
 	'designsetgo/grid',
 	// DesignSetGo visual blocks
 	'designsetgo/flip-card',
+	'designsetgo/flip-card-face',
 	'designsetgo/flip-card-front',
 	'designsetgo/flip-card-back',
 	'designsetgo/icon',

--- a/src/style.scss
+++ b/src/style.scss
@@ -50,7 +50,7 @@
 // - accordion, accordion-item
 // - tabs, tab
 // - icon-list, icon-list-item
-// - pill, flip-card, flip-card-front, flip-card-back
+// - pill, flip-card, flip-card-face
 // - scroll-accordion, scroll-accordion-item
 // - blobs, slider, slide, form-builder
 // ===================================================================

--- a/wiki-content/Blocks-Reference.md
+++ b/wiki-content/Blocks-Reference.md
@@ -121,7 +121,7 @@ Complete reference guide for all DesignSetGo blocks organized by category.
 ### Flip Card
 **Name**: `designsetgo/flip-card`
 **Category**: Design
-**Parent Blocks**: `designsetgo/flip-card-front`, `designsetgo/flip-card-back`
+**Child Blocks**: `designsetgo/flip-card-face` (Side attribute: `front` or `back`)
 **Description**: Interactive card that flips to reveal content on the back. Perfect for team profiles, product showcases, and feature highlights.
 
 **Key Features**:
@@ -417,7 +417,7 @@ Many DesignSetGo blocks use parent-child relationships for better organization:
 1. **Accordion** → Accordion Item
 2. **Tabs** → Tab
 3. **Slider** → Slide
-4. **Flip Card** → Flip Card Front + Flip Card Back
+4. **Flip Card** → Flip Card Face (Side = Front/Back)
 5. **Icon List** → Icon List Item
 6. **Counter Group** → Counter
 7. **Scroll Accordion** → Scroll Accordion Item


### PR DESCRIPTION
## Summary

Implements **Theme 2 — Consolidation via Variations (Narrowly Scoped)** from [`docs/plans/2026-04-16-blocks-editor-ux-design.md`](docs/plans/2026-04-16-blocks-editor-ux-design.md).

The `flip-card-front` and `flip-card-back` children differed only by semantic intent and a class name — same `supports`, same `save()` shape, same inner-block behaviour. This PR collapses them into a single `flip-card-face` child block with a `side: 'front' | 'back'` attribute.

- New block `designsetgo/flip-card-face` (child-only, parent locked to `designsetgo/flip-card`).
- Parent `flip-card` template now seeds two `flip-card-face` blocks (one per side) and caps child count at two.
- Legacy `flip-card-front` / `flip-card-back` stay registered with `inserter: false` so existing content keeps rendering. Each exposes a `transforms.to` entry (and the new block exposes matching `transforms.from`) so editors can one-click convert.
- Shipped patterns (features × 2, homepage × 2, team × 1) rewritten to emit `flip-card-face` directly, preserving the existing `dsgo-flip-card__front` / `__back` class names the stylesheet and view script already match.
- Updated PHP block inserter ability (`class-block-inserter.php`), extension allow-lists (background-video, vertical-parallax — both JS + PHP), admin blocks registry, and docs (FLIP-CARD.md, Blocks-Reference.md, add-pattern catalog).

### Forward-looking rule

Per the design doc, added a **"Variations vs. new blocks"** section to `.claude/claude.md` and a pre-flight check to the `add-block` skill. The rule:

> If a new block would differ from an existing block only by 1–3 attributes **and share the same `save()` output structure**, register a variation, not a new block.

## Test plan

- [ ] `npm run build` — passes locally; only pre-existing SCSS `@import` deprecation warnings remain.
- [ ] `npm run lint:js` / `lint:css` on touched files — clean.
- [ ] `npm run test:unit -- --testPathPattern='block-(registration|schema|attributes)'` — 990 tests passing.
- [ ] Manual: insert Flip Card block in a fresh editor. Expect two `Flip Card Face` children with Side = Front / Back. The Inserter should no longer list `Flip Card Front` / `Flip Card Back` separately.
- [ ] Manual: load a post that has legacy `flip-card-front` / `flip-card-back` content — should render identically and expose a toolbar "Transform to Flip Card Face" option.
- [ ] Manual: insert each updated pattern (Flip Card Services, Flip Card Grid, Luxury Real Estate, Modern SaaS, Team Flip Cards) and verify frontend flip behaviour is unchanged.
- [ ] Manual: verify the `Background Video` and `Vertical Scroll Parallax` extension panels appear on `flip-card-face` (and still on legacy front/back for now).

https://claude.ai/code/session_019FL5PbLFhYeux2vKEPuNtG