### PR TITLE
fix(section): clear default padding on nested sections

### DIFF
--- a/src/blocks/section/edit.js
+++ b/src/blocks/section/edit.js
@@ -226,6 +226,7 @@ export default function SectionEdit({ attributes, setAttributes, clientId }) {
 		const isDefault = (value, slug) =>
 			value === `var:preset|spacing|${slug}` ||
 			value === `var(--wp--preset--spacing--${slug})`;
+		// Slugs must match block.json attributes.style.spacing.padding defaults.
 		const hasDefaultPadding =
 			isDefault(currentPadding?.top, '50') &&
 			isDefault(currentPadding?.bottom, '50') &&

--- a/src/blocks/section/edit.js
+++ b/src/blocks/section/edit.js
@@ -36,7 +36,10 @@ import {
 	encodeColorValue,
 	decodeColorValue,
 } from '../../utils/encode-color-value';
-import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
+import {
+	convertColorToCSSVar,
+	convertPresetToCSSVar,
+} from '../../utils/convert-preset-to-css-var';
 import { useBlockColors } from '../../hooks';
 
 /**
@@ -219,14 +222,13 @@ export default function SectionEdit({ attributes, setAttributes, clientId }) {
 			return;
 		}
 
-		// Default padding is stored in preset-reference format ("var:preset|spacing|50"),
-		// not the CSS-resolved format. Match against both so the check works regardless
-		// of how WordPress serializes the value.
+		// Normalize through the shared preset utility so either the preset-reference
+		// format ("var:preset|spacing|50") or the CSS-resolved form compares equal.
+		// Slugs must match block.json attributes.style.spacing.padding defaults.
 		const currentPadding = attributes.style?.spacing?.padding;
 		const isDefault = (value, slug) =>
-			value === `var:preset|spacing|${slug}` ||
-			value === `var(--wp--preset--spacing--${slug})`;
-		// Slugs must match block.json attributes.style.spacing.padding defaults.
+			convertPresetToCSSVar(value) ===
+			`var(--wp--preset--spacing--${slug})`;
 		const hasDefaultPadding =
 			isDefault(currentPadding?.top, '50') &&
 			isDefault(currentPadding?.bottom, '50') &&

--- a/src/blocks/section/edit.js
+++ b/src/blocks/section/edit.js
@@ -219,12 +219,18 @@ export default function SectionEdit({ attributes, setAttributes, clientId }) {
 			return;
 		}
 
+		// Default padding is stored in preset-reference format ("var:preset|spacing|50"),
+		// not the CSS-resolved format. Match against both so the check works regardless
+		// of how WordPress serializes the value.
 		const currentPadding = attributes.style?.spacing?.padding;
+		const isDefault = (value, slug) =>
+			value === `var:preset|spacing|${slug}` ||
+			value === `var(--wp--preset--spacing--${slug})`;
 		const hasDefaultPadding =
-			currentPadding?.top === 'var(--wp--preset--spacing--50)' &&
-			currentPadding?.bottom === 'var(--wp--preset--spacing--50)' &&
-			currentPadding?.left === 'var(--wp--preset--spacing--30)' &&
-			currentPadding?.right === 'var(--wp--preset--spacing--30)';
+			isDefault(currentPadding?.top, '50') &&
+			isDefault(currentPadding?.bottom, '50') &&
+			isDefault(currentPadding?.left, '30') &&
+			isDefault(currentPadding?.right, '30');
 
 		if (hasDefaultPadding) {
 			setAttributes({


### PR DESCRIPTION
## Summary
- Fixes the nested-section padding auto-clear that was silently broken due to a value-format mismatch.
- Top-level sections still get the default padding; sections inserted inside another section now get zeroed padding on mount.

## Context
The Section block (`src/blocks/section/block.json`) ships with a default `style.spacing.padding` using preset references (`var:preset|spacing|50`). `edit.js` already had a mount-only `useEffect` (`src/blocks/section/edit.js:217`) to detect nested sections via `getBlockParents` and zero that default — but it compared against the CSS-resolved form (`var(--wp--preset--spacing--50)`), which never matches the stored attribute value. Result: nested sections kept their default padding.

## Change
`src/blocks/section/edit.js:225` — helper that accepts either the preset-reference format or the CSS-resolved form, so the check fires regardless of how the value is serialized. Behavior otherwise unchanged: mount-only effect, only clears if padding still matches the defaults (user-customized values are preserved).

## Test plan
- [ ] Insert a top-level Section → keeps default padding (top/bottom `spacing|50`, left/right `spacing|30`).
- [ ] Insert a Section inside an existing Section → padding is zeroed on insertion.
- [ ] Manually set custom padding on a top-level Section, then move/drag it inside another Section → custom padding is preserved (mount-only effect, doesn't re-fire on moves).
- [ ] Duplicate/paste a nested Section → padding stays zeroed.
- [ ] Frontend render matches editor (no padding on nested sections).
