### PR TITLE
fix(llms-txt): serve per-post .md files inline instead of auto-downloading

### DIFF
--- a/includes/llms-txt/class-controller.php
+++ b/includes/llms-txt/class-controller.php
@@ -396,11 +396,24 @@ class Controller {
 			return;
 		}
 
-		if ( is_dir( $this->file_manager->get_directory() ) ) {
-			$this->file_manager->ensure_directory();
+		$directory = $this->file_manager->get_directory();
+
+		// If the legacy dir doesn't exist yet, there is nothing to backfill.
+		// The normal post-save path will create both the dir and the .htaccess
+		// on first publish, so mark done to avoid repeating the init-time check.
+		if ( ! is_dir( $directory ) ) {
+			update_option( self::HTACCESS_BACKFILL_OPTION, 1, true );
+			return;
 		}
 
-		update_option( self::HTACCESS_BACKFILL_OPTION, 1, true );
+		$this->file_manager->ensure_directory();
+
+		// Only mark done once the .htaccess is actually on disk; leaving the
+		// option unset means we retry next request if the write failed
+		// (e.g. permissions).
+		if ( file_exists( trailingslashit( $directory ) . '.htaccess' ) ) {
+			update_option( self::HTACCESS_BACKFILL_OPTION, 1, true );
+		}
 	}
 
 	/**

--- a/includes/llms-txt/class-controller.php
+++ b/includes/llms-txt/class-controller.php
@@ -53,6 +53,11 @@ class Controller {
 	const PHYSICAL_FULL_FILE_OPTION = 'designsetgo_llms_full_txt_physical';
 
 	/**
+	 * Option key tracking whether the per-post markdown .htaccess has been backfilled.
+	 */
+	const HTACCESS_BACKFILL_OPTION = 'designsetgo_llms_htaccess_backfilled';
+
+	/**
 	 * File manager instance.
 	 *
 	 * @var File_Manager
@@ -104,6 +109,7 @@ class Controller {
 		add_action( 'transition_post_status', array( $this, 'invalidate_cache' ) );
 		add_action( 'update_option_designsetgo_settings', array( $this, 'handle_settings_update' ), 10, 2 );
 		add_action( 'init', array( $this, 'register_post_meta' ) );
+		add_action( 'init', array( $this, 'maybe_backfill_htaccess' ), 20 );
 		add_action( 'rest_api_init', array( $this->rest_controller, 'register_routes' ) );
 		add_action( 'admin_notices', array( $this->conflict_detector, 'maybe_show_notice' ) );
 		add_action( 'admin_init', array( $this->conflict_detector, 'handle_dismiss_action' ) );
@@ -371,6 +377,30 @@ class Controller {
 				$this->delete_physical_full_file();
 			}
 		}
+	}
+
+	/**
+	 * One-time backfill: drop an .htaccess into the markdown dir on legacy installs.
+	 *
+	 * New installs pick it up via ensure_directory() on the next post save; this
+	 * covers sites that enabled llms.txt before this fix shipped and haven't
+	 * re-saved settings or published a post since.
+	 */
+	public function maybe_backfill_htaccess(): void {
+		if ( get_option( self::HTACCESS_BACKFILL_OPTION ) ) {
+			return;
+		}
+
+		$settings = \DesignSetGo\Admin\Settings::get_settings();
+		if ( empty( $settings['llms_txt']['enable'] ) ) {
+			return;
+		}
+
+		if ( is_dir( $this->file_manager->get_directory() ) ) {
+			$this->file_manager->ensure_directory();
+		}
+
+		update_option( self::HTACCESS_BACKFILL_OPTION, 1, true );
 	}
 
 	/**

--- a/includes/llms-txt/class-file-manager.php
+++ b/includes/llms-txt/class-file-manager.php
@@ -148,19 +148,26 @@ class File_Manager {
 	 * @return bool True if directory exists or was created.
 	 */
 	public function ensure_directory( string $subdirectory = '' ): bool {
-		$dir = $this->get_directory();
+		$root = $this->get_directory();
+		$dir  = $root;
 
 		if ( $subdirectory ) {
-			$dir = trailingslashit( $dir ) . $subdirectory;
+			$dir = trailingslashit( $root ) . $subdirectory;
 		}
 
 		if ( ! file_exists( $dir ) ) {
-			return wp_mkdir_p( $dir );
+			if ( ! wp_mkdir_p( $dir ) ) {
+				return false;
+			}
+			$this->maybe_write_htaccess( $root );
+			return true;
 		}
 
 		if ( ! is_dir( $dir ) ) {
 			return false;
 		}
+
+		$this->maybe_write_htaccess( $root );
 
 		// Use WP_Filesystem for writability check, with fallback to native function.
 		global $wp_filesystem;
@@ -171,6 +178,33 @@ class File_Manager {
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- Fallback when WP_Filesystem fails.
 		return $wp_filesystem ? $wp_filesystem->is_writable( $dir ) : is_writable( $dir );
+	}
+
+	/**
+	 * Drop a root-level .htaccess that tells Apache to serve .md as text/markdown.
+	 *
+	 * Without it, most servers fall back to application/octet-stream for .md and
+	 * browsers download the file instead of rendering it inline. Idempotent: only
+	 * writes when missing so any admin-authored overrides survive. Nginx cannot
+	 * honour .htaccess — those users need a server-level text/markdown MIME entry.
+	 *
+	 * @param string $root Absolute path to the markdown root directory.
+	 */
+	private function maybe_write_htaccess( string $root ): void {
+		if ( ! is_dir( $root ) ) {
+			return;
+		}
+
+		$path = trailingslashit( $root ) . '.htaccess';
+		if ( file_exists( $path ) ) {
+			return;
+		}
+
+		$contents = "# DesignSetGo llms.txt - serve Markdown inline\n"
+			. "AddType text/markdown .md\n";
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Small MIME-hint file.
+		@file_put_contents( $path, $contents ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Best-effort; failures are non-fatal.
 	}
 
 	/**

--- a/includes/llms-txt/class-file-manager.php
+++ b/includes/llms-txt/class-file-manager.php
@@ -188,6 +188,9 @@ class File_Manager {
 	 * writes when missing so any admin-authored overrides survive. Nginx cannot
 	 * honour .htaccess — those users need a server-level text/markdown MIME entry.
 	 *
+	 * Uses `AddType` + `AddCharset` (separate directives) rather than a
+	 * parameterised media-type string, which older Apache versions silently drop.
+	 *
 	 * @param string $root Absolute path to the markdown root directory.
 	 */
 	private function maybe_write_htaccess( string $root ): void {
@@ -201,10 +204,18 @@ class File_Manager {
 		}
 
 		$contents = "# DesignSetGo llms.txt - serve Markdown inline\n"
-			. "AddType text/markdown .md\n";
+			. "<IfModule mod_mime.c>\n"
+			. "\tAddType text/markdown .md\n"
+			. "\tAddCharset UTF-8 .md\n"
+			. "</IfModule>\n";
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Small MIME-hint file.
-		@file_put_contents( $path, $contents ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Best-effort; failures are non-fatal.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Matches existing write pattern in this class.
+		$result = file_put_contents( $path, $contents );
+
+		if ( false === $result && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Debug-only logging for non-fatal filesystem failure.
+			error_log( 'DesignSetGo: Failed to write llms.txt .htaccess file to ' . $path );
+		}
 	}
 
 	/**

--- a/tests/phpunit/llms-txt-test.php
+++ b/tests/phpunit/llms-txt-test.php
@@ -15,6 +15,7 @@ use WP_REST_Request;
 use DesignSetGo\LLMS_Txt\Controller;
 use DesignSetGo\LLMS_Txt\REST_Controller;
 use DesignSetGo\LLMS_Txt\Generator;
+use DesignSetGo\LLMS_Txt\File_Manager;
 use DesignSetGo\Markdown\Converter;
 use DesignSetGo\Admin\Settings;
 
@@ -80,7 +81,49 @@ class Test_LLMS_Txt extends WP_UnitTestCase {
 		delete_transient( Controller::FULL_CACHE_KEY );
 		Settings::invalidate_cache();
 
+		// Reset the backfill option so each test runs against a clean state.
+		delete_option( Controller::HTACCESS_BACKFILL_OPTION );
+
+		// Remove any .htaccess the tests may have written in the uploads dir.
+		$upload_dir = wp_upload_dir();
+		$htaccess   = trailingslashit( $upload_dir['basedir'] ) . File_Manager::MARKDOWN_DIR . '/.htaccess';
+		if ( file_exists( $htaccess ) ) {
+			unlink( $htaccess );
+		}
+
 		parent::tear_down();
+	}
+
+	/**
+	 * Helper: create the markdown root directory without any contents.
+	 *
+	 * Simulates a legacy install whose llms.txt feature was enabled before
+	 * this PR shipped — directory exists but no .htaccess yet.
+	 */
+	private function make_legacy_markdown_dir(): string {
+		$upload_dir = wp_upload_dir();
+		$dir        = trailingslashit( $upload_dir['basedir'] ) . File_Manager::MARKDOWN_DIR;
+		wp_mkdir_p( $dir );
+		$htaccess = trailingslashit( $dir ) . '.htaccess';
+		if ( file_exists( $htaccess ) ) {
+			unlink( $htaccess );
+		}
+		return $dir;
+	}
+
+	/**
+	 * Helper: enable the llms.txt feature in settings.
+	 */
+	private function enable_llms_feature(): void {
+		update_option(
+			'designsetgo_settings',
+			array(
+				'llms_txt' => array(
+					'enable' => true,
+				),
+			)
+		);
+		Settings::invalidate_cache();
 	}
 
 	/**
@@ -525,6 +568,113 @@ class Test_LLMS_Txt extends WP_UnitTestCase {
 		$output = $this->controller->add_to_robots_txt( '', true );
 
 		$this->assertStringNotContainsString( 'llms.txt', $output );
+	}
+
+	/**
+	 * Test backfill writes .htaccess into an existing legacy markdown dir.
+	 */
+	public function test_htaccess_backfill_writes_file_on_legacy_dir() {
+		$dir = $this->make_legacy_markdown_dir();
+		$this->enable_llms_feature();
+
+		$this->controller->maybe_backfill_htaccess();
+
+		$this->assertFileExists( trailingslashit( $dir ) . '.htaccess' );
+		$this->assertEquals( 1, (int) get_option( Controller::HTACCESS_BACKFILL_OPTION ) );
+	}
+
+	/**
+	 * Test backfill short-circuits when the option is already set.
+	 */
+	public function test_htaccess_backfill_skips_when_option_already_set() {
+		$dir = $this->make_legacy_markdown_dir();
+		$this->enable_llms_feature();
+		update_option( Controller::HTACCESS_BACKFILL_OPTION, 1, true );
+
+		$this->controller->maybe_backfill_htaccess();
+
+		$this->assertFileDoesNotExist( trailingslashit( $dir ) . '.htaccess' );
+	}
+
+	/**
+	 * Test backfill is a no-op when the feature is disabled.
+	 */
+	public function test_htaccess_backfill_noop_when_feature_disabled() {
+		$dir = $this->make_legacy_markdown_dir();
+		update_option(
+			'designsetgo_settings',
+			array(
+				'llms_txt' => array(
+					'enable' => false,
+				),
+			)
+		);
+		Settings::invalidate_cache();
+
+		$this->controller->maybe_backfill_htaccess();
+
+		$this->assertFileDoesNotExist( trailingslashit( $dir ) . '.htaccess' );
+		$this->assertFalse( get_option( Controller::HTACCESS_BACKFILL_OPTION ) );
+	}
+
+	/**
+	 * Test backfill marks done (without writing) when the dir doesn't exist.
+	 *
+	 * In that case the normal post-save path creates both dir and .htaccess,
+	 * so we short-circuit to avoid rechecking every init.
+	 */
+	public function test_htaccess_backfill_marks_done_when_dir_missing() {
+		// Ensure the directory is absent.
+		$upload_dir = wp_upload_dir();
+		$dir        = trailingslashit( $upload_dir['basedir'] ) . File_Manager::MARKDOWN_DIR;
+		if ( is_dir( $dir ) ) {
+			// Remove htaccess first if present; then the dir (must be empty).
+			$htaccess = trailingslashit( $dir ) . '.htaccess';
+			if ( file_exists( $htaccess ) ) {
+				unlink( $htaccess );
+			}
+			@rmdir( $dir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Best-effort cleanup; if non-empty we skip the test.
+			if ( is_dir( $dir ) ) {
+				$this->markTestSkipped( 'Could not remove markdown dir to simulate missing-dir scenario.' );
+			}
+		}
+
+		$this->enable_llms_feature();
+
+		$this->controller->maybe_backfill_htaccess();
+
+		$this->assertDirectoryDoesNotExist( $dir );
+		$this->assertEquals( 1, (int) get_option( Controller::HTACCESS_BACKFILL_OPTION ) );
+	}
+
+	/**
+	 * Test the .htaccess preserves an existing (admin-authored) file.
+	 */
+	public function test_htaccess_preserves_existing_file() {
+		$dir           = $this->make_legacy_markdown_dir();
+		$htaccess_path = trailingslashit( $dir ) . '.htaccess';
+		$custom        = "# admin override\nAddType text/plain .md\n";
+		file_put_contents( $htaccess_path, $custom ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture.
+		$this->enable_llms_feature();
+
+		$this->controller->maybe_backfill_htaccess();
+
+		$this->assertStringEqualsFile( $htaccess_path, $custom );
+	}
+
+	/**
+	 * Test the generated .htaccess declares markdown + UTF-8.
+	 */
+	public function test_htaccess_contents_declare_markdown_and_utf8() {
+		$dir = $this->make_legacy_markdown_dir();
+		$this->enable_llms_feature();
+
+		$this->controller->maybe_backfill_htaccess();
+
+		$contents = file_get_contents( trailingslashit( $dir ) . '.htaccess' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_get_contents -- Test read.
+		$this->assertStringContainsString( 'AddType text/markdown .md', $contents );
+		$this->assertStringContainsString( 'AddCharset UTF-8 .md', $contents );
+		$this->assertStringContainsString( '<IfModule mod_mime.c>', $contents );
 	}
 
 	/**

--- a/uninstall.php
+++ b/uninstall.php
@@ -59,7 +59,7 @@ designsetgo_uninstall_step(
 	}
 );
 
-// 3. Remove physical llms.txt if we own it, then delete plugin options.
+// 3. Remove physical llms.txt / llms-full.txt if we own them, then delete plugin options.
 designsetgo_uninstall_step(
 	'options and llms.txt',
 	function () {
@@ -70,9 +70,17 @@ designsetgo_uninstall_step(
 			}
 		}
 
+		if ( get_option( 'designsetgo_llms_full_txt_physical' ) ) {
+			$full_path = ABSPATH . 'llms-full.txt';
+			if ( file_exists( $full_path ) && is_writable( $full_path ) ) {
+				wp_delete_file( $full_path );
+			}
+		}
+
 		delete_option( 'designsetgo_global_styles' );
 		delete_option( 'designsetgo_settings' );
 		delete_option( 'designsetgo_llms_txt_physical' );
+		delete_option( 'designsetgo_llms_full_txt_physical' );
 		delete_option( 'designsetgo_llms_htaccess_backfilled' );
 	}
 );

--- a/uninstall.php
+++ b/uninstall.php
@@ -73,6 +73,7 @@ designsetgo_uninstall_step(
 		delete_option( 'designsetgo_global_styles' );
 		delete_option( 'designsetgo_settings' );
 		delete_option( 'designsetgo_llms_txt_physical' );
+		delete_option( 'designsetgo_llms_htaccess_backfilled' );
 	}
 );
 


### PR DESCRIPTION
## Summary

- Per-post `.md` files under `wp-content/uploads/designsetgo/llms/` were written directly to disk and served by Apache/nginx — but with no MIME mapping for `.md`, servers fall back to `application/octet-stream` and browsers force a download rather than rendering inline.
- This adds a root-level `.htaccess` in the markdown directory containing `AddType text/markdown .md`, written lazily on directory creation and idempotent so admin-authored overrides survive.
- A one-shot `init`-hooked backfill (`designsetgo_llms_htaccess_backfilled` option) covers legacy installs that enabled llms.txt before this fix shipped and haven't re-saved settings or published a post since.

## Caveats

- **Apache only.** Nginx ignores `.htaccess`; those users need `location ~ \.md$ { add_header Content-Type "text/markdown; charset=utf-8"; }` at the server level. Not auto-detected here.
- Hosts that disable `AllowOverride` in `wp-content/uploads/` will still see the download behavior — no reliable way to detect without firing a test request.
- The `/llms.txt` and `/llms-full.txt` endpoints already render correctly (they go through `template_redirect` and set `Content-Type: text/plain`); this only affects the per-post `.md` files.

## Test plan

- [ ] Enable llms.txt, save a post, confirm `wp-content/uploads/designsetgo/llms/.htaccess` now exists with the `AddType` line.
- [ ] Visit `/wp-content/uploads/designsetgo/llms/<slug>.md` in Apache — confirm browser renders inline (or shows as text) instead of triggering a download.
- [ ] Manually edit the generated `.htaccess`, trigger another post save, confirm custom edits survive (idempotent).
- [ ] On a fresh Apache install with llms.txt already enabled from before this change, load any admin page once, confirm `.htaccess` appears and `designsetgo_llms_htaccess_backfilled` option is set to `1`.
- [ ] Uninstall the plugin, confirm `designsetgo_llms_htaccess_backfilled` is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)