### PR TITLE
feat(extensions): add hover-effects extension

### DIFF
--- a/src/extensions/hover-effects/_tokens.scss
+++ b/src/extensions/hover-effects/_tokens.scss
@@ -1,0 +1,11 @@
+/**
+ * Hover Effects Extension - Shared Tokens
+ *
+ * Timing tokens shared by frontend and editor styles so a single
+ * change propagates to both.
+ *
+ * @package
+ */
+
+$dsgo-hover-duration: 300ms;
+$dsgo-hover-easing: ease-out;

--- a/src/extensions/hover-effects/constants.js
+++ b/src/extensions/hover-effects/constants.js
@@ -1,0 +1,42 @@
+/**
+ * Hover Effects - Constants
+ *
+ * Preset hover micro-interactions and supported block list.
+ *
+ * @package
+ * @since 1.0.0
+ */
+
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Hover effect presets
+ *
+ * Values map 1:1 to CSS class modifiers:
+ * `.dsgo-hover-effect--{value}` in styles.scss.
+ */
+export const HOVER_EFFECTS = [
+	{ label: __('None', 'designsetgo'), value: '' },
+	{ label: __('Lift', 'designsetgo'), value: 'lift' },
+	{ label: __('Sink', 'designsetgo'), value: 'sink' },
+	{ label: __('Grow', 'designsetgo'), value: 'grow' },
+	{ label: __('Shrink', 'designsetgo'), value: 'shrink' },
+	{ label: __('Tilt', 'designsetgo'), value: 'tilt' },
+	{ label: __('Glow', 'designsetgo'), value: 'glow' },
+];
+
+/**
+ * Blocks that receive the hover effect control
+ */
+export const SUPPORTED_BLOCKS = [
+	'core/group',
+	'core/cover',
+	'core/column',
+	'core/columns',
+	'core/image',
+	'core/button',
+	'core/buttons',
+	'core/media-text',
+	'core/post-template',
+	'core/query',
+];

--- a/src/extensions/hover-effects/edit.js
+++ b/src/extensions/hover-effects/edit.js
@@ -1,0 +1,42 @@
+/**
+ * Hover Effects Extension - Inspector Panel
+ *
+ * Lazy-loaded inspector panel that lets authors pick one of the
+ * preset hover micro-interactions.
+ *
+ * @since 1.0.0
+ */
+
+import { __ } from '@wordpress/i18n';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, SelectControl } from '@wordpress/components';
+import { HOVER_EFFECTS } from './constants';
+
+export default function HoverEffectsPanel(props) {
+	const { attributes, setAttributes } = props;
+	const { dsgoHoverEffect = '' } = attributes;
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={__('Hover Effect', 'designsetgo')}
+				initialOpen={false}
+			>
+				<SelectControl
+					label={__('Effect', 'designsetgo')}
+					value={dsgoHoverEffect}
+					options={HOVER_EFFECTS}
+					onChange={(value) =>
+						setAttributes({ dsgoHoverEffect: value })
+					}
+					help={__(
+						'Subtle animation that plays when visitors hover this block.',
+						'designsetgo'
+					)}
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+}

