### PR TITLE
fix(advanced-heading): default segment gap to 0

### DIFF
--- a/src/blocks/advanced-heading/editor.scss
+++ b/src/blocks/advanced-heading/editor.scss
@@ -11,7 +11,7 @@
 
 	// Gap between heading segments — matches frontend style.scss
 	.dsgo-heading-segment + .dsgo-heading-segment {
-		margin-inline-start: var(--dsgo-segment-gap, 0.3em);
+		margin-inline-start: var(--dsgo-segment-gap, 0);
 	}
 }
 

--- a/src/blocks/advanced-heading/style.scss
+++ b/src/blocks/advanced-heading/style.scss
@@ -10,10 +10,10 @@
 		padding: 0;
 	}
 
-	// Gap between heading segments — uses CSS custom property
-	// so the editor block-gap control can override the default
+	// Gap between heading segments — defaults to 0 so segments run
+	// together as one heading; editor block-gap control can override
 	.dsgo-heading-segment + .dsgo-heading-segment {
-		margin-inline-start: var(--dsgo-segment-gap, 0.3em);
+		margin-inline-start: var(--dsgo-segment-gap, 0);
 	}
 }
 


### PR DESCRIPTION
## Summary
- Change the default `--dsgo-segment-gap` fallback from `0.3em` to `0` in both `style.scss` and `editor.scss` so Advanced Heading segments butt up against each other and read as a single heading by default.
- Authors can still open the gap via the existing block-gap control.

## Test plan
- [ ] Insert an Advanced Heading; confirm the two default segments render with no gap between them in the editor and on the frontend.
- [ ] Set a block-gap value in the inspector and confirm segments separate by that amount.
- [ ] Existing blocks that already have a block-gap set continue to render with that gap.
