### PR TITLE
Theme 4 follow-ups: filename, dashicon, naming polish

### DIFF
--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -20,7 +20,7 @@ designsetgo/                        # WordPress plugin root
 │   ├── index.js                    # Editor bundle entry (extensions + filters)
 │   ├── style.scss                  # Frontend global CSS entry
 │   ├── frontend.js                 # Frontend JS bundle entry
-│   ├── block-category-filter.js    # Editor: dual-categorization filter
+│   ├── block-category-icon.js      # Editor: branded SVG for designsetgo category
 │   │
 │   ├── blocks/                     # All custom blocks
 │   │   ├── {block-name}/           # One directory per block

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -620,15 +620,15 @@ class Plugin {
 	 * Note: Block-specific assets are loaded automatically via block.json.
 	 */
 	public function editor_assets() {
-		// Enqueue block category filter to show blocks in multiple categories.
-		$asset_file = DESIGNSETGO_PATH . 'build/block-category-filter.asset.php';
+		// Enqueue the branded SVG icon for the DesignSetGo block category.
+		$asset_file = DESIGNSETGO_PATH . 'build/block-category-icon.asset.php';
 
 		if ( file_exists( $asset_file ) ) {
 			$asset = include $asset_file;
 
 			wp_enqueue_script(
-				'designsetgo-block-category-filter',
-				DESIGNSETGO_URL . 'build/block-category-filter.js',
+				'designsetgo-block-category-icon',
+				DESIGNSETGO_URL . 'build/block-category-icon.js',
 				$asset['dependencies'],
 				$asset['version'],
 				true
@@ -641,7 +641,7 @@ class Plugin {
 			$sticky_settings = wp_parse_args( $sticky_settings, $defaults['sticky_header'] );
 
 			wp_localize_script(
-				'designsetgo-block-category-filter',
+				'designsetgo-block-category-icon',
 				'dsgoStickyHeaderGlobalSettings',
 				array(
 					'enabled' => (bool) $sticky_settings['enable'],
@@ -654,7 +654,7 @@ class Plugin {
 			$integrations_settings = wp_parse_args( $integrations_settings, $integrations_defaults );
 
 			wp_localize_script(
-				'designsetgo-block-category-filter',
+				'designsetgo-block-category-icon',
 				'dsgoIntegrations',
 				array(
 					'googleMapsApiKey'    => ! empty( $integrations_settings['google_maps_api_key'] ) ? esc_js( $integrations_settings['google_maps_api_key'] ) : '',
@@ -695,7 +695,7 @@ class Plugin {
 		}
 
 		// Localize excluded blocks setting for extension filtering.
-		// This is done outside the block-category-filter conditional because
+		// This is done outside the block-category-icon conditional because
 		// the 'designsetgo-extensions' script is registered separately in the Assets class.
 		if ( wp_script_is( 'designsetgo-extensions', 'registered' ) || wp_script_is( 'designsetgo-extensions', 'enqueued' ) ) {
 			$settings        = $settings ?? \DesignSetGo\Admin\Settings::get_settings();

--- a/src/block-category-icon.js
+++ b/src/block-category-icon.js
@@ -29,8 +29,8 @@ const categoryIcon = createElement(
 );
 
 domReady(() => {
-	const store = dispatch('core/blocks');
-	if (store && typeof store.updateCategory === 'function') {
-		store.updateCategory(CATEGORY_SLUG, { icon: categoryIcon });
+	const actions = dispatch('core/blocks');
+	if (actions && typeof actions.updateCategory === 'function') {
+		actions.updateCategory(CATEGORY_SLUG, { icon: categoryIcon });
 	}
 });

--- a/src/blocks/form-textarea-field/block.json
+++ b/src/blocks/form-textarea-field/block.json
@@ -14,7 +14,7 @@
 		"field"
 	],
 	"textdomain": "designsetgo",
-	"icon": "edit-large",
+	"icon": "edit-page",
 	"parent": [
 		"designsetgo/form-builder"
 	],

--- a/src/extensions/reveal-control/index.js
+++ b/src/extensions/reveal-control/index.js
@@ -18,6 +18,11 @@ const CONTAINER_BLOCKS = [
 	'designsetgo/grid',
 ];
 
+// NOTE: The `designsetgo/reveal/*` strings below are context-key names, not
+// references to the retired `designsetgo/reveal` block. Renaming them would
+// require block deprecations for every container using this extension, so the
+// prefix is intentionally preserved.
+
 /**
  * Add reveal control attributes to all blocks
  * @param {Object} settings - Block settings

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -107,11 +107,11 @@ module.exports = {
 		frontend: path.resolve(process.cwd(), 'src', 'frontend.js'),
 		// Admin dashboard entry point
 		admin: path.resolve(process.cwd(), 'src', 'admin', 'index.js'),
-		// Block category filter for dual categorization
-		'block-category-filter': path.resolve(
+		// Branded SVG icon for the DesignSetGo block category.
+		'block-category-icon': path.resolve(
 			process.cwd(),
 			'src',
-			'block-category-filter.js'
+			'block-category-icon.js'
 		),
 		// Sticky header utility script
 		'utils/sticky-header': path.resolve(


### PR DESCRIPTION
## Summary

Follow-up to the merged #358 addressing review feedback that landed after merge.

- Rename `src/block-category-filter.js` → `src/block-category-icon.js` (the file is now exclusively a category-icon setter, not a filter). Updates webpack entry, `wp_enqueue_script` handle in `class-plugin.php`, and the `STRUCTURE.md` reference.
- Swap `form-textarea-field/block.json` icon from `edit-large` → `edit-page`. `edit-large` is not a valid core Dashicon slug; the field is exposed via `/wp/v2/block-types` even though JS overrides the editor icon.
- Rename `store` → `actions` in `block-category-icon.js`. `dispatch('core/blocks')` returns action dispatchers, not a store — clearer name for future readers.
- Add a short comment in `reveal-control/index.js` documenting that the `designsetgo/reveal/*` context-key strings are intentionally preserved (they're context keys, not references to the retired block; renaming would require a block deprecation migration).

## Test plan

- [x] `npm run build` — clean
- [x] `npm run test:unit` — 1406 / 1406 pass
- [x] `build/block-category-icon.js` + `.asset.php` generated; no stale `block-category-filter` artifacts
- [x] All 57 `block.json` files still parse
- [ ] Manual smoke test in editor to confirm the category icon still renders (the JS enqueue was just renamed)

https://claude.ai/code/session_01MSyfJ2rn4HFChkmQU3fpax