--- a/src/extensions/hover-effects/editor.scss
+++ b/src/extensions/hover-effects/editor.scss
@@ -1,0 +1,61 @@
+/**
+ * Hover Effects Extension - Editor Styles
+ *
+ * Mirrors the frontend hover effects inside the block editor so
+ * authors can preview the effect while hovering a block in the canvas.
+ *
+ * @package
+ */
+
+$dsgo-hover-duration: 300ms;
+$dsgo-hover-easing: ease-out;
+
+.editor-styles-wrapper {
+
+	.dsgo-hover-effect {
+		transition:
+			transform $dsgo-hover-duration $dsgo-hover-easing,
+			box-shadow $dsgo-hover-duration $dsgo-hover-easing,
+			filter $dsgo-hover-duration $dsgo-hover-easing;
+		will-change: transform;
+
+		&--lift:hover {
+			transform: translateY(-4px);
+			box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+		}
+
+		&--sink:hover {
+			transform: translateY(4px);
+		}
+
+		&--grow:hover {
+			transform: scale(1.03);
+		}
+
+		&--shrink:hover {
+			transform: scale(0.97);
+		}
+
+		&--tilt:hover {
+			transform: rotate(-1deg) scale(1.01);
+		}
+
+		&--glow:hover {
+			box-shadow: 0 0 24px rgba(0, 0, 0, 0.15);
+			filter: brightness(1.05);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+
+		.dsgo-hover-effect {
+			transition: none;
+
+			&:hover {
+				transform: none;
+				box-shadow: none;
+				filter: none;
+			}
+		}
+	}
+}

--- a/src/extensions/hover-effects/editor.scss
+++ b/src/extensions/hover-effects/editor.scss
@@ -7,8 +7,7 @@
  * @package
  */
 
-$dsgo-hover-duration: 300ms;
-$dsgo-hover-easing: ease-out;
+@use 'tokens' as *;
 
 .editor-styles-wrapper {
 
@@ -17,7 +16,18 @@ $dsgo-hover-easing: ease-out;
 			transform $dsgo-hover-duration $dsgo-hover-easing,
 			box-shadow $dsgo-hover-duration $dsgo-hover-easing,
 			filter $dsgo-hover-duration $dsgo-hover-easing;
-		will-change: transform;
+
+		&--lift,
+		&--sink,
+		&--grow,
+		&--shrink,
+		&--tilt {
+			will-change: transform;
+		}
+
+		&--glow {
+			will-change: filter;
+		}
 
 		&--lift:hover {
 			transform: translateY(-4px);

--- a/src/extensions/hover-effects/editor.scss
+++ b/src/extensions/hover-effects/editor.scss
@@ -56,6 +56,133 @@
 		}
 	}
 
+	// Retarget button/image effects to their rounded inner surface so
+	// shadows follow the real border-radius. See styles.scss for details.
+	.wp-block-button.dsgo-hover-effect {
+		transition: none;
+		will-change: auto;
+
+		&:hover {
+			transform: none;
+			box-shadow: none;
+			filter: none;
+		}
+
+		> .wp-block-button__link {
+			transition:
+				transform $dsgo-hover-duration $dsgo-hover-easing,
+				box-shadow $dsgo-hover-duration $dsgo-hover-easing,
+				filter $dsgo-hover-duration $dsgo-hover-easing;
+		}
+
+		&--lift > .wp-block-button__link,
+		&--sink > .wp-block-button__link,
+		&--grow > .wp-block-button__link,
+		&--shrink > .wp-block-button__link,
+		&--tilt > .wp-block-button__link {
+			will-change: transform;
+		}
+
+		&--glow > .wp-block-button__link {
+			will-change: filter;
+		}
+
+		&--lift:hover > .wp-block-button__link {
+			transform: translateY(-4px);
+			box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+		}
+
+		&--sink:hover > .wp-block-button__link {
+			transform: translateY(4px);
+		}
+
+		&--grow:hover > .wp-block-button__link {
+			transform: scale(1.03);
+		}
+
+		&--shrink:hover > .wp-block-button__link {
+			transform: scale(0.97);
+		}
+
+		&--tilt:hover > .wp-block-button__link {
+			transform: rotate(-1deg) scale(1.01);
+		}
+
+		&--glow:hover > .wp-block-button__link {
+			box-shadow: 0 0 24px rgba(0, 0, 0, 0.15);
+			filter: brightness(1.05);
+		}
+	}
+
+	.wp-block-image.dsgo-hover-effect {
+		transition: none;
+		will-change: auto;
+
+		&:hover {
+			transform: none;
+			box-shadow: none;
+			filter: none;
+		}
+
+		> img,
+		> a > img {
+			transition:
+				transform $dsgo-hover-duration $dsgo-hover-easing,
+				box-shadow $dsgo-hover-duration $dsgo-hover-easing,
+				filter $dsgo-hover-duration $dsgo-hover-easing;
+		}
+
+		&--lift > img,
+		&--lift > a > img,
+		&--sink > img,
+		&--sink > a > img,
+		&--grow > img,
+		&--grow > a > img,
+		&--shrink > img,
+		&--shrink > a > img,
+		&--tilt > img,
+		&--tilt > a > img {
+			will-change: transform;
+		}
+
+		&--glow > img,
+		&--glow > a > img {
+			will-change: filter;
+		}
+
+		&--lift:hover > img,
+		&--lift:hover > a > img {
+			transform: translateY(-4px);
+			box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+		}
+
+		&--sink:hover > img,
+		&--sink:hover > a > img {
+			transform: translateY(4px);
+		}
+
+		&--grow:hover > img,
+		&--grow:hover > a > img {
+			transform: scale(1.03);
+		}
+
+		&--shrink:hover > img,
+		&--shrink:hover > a > img {
+			transform: scale(0.97);
+		}
+
+		&--tilt:hover > img,
+		&--tilt:hover > a > img {
+			transform: rotate(-1deg) scale(1.01);
+		}
+
+		&--glow:hover > img,
+		&--glow:hover > a > img {
+			box-shadow: 0 0 24px rgba(0, 0, 0, 0.15);
+			filter: brightness(1.05);
+		}
+	}
+
 	@media (prefers-reduced-motion: reduce) {
 
 		.dsgo-hover-effect {
@@ -66,6 +193,28 @@
 				box-shadow: none;
 				filter: none;
 			}
+		}
+
+		.wp-block-button.dsgo-hover-effect > .wp-block-button__link {
+			transition: none;
+		}
+
+		.wp-block-button.dsgo-hover-effect:hover > .wp-block-button__link {
+			transform: none;
+			box-shadow: none;
+			filter: none;
+		}
+
+		.wp-block-image.dsgo-hover-effect > img,
+		.wp-block-image.dsgo-hover-effect > a > img {
+			transition: none;
+		}
+
+		.wp-block-image.dsgo-hover-effect:hover > img,
+		.wp-block-image.dsgo-hover-effect:hover > a > img {
+			transform: none;
+			box-shadow: none;
+			filter: none;
 		}
 	}
 }

