### PR TITLE
feat(grid-span): add row span control for grid children

### DIFF
--- a/includes/extension-configs/grid-span.php
+++ b/includes/extension-configs/grid-span.php
@@ -16,5 +16,9 @@ return array(
 			'type'    => 'number',
 			'default' => 1,
 		),
+		'dsgoRowSpan'    => array(
+			'type'    => 'number',
+			'default' => 1,
+		),
 	),
 );

--- a/src/extensions/grid-span/editor.scss
+++ b/src/extensions/grid-span/editor.scss
@@ -13,6 +13,9 @@
  * On mobile/tablet, if the grid has fewer columns than the span,
  * the span should be constrained to the max available columns.
  * This prevents blocks from spanning more columns than exist.
+ *
+ * Selectors explicitly match grid-column / gridColumn to avoid false
+ * positives on row-span styles (grid-row: span N).
  */
 
 // Generate responsive constraints for each grid column configuration
@@ -23,8 +26,12 @@
 		.dsgo-grid-cols-tablet-#{$cols} .dsgo-grid__inner > [data-block] {
 			// If span exceeds available columns, constrain it
 			@for $span from ($cols + 1) through 12 {
-				&[style*="span #{$span}"],
-				&[style*="span#{$span}"] {
+				&[style*="grid-column: span #{$span}"],
+				&[style*="grid-column:span #{$span}"],
+				&[style*="grid-column:span#{$span}"],
+				&[style*="gridColumn: span #{$span}"],
+				&[style*="gridColumn:span #{$span}"],
+				&[style*="gridColumn:span#{$span}"] {
 					grid-column: span #{$cols} !important;
 				}
 			}
@@ -39,8 +46,12 @@
 		.dsgo-grid-cols-mobile-#{$cols} .dsgo-grid__inner > [data-block] {
 			// If span exceeds available columns, constrain it
 			@for $span from ($cols + 1) through 12 {
-				&[style*="span #{$span}"],
-				&[style*="span#{$span}"] {
+				&[style*="grid-column: span #{$span}"],
+				&[style*="grid-column:span #{$span}"],
+				&[style*="grid-column:span#{$span}"],
+				&[style*="gridColumn: span #{$span}"],
+				&[style*="gridColumn:span #{$span}"],
+				&[style*="gridColumn:span#{$span}"] {
 					grid-column: span #{$cols} !important;
 				}
 			}

--- a/src/extensions/grid-span/editor.scss
+++ b/src/extensions/grid-span/editor.scss
@@ -28,10 +28,7 @@
 			@for $span from ($cols + 1) through 12 {
 				&[style*="grid-column: span #{$span}"],
 				&[style*="grid-column:span #{$span}"],
-				&[style*="grid-column:span#{$span}"],
-				&[style*="gridColumn: span #{$span}"],
-				&[style*="gridColumn:span #{$span}"],
-				&[style*="gridColumn:span#{$span}"] {
+				&[style*="grid-column:span#{$span}"] {
 					grid-column: span #{$cols} !important;
 				}
 			}
@@ -48,10 +45,7 @@
 			@for $span from ($cols + 1) through 12 {
 				&[style*="grid-column: span #{$span}"],
 				&[style*="grid-column:span #{$span}"],
-				&[style*="grid-column:span#{$span}"],
-				&[style*="gridColumn: span #{$span}"],
-				&[style*="gridColumn:span #{$span}"],
-				&[style*="gridColumn:span#{$span}"] {
+				&[style*="grid-column:span#{$span}"] {
 					grid-column: span #{$cols} !important;
 				}
 			}

--- a/src/extensions/grid-span/editor.scss
+++ b/src/extensions/grid-span/editor.scss
@@ -14,8 +14,8 @@
  * the span should be constrained to the max available columns.
  * This prevents blocks from spanning more columns than exist.
  *
- * Selectors explicitly match grid-column / gridColumn to avoid false
- * positives on row-span styles (grid-row: span N).
+ * Selectors explicitly match the `grid-column` style property to avoid
+ * false positives on row-span styles (`grid-row: span N`).
  */
 
 // Generate responsive constraints for each grid column configuration

--- a/src/extensions/grid-span/index.js
+++ b/src/extensions/grid-span/index.js
@@ -1,8 +1,8 @@
 /**
  * Grid Span Extension
  *
- * Adds column span controls to blocks when they're inside a Grid container.
- * Allows blocks to span multiple columns in the grid.
+ * Adds column and row span controls to blocks when they're inside a Grid
+ * container. Allows blocks to span multiple columns and/or rows in the grid.
  *
  * @since 1.0.0
  */
@@ -18,13 +18,17 @@ import { PanelBody, RangeControl } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 
+// Upper bound for row span. Rows are implicit in CSS Grid so any value works;
+// we cap at the same max as columns for UI parity and to discourage extreme values.
+const MAX_ROW_SPAN = 12;
+
 /**
- * Add columnSpan attribute to all blocks
+ * Add columnSpan and rowSpan attributes to all blocks
  * @param {Object} settings Block settings
  * @param {string} name     Block name
  * @return {Object} Modified block settings
  */
-function addColumnSpanAttribute(settings, name) {
+function addSpanAttributes(settings, name) {
 	// Check user exclusion list first
 	if (!shouldExtendBlock(name)) {
 		return settings;
@@ -38,23 +42,27 @@ function addColumnSpanAttribute(settings, name) {
 				type: 'number',
 				default: 1,
 			},
+			dsgoRowSpan: {
+				type: 'number',
+				default: 1,
+			},
 		},
 	};
 }
 
 addFilter(
 	'blocks.registerBlockType',
-	'designsetgo/add-column-span-attribute',
-	addColumnSpanAttribute
+	'designsetgo/add-grid-span-attributes',
+	addSpanAttributes
 );
 
 /**
- * Add Column Span control to block inspector when inside Grid
+ * Add Column and Row Span controls to block inspector when inside Grid
  */
-const withColumnSpanControl = createHigherOrderComponent((BlockEdit) => {
+const withGridSpanControls = createHigherOrderComponent((BlockEdit) => {
 	return (props) => {
 		const { attributes, setAttributes, clientId } = props;
-		const { dsgoColumnSpan } = attributes;
+		const { dsgoColumnSpan, dsgoRowSpan } = attributes;
 
 		// Check if this block is inside a Grid container
 		const parentBlock = useSelect(
@@ -102,32 +110,47 @@ const withColumnSpanControl = createHigherOrderComponent((BlockEdit) => {
 								__nextHasNoMarginBottom
 								__next40pxDefaultSize
 							/>
+							<RangeControl
+								label={__('Row Span', 'designsetgo')}
+								value={dsgoRowSpan}
+								onChange={(value) =>
+									setAttributes({ dsgoRowSpan: value })
+								}
+								min={1}
+								max={MAX_ROW_SPAN}
+								help={__(
+									'Number of rows this block spans in the grid',
+									'designsetgo'
+								)}
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+							/>
 						</PanelBody>
 					</InspectorControls>
 				)}
 			</>
 		);
 	};
-}, 'withColumnSpanControl');
+}, 'withGridSpanControls');
 
 addFilter(
 	'editor.BlockEdit',
-	'designsetgo/add-column-span-control',
-	withColumnSpanControl,
+	'designsetgo/add-grid-span-controls',
+	withGridSpanControls,
 	20
 );
 
 /**
- * Apply column span styles in editor via wrapperProps
+ * Apply column and row span styles in editor via wrapperProps
  *
  * Uses inline styles on the block wrapper instead of dynamic <style> injection.
- * This ensures grid-column spans work in both the editor canvas AND pattern
+ * This ensures grid spans work in both the editor canvas AND pattern
  * previews (which render in separate iframes without name="editor-canvas").
  */
-const withColumnSpanStyles = createHigherOrderComponent((BlockListBlock) => {
+const withGridSpanStyles = createHigherOrderComponent((BlockListBlock) => {
 	return (props) => {
 		const { attributes, clientId } = props;
-		const { dsgoColumnSpan } = attributes;
+		const { dsgoColumnSpan, dsgoRowSpan } = attributes;
 
 		// Check if this block is inside a Grid container
 		const isInGrid = useSelect(
@@ -147,13 +170,21 @@ const withColumnSpanStyles = createHigherOrderComponent((BlockListBlock) => {
 			[clientId]
 		);
 
-		// Apply grid-column span directly via wrapperProps
-		if (isInGrid && dsgoColumnSpan && dsgoColumnSpan > 1) {
+		const hasColumnSpan =
+			isInGrid && dsgoColumnSpan && dsgoColumnSpan > 1;
+		const hasRowSpan = isInGrid && dsgoRowSpan && dsgoRowSpan > 1;
+
+		if (hasColumnSpan || hasRowSpan) {
 			const wrapperProps = {
 				...props.wrapperProps,
 				style: {
 					...props.wrapperProps?.style,
-					gridColumn: `span ${dsgoColumnSpan}`,
+					...(hasColumnSpan && {
+						gridColumn: `span ${dsgoColumnSpan}`,
+					}),
+					...(hasRowSpan && {
+						gridRow: `span ${dsgoRowSpan}`,
+					}),
 				},
 			};
 
@@ -162,27 +193,29 @@ const withColumnSpanStyles = createHigherOrderComponent((BlockListBlock) => {
 
 		return <BlockListBlock {...props} />;
 	};
-}, 'withColumnSpanStyles');
+}, 'withGridSpanStyles');
 
 addFilter(
 	'editor.BlockListBlock',
-	'designsetgo/add-column-span-styles-editor',
-	withColumnSpanStyles,
+	'designsetgo/add-grid-span-styles-editor',
+	withGridSpanStyles,
 	20
 );
 
 /**
- * Apply column span styles on frontend
+ * Apply column and row span styles on frontend
  * @param {Object} props      Block props
  * @param {Object} blockType  Block type
  * @param {Object} attributes Block attributes
  * @return {Object} Modified props
  */
-function applyColumnSpanStyles(props, blockType, attributes) {
-	const { dsgoColumnSpan } = attributes;
+function applyGridSpanStyles(props, blockType, attributes) {
+	const { dsgoColumnSpan, dsgoRowSpan } = attributes;
 
-	// Only apply if columnSpan is set and > 1
-	if (!dsgoColumnSpan || dsgoColumnSpan === 1) {
+	const applyColumn = dsgoColumnSpan && dsgoColumnSpan > 1;
+	const applyRow = dsgoRowSpan && dsgoRowSpan > 1;
+
+	if (!applyColumn && !applyRow) {
 		return props;
 	}
 
@@ -190,13 +223,14 @@ function applyColumnSpanStyles(props, blockType, attributes) {
 		...props,
 		style: {
 			...props.style,
-			gridColumn: `span ${dsgoColumnSpan}`,
+			...(applyColumn && { gridColumn: `span ${dsgoColumnSpan}` }),
+			...(applyRow && { gridRow: `span ${dsgoRowSpan}` }),
 		},
 	};
 }
 
 addFilter(
 	'blocks.getSaveContent.extraProps',
-	'designsetgo/apply-column-span-styles',
-	applyColumnSpanStyles
+	'designsetgo/apply-grid-span-styles',
+	applyGridSpanStyles
 );


### PR DESCRIPTION
## Summary

- Adds a **Row Span** control alongside the existing Column Span control for blocks inside a `designsetgo/grid` container, using a new `dsgoRowSpan` attribute (default `1`) registered both client-side and server-side.
- Renders `grid-row: span N` inline styles in the editor (via `BlockListBlock` wrapperProps) and on the frontend (via `getSaveContent.extraProps`), relying on CSS Grid's implicit rows so the grid container itself needs no changes.
- Tightens the editor SCSS responsive constraints to explicitly match `grid-column` declarations only, preventing the loose `[style*="span N"]` selector from accidentally constraining row-span-only blocks.

## Deprecation / migration

**None needed.** `dsgoRowSpan` defaults to `1`, and no style is emitted at the default, so save output (and block validation) is byte-identical for existing content. Old blocks simply pick up the default on hydration.

## Files changed

- `src/extensions/grid-span/index.js` — adds attribute, inspector control, editor + save style application
- `src/extensions/grid-span/editor.scss` — tightens column-span selectors so row spans aren't false-matched
- `includes/extension-configs/grid-span.php` — registers `dsgoRowSpan` for REST block-type schema parity

## Test plan

- [ ] Insert a `designsetgo/grid` block and confirm a child block's inspector shows both Column Span and Row Span under "Grid Settings"
- [ ] Set Row Span > 1 on a child and verify it visually spans multiple rows in the editor
- [ ] Save and view on the frontend — confirm `grid-row: span N` is present and rendering correctly
- [ ] Verify a child with Row Span only (no Column Span) is NOT incorrectly constrained at tablet/mobile breakpoints
- [ ] Load content created before this change and confirm no block validation warnings
- [ ] Run PHPUnit `Test_Extension_Attributes` — config files should still pass schema validation
- [ ] Verify `/wp-json/wp/v2/block-types` exposes `dsgoRowSpan` on applicable block types

https://claude.ai/code/session_01Hc9nSoYKmsrNMvsyUze4rw