--- a/src/extensions/hover-effects/index.js
+++ b/src/extensions/hover-effects/index.js
@@ -121,7 +121,7 @@ const withHoverEffectClass = createHigherOrderComponent((BlockListBlock) => {
 		);
 		const updatedWrapperProps = {
 			...wrapperProps,
-			className: mergedClassName || undefined,
+			className: mergedClassName,
 		};
 
 		return <BlockListBlock {...props} wrapperProps={updatedWrapperProps} />;

--- a/src/extensions/hover-effects/index.js
+++ b/src/extensions/hover-effects/index.js
@@ -1,0 +1,166 @@
+/**
+ * Hover Effects Extension
+ *
+ * Adds subtle CSS hover micro-interactions (lift, grow, tilt, etc.)
+ * to common container and interactive core blocks.
+ *
+ * @package
+ * @since 1.0.0
+ */
+
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { lazy, Suspense } from '@wordpress/element';
+import classnames from 'classnames';
+import { shouldExtendBlock } from '../../utils/should-extend-block';
+import { HOVER_EFFECTS, SUPPORTED_BLOCKS } from './constants';
+
+// Editor-only styles (frontend styles live in src/styles/style.scss)
+import './editor.scss';
+
+const HoverEffectsPanel = lazy(
+	() => import(/* webpackChunkName: "ext-hover-effects" */ './edit')
+);
+
+const VALID_EFFECTS = HOVER_EFFECTS.map((option) => option.value).filter(
+	Boolean
+);
+
+/**
+ * Build the class list for a given effect value.
+ *
+ * @param {string} effect Effect preset value.
+ * @return {string} Space-separated class list, or empty string.
+ */
+function getHoverEffectClasses(effect) {
+	if (!effect || !VALID_EFFECTS.includes(effect)) {
+		return '';
+	}
+	return `dsgo-hover-effect dsgo-hover-effect--${effect}`;
+}
+
+/**
+ * Register the dsgoHoverEffect attribute on supported blocks.
+ *
+ * @param {Object} settings Block settings.
+ * @param {string} name     Block name.
+ * @return {Object} Filtered block settings.
+ */
+function addHoverEffectAttribute(settings, name) {
+	if (!shouldExtendBlock(name)) {
+		return settings;
+	}
+
+	if (!SUPPORTED_BLOCKS.includes(name)) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		attributes: {
+			...settings.attributes,
+			dsgoHoverEffect: { type: 'string', default: '' },
+		},
+	};
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'designsetgo/hover-effects-attributes',
+	addHoverEffectAttribute
+);
+
+/**
+ * Append the Inspector panel to supported blocks (lazy-loaded).
+ */
+const withHoverEffectControls = createHigherOrderComponent((BlockEdit) => {
+	return (props) => {
+		if (!SUPPORTED_BLOCKS.includes(props.name)) {
+			return <BlockEdit {...props} />;
+		}
+
+		return (
+			<>
+				<BlockEdit {...props} />
+				<Suspense fallback={null}>
+					<HoverEffectsPanel {...props} />
+				</Suspense>
+			</>
+		);
+	};
+}, 'withHoverEffectControls');
+
+addFilter(
+	'editor.BlockEdit',
+	'designsetgo/hover-effects-controls',
+	withHoverEffectControls
+);
+
+/**
+ * Add hover effect classes to the editor block wrapper for live preview.
+ */
+const withHoverEffectClass = createHigherOrderComponent((BlockListBlock) => {
+	return (props) => {
+		const { name, attributes, className, wrapperProps = {} } = props;
+
+		if (!SUPPORTED_BLOCKS.includes(name)) {
+			return <BlockListBlock {...props} />;
+		}
+
+		const effectClasses = getHoverEffectClasses(
+			attributes?.dsgoHoverEffect
+		);
+		if (!effectClasses) {
+			return <BlockListBlock {...props} />;
+		}
+
+		const mergedClassName = classnames(
+			className,
+			wrapperProps.className,
+			effectClasses
+		);
+		const updatedWrapperProps = {
+			...wrapperProps,
+			className: mergedClassName || undefined,
+		};
+
+		return <BlockListBlock {...props} wrapperProps={updatedWrapperProps} />;
+	};
+}, 'withHoverEffectClass');
+
+addFilter(
+	'editor.BlockListBlock',
+	'designsetgo/hover-effects-class',
+	withHoverEffectClass
+);
+
+/**
+ * Write hover effect classes into the saved markup so the effect
+ * applies on the frontend.
+ *
+ * @param {Object} extraProps Save props.
+ * @param {Object} blockType  Block type.
+ * @param {Object} attributes Block attributes.
+ * @return {Object} Filtered save props.
+ */
+function addHoverEffectSaveProps(extraProps, blockType, attributes) {
+	if (!SUPPORTED_BLOCKS.includes(blockType.name)) {
+		return extraProps;
+	}
+
+	const effectClasses = getHoverEffectClasses(attributes?.dsgoHoverEffect);
+	if (!effectClasses) {
+		return extraProps;
+	}
+
+	return {
+		...extraProps,
+		className: classnames(extraProps.className, effectClasses),
+	};
+}
+
+addFilter(
+	'blocks.getSaveContent.extraProps',
+	'designsetgo/hover-effects-save-props',
+	addHoverEffectSaveProps
+);

--- a/src/extensions/hover-effects/styles.scss
+++ b/src/extensions/hover-effects/styles.scss
@@ -9,6 +9,11 @@
 
 @use 'tokens' as *;
 
+// Base rules: apply transforms, shadows and transitions to whichever
+// element carries the effect class. For most supported blocks (Group,
+// Cover, Columns, etc.) this IS the visible rounded surface. For button
+// and image — whose visible surface is a child — we cancel these on the
+// outer wrapper further down and reapply on the child.
 .dsgo-hover-effect {
 	transition:
 		transform $dsgo-hover-duration $dsgo-hover-easing,
@@ -54,6 +59,138 @@
 	}
 }
 
+// Button: the outer `.wp-block-button` is a transparent layout wrapper;
+// the rounded, background-bearing surface is `.wp-block-button__link`
+// (the <a>). Painting transform/shadow on the wrapper produces a
+// rectangular halo that does not follow the link's border-radius.
+// Cancel on the wrapper and reapply on the link.
+.wp-block-button.dsgo-hover-effect {
+	transition: none;
+	will-change: auto;
+
+	&:hover {
+		transform: none;
+		box-shadow: none;
+		filter: none;
+	}
+
+	> .wp-block-button__link {
+		transition:
+			transform $dsgo-hover-duration $dsgo-hover-easing,
+			box-shadow $dsgo-hover-duration $dsgo-hover-easing,
+			filter $dsgo-hover-duration $dsgo-hover-easing;
+	}
+
+	&--lift > .wp-block-button__link,
+	&--sink > .wp-block-button__link,
+	&--grow > .wp-block-button__link,
+	&--shrink > .wp-block-button__link,
+	&--tilt > .wp-block-button__link {
+		will-change: transform;
+	}
+
+	&--glow > .wp-block-button__link {
+		will-change: filter;
+	}
+
+	&--lift:hover > .wp-block-button__link {
+		transform: translateY(-4px);
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+	}
+
+	&--sink:hover > .wp-block-button__link {
+		transform: translateY(4px);
+	}
+
+	&--grow:hover > .wp-block-button__link {
+		transform: scale(1.03);
+	}
+
+	&--shrink:hover > .wp-block-button__link {
+		transform: scale(0.97);
+	}
+
+	&--tilt:hover > .wp-block-button__link {
+		transform: rotate(-1deg) scale(1.01);
+	}
+
+	&--glow:hover > .wp-block-button__link {
+		box-shadow: 0 0 24px rgba(0, 0, 0, 0.15);
+		filter: brightness(1.05);
+	}
+}
+
+// Image: the outer `<figure>` may be larger than the `<img>` and the
+// block-support border-radius applies to the img. Same retarget pattern.
+.wp-block-image.dsgo-hover-effect {
+	transition: none;
+	will-change: auto;
+
+	&:hover {
+		transform: none;
+		box-shadow: none;
+		filter: none;
+	}
+
+	> img,
+	> a > img {
+		transition:
+			transform $dsgo-hover-duration $dsgo-hover-easing,
+			box-shadow $dsgo-hover-duration $dsgo-hover-easing,
+			filter $dsgo-hover-duration $dsgo-hover-easing;
+	}
+
+	&--lift > img,
+	&--lift > a > img,
+	&--sink > img,
+	&--sink > a > img,
+	&--grow > img,
+	&--grow > a > img,
+	&--shrink > img,
+	&--shrink > a > img,
+	&--tilt > img,
+	&--tilt > a > img {
+		will-change: transform;
+	}
+
+	&--glow > img,
+	&--glow > a > img {
+		will-change: filter;
+	}
+
+	&--lift:hover > img,
+	&--lift:hover > a > img {
+		transform: translateY(-4px);
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+	}
+
+	&--sink:hover > img,
+	&--sink:hover > a > img {
+		transform: translateY(4px);
+	}
+
+	&--grow:hover > img,
+	&--grow:hover > a > img {
+		transform: scale(1.03);
+	}
+
+	&--shrink:hover > img,
+	&--shrink:hover > a > img {
+		transform: scale(0.97);
+	}
+
+	&--tilt:hover > img,
+	&--tilt:hover > a > img {
+		transform: rotate(-1deg) scale(1.01);
+	}
+
+	&--glow:hover > img,
+	&--glow:hover > a > img {
+		box-shadow: 0 0 24px rgba(0, 0, 0, 0.15);
+		filter: brightness(1.05);
+	}
+}
+
 @media (prefers-reduced-motion: reduce) {
 
 	.dsgo-hover-effect {
@@ -64,5 +201,27 @@
 			box-shadow: none;
 			filter: none;
 		}
+	}
+
+	.wp-block-button.dsgo-hover-effect > .wp-block-button__link {
+		transition: none;
+	}
+
+	.wp-block-button.dsgo-hover-effect:hover > .wp-block-button__link {
+		transform: none;
+		box-shadow: none;
+		filter: none;
+	}
+
+	.wp-block-image.dsgo-hover-effect > img,
+	.wp-block-image.dsgo-hover-effect > a > img {
+		transition: none;
+	}
+
+	.wp-block-image.dsgo-hover-effect:hover > img,
+	.wp-block-image.dsgo-hover-effect:hover > a > img {
+		transform: none;
+		box-shadow: none;
+		filter: none;
 	}
 }

--- a/src/extensions/hover-effects/styles.scss
+++ b/src/extensions/hover-effects/styles.scss
@@ -7,15 +7,25 @@
  * @package
  */
 
-$dsgo-hover-duration: 300ms;
-$dsgo-hover-easing: ease-out;
+@use 'tokens' as *;
 
 .dsgo-hover-effect {
 	transition:
 		transform $dsgo-hover-duration $dsgo-hover-easing,
 		box-shadow $dsgo-hover-duration $dsgo-hover-easing,
 		filter $dsgo-hover-duration $dsgo-hover-easing;
-	will-change: transform;
+
+	&--lift,
+	&--sink,
+	&--grow,
+	&--shrink,
+	&--tilt {
+		will-change: transform;
+	}
+
+	&--glow {
+		will-change: filter;
+	}
 
 	&--lift:hover {
 		transform: translateY(-4px);

--- a/src/extensions/hover-effects/styles.scss
+++ b/src/extensions/hover-effects/styles.scss
@@ -1,0 +1,58 @@
+/**
+ * Hover Effects Extension - Frontend Styles
+ *
+ * Pure-CSS hover micro-interactions applied via
+ * `.dsgo-hover-effect.dsgo-hover-effect--{effect}`.
+ *
+ * @package
+ */
+
+$dsgo-hover-duration: 300ms;
+$dsgo-hover-easing: ease-out;
+
+.dsgo-hover-effect {
+	transition:
+		transform $dsgo-hover-duration $dsgo-hover-easing,
+		box-shadow $dsgo-hover-duration $dsgo-hover-easing,
+		filter $dsgo-hover-duration $dsgo-hover-easing;
+	will-change: transform;
+
+	&--lift:hover {
+		transform: translateY(-4px);
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+	}
+
+	&--sink:hover {
+		transform: translateY(4px);
+	}
+
+	&--grow:hover {
+		transform: scale(1.03);
+	}
+
+	&--shrink:hover {
+		transform: scale(0.97);
+	}
+
+	&--tilt:hover {
+		transform: rotate(-1deg) scale(1.01);
+	}
+
+	&--glow:hover {
+		box-shadow: 0 0 24px rgba(0, 0, 0, 0.15);
+		filter: brightness(1.05);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+	.dsgo-hover-effect {
+		transition: none;
+
+		&:hover {
+			transform: none;
+			box-shadow: none;
+			filter: none;
+		}
+	}
+}

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,9 @@ import './extensions/vertical-scroll-parallax';
 // Draft Mode - adds "draft mode" functionality for published pages
 import './extensions/draft-mode';
 
+// Hover Effects - adds subtle hover micro-interactions to common core blocks
+import './extensions/hover-effects';
+
 // ===== RICH TEXT FORMATS =====
 // Text Style - adds inline text styling (color, gradient, size) to selected text
 import './formats/text-style';

--- a/src/style.scss
+++ b/src/style.scss
@@ -22,6 +22,7 @@
 @use './extensions/grid-mobile-order/style' as grid-mobile-order;
 @use './extensions/reveal-control/styles' as reveal-control;
 @use './extensions/clickable-group/styles' as clickable-group;
+@use './extensions/hover-effects/styles' as hover-effects;
 @use './extensions/text-reveal/style' as text-reveal;
 @use './extensions/expanding-background/style' as expanding-background;
 @use './extensions/svg-patterns/style' as svg-patterns;


### PR DESCRIPTION
## Summary
- New `hover-effects` extension adds subtle CSS hover micro-interactions (Lift, Sink, Grow, Shrink, Tilt, Glow) to common container/interactive core blocks.
- Pure-CSS implementation with `prefers-reduced-motion` support; no frontend JS.
- Effects preview live inside the editor canvas.

## Details
- Scope: `core/group`, `core/cover`, `core/column`, `core/columns`, `core/image`, `core/button`, `core/buttons`, `core/media-text`, `core/post-template`, `core/query`.
- Adds a single `dsgoHoverEffect` string attribute (default `''`); writes `dsgo-hover-effect dsgo-hover-effect--{value}` classes via `editor.BlockListBlock` (editor) and `blocks.getSaveContent.extraProps` (saved markup).
- Inspector panel is lazy-loaded (`ext-hover-effects` chunk) to keep the main editor bundle lean.
- Preset-only UI — a single `SelectControl` with 6 effects plus None.

## Test plan
- [ ] `npm run build` succeeds and emits `build/ext-hover-effects.js`.
- [ ] In the block editor, add a Group/Cover/Image/Button and confirm the "Hover Effect" panel appears in the Inspector.
- [ ] Pick each effect and confirm the block animates when hovered in the canvas.
- [ ] Save and view on the frontend — hover plays the same effect.
- [ ] With `prefers-reduced-motion: reduce` set in the OS, confirm effects are suppressed.
- [ ] Unsupported blocks (e.g., Paragraph, Heading) do not show the panel.

https://claude.ai/code/session_019L1Dg6RmRRNuKYmVTspuqm