### PR TITLE
feat(query): Dynamic Query v2.3 — nested loops, relationships, visibility, group-by

### DIFF
--- a/.claude/claude.md
+++ b/.claude/claude.md
@@ -65,6 +65,16 @@ For sibling blocks that already exist and meet the "1–3 attribute difference +
 - Editor live preview: Posts via `useEntityRecords`, users/terms via `/designsetgo/v1/query/preview` REST route. First item wraps editable `InnerBlocks`; items 2..N render `BlockPreview`.
 - Admin dashboard: Settings → DesignSetGo → Dynamic Query (requires `manage_options`).
 
+### Query block family (Dynamic Query v2.3)
+
+- Relationship source (`source: 'relationship'`) reads `relationshipField` from the nearest parent-stack item and iterates referenced post IDs via `post__in`.
+- `relationshipFallback`: `'empty'` | `'all'` | `'parent'` controls behavior when the field yields zero IDs.
+- DSGo bindings (`designsetgo/post-meta`, `designsetgo/acf`) accept a `scope` arg: `'self'` (default), `'parent'`, `'root'`. Reads from `$GLOBALS['designsetgo_parent_stack']` pushed by `designsetgo_query_render_item()`.
+- Every block has a `dsgoVisibility` attribute (registered via `blocks.registerBlockType` filter in `src/extensions/visibility/filters.js`). Rule shape: `{ operator: 'AND'|'OR', rules: [{ type: 'meta'|'taxonomy'|'index'|'auth', op, key?, value }] }`. Server evaluator: `DesignSetGo\BlockVisibility::matches()`. Editor mirror: `src/extensions/visibility/evaluateRules.js`.
+- New sibling block `designsetgo/query-group-header` renders once per group inside a parent Query when `groupBy` is set.
+- `groupBy` attribute on the Query block — shape `{ field: 'taxonomy'|'meta'|'date', key: string }`. Server partitions items in `designsetgo_query_partition_items()` (in `render-helpers.php`).
+- Custom visibility rule types via `designsetgo_visibility_rule` filter (`($match, $rule, $context)` → bool|null).
+
 ### Inspector IA (Theme 3)
 
 Three panels per block, in this order: **Settings** → **Style** → **Advanced**. Use `<DsgoInspectorPanel>` (the `ToolsPanel` wrapper) for all custom inspector controls; never reach for `PanelBody` directly.

--- a/.claude/docs/QUERY-BLOCK-GUIDE.md
+++ b/.claude/docs/QUERY-BLOCK-GUIDE.md
@@ -356,6 +356,216 @@ The endpoint calls `designsetgo_query_render()` — the same function used by th
 
 ---
 
+## v2.3 Recipes
+
+### Recipe — show posts linked via an ACF/Meta relationship field
+
+An outer post stores an ACF relationship field (`related_posts`) containing an array of post IDs. Configure the Query block to iterate exactly those posts:
+
+1. Query block → Settings → **Source**: Relationship.
+2. **Relationship field**: `related_posts` (the ACF or postmeta key that stores the IDs array).
+3. **Fallback when field is empty**: choose `Render no items` (or `all` / `parent` depending on your intent).
+
+The server renderer reads the nearest parent-stack item's `related_posts` meta value, passes the IDs through `post__in`, and falls back according to `relationshipFallback`.
+
+```html
+<!-- wp:designsetgo/query {
+    "queryId":"related-products",
+    "source":"relationship",
+    "relationshipField":"related_posts",
+    "relationshipFallback":"empty"
+} -->
+<ul class="wp-block-designsetgo-query">
+
+    <!-- wp:core/post-title {"level":3} /-->
+    <!-- wp:core/post-featured-image /-->
+
+</ul>
+<!-- /wp:designsetgo/query -->
+```
+
+---
+
+### Recipe — hide a "Featured" badge on non-featured posts
+
+Use the Visibility panel on any inner block to show it only when a meta condition is met. No custom PHP required.
+
+1. Select the inner block you want to conditionally show (e.g. a Heading that says "Featured").
+2. Open **Block Settings** → **Visibility** panel.
+3. Add a rule: **Type** = Meta, **Key** = `featured`, **Op** = equals, **Value** = `1`.
+4. Leave operator at `AND` (default).
+
+The `dsgoVisibility` attribute is registered on every block via the `blocks.registerBlockType` filter in `src/extensions/visibility/filters.js`. The server evaluator is `DesignSetGo\BlockVisibility::matches()`.
+
+```html
+<!-- wp:heading {
+    "level":3,
+    "dsgoVisibility":{
+        "operator":"AND",
+        "rules":[{"type":"meta","op":"equals","key":"featured","value":"1"}]
+    }
+} -->
+<h3 class="wp-block-heading">Featured</h3>
+<!-- /wp:heading -->
+```
+
+---
+
+### Recipe — group posts by category with custom group headers
+
+1. Query block → Settings → **Group by**: Taxonomy, **Group taxonomy**: `category`.
+2. Inside the Query block, insert a **Query Group Header** block (`designsetgo/query-group-header`). It renders once per group, before that group's items.
+3. Inside the Group Header, add a Heading and bind its content to the group context key `designsetgo/groupLabel` (the term name) or `designsetgo/groupCount` (item count).
+
+```html
+<!-- wp:designsetgo/query {
+    "queryId":"by-category",
+    "source":"posts",
+    "groupBy":{"field":"taxonomy","key":"category"}
+} -->
+<ul class="wp-block-designsetgo-query">
+
+    <!-- wp:designsetgo/query-group-header -->
+    <div class="wp-block-designsetgo-query-group-header">
+        <!-- wp:heading {"level":2,"metadata":{"bindings":{"content":{"source":"designsetgo/post-meta","args":{"key":"designsetgo/groupLabel","scope":"self"}}}}} -->
+        <h2></h2>
+        <!-- /wp:heading -->
+    </div>
+    <!-- /wp:designsetgo/query-group-header -->
+
+    <!-- wp:core/post-title {"level":3} /-->
+
+</ul>
+<!-- /wp:designsetgo/query -->
+```
+
+Server partitioning logic lives in `designsetgo_query_partition_items()` inside `render-helpers.php`.
+
+---
+
+### Recipe — nested loops: for each post, show its 3 latest sibling posts
+
+Outer Query iterates a post list; the inner Query, placed inside the item template, fetches that post's category siblings.
+
+1. Outer Query: source = Posts, any post type.
+2. Inside the item template, insert an inner Query block: source = Posts, `perPage = 3`, give it a unique `queryId` (e.g. `siblings`).
+3. Use the scoped filter to restrict the inner query to the outer post's primary category. The outer post's context is available via `$GLOBALS['designsetgo_parent_stack']` during any `render_block` hook that fires inside a query item.
+
+```php
+add_filter( 'designsetgo/query/siblings/args', function ( $args, $atts, $context ) {
+    // $GLOBALS['designsetgo_parent_stack'] is an ordered list (outermost first).
+    $stack   = $GLOBALS['designsetgo_parent_stack'] ?? array();
+    $parent  = end( $stack ); // nearest ancestor item
+    if ( empty( $parent['postId'] ) ) {
+        return $args;
+    }
+
+    $cats = wp_get_post_categories( $parent['postId'], array( 'fields' => 'ids' ) );
+    if ( $cats ) {
+        $args['tax_query'] = array(
+            array(
+                'taxonomy' => 'category',
+                'field'    => 'term_id',
+                'terms'    => $cats,
+            ),
+        );
+    }
+    $args['post__not_in'] = array( $parent['postId'] ); // exclude the parent post itself
+    return $args;
+}, 10, 3 );
+```
+
+You can also read the parent context via bindings using `scope: 'parent'`:
+
+```html
+<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"designsetgo/post-meta","args":{"key":"subtitle","scope":"parent"}}}}} -->
+<p></p>
+<!-- /wp:paragraph -->
+```
+
+---
+
+## v2.3 Extension points
+
+### `scope` arg on binding sources
+
+Both `designsetgo/post-meta` and `designsetgo/acf` accept a `scope` arg that controls which item in the parent stack is read:
+
+| `scope` value | Reads from |
+|---|---|
+| `'self'` (default) | Current item |
+| `'parent'` | Nearest enclosing query item (one level up) |
+| `'root'` | Outermost item in the stack |
+
+The stack itself is `$GLOBALS['designsetgo_parent_stack']` — an ordered list of item contexts pushed by `designsetgo_query_render_item()` in `render-helpers.php`.
+
+```html
+<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"designsetgo/post-meta","args":{"key":"company_name","scope":"parent"}}}}} -->
+<p></p>
+<!-- /wp:paragraph -->
+```
+
+### `designsetgo_visibility_rule` filter
+
+Register custom visibility rule types in PHP. Return `true` to show the block, `false` to hide it, or `null` to fall through to the next rule handler.
+
+```php
+/**
+ * @param bool|null $match   Current match result (null = not yet determined).
+ * @param array     $rule    Rule definition from the dsgoVisibility attribute.
+ * @param array     $context Render context: postId, postType, currentItemId, etc.
+ * @return bool|null
+ */
+add_filter( 'designsetgo_visibility_rule', function ( $match, $rule, $context ) {
+    if ( $rule['type'] !== 'my_custom_type' ) {
+        return $match; // pass through
+    }
+    // Example: show only to admins
+    return current_user_can( 'manage_options' );
+}, 10, 3 );
+```
+
+Built-in rule types (`meta`, `taxonomy`, `index`, `auth`) are evaluated in `DesignSetGo\BlockVisibility::matches()`. Custom types hook in after the built-ins.
+
+### `groupBy` attribute shape
+
+```json
+{
+    "field": "taxonomy",
+    "key": "category"
+}
+```
+
+| `field` | `key` meaning |
+|---|---|
+| `"taxonomy"` | Taxonomy slug (e.g. `"category"`, `"genre"`) |
+| `"meta"` | Postmeta key whose value is used as the group identifier |
+| `"date"` | Date part: `"year"`, `"month"`, `"year-month"` |
+
+Group context keys injected into the `designsetgo/query-group-header` inner blocks:
+
+| Key | Value |
+|---|---|
+| `designsetgo/groupLabel` | Human-readable group name (term name, meta value, or formatted date) |
+| `designsetgo/groupKey` | Raw group identifier (term slug, meta value, or ISO date fragment) |
+| `designsetgo/groupCount` | Number of items in this group |
+
+### `$GLOBALS['designsetgo_parent_stack']`
+
+An ordered list (outermost first) of item-context arrays. Each entry mirrors the per-item context shape:
+
+```php
+[
+    'postId'   => 42,
+    'postType' => 'post',
+    // users/terms: 'currentItemId', 'currentItemType'
+]
+```
+
+The stack is pushed before each item is rendered and popped after. It is safe to read during any `render_block` or `designsetgo_query_args` hook that fires inside a query item. The scoped filter hook name `designsetgo/query/{queryId}/args` fires with the stack already populated, so the nearest ancestor is always available.
+
+---
+
 ## Known v1 limits
 
 | Limit | Notes |

--- a/.claude/docs/QUERY-BLOCK-GUIDE.md
+++ b/.claude/docs/QUERY-BLOCK-GUIDE.md
@@ -549,6 +549,17 @@ Group context keys injected into the `designsetgo/query-group-header` inner bloc
 | `designsetgo/groupLabel` | Human-readable group name (term name, meta value, or formatted date) |
 | `designsetgo/groupValue` | Raw group identifier (term slug, meta value, or ISO date fragment) |
 
+Per-item context keys available inside each item in a grouped query (in addition to the standard `postId`, `postType`, `designsetgo/itemIndex` keys):
+
+| Key | Value |
+|---|---|
+| `designsetgo/itemIndex` | Flat, zero-based position across all groups (consistent with non-grouped queries) |
+| `designsetgo/groupItemIndex` | Zero-based position within the current group (resets to 0 for each new group) |
+
+Use `designsetgo/groupItemIndex` in custom Block Bindings or `wp:if` conditions when you want to target the first item in each group (e.g. a featured card), independent of that group's absolute position in the result set.
+
+> **Note:** A `type: 'groupItemIndex'` visibility rule is not yet implemented in the built-in UI. Use Block Bindings or a custom `designsetgo_visibility_rule` filter for now. The UI rule type is planned for a future release.
+
 > **Note:** `designsetgo/groupKey` and `designsetgo/groupCount` are **not** provided by the server renderer. Do not bind to these keys — bindings will resolve to empty. A `groupCount` context key may be added in a future release once counting is integrated into the partition step.
 
 ### `$GLOBALS['designsetgo_parent_stack']`

--- a/.claude/docs/QUERY-BLOCK-GUIDE.md
+++ b/.claude/docs/QUERY-BLOCK-GUIDE.md
@@ -415,7 +415,7 @@ The `dsgoVisibility` attribute is registered on every block via the `blocks.regi
 
 1. Query block → Settings → **Group by**: Taxonomy, **Group taxonomy**: `category`.
 2. Inside the Query block, insert a **Query Group Header** block (`designsetgo/query-group-header`). It renders once per group, before that group's items.
-3. Inside the Group Header, add a Heading and bind its content to the group context key `designsetgo/groupLabel` (the term name) or `designsetgo/groupCount` (item count).
+3. Inside the Group Header, add a Heading and bind its content to the group context key `designsetgo/groupLabel` (the term name) or `designsetgo/groupValue` (the raw group identifier, e.g. the term slug).
 
 ```html
 <!-- wp:designsetgo/query {
@@ -547,8 +547,9 @@ Group context keys injected into the `designsetgo/query-group-header` inner bloc
 | Key | Value |
 |---|---|
 | `designsetgo/groupLabel` | Human-readable group name (term name, meta value, or formatted date) |
-| `designsetgo/groupKey` | Raw group identifier (term slug, meta value, or ISO date fragment) |
-| `designsetgo/groupCount` | Number of items in this group |
+| `designsetgo/groupValue` | Raw group identifier (term slug, meta value, or ISO date fragment) |
+
+> **Note:** `designsetgo/groupKey` and `designsetgo/groupCount` are **not** provided by the server renderer. Do not bind to these keys — bindings will resolve to empty. A `groupCount` context key may be added in a future release once counting is integrated into the partition step.
 
 ### `$GLOBALS['designsetgo_parent_stack']`
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
         run: |
           echo "Waiting for WordPress..."
           for i in $(seq 1 30); do
-            if curl -s -o /dev/null -w '%{http_code}' http://localhost:9449/wp-login.php | grep -q '200'; then
+            if curl -s -o /dev/null -w '%{http_code}' http://localhost:9451/wp-login.php | grep -q '200'; then
               echo "WordPress is ready (attempt $i)"
               break
             fi

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,38 +1,30 @@
 {
-	"core": "WordPress/WordPress#6.9",
-	"phpVersion": "8.3",
-	"plugins": [
-		"."
-	],
-	"themes": [
-		"https://downloads.wordpress.org/theme/twentytwentyfour.1.3.zip",
-		"https://downloads.wordpress.org/theme/twentytwentyfive.1.4.zip"
-	],
-	"mappings": {},
-	"env": {
-		"development": {
-			"themes": [
-				"https://downloads.wordpress.org/theme/twentytwentyfour.1.3.zip",
-				"https://downloads.wordpress.org/theme/twentytwentyfive.1.4.zip"
-			]
-		},
-		"tests": {
-			"core": "WordPress/WordPress#6.8",
-			"themes": [
-				"https://downloads.wordpress.org/theme/twentytwentyfour.1.3.zip",
-				"https://downloads.wordpress.org/theme/twentytwentyfive.1.4.zip"
-			]
-		}
-	},
-	"lifecycleScripts": {
-		"afterStart": "npx wp-env run cli wp theme activate twentytwentyfive"
-	},
-	"port": 9449,
-	"testsPort": 9450,
-	"config": {
-		"WP_DEBUG": true,
-		"WP_DEBUG_LOG": true,
-		"WP_DEBUG_DISPLAY": false,
-		"SCRIPT_DEBUG": true
-	}
+  "core": "WordPress/WordPress#6.9",
+  "phpVersion": "8.3",
+  "plugins": [
+    "."
+  ],
+  "themes": [
+    "https://downloads.wordpress.org/theme/twentytwentyfour.1.3.zip",
+    "https://downloads.wordpress.org/theme/twentytwentyfive.1.4.zip"
+  ],
+  "mappings": {},
+  "env": {
+    "development": {
+      "themes": [
+        "https://downloads.wordpress.org/theme/twentytwentyfour.1.3.zip",
+        "https://downloads.wordpress.org/theme/twentytwentyfive.1.4.zip"
+      ]
+    }
+  },
+  "lifecycleScripts": {
+    "afterStart": "npx wp-env run cli wp theme activate twentytwentyfive"
+  },
+  "port": 9451,
+  "config": {
+    "WP_DEBUG": true,
+    "WP_DEBUG_LOG": true,
+    "WP_DEBUG_DISPLAY": false,
+    "SCRIPT_DEBUG": true
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New Blocks
 - **Fifty Fifty** - Full-width 50/50 split layout with edge-to-edge media on one side and constrained content on the other — includes media position toggle (left/right), focal point picker, configurable min height, content vertical alignment, and mobile-responsive stacking
 
+## [2.3.0] - 2026-04-19
+
+### Added
+- **Dynamic Query — Relationship source** - New `source: 'relationship'` on the Dynamic Query block reads a parent-context field (meta or ACF relationship) and iterates the referenced posts via `post__in`; configurable fallback when no IDs are resolved (render nothing, all posts, or the parent item)
+- **Dynamic Query — Nested loops with parent context** - Outer Query's current item now flows into inner Queries via the `designsetgo/parentItem` block context; DSGo bindings (`designsetgo/post-meta`, `designsetgo/acf`) accept a new optional `scope` arg of `'self'` (default), `'parent'`, or `'root'` — reading from a parent-stack maintained by `designsetgo_query_render_item()`
+- **Dynamic Query — Conditional inner-block visibility** - Every block now carries a `dsgoVisibility` attribute with an inspector panel under Advanced → Visibility. Rule types: meta / taxonomy / index / auth, combined with AND/OR relations and ops (`equals`, `not_equals`, `contains`, `gt`, `lt`, `empty`, `not_empty`, `has`, `not_has`). Editor previews mirror server-side evaluation so authors see what will ship
+- **Dynamic Query — Group-by partitioning** - New `groupBy` attribute on the Query block partitions iterated items by taxonomy / meta / date (with year / year-month / year-month-day precision). New sibling block `designsetgo/query-group-header` renders once per group inside a `<section class="dsgo-query-group">` wrapper
+
+### Changed
+- `designsetgo/post-meta` and `designsetgo/acf` binding sources accept an optional `scope` arg — defaults to `'self'`; existing bindings unchanged
+
+### Extension points
+- `designsetgo_visibility_rule` filter — add custom rule types by returning a bool from `($match, $rule, $context) → bool|null`
+- `$GLOBALS['designsetgo_parent_stack']` — ordered list of `{ postId, postType }` contexts available during any `render_block` hook fired inside a query item
+- `designsetgo_query_partition_items( $post_ids, $group_spec )` — public PHP helper for custom group-by integrations
+
+### Migration
+No breaking changes. All new attributes default to `null` / `'self'`; existing block markup renders identically.
+
 ## [2.0.0] - 2026-02-08
 
 ### New Blocks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New Blocks
 - **Fifty Fifty** - Full-width 50/50 split layout with edge-to-edge media on one side and constrained content on the other — includes media position toggle (left/right), focal point picker, configurable min height, content vertical alignment, and mobile-responsive stacking
-
-## [2.3.0] - 2026-04-19
+- **Query Group Header** - Sibling block for the Dynamic Query that renders once per group when group-by is enabled; hosts an InnerBlocks area for a heading or any custom content, and receives `designsetgo/groupLabel` + `designsetgo/groupValue` context so bindings can display the current group's name
 
 ### Added
-- **Dynamic Query — Relationship source** - New `source: 'relationship'` on the Dynamic Query block reads a parent-context field (meta or ACF relationship) and iterates the referenced posts via `post__in`; configurable fallback when no IDs are resolved (render nothing, all posts, or the parent item)
-- **Dynamic Query — Nested loops with parent context** - Outer Query's current item now flows into inner Queries via the `designsetgo/parentItem` block context; DSGo bindings (`designsetgo/post-meta`, `designsetgo/acf`) accept a new optional `scope` arg of `'self'` (default), `'parent'`, or `'root'` — reading from a parent-stack maintained by `designsetgo_query_render_item()`
-- **Dynamic Query — Conditional inner-block visibility** - Every block now carries a `dsgoVisibility` attribute with an inspector panel under Advanced → Visibility. Rule types: meta / taxonomy / index / auth, combined with AND/OR relations and ops (`equals`, `not_equals`, `contains`, `gt`, `lt`, `empty`, `not_empty`, `has`, `not_has`). Editor previews mirror server-side evaluation so authors see what will ship
-- **Dynamic Query — Group-by partitioning** - New `groupBy` attribute on the Query block partitions iterated items by taxonomy / meta / date (with year / year-month / year-month-day precision). New sibling block `designsetgo/query-group-header` renders once per group inside a `<section class="dsgo-query-group">` wrapper
+- **Dynamic Query — Relationship source** - New `source: 'relationship'` reads a parent-context field (meta or ACF relationship) and iterates the referenced posts via `post__in`; configurable fallback when no IDs are resolved (render nothing, all posts, or the parent item)
+- **Dynamic Query — Nested loops with parent context** - Outer Query's current item flows into inner Queries via the `designsetgo/parentItem` block context; DSGo bindings (`designsetgo/post-meta`, `designsetgo/acf`) accept a new optional `scope` arg of `'self'` (default), `'parent'`, or `'root'` — reading from a parent-stack maintained by `designsetgo_query_render_item()`
+- **Conditional inner-block visibility** - Every block now carries a `dsgoVisibility` attribute with an inspector panel under Advanced → Visibility. Rule types: meta / taxonomy / index / auth, combined with AND/OR relations and ops (`equals`, `not_equals`, `contains`, `gt`, `lt`, `empty`, `not_empty`, `has`, `not_has`). Editor previews mirror server-side evaluation so authors see what will ship
+- **Dynamic Query — Group-by partitioning** - New `groupBy` attribute on the Query block partitions iterated items by taxonomy / meta / date (with year / year-month / year-month-day precision); server wraps each group in `<section class="dsgo-query-group">` and renders the new Query Group Header block once per group
 
 ### Changed
 - `designsetgo/post-meta` and `designsetgo/acf` binding sources accept an optional `scope` arg — defaults to `'self'`; existing bindings unchanged
@@ -46,9 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `designsetgo_visibility_rule` filter — add custom rule types by returning a bool from `($match, $rule, $context) → bool|null`
 - `$GLOBALS['designsetgo_parent_stack']` — ordered list of `{ postId, postType }` contexts available during any `render_block` hook fired inside a query item
 - `designsetgo_query_partition_items( $post_ids, $group_spec )` — public PHP helper for custom group-by integrations
-
-### Migration
-No breaking changes. All new attributes default to `null` / `'self'`; existing block markup renders identically.
 
 ## [2.0.0] - 2026-02-08
 

--- a/designsetgo.php
+++ b/designsetgo.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DesignSetGo
  * Plugin URI:        https://designsetgoblocks.com
  * Description:       Professional Gutenberg block library with 52 blocks and 16 powerful extensions - complete Form Builder, container system, interactive elements, maps, modals, breadcrumbs, timelines, scroll effects, and animations. Built with WordPress standards for guaranteed editor/frontend parity.
- * Version:           2.2.0
+ * Version:           2.3.0
  * Requires at least: 6.7
  * Requires PHP:      8.0
  * Author:            DesignSetGo
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'DESIGNSETGO_VERSION', '2.2.0' );
+define( 'DESIGNSETGO_VERSION', '2.3.0' );
 define( 'DESIGNSETGO_FILE', __FILE__ );
 define( 'DESIGNSETGO_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DESIGNSETGO_URL', plugin_dir_url( __FILE__ ) );

--- a/designsetgo.php
+++ b/designsetgo.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DesignSetGo
  * Plugin URI:        https://designsetgoblocks.com
  * Description:       Professional Gutenberg block library with 52 blocks and 16 powerful extensions - complete Form Builder, container system, interactive elements, maps, modals, breadcrumbs, timelines, scroll effects, and animations. Built with WordPress standards for guaranteed editor/frontend parity.
- * Version:           2.3.0
+ * Version:           2.1.0
  * Requires at least: 6.7
  * Requires PHP:      8.0
  * Author:            DesignSetGo
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'DESIGNSETGO_VERSION', '2.3.0' );
+define( 'DESIGNSETGO_VERSION', '2.1.0' );
 define( 'DESIGNSETGO_FILE', __FILE__ );
 define( 'DESIGNSETGO_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DESIGNSETGO_URL', plugin_dir_url( __FILE__ ) );

--- a/docs/plans/2026-04-19-dynamic-query-v2.3-nested.md
+++ b/docs/plans/2026-04-19-dynamic-query-v2.3-nested.md
@@ -1,0 +1,1900 @@
+# Dynamic Query v2.3 — "Rival Bricks" Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (or superpowers:subagent-driven-development if staying in this session) to implement this plan task-by-task.
+
+**Goal:** Ship four headline Dynamic Query features — nested loops with parent context, relationship-field source, conditional inner-block visibility, and group-by partitioning — closing the feature gap with Bricks, Elementor Pro, and JetEngine.
+
+**Architecture:**
+- **Parent-scoped bindings** — extend `designsetgo/post-meta` + `designsetgo/acf` with an optional `scope` arg (`self` | `parent` | `root`) resolved from a stack pushed by each outer Query's render loop. No new binding sources; no token parser.
+- **Relationship source** — new `source: 'relationship'` that reads a parent-context post ID + field name, resolves to `post__in` + `orderby=post__in`. Parent context is a hard requirement; fails gracefully when absent.
+- **Conditional visibility** — shared filter attribute `dsgoVisibility` (rules object) registered via `blocks.registerBlockType`. Server-side evaluator in the render helpers short-circuits inner blocks that don't match. Editor mirrors server logic for accurate previews.
+- **Group-by** — optional `groupBy` attribute on Query block; render-helpers partition iterated items into buckets and render a user-defined `query-group-header` inner block once per group. Header block is a new sibling in the query family.
+
+**Tech Stack:**
+- WordPress 6.5+ Block Bindings API (parent/root scope plumbing).
+- PHP 8.0+ with the `WP_Block` + `render_block` pipeline.
+- `@wordpress/block-editor` context providers (`BlockContextProvider`) for editor-side nested loop previews.
+- IAPI store `designsetgo/query` (existing) — no new frontend JS actions; nested loops inherit pagination/filter behavior per queryId.
+
+---
+
+## Pre-flight
+
+- Branch is already created: `claude/query-v2.3-nested`, based on `origin/main`.
+- Worktree: `.worktrees/query-v2.3-nested/`.
+- Local dev port: `9451` (`.wp-env.json` already updated, no tests env).
+- Before starting, run once in the worktree:
+
+```bash
+npm ci
+composer install
+npx wp-env start
+npx wp-env run cli wp theme activate twentytwentyfive
+```
+
+Visit `http://localhost:9451/` to confirm WP boots. Admin is `/wp-admin/` (credentials `admin` / `password`).
+
+---
+
+## Phase A — Relationship source
+
+Ships first because it has the smallest blast radius and the biggest single-feature value-per-line: "show posts this post references via an ACF/meta relationship field."
+
+### Task A1: Relationship-source skeleton (PHP render path)
+
+**Why:** Establish the new source value, its defaults, and the dispatcher wiring before touching the UI. This task alone unblocks all subsequent relationship tasks.
+
+**Files:**
+- Modify: `src/blocks/query/render-helpers.php` (add `'relationship'` to dispatcher + defaults)
+- Modify: `src/blocks/query/block.json` (add `relationship` to `source` enum + new `relationshipField` + `relationshipFallback` attributes)
+- Create: `src/blocks/query/render-relationship.php`
+- Test: `tests/integration/blocks/query/RelationshipRenderTest.php`
+
+**Step 1: Write the failing PHPUnit test**
+
+```php
+<?php
+// tests/integration/blocks/query/RelationshipRenderTest.php
+namespace DesignSetGo\Tests\Integration\Blocks\Query;
+
+use WP_UnitTestCase;
+
+class RelationshipRenderTest extends WP_UnitTestCase {
+
+    public function test_resolves_parent_meta_to_post_ids() {
+        $parent  = self::factory()->post->create( array( 'post_title' => 'Parent' ) );
+        $child_a = self::factory()->post->create( array( 'post_title' => 'Child A' ) );
+        $child_b = self::factory()->post->create( array( 'post_title' => 'Child B' ) );
+        update_post_meta( $parent, 'related_posts', array( $child_a, $child_b ) );
+
+        require_once DSGO_PLUGIN_DIR . 'src/blocks/query/render-helpers.php';
+
+        $result = designsetgo_query_render(
+            array(
+                'source'            => 'relationship',
+                'relationshipField' => 'related_posts',
+                'postType'          => 'post',
+                'perPage'           => 10,
+                'tagName'           => 'ul',
+                'itemTagName'       => 'li',
+            ),
+            array(
+                'query_id'     => 'rel-1',
+                'page'         => 1,
+                'inner_html'   => '<!-- wp:paragraph --><p>x</p><!-- /wp:paragraph -->',
+                'params'       => array(),
+                'parent_stack' => array(
+                    array( 'postId' => $parent, 'postType' => 'post' ),
+                ),
+            )
+        );
+
+        $this->assertSame( 2, $result['totalItems'] );
+        $this->assertStringContainsString( 'dsgo-query__item', $result['html'] );
+    }
+
+    public function test_returns_empty_when_parent_stack_missing() {
+        $result = designsetgo_query_render(
+            array( 'source' => 'relationship', 'relationshipField' => 'x' ),
+            array( 'query_id' => 'rel-2', 'page' => 1, 'inner_html' => '', 'params' => array() )
+        );
+        $this->assertSame( 0, $result['totalItems'] );
+        $this->assertSame( '', trim( wp_strip_all_tags( $result['html'] ) ) );
+    }
+}
+```
+
+**Step 2: Run and verify it fails**
+
+```bash
+composer test -- --filter=RelationshipRenderTest
+```
+
+Expected: FAIL ("source value 'relationship' unsupported" or similar).
+
+**Step 3: Add the dispatcher branch + defaults**
+
+In `src/blocks/query/render-helpers.php::designsetgo_query_render()`, add:
+
+```php
+case 'relationship':
+    require_once __DIR__ . '/render-relationship.php';
+    if ( function_exists( 'designsetgo_query_render_relationship' ) ) {
+        return designsetgo_query_render_relationship( $attributes, $context );
+    }
+    break;
+```
+
+In `designsetgo_query_defaults()` add the two new keys:
+
+```php
+'relationshipField'    => '',
+'relationshipFallback' => 'empty', // empty | all | parent
+```
+
+In `src/blocks/query/block.json`, extend:
+
+```json
+"source": {
+    "type": "string",
+    "default": "posts",
+    "enum": ["posts", "users", "terms", "manual", "current", "relationship"]
+},
+"relationshipField":    { "type": "string", "default": "" },
+"relationshipFallback": { "type": "string", "default": "empty", "enum": ["empty", "all", "parent"] }
+```
+
+**Step 4: Implement the renderer**
+
+Create `src/blocks/query/render-relationship.php`:
+
+```php
+<?php
+/**
+ * Dynamic Query — Relationship source renderer.
+ *
+ * Reads an ID-bearing field from the nearest parent Query item's
+ * post and iterates the referenced posts in their declared order.
+ *
+ * Supported field storage shapes:
+ *  - array of ints or WP_Post objects (ACF relationship)
+ *  - comma-separated string of ints ("12, 34, 56")
+ *  - serialized array (legacy ACF)
+ *  - single int
+ *
+ * Requires a parent_stack entry; returns empty when the Query
+ * block is used outside another Query's item template.
+ *
+ * @package DesignSetGo
+ * @since   2.3.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'designsetgo_query_render_relationship' ) ) :
+
+    function designsetgo_query_render_relationship( array $atts, array $context ) {
+        $field = isset( $atts['relationshipField'] ) ? sanitize_text_field( (string) $atts['relationshipField'] ) : '';
+        if ( '' === $field ) {
+            return array( 'html' => '', 'totalPages' => 0, 'totalItems' => 0 );
+        }
+
+        $parent_stack = isset( $context['parent_stack'] ) && is_array( $context['parent_stack'] )
+            ? $context['parent_stack']
+            : array();
+        $parent = empty( $parent_stack ) ? null : end( $parent_stack );
+
+        $parent_post_id = 0;
+        if ( is_array( $parent ) && ! empty( $parent['postId'] ) ) {
+            $parent_post_id = (int) $parent['postId'];
+        }
+
+        if ( ! $parent_post_id ) {
+            return designsetgo_query_relationship_fallback( $atts, $context );
+        }
+
+        $raw_value = function_exists( 'get_field' )
+            ? get_field( $field, $parent_post_id )
+            : get_post_meta( $parent_post_id, $field, true );
+
+        $ids = designsetgo_query_relationship_normalize_ids( $raw_value );
+        if ( empty( $ids ) ) {
+            return designsetgo_query_relationship_fallback( $atts, $context );
+        }
+
+        // Delegate to the Posts renderer — override attributes so WP_Query
+        // runs with post__in + orderby=post__in + post_type=any (relationship
+        // fields are frequently cross-type).
+        require_once __DIR__ . '/render-posts.php';
+
+        $atts_override = array_merge(
+            $atts,
+            array(
+                'source'     => 'manual',
+                'manualIds'  => $ids,
+                'postType'   => 'any',
+                'perPage'    => max( 1, min( count( $ids ), (int) $atts['perPage'] ) ),
+            )
+        );
+
+        return designsetgo_query_render_posts( $atts_override, $context );
+    }
+
+    /**
+     * Normalize ACF/meta field values to a list of post IDs.
+     */
+    function designsetgo_query_relationship_normalize_ids( $value ) {
+        if ( is_array( $value ) ) {
+            $ids = array();
+            foreach ( $value as $v ) {
+                if ( $v instanceof \WP_Post ) {
+                    $ids[] = (int) $v->ID;
+                } elseif ( is_numeric( $v ) ) {
+                    $ids[] = (int) $v;
+                }
+            }
+            return array_values( array_filter( $ids ) );
+        }
+        if ( is_string( $value ) && '' !== $value ) {
+            if ( str_contains( $value, ',' ) ) {
+                return array_values( array_filter( array_map( 'absint', explode( ',', $value ) ) ) );
+            }
+            if ( is_numeric( $value ) ) {
+                return array( (int) $value );
+            }
+            $unserialized = maybe_unserialize( $value );
+            if ( is_array( $unserialized ) ) {
+                return designsetgo_query_relationship_normalize_ids( $unserialized );
+            }
+        }
+        if ( is_numeric( $value ) ) {
+            return array( (int) $value );
+        }
+        return array();
+    }
+
+    /**
+     * Empty / all / parent fallback for no-result relationship queries.
+     */
+    function designsetgo_query_relationship_fallback( array $atts, array $context ) {
+        $mode = isset( $atts['relationshipFallback'] ) ? (string) $atts['relationshipFallback'] : 'empty';
+
+        if ( 'empty' === $mode ) {
+            return array( 'html' => designsetgo_query_wrap( '', $atts, $context, $context['wrapper_attrs'] ?? null ), 'totalPages' => 0, 'totalItems' => 0 );
+        }
+
+        require_once __DIR__ . '/render-posts.php';
+
+        if ( 'all' === $mode ) {
+            $atts['source'] = 'posts';
+            return designsetgo_query_render_posts( $atts, $context );
+        }
+
+        // 'parent' fallback: render a single item using the parent post itself.
+        $parent = null;
+        if ( isset( $context['parent_stack'] ) && is_array( $context['parent_stack'] ) ) {
+            $parent = end( $context['parent_stack'] );
+        }
+        if ( ! is_array( $parent ) || empty( $parent['postId'] ) ) {
+            return array( 'html' => '', 'totalPages' => 0, 'totalItems' => 0 );
+        }
+        $atts['source']    = 'manual';
+        $atts['manualIds'] = array( (int) $parent['postId'] );
+        $atts['perPage']   = 1;
+        return designsetgo_query_render_posts( $atts, $context );
+    }
+
+endif;
+```
+
+**Step 5: Run and verify tests pass**
+
+```bash
+composer test -- --filter=RelationshipRenderTest
+```
+
+Expected: 2/2 PASS.
+
+**Step 6: Commit**
+
+```bash
+git add src/blocks/query/block.json src/blocks/query/render-helpers.php src/blocks/query/render-relationship.php tests/integration/blocks/query/RelationshipRenderTest.php
+git commit -m "feat(query): add relationship source reading parent post field"
+```
+
+---
+
+### Task A2: Relationship inspector UI
+
+**Why:** Expose `relationshipField` + `relationshipFallback` in the Settings panel so users can pick it up without editing block attributes by hand.
+
+**Files:**
+- Modify: `src/blocks/query/components/QuerySourcePanel.js` (or wherever source-dependent controls live)
+- Test: `tests/unit/blocks/query/edit.test.js` (extend existing suite)
+
+**Step 1: Locate the existing source switch**
+
+```bash
+grep -n "source === 'users'" src/blocks/query/components/*.js
+grep -n "SelectControl" src/blocks/query/components/QuerySourcePanel.js | head -5
+```
+
+Read the file so you see how existing source-gated controls render.
+
+**Step 2: Write the failing Jest test**
+
+Add to `tests/unit/blocks/query/edit.test.js`:
+
+```js
+it('renders the relationship field input when source is relationship', () => {
+    renderWith({ source: 'relationship' });
+    expect(screen.getByLabelText(/relationship field/i)).toBeInTheDocument();
+});
+
+it('renders the fallback select when source is relationship', () => {
+    renderWith({ source: 'relationship' });
+    expect(screen.getByLabelText(/when no related items/i)).toBeInTheDocument();
+});
+
+it('does not render relationship field input when source is posts', () => {
+    renderWith({ source: 'posts' });
+    expect(screen.queryByLabelText(/relationship field/i)).not.toBeInTheDocument();
+});
+```
+
+**Step 3: Run and verify tests fail**
+
+```bash
+npm run test:unit -- --testPathPattern=query/edit.test.js
+```
+
+Expected: 3 new tests FAIL.
+
+**Step 4: Wire the controls**
+
+In `QuerySourcePanel.js`, add:
+
+```js
+if (source === 'relationship') {
+    return (
+        <>
+            <TextControl
+                __next40pxDefaultSize
+                __nextHasNoMarginBottom
+                label={__('Relationship field', 'designsetgo')}
+                help={__('Meta key or ACF field on the parent item that holds the related post IDs.', 'designsetgo')}
+                value={attributes.relationshipField || ''}
+                onChange={(v) => setAttributes({ relationshipField: v })}
+            />
+            <SelectControl
+                __next40pxDefaultSize
+                __nextHasNoMarginBottom
+                label={__('When no related items', 'designsetgo')}
+                value={attributes.relationshipFallback || 'empty'}
+                onChange={(v) => setAttributes({ relationshipFallback: v })}
+                options={[
+                    { value: 'empty',  label: __('Render no items', 'designsetgo') },
+                    { value: 'all',    label: __('Fall back to all posts', 'designsetgo') },
+                    { value: 'parent', label: __('Render the parent item', 'designsetgo') },
+                ]}
+            />
+        </>
+    );
+}
+```
+
+Extend the source `SelectControl` options list to include `{ value: 'relationship', label: __('Related items (field-driven)', 'designsetgo') }`.
+
+**Step 5: Verify tests pass**
+
+```bash
+npm run test:unit -- --testPathPattern=query/edit.test.js
+```
+
+Expected: all tests PASS.
+
+**Step 6: Commit**
+
+```bash
+git add src/blocks/query/components/QuerySourcePanel.js tests/unit/blocks/query/edit.test.js
+git commit -m "feat(query): inspector controls for relationship source"
+```
+
+---
+
+### Task A3: Editor preview parity for relationship source
+
+**Why:** v2.2 added editor live preview via `useEntityRecords`. Relationship source needs a preview path so users see "this is what it'll render" instead of a blank placeholder.
+
+**Files:**
+- Modify: `src/blocks/query/hooks/useQueryPreview.js` (the hook added in v2.2 for editor previews)
+- Test: `tests/unit/blocks/query/useQueryPreview.test.js`
+
+**Step 1: Write the failing test**
+
+```js
+// tests/unit/blocks/query/useQueryPreview.test.js
+import { renderHook } from '@testing-library/react';
+import useQueryPreview from '../../../../src/blocks/query/hooks/useQueryPreview';
+
+jest.mock('@wordpress/core-data', () => ({
+    store: 'core',
+    useEntityRecords: jest.fn(),
+}));
+
+const { useEntityRecords } = require('@wordpress/core-data');
+
+describe('useQueryPreview — relationship source', () => {
+    beforeEach(() => useEntityRecords.mockReset());
+
+    it('returns empty state when relationshipField is empty', () => {
+        useEntityRecords.mockReturnValue({ records: [], hasResolved: true });
+        const { result } = renderHook(() =>
+            useQueryPreview({ source: 'relationship', relationshipField: '', perPage: 3 })
+        );
+        expect(result.current.records).toEqual([]);
+        expect(result.current.hasResolved).toBe(true);
+    });
+});
+```
+
+**Step 2: Run and verify it fails**
+
+```bash
+npm run test:unit -- --testPathPattern=useQueryPreview
+```
+
+Expected: FAIL (hook doesn't recognize `relationship` source yet).
+
+**Step 3: Add the relationship branch**
+
+In `useQueryPreview.js`, add a source switch that returns `{ records: [], hasResolved: true }` for `'relationship'` when `relationshipField` is empty, and — when present — falls through to `useEntityRecords('postType', 'post', { include: manualIds, per_page: perPage })` using the editor's current post ID as parent. Use `useSelect` + `getEditedPostAttribute('meta')` to read the field value.
+
+```js
+if (source === 'relationship') {
+    const parentId = useSelect((s) => s('core/editor').getCurrentPostId(), []);
+    const fieldValue = useSelect(
+        (s) => (parentId ? s('core').getEntityRecord('postType', 'post', parentId)?.meta?.[relationshipField] : null),
+        [parentId, relationshipField]
+    );
+    const ids = Array.isArray(fieldValue)
+        ? fieldValue.map((v) => (typeof v === 'object' ? v.ID : Number(v))).filter(Boolean)
+        : [];
+    const { records, hasResolved } = useEntityRecords('postType', 'any', {
+        include: ids.length ? ids : [0],
+        per_page: Math.max(1, perPage),
+        orderby: 'include',
+    });
+    return { records: ids.length ? records : [], hasResolved };
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+npm run test:unit -- --testPathPattern=useQueryPreview
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/blocks/query/hooks/useQueryPreview.js tests/unit/blocks/query/useQueryPreview.test.js
+git commit -m "feat(query): editor preview for relationship source"
+```
+
+---
+
+### Task A4: Relationship manual QA
+
+**Why:** An integration test can't validate "does the admin feel right when I pick a field." Run the feature end-to-end once before moving on.
+
+**Steps:**
+
+1. `npm run build`
+2. In the editor, create a new Post titled "Parent".
+3. Add a custom field (`related_posts`) with value `12,34` (IDs of two real posts in the site).
+4. Add a Dynamic Query block, set source → Relationship, field → `related_posts`.
+5. Confirm the editor preview shows both referenced posts.
+6. Save and view on the frontend. Confirm same two items render.
+7. Change `relationshipFallback` to "all posts", clear the meta value, and re-check that all posts now show.
+
+No commit for this task; log observations in the PR description.
+
+---
+
+## Phase B — Conditional inner-block visibility
+
+A compound feature: a shared attribute registered on every block, server-side evaluation in the render helpers, editor-side evaluation that matches.
+
+### Task B1: `dsgoVisibility` attribute registration
+
+**Why:** WP's Block Editor needs to know every block can carry the attribute before we write UI or server logic.
+
+**Files:**
+- Create: `src/extensions/visibility/index.js`
+- Create: `src/extensions/visibility/filters.js`
+- Modify: `src/index.js` (import the extension)
+- Test: `tests/unit/extensions/visibility/attribute.test.js`
+
+**Step 1: Write the failing test**
+
+```js
+// tests/unit/extensions/visibility/attribute.test.js
+import { applyFilters } from '@wordpress/hooks';
+import '../../../../src/extensions/visibility';
+
+describe('dsgoVisibility attribute filter', () => {
+    it('adds the attribute to an allowed block', () => {
+        const settings = applyFilters(
+            'blocks.registerBlockType',
+            { attributes: {} },
+            'core/paragraph'
+        );
+        expect(settings.attributes.dsgoVisibility).toEqual({
+            type: 'object',
+            default: null,
+        });
+    });
+
+    it('leaves unsupported blocks untouched', () => {
+        const settings = applyFilters(
+            'blocks.registerBlockType',
+            { attributes: {} },
+            'core/freeform'
+        );
+        expect(settings.attributes.dsgoVisibility).toBeUndefined();
+    });
+});
+```
+
+**Step 2: Run and verify it fails**
+
+```bash
+npm run test:unit -- --testPathPattern=visibility/attribute
+```
+
+Expected: FAIL — `dsgoVisibility` undefined.
+
+**Step 3: Register the filter**
+
+`src/extensions/visibility/filters.js`:
+
+```js
+import { addFilter } from '@wordpress/hooks';
+
+const BLOCKED = new Set([
+    'core/freeform',
+    'core/missing',
+    'core/template-part',
+]);
+
+function addVisibilityAttribute(settings, name) {
+    if (BLOCKED.has(name)) return settings;
+    if (!settings.attributes) settings.attributes = {};
+    settings.attributes.dsgoVisibility = { type: 'object', default: null };
+    return settings;
+}
+
+addFilter(
+    'blocks.registerBlockType',
+    'designsetgo/visibility/add-attribute',
+    addVisibilityAttribute
+);
+```
+
+`src/extensions/visibility/index.js`:
+
+```js
+import './filters';
+```
+
+Import in `src/index.js`:
+
+```js
+import './extensions/visibility';
+```
+
+**Step 4: Run tests**
+
+```bash
+npm run test:unit -- --testPathPattern=visibility/attribute
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/extensions/visibility src/index.js tests/unit/extensions/visibility
+git commit -m "feat(visibility): register dsgoVisibility attribute on all blocks"
+```
+
+---
+
+### Task B2: Rule-matching engine (server)
+
+**Why:** Provide a pure, unit-testable evaluator that answers "given these rules and this context, should this block render?" Kept isolated from the Query block so other features can reuse it later.
+
+**Files:**
+- Create: `includes/class-block-visibility.php`
+- Modify: `includes/class-plugin.php` (instantiate)
+- Test: `tests/integration/BlockVisibilityTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+// tests/integration/BlockVisibilityTest.php
+namespace DesignSetGo\Tests\Integration;
+
+use DesignSetGo\BlockVisibility;
+use WP_UnitTestCase;
+
+class BlockVisibilityTest extends WP_UnitTestCase {
+
+    public function test_null_rules_always_visible() {
+        $this->assertTrue( BlockVisibility::matches( null, array( 'postId' => 1 ) ) );
+        $this->assertTrue( BlockVisibility::matches( array(), array() ) );
+    }
+
+    public function test_meta_equals_rule() {
+        $post_id = self::factory()->post->create();
+        update_post_meta( $post_id, 'featured', '1' );
+
+        $rules = array(
+            'operator' => 'AND',
+            'rules'    => array(
+                array( 'type' => 'meta', 'key' => 'featured', 'op' => 'equals', 'value' => '1' ),
+            ),
+        );
+        $this->assertTrue( BlockVisibility::matches( $rules, array( 'postId' => $post_id ) ) );
+
+        update_post_meta( $post_id, 'featured', '0' );
+        $this->assertFalse( BlockVisibility::matches( $rules, array( 'postId' => $post_id ) ) );
+    }
+
+    public function test_taxonomy_has_rule() {
+        $post_id = self::factory()->post->create();
+        $term_id = self::factory()->term->create( array( 'taxonomy' => 'category', 'slug' => 'news' ) );
+        wp_set_post_terms( $post_id, array( $term_id ), 'category' );
+
+        $rules = array(
+            'operator' => 'AND',
+            'rules'    => array(
+                array( 'type' => 'taxonomy', 'taxonomy' => 'category', 'op' => 'has', 'value' => 'news' ),
+            ),
+        );
+        $this->assertTrue( BlockVisibility::matches( $rules, array( 'postId' => $post_id ) ) );
+    }
+
+    public function test_index_rule() {
+        $rules = array(
+            'operator' => 'AND',
+            'rules'    => array(
+                array( 'type' => 'index', 'op' => 'equals', 'value' => 0 ),
+            ),
+        );
+        $this->assertTrue( BlockVisibility::matches( $rules, array( 'postId' => 1, 'index' => 0 ) ) );
+        $this->assertFalse( BlockVisibility::matches( $rules, array( 'postId' => 1, 'index' => 3 ) ) );
+    }
+
+    public function test_or_relation() {
+        $rules = array(
+            'operator' => 'OR',
+            'rules'    => array(
+                array( 'type' => 'index', 'op' => 'equals', 'value' => 0 ),
+                array( 'type' => 'index', 'op' => 'equals', 'value' => 2 ),
+            ),
+        );
+        $this->assertTrue( BlockVisibility::matches( $rules, array( 'index' => 0 ) ) );
+        $this->assertTrue( BlockVisibility::matches( $rules, array( 'index' => 2 ) ) );
+        $this->assertFalse( BlockVisibility::matches( $rules, array( 'index' => 1 ) ) );
+    }
+}
+```
+
+**Step 2: Run and verify it fails**
+
+```bash
+composer test -- --filter=BlockVisibilityTest
+```
+
+Expected: FAIL — class not found.
+
+**Step 3: Implement the evaluator**
+
+`includes/class-block-visibility.php`:
+
+```php
+<?php
+/**
+ * Shared rule evaluator for the dsgoVisibility attribute.
+ *
+ * Pure static methods — no WordPress hooks, no state. Consumers
+ * (render helpers, REST endpoints) pass a rules array and a
+ * per-item context; the evaluator returns bool.
+ *
+ * @package DesignSetGo
+ * @since   2.3.0
+ */
+
+namespace DesignSetGo;
+
+defined( 'ABSPATH' ) || exit;
+
+class BlockVisibility {
+
+    public static function matches( $rules, array $context ) {
+        if ( empty( $rules ) || ! is_array( $rules ) || empty( $rules['rules'] ) ) {
+            return true;
+        }
+
+        $operator = isset( $rules['operator'] ) && 'OR' === strtoupper( (string) $rules['operator'] ) ? 'OR' : 'AND';
+
+        foreach ( (array) $rules['rules'] as $rule ) {
+            $matched = self::evaluate_rule( (array) $rule, $context );
+            if ( 'OR' === $operator && $matched ) {
+                return true;
+            }
+            if ( 'AND' === $operator && ! $matched ) {
+                return false;
+            }
+        }
+        return 'AND' === $operator;
+    }
+
+    private static function evaluate_rule( array $rule, array $context ) {
+        $type = isset( $rule['type'] ) ? (string) $rule['type'] : '';
+        switch ( $type ) {
+            case 'meta':     return self::evaluate_meta( $rule, $context );
+            case 'taxonomy': return self::evaluate_taxonomy( $rule, $context );
+            case 'index':    return self::evaluate_index( $rule, $context );
+            case 'auth':     return self::evaluate_auth( $rule );
+        }
+
+        /**
+         * Filter to add custom rule types.
+         *
+         * @param bool|null $match   Return bool to short-circuit; null to fall through.
+         * @param array     $rule
+         * @param array     $context
+         */
+        $filtered = apply_filters( 'designsetgo_visibility_rule', null, $rule, $context );
+        return (bool) $filtered;
+    }
+
+    private static function evaluate_meta( array $rule, array $context ) {
+        $post_id = isset( $context['postId'] ) ? (int) $context['postId'] : 0;
+        $key     = isset( $rule['key'] ) ? sanitize_text_field( (string) $rule['key'] ) : '';
+        if ( ! $post_id || '' === $key ) {
+            return false;
+        }
+        $actual = get_post_meta( $post_id, $key, true );
+        return self::compare( $actual, $rule['op'] ?? 'equals', $rule['value'] ?? '' );
+    }
+
+    private static function evaluate_taxonomy( array $rule, array $context ) {
+        $post_id  = isset( $context['postId'] ) ? (int) $context['postId'] : 0;
+        $taxonomy = isset( $rule['taxonomy'] ) ? sanitize_key( (string) $rule['taxonomy'] ) : '';
+        if ( ! $post_id || '' === $taxonomy ) {
+            return false;
+        }
+        $terms = get_the_terms( $post_id, $taxonomy );
+        if ( empty( $terms ) || is_wp_error( $terms ) ) {
+            return 'not_has' === ( $rule['op'] ?? 'has' );
+        }
+        $slugs = wp_list_pluck( $terms, 'slug' );
+        $needle = sanitize_title( (string) ( $rule['value'] ?? '' ) );
+        $contains = in_array( $needle, $slugs, true );
+        return 'not_has' === ( $rule['op'] ?? 'has' ) ? ! $contains : $contains;
+    }
+
+    private static function evaluate_index( array $rule, array $context ) {
+        $actual = isset( $context['index'] ) ? (int) $context['index'] : -1;
+        return self::compare( $actual, $rule['op'] ?? 'equals', (int) ( $rule['value'] ?? 0 ) );
+    }
+
+    private static function evaluate_auth( array $rule ) {
+        $expect = isset( $rule['value'] ) ? (bool) $rule['value'] : true;
+        return is_user_logged_in() === $expect;
+    }
+
+    private static function compare( $actual, $op, $expected ) {
+        switch ( $op ) {
+            case 'not_equals': return (string) $actual !== (string) $expected;
+            case 'contains':   return false !== stripos( (string) $actual, (string) $expected );
+            case 'gt':         return (float) $actual > (float) $expected;
+            case 'lt':         return (float) $actual < (float) $expected;
+            case 'empty':      return '' === (string) $actual || null === $actual;
+            case 'not_empty':  return '' !== (string) $actual && null !== $actual;
+            case 'equals':
+            default:           return (string) $actual === (string) $expected;
+        }
+    }
+}
+```
+
+**Step 4: Register in the plugin class**
+
+In `includes/class-plugin.php`, add to the requires list:
+
+```php
+require_once DSGO_PLUGIN_DIR . 'includes/class-block-visibility.php';
+```
+
+(No instantiation needed — it's a static-only class.)
+
+**Step 5: Run tests**
+
+```bash
+composer test -- --filter=BlockVisibilityTest
+```
+
+Expected: 5/5 PASS.
+
+**Step 6: Commit**
+
+```bash
+git add includes/class-block-visibility.php includes/class-plugin.php tests/integration/BlockVisibilityTest.php
+git commit -m "feat(visibility): rule-matching engine with AND/OR and meta/tax/index/auth rule types"
+```
+
+---
+
+### Task B3: Server-side application inside query items
+
+**Why:** The evaluator exists; now wire it into the one place that iterates items: `designsetgo_query_render_item()`.
+
+**Files:**
+- Modify: `src/blocks/query/render-helpers.php` (add visibility check in the item renderer)
+- Test: `tests/integration/blocks/query/VisibilityIntegrationTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+// tests/integration/blocks/query/VisibilityIntegrationTest.php
+namespace DesignSetGo\Tests\Integration\Blocks\Query;
+
+use WP_UnitTestCase;
+
+class VisibilityIntegrationTest extends WP_UnitTestCase {
+
+    public function test_hides_block_when_rule_does_not_match() {
+        $post_id = self::factory()->post->create();
+        update_post_meta( $post_id, 'featured', '0' );
+
+        require_once DSGO_PLUGIN_DIR . 'src/blocks/query/render-helpers.php';
+
+        $inner_html = '<!-- wp:paragraph {"dsgoVisibility":{"operator":"AND","rules":[{"type":"meta","key":"featured","op":"equals","value":"1"}]}} -->'
+                    . '<p>Featured badge</p>'
+                    . '<!-- /wp:paragraph -->'
+                    . '<!-- wp:paragraph --><p>Always shown</p><!-- /wp:paragraph -->';
+
+        $html = designsetgo_query_render_item(
+            $inner_html,
+            array( 'postId' => $post_id, 'postType' => 'post', 'index' => 0 ),
+            'li'
+        );
+
+        $this->assertStringNotContainsString( 'Featured badge', $html );
+        $this->assertStringContainsString( 'Always shown', $html );
+    }
+}
+```
+
+**Step 2: Run and verify it fails**
+
+```bash
+composer test -- --filter=VisibilityIntegrationTest
+```
+
+Expected: FAIL — both paragraphs render.
+
+**Step 3: Apply visibility in the item renderer**
+
+In `designsetgo_query_render_item()`, before calling `$block_instance->render()`:
+
+```php
+$visibility = isset( $parsed_block['attrs']['dsgoVisibility'] ) ? $parsed_block['attrs']['dsgoVisibility'] : null;
+if ( ! \DesignSetGo\BlockVisibility::matches( $visibility, $item_context ) ) {
+    continue;
+}
+```
+
+**Step 4: Verify tests pass**
+
+```bash
+composer test -- --filter=VisibilityIntegrationTest
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/blocks/query/render-helpers.php tests/integration/blocks/query/VisibilityIntegrationTest.php
+git commit -m "feat(visibility): apply rules when rendering query items"
+```
+
+---
+
+### Task B4: Visibility controls in the block inspector
+
+**Why:** The attribute and engine exist; now an author needs a UI to set rules without hand-editing block markup.
+
+**Files:**
+- Create: `src/extensions/visibility/VisibilityPanel.js`
+- Create: `src/extensions/visibility/RuleRow.js`
+- Modify: `src/extensions/visibility/filters.js` (inject panel into BlockEdit)
+- Test: `tests/unit/extensions/visibility/VisibilityPanel.test.js`
+
+**Step 1: Write the failing test**
+
+```js
+// tests/unit/extensions/visibility/VisibilityPanel.test.js
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import VisibilityPanel from '../../../../src/extensions/visibility/VisibilityPanel';
+
+// Mocks mirroring src/blocks/query/edit.test.js conventions
+jest.mock('@wordpress/i18n', () => ({ __: (t) => t, sprintf: (t, a) => t.replace('%s', a) }));
+jest.mock('@wordpress/components', () => ({
+    SelectControl: ({ label, value, onChange, options }) => (
+        <label>{label}<select value={value} onChange={(e) => onChange(e.target.value)}>{options.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}</select></label>
+    ),
+    TextControl: ({ label, value, onChange }) => (
+        <label>{label}<input value={value || ''} onChange={(e) => onChange(e.target.value)} /></label>
+    ),
+    Button: ({ children, onClick }) => <button onClick={onClick}>{children}</button>,
+    __experimentalVStack: ({ children }) => <div>{children}</div>,
+}));
+
+describe('VisibilityPanel', () => {
+    it('shows empty state when no rules exist', () => {
+        render(<VisibilityPanel value={null} onChange={jest.fn()} />);
+        expect(screen.getByText(/always visible/i)).toBeInTheDocument();
+    });
+
+    it('renders a row per rule', () => {
+        const value = {
+            operator: 'AND',
+            rules: [{ type: 'meta', key: 'foo', op: 'equals', value: 'bar' }],
+        };
+        render(<VisibilityPanel value={value} onChange={jest.fn()} />);
+        expect(screen.getByDisplayValue('foo')).toBeInTheDocument();
+    });
+
+    it('calls onChange with a new rule when Add clicked', () => {
+        const onChange = jest.fn();
+        render(<VisibilityPanel value={null} onChange={onChange} />);
+        fireEvent.click(screen.getByText(/add rule/i));
+        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+            operator: 'AND',
+            rules: expect.arrayContaining([expect.objectContaining({ type: 'meta' })]),
+        }));
+    });
+});
+```
+
+**Step 2: Run and verify it fails**
+
+```bash
+npm run test:unit -- --testPathPattern=VisibilityPanel.test
+```
+
+Expected: FAIL — component not found.
+
+**Step 3: Build the panel**
+
+Keep both new files under 200 lines. The Panel renders:
+- A relation selector (AND / OR) — only shown when `rules.length > 1`.
+- One `RuleRow` per rule with type picker (meta / taxonomy / index / auth), fields relevant to the type, op picker, value input.
+- An "Add rule" button appending a default `{ type: 'meta', op: 'equals', key: '', value: '' }`.
+- A "Remove" button per row.
+
+The panel lives inside `<InspectorControls group="advanced">` via a `BlockEdit` HOC filter in `filters.js`:
+
+```js
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { InspectorControls } from '@wordpress/block-editor';
+import { Fragment } from '@wordpress/element';
+import VisibilityPanel from './VisibilityPanel';
+
+const withVisibilityPanel = createHigherOrderComponent((BlockEdit) => (props) => {
+    if (BLOCKED.has(props.name)) return <BlockEdit {...props} />;
+    return (
+        <Fragment>
+            <BlockEdit {...props} />
+            <InspectorControls group="advanced">
+                <VisibilityPanel
+                    value={props.attributes.dsgoVisibility}
+                    onChange={(value) => props.setAttributes({ dsgoVisibility: value })}
+                />
+            </InspectorControls>
+        </Fragment>
+    );
+}, 'withDsgoVisibilityPanel');
+
+addFilter('editor.BlockEdit', 'designsetgo/visibility/inspector', withVisibilityPanel);
+```
+
+**Step 4: Run the tests**
+
+```bash
+npm run test:unit -- --testPathPattern=VisibilityPanel.test
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/extensions/visibility tests/unit/extensions/visibility
+git commit -m "feat(visibility): inspector panel for configuring rules"
+```
+
+---
+
+### Task B5: Editor-preview visibility evaluator
+
+**Why:** Server hides blocks that don't match; editor should do the same so previews are honest. Otherwise users see their "Featured" badge in the editor but never on the frontend.
+
+**Files:**
+- Create: `src/extensions/visibility/evaluateRules.js` (JS mirror of PHP evaluator)
+- Modify: `src/extensions/visibility/filters.js` (wrap BlockListBlock to hide children in item preview contexts)
+- Test: `tests/unit/extensions/visibility/evaluateRules.test.js`
+
+**Step 1: Write the failing test**
+
+```js
+// tests/unit/extensions/visibility/evaluateRules.test.js
+import evaluateRules from '../../../../src/extensions/visibility/evaluateRules';
+
+describe('evaluateRules', () => {
+    it('defaults visible when rules null', () => {
+        expect(evaluateRules(null, { postId: 1 })).toBe(true);
+    });
+
+    it('meta equals', () => {
+        const ctx = { meta: { featured: '1' } };
+        expect(evaluateRules({ operator: 'AND', rules: [{ type: 'meta', key: 'featured', op: 'equals', value: '1' }] }, ctx)).toBe(true);
+        expect(evaluateRules({ operator: 'AND', rules: [{ type: 'meta', key: 'featured', op: 'equals', value: '0' }] }, ctx)).toBe(false);
+    });
+
+    it('index equals', () => {
+        expect(evaluateRules({ operator: 'AND', rules: [{ type: 'index', op: 'equals', value: 0 }] }, { index: 0 })).toBe(true);
+    });
+
+    it('OR relation', () => {
+        const rules = { operator: 'OR', rules: [{ type: 'index', op: 'equals', value: 0 }, { type: 'index', op: 'equals', value: 1 }] };
+        expect(evaluateRules(rules, { index: 1 })).toBe(true);
+        expect(evaluateRules(rules, { index: 5 })).toBe(false);
+    });
+});
+```
+
+**Step 2: Run and verify it fails**
+
+```bash
+npm run test:unit -- --testPathPattern=evaluateRules.test
+```
+
+Expected: FAIL — module not found.
+
+**Step 3: Implement the mirror**
+
+`src/extensions/visibility/evaluateRules.js`:
+
+```js
+/**
+ * JS mirror of DesignSetGo\BlockVisibility::matches — keep in sync.
+ *
+ * @param {object|null} rules   The dsgoVisibility attribute.
+ * @param {object}      context Per-item: { postId, postType, index, meta, terms }.
+ */
+export default function evaluateRules(rules, context = {}) {
+    if (!rules || !rules.rules?.length) return true;
+
+    const op = (rules.operator || 'AND').toUpperCase();
+    for (const rule of rules.rules) {
+        const ok = evaluate(rule, context);
+        if (op === 'OR' && ok) return true;
+        if (op === 'AND' && !ok) return false;
+    }
+    return op === 'AND';
+}
+
+function evaluate(rule, ctx) {
+    const { type, op = 'equals', value } = rule;
+    switch (type) {
+        case 'meta':     return compare(ctx.meta?.[rule.key], op, value);
+        case 'taxonomy': {
+            const slugs = ctx.terms?.[rule.taxonomy] || [];
+            const has = slugs.includes(String(value));
+            return op === 'not_has' ? !has : has;
+        }
+        case 'index':    return compare(ctx.index, op, Number(value));
+        case 'auth':     return !!ctx.isAuthenticated === !!value;
+        default:         return false;
+    }
+}
+
+function compare(actual, op, expected) {
+    switch (op) {
+        case 'not_equals': return String(actual) !== String(expected);
+        case 'contains':   return String(actual).toLowerCase().includes(String(expected).toLowerCase());
+        case 'gt':         return Number(actual) > Number(expected);
+        case 'lt':         return Number(actual) < Number(expected);
+        case 'empty':      return actual === '' || actual == null;
+        case 'not_empty':  return actual !== '' && actual != null;
+        case 'equals':
+        default:           return String(actual) === String(expected);
+    }
+}
+```
+
+Then in `filters.js`, add a block-list-block wrapper that consults `BlockContext` for `designsetgo/itemMeta`, `designsetgo/itemTerms`, `designsetgo/itemIndex` (provided in Phase C by the Query edit component) and short-circuits rendering when `evaluateRules()` returns false.
+
+**Step 4: Run tests**
+
+```bash
+npm run test:unit -- --testPathPattern=evaluateRules.test
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/extensions/visibility tests/unit/extensions/visibility/evaluateRules.test.js
+git commit -m "feat(visibility): editor preview hides non-matching blocks in query items"
+```
+
+---
+
+## Phase C — Nested loops with parent context
+
+### Task C1: Parent-context stack in render pipeline
+
+**Why:** Bindings and the relationship source both depend on being able to ask "what's the outer Query's current item?" This task adds that stack; nothing else works without it.
+
+**Files:**
+- Modify: `src/blocks/query/render-helpers.php` (push/pop around `designsetgo_query_render_item()`)
+- Modify: `src/blocks/query/render-posts.php`, `render-users.php`, `render-terms.php` (pass `parent_stack` through in the per-item inner call)
+- Test: `tests/integration/blocks/query/ParentStackTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+// tests/integration/blocks/query/ParentStackTest.php
+namespace DesignSetGo\Tests\Integration\Blocks\Query;
+
+use WP_UnitTestCase;
+
+class ParentStackTest extends WP_UnitTestCase {
+
+    public function test_stack_is_pushed_and_popped_per_item() {
+        $posts = self::factory()->post->create_many( 2 );
+
+        // Accumulate stack snapshots captured inside a custom inner block.
+        $GLOBALS['dsgo_stack_capture'] = array();
+        add_action( 'render_block', function ( $html, $block ) {
+            if ( ! empty( $block['blockName'] ) && 'core/paragraph' === $block['blockName'] ) {
+                $GLOBALS['dsgo_stack_capture'][] = $GLOBALS['designsetgo_parent_stack'] ?? array();
+            }
+            return $html;
+        }, 10, 2 );
+
+        require_once DSGO_PLUGIN_DIR . 'src/blocks/query/render-helpers.php';
+        designsetgo_query_render(
+            array( 'source' => 'posts', 'postType' => 'post', 'perPage' => 2, 'tagName' => 'ul', 'itemTagName' => 'li' ),
+            array( 'query_id' => 'c1', 'page' => 1, 'inner_html' => '<!-- wp:paragraph --><p>x</p><!-- /wp:paragraph -->', 'params' => array() )
+        );
+
+        $this->assertCount( 2, $GLOBALS['dsgo_stack_capture'] );
+        $this->assertSame( $posts[0], $GLOBALS['dsgo_stack_capture'][0][0]['postId'] );
+        $this->assertSame( $posts[1], $GLOBALS['dsgo_stack_capture'][1][0]['postId'] );
+        $this->assertArrayNotHasKey( 'designsetgo_parent_stack', $GLOBALS ); // popped after render
+    }
+}
+```
+
+**Step 2: Run and verify it fails**
+
+```bash
+composer test -- --filter=ParentStackTest
+```
+
+Expected: FAIL — global is never set.
+
+**Step 3: Push/pop the stack in `designsetgo_query_render_item()`**
+
+```php
+function designsetgo_query_render_item( $inner_html, array $item_context, $item_tag ) {
+    $tag    = in_array( $item_tag, array( 'li', 'div', 'article' ), true ) ? $item_tag : 'li';
+    $html   = '';
+    $parsed = parse_blocks( $inner_html );
+
+    if ( ! isset( $GLOBALS['designsetgo_parent_stack'] ) || ! is_array( $GLOBALS['designsetgo_parent_stack'] ) ) {
+        $GLOBALS['designsetgo_parent_stack'] = array();
+    }
+    array_push( $GLOBALS['designsetgo_parent_stack'], $item_context );
+
+    try {
+        foreach ( $parsed as $parsed_block ) {
+            if ( empty( $parsed_block['blockName'] ) ) continue;
+            $visibility = $parsed_block['attrs']['dsgoVisibility'] ?? null;
+            if ( ! \DesignSetGo\BlockVisibility::matches( $visibility, $item_context ) ) continue;
+            $block_instance = new \WP_Block( $parsed_block, $item_context );
+            $html          .= $block_instance->render();
+        }
+    } finally {
+        array_pop( $GLOBALS['designsetgo_parent_stack'] );
+        if ( empty( $GLOBALS['designsetgo_parent_stack'] ) ) {
+            unset( $GLOBALS['designsetgo_parent_stack'] );
+        }
+    }
+
+    return sprintf( '<%1$s class="dsgo-query__item">%2$s</%1$s>', $tag, $html );
+}
+```
+
+Also in each `render-*.php`, add `$context['parent_stack'] = $GLOBALS['designsetgo_parent_stack'] ?? array();` before calling `designsetgo_query_render_item()` via the nested render dispatcher. (This lets nested queries know their ancestors without reading a global directly — context remains explicit.)
+
+**Step 4: Verify tests pass**
+
+```bash
+composer test -- --filter=ParentStackTest
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/blocks/query/render-helpers.php src/blocks/query/render-posts.php src/blocks/query/render-users.php src/blocks/query/render-terms.php tests/integration/blocks/query/ParentStackTest.php
+git commit -m "feat(query): push/pop parent-context stack during item render"
+```
+
+---
+
+### Task C2: `scope` arg on DSGo bindings
+
+**Why:** With the stack in place, bindings can resolve `{ scope: 'parent', key: 'featured' }` against the outer Query's current item instead of the current post.
+
+**Files:**
+- Modify: `includes/blocks/class-query-bindings.php`
+- Test: `tests/integration/blocks/query/BindingsScopeTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+// tests/integration/blocks/query/BindingsScopeTest.php
+namespace DesignSetGo\Tests\Integration\Blocks\Query;
+
+use DesignSetGo\Blocks\Query\Bindings;
+use WP_Block;
+use WP_UnitTestCase;
+
+class BindingsScopeTest extends WP_UnitTestCase {
+
+    public function test_parent_scope_reads_from_parent_stack() {
+        $parent_id = self::factory()->post->create();
+        $child_id  = self::factory()->post->create();
+        update_post_meta( $parent_id, 'parent_label', 'HELLO-PARENT' );
+
+        $GLOBALS['designsetgo_parent_stack'] = array(
+            array( 'postId' => $parent_id, 'postType' => 'post' ),
+        );
+
+        $bindings = new Bindings();
+        $block    = new WP_Block(
+            array( 'blockName' => 'core/paragraph' ),
+            array( 'postId' => $child_id, 'postType' => 'post' )
+        );
+        $value = $bindings->get_post_meta_value(
+            array( 'key' => 'parent_label', 'scope' => 'parent' ),
+            $block,
+            'content'
+        );
+
+        $this->assertSame( 'HELLO-PARENT', $value );
+        unset( $GLOBALS['designsetgo_parent_stack'] );
+    }
+
+    public function test_self_scope_is_default() {
+        $post_id = self::factory()->post->create();
+        update_post_meta( $post_id, 'label', 'ME' );
+
+        $bindings = new Bindings();
+        $block    = new WP_Block(
+            array( 'blockName' => 'core/paragraph' ),
+            array( 'postId' => $post_id, 'postType' => 'post' )
+        );
+        $value = $bindings->get_post_meta_value( array( 'key' => 'label' ), $block, 'content' );
+        $this->assertSame( 'ME', $value );
+    }
+}
+```
+
+**Step 2: Run and verify it fails**
+
+```bash
+composer test -- --filter=BindingsScopeTest
+```
+
+Expected: FAIL — scope arg ignored.
+
+**Step 3: Extend the binding**
+
+In both `get_post_meta_value()` and `get_acf_value()`, replace the existing `$post_id` resolution with:
+
+```php
+$scope = isset( $args['scope'] ) ? (string) $args['scope'] : 'self';
+
+$post_id = 0;
+if ( 'parent' === $scope ) {
+    $stack  = $GLOBALS['designsetgo_parent_stack'] ?? array();
+    $parent = empty( $stack ) ? null : end( $stack );
+    if ( is_array( $parent ) && ! empty( $parent['postId'] ) ) {
+        $post_id = (int) $parent['postId'];
+    }
+} elseif ( 'root' === $scope ) {
+    $stack = $GLOBALS['designsetgo_parent_stack'] ?? array();
+    $root  = empty( $stack ) ? null : reset( $stack );
+    if ( is_array( $root ) && ! empty( $root['postId'] ) ) {
+        $post_id = (int) $root['postId'];
+    }
+} else {
+    if ( $block && isset( $block->context['postId'] ) ) {
+        $post_id = (int) $block->context['postId'];
+    }
+}
+
+if ( ! $post_id ) {
+    $post_id = get_the_ID();
+}
+```
+
+**Step 4: Verify tests pass**
+
+```bash
+composer test -- --filter=BindingsScopeTest
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add includes/blocks/class-query-bindings.php tests/integration/blocks/query/BindingsScopeTest.php
+git commit -m "feat(bindings): add scope=parent|root|self to DSGo post-meta + ACF sources"
+```
+
+---
+
+### Task C3: Editor-side context provider for nested previews
+
+**Why:** The editor needs to provide matching context so nested-loop previews + `scope: 'parent'` bindings render right while authoring. Without this, a paragraph with `{scope:'parent'}` would silently fall back to the edited post's own meta in the editor, hiding bugs until publish.
+
+**Files:**
+- Modify: `src/blocks/query/edit-template.js` (the component that maps over preview records)
+- Create: `src/extensions/visibility/ItemContextBridge.js` (pulls parent data from BlockContext into item context for visibility)
+- Test: `tests/unit/blocks/query/NestedPreview.test.js`
+
+**Step 1: Write the failing test**
+
+```js
+// tests/unit/blocks/query/NestedPreview.test.js
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import QueryEdit from '../../../../src/blocks/query/edit';
+
+// Re-use the shared mock setup from edit.test.js for i18n, components, etc.
+// Only the new thing is checking that BlockContextProvider receives a parentItem.
+const ctxCapture = [];
+jest.mock('@wordpress/block-editor', () => ({
+    useBlockProps: () => ({ className: 'wp-block-designsetgo-query' }),
+    useInnerBlocksProps: (p = {}) => ({ ...p, children: null }),
+    InspectorControls: ({ children }) => <div data-testid="inspector">{children}</div>,
+    InnerBlocks: () => <div data-testid="inner-blocks" />,
+    BlockPreview: () => <div data-testid="block-preview" />,
+    BlockContextProvider: ({ value, children }) => {
+        ctxCapture.push(value);
+        return <>{children}</>;
+    },
+    store: 'core/block-editor',
+}));
+
+// (Other mocks mirror existing edit.test.js — for brevity refer to it.)
+
+describe('QueryEdit nested preview', () => {
+    it('provides parent context to BlockContextProvider', () => {
+        render(
+            <QueryEdit
+                attributes={{ queryId: 'nested-1', source: 'posts', perPage: 1, /* ... */ }}
+                setAttributes={jest.fn()}
+                clientId="cli-1"
+                context={{ 'designsetgo/parentItem': { postId: 99, postType: 'post' } }}
+            />
+        );
+        expect(ctxCapture.some((c) => c?.['designsetgo/parentItem']?.postId === 99)).toBe(true);
+    });
+});
+```
+
+**Step 2: Run and verify it fails**
+
+```bash
+npm run test:unit -- --testPathPattern=NestedPreview
+```
+
+Expected: FAIL — context not forwarded.
+
+**Step 3: Forward and provide context**
+
+In `block.json`, add:
+
+```json
+"usesContext":     ["designsetgo/parentItem", "postId", "postType"],
+"providesContext": {
+    "designsetgo/queryId":      "queryId",
+    "designsetgo/querySource":  "source",
+    "designsetgo/queryPostType":"postType",
+    "designsetgo/parentItem":   "__dsgo_currentItem"
+}
+```
+
+Note: `__dsgo_currentItem` is a synthetic attribute we never persist — it's set dynamically in the edit component via a wrapper component.
+
+In `edit-template.js`, wrap each previewed item with:
+
+```jsx
+<BlockContextProvider
+    key={record.id}
+    value={{
+        postId: record.id,
+        postType: record.type,
+        'designsetgo/parentItem': props.context?.['designsetgo/parentItem'] ?? null,
+    }}
+>
+    {/* BlockPreview or InnerBlocks */}
+</BlockContextProvider>
+```
+
+**Step 4: Run tests**
+
+```bash
+npm run test:unit -- --testPathPattern=NestedPreview
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/blocks/query/block.json src/blocks/query/edit-template.js src/extensions/visibility/ItemContextBridge.js tests/unit/blocks/query/NestedPreview.test.js
+git commit -m "feat(query): forward parent item via BlockContext for nested previews"
+```
+
+---
+
+### Task C4: Nested loop manual QA
+
+**Steps:**
+
+1. `npm run build`
+2. Create a page with:
+   - Outer Query (Posts source, perPage 3)
+     - Item template:
+       - Heading bound to `designsetgo/post-meta` with `scope: self`, key `title`
+       - Inner Query (Posts source, perPage 2), with tax_query scoped to the parent term:
+         - Item template: Paragraph bound to `designsetgo/post-meta` with `scope: self`, key `excerpt`
+3. Save. Verify outer renders three posts, each with up to two nested posts from the same category.
+4. Open the editor; confirm the nested preview shows items (even with mock data).
+5. Add `?q=foo` to the frontend URL; confirm only the outer loop's search applies (since nested query has its own `queryId`).
+
+No commit; log observations in the PR description.
+
+---
+
+## Phase D — Group-by / partitioning
+
+### Task D1: `query-group-header` sibling block
+
+**Why:** Grouping needs a user-editable template for the group header ("Category: News", "Year: 2024"). Cleanest route is a new sibling block similar to `query-no-results`.
+
+**Files:**
+- Create: `src/blocks/query-group-header/block.json`
+- Create: `src/blocks/query-group-header/index.js`
+- Create: `src/blocks/query-group-header/edit.js`
+- Create: `src/blocks/query-group-header/save.js`
+- Create: `src/blocks/query-group-header/render.php`
+- Modify: `src/index.js` (register block)
+- Test: `tests/unit/blocks/query-group-header/edit.test.js`
+
+**Step 1: Write the failing test**
+
+```js
+// tests/unit/blocks/query-group-header/edit.test.js
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+// Reuse the same @wordpress/* mocks pattern from edit.test.js
+import Edit from '../../../../src/blocks/query-group-header/edit';
+
+describe('QueryGroupHeader edit', () => {
+    it('renders an InnerBlocks wrapper', () => {
+        render(<Edit attributes={{}} context={{}} clientId="g1" />);
+        expect(screen.getByTestId('inner-blocks')).toBeInTheDocument();
+    });
+});
+```
+
+**Step 2: Run and verify it fails**
+
+```bash
+npm run test:unit -- --testPathPattern=query-group-header
+```
+
+Expected: FAIL — module not found.
+
+**Step 3: Implement skeleton**
+
+Minimal `block.json` (`apiVersion: 3`, textdomain `"designsetgo"`, `parent: ["designsetgo/query"]`, `usesContext: ["designsetgo/queryId", "designsetgo/groupLabel", "designsetgo/groupValue"]`).
+
+`edit.js` returns `<div {...useBlockProps()}>{useInnerBlocksProps(useBlockProps(), {template: [['core/heading', { level: 3, placeholder: __('Group header', 'designsetgo') }]]}).children}</div>` — follow the same pattern as `query-no-results`.
+
+`render.php` renders `innerBlocks` with the group context set, wrapped in `<div class="dsgo-query-group-header">`.
+
+**Step 4: Verify tests pass**
+
+```bash
+npm run test:unit -- --testPathPattern=query-group-header
+npm run build
+```
+
+Expected: PASS, build green.
+
+**Step 5: Commit**
+
+```bash
+git add src/blocks/query-group-header src/index.js tests/unit/blocks/query-group-header
+git commit -m "feat(query-group-header): new sibling block for group headers"
+```
+
+---
+
+### Task D2: `groupBy` attribute + partitioning logic
+
+**Why:** The parent Query needs a `groupBy` attribute plus render logic that buckets items before emitting them, interleaving group-header blocks.
+
+**Files:**
+- Modify: `src/blocks/query/block.json` (add `groupBy`)
+- Modify: `src/blocks/query/render-helpers.php` (new `designsetgo_query_partition_items()`)
+- Modify: `src/blocks/query/render-posts.php` (integrate partitioning before the items loop)
+- Test: `tests/integration/blocks/query/GroupByTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+// tests/integration/blocks/query/GroupByTest.php
+namespace DesignSetGo\Tests\Integration\Blocks\Query;
+
+use WP_UnitTestCase;
+
+class GroupByTest extends WP_UnitTestCase {
+
+    public function test_partitions_by_taxonomy() {
+        $news_term   = self::factory()->term->create( array( 'taxonomy' => 'category', 'slug' => 'news' ) );
+        $events_term = self::factory()->term->create( array( 'taxonomy' => 'category', 'slug' => 'events' ) );
+
+        $news_post_ids = self::factory()->post->create_many( 2 );
+        foreach ( $news_post_ids as $pid ) wp_set_post_terms( $pid, array( $news_term ), 'category' );
+
+        $events_post_ids = self::factory()->post->create_many( 1 );
+        wp_set_post_terms( $events_post_ids[0], array( $events_term ), 'category' );
+
+        require_once DSGO_PLUGIN_DIR . 'src/blocks/query/render-helpers.php';
+
+        $header_html = '<!-- wp:designsetgo/query-group-header -->'
+                      . '<div class="wp-block-designsetgo-query-group-header"><h3>Group</h3></div>'
+                      . '<!-- /wp:designsetgo/query-group-header -->';
+        $inner       = $header_html . '<!-- wp:paragraph --><p>x</p><!-- /wp:paragraph -->';
+
+        $html = designsetgo_query_render(
+            array(
+                'source'   => 'posts',
+                'postType' => 'post',
+                'perPage'  => 10,
+                'tagName'  => 'ul',
+                'itemTagName' => 'li',
+                'groupBy'  => array( 'field' => 'taxonomy', 'key' => 'category' ),
+            ),
+            array( 'query_id' => 'g1', 'page' => 1, 'inner_html' => $inner, 'params' => array() )
+        )['html'];
+
+        // Two groups → two headers in output.
+        $this->assertSame( 2, substr_count( $html, 'dsgo-query-group-header' ) );
+    }
+}
+```
+
+**Step 2: Run and verify it fails**
+
+```bash
+composer test -- --filter=GroupByTest
+```
+
+Expected: FAIL — groupBy attribute ignored.
+
+**Step 3: Add attribute and partition helper**
+
+In `block.json`:
+
+```json
+"groupBy": { "type": "object", "default": null }
+```
+
+And in `designsetgo_query_defaults()` add `'groupBy' => null`.
+
+Add the partitioner in `render-helpers.php`:
+
+```php
+function designsetgo_query_partition_items( array $post_ids, array $group_spec ) {
+    if ( empty( $group_spec['field'] ) || empty( $group_spec['key'] ) ) {
+        return array( array( 'label' => '', 'value' => '', 'ids' => $post_ids ) );
+    }
+    $field = (string) $group_spec['field'];
+    $key   = (string) $group_spec['key'];
+
+    $groups = array();
+    foreach ( $post_ids as $pid ) {
+        $values = array();
+        if ( 'taxonomy' === $field ) {
+            $terms  = get_the_terms( $pid, $key );
+            $values = empty( $terms ) || is_wp_error( $terms ) ? array( '' ) : wp_list_pluck( $terms, 'slug' );
+            $labels = empty( $terms ) || is_wp_error( $terms ) ? array( __( 'Uncategorized', 'designsetgo' ) ) : wp_list_pluck( $terms, 'name' );
+        } elseif ( 'meta' === $field ) {
+            $values = array( (string) get_post_meta( $pid, $key, true ) );
+            $labels = $values;
+        } elseif ( 'date' === $field ) {
+            $d      = get_post_field( 'post_date', $pid );
+            $values = array( gmdate( 'Y' === $key ? 'Y' : ( 'Y-M' === $key ? 'Y-m' : 'Y-m-d' ), strtotime( $d ) ) );
+            $labels = $values;
+        } else {
+            $values = array( '' );
+            $labels = array( '' );
+        }
+        foreach ( $values as $i => $v ) {
+            $groups[ $v ] ??= array( 'label' => $labels[ $i ] ?? $v, 'value' => $v, 'ids' => array() );
+            $groups[ $v ]['ids'][] = $pid;
+        }
+    }
+    return array_values( $groups );
+}
+```
+
+In `render-posts.php`, split the existing loop: pre-collect IDs, split `innerBlocks` into `group_header_blocks` vs `item_template_blocks` (similar to how `render-helpers.php` already splits siblings), iterate over partitions, and interleave group-header render + item render.
+
+Wrap each group in `<section class="dsgo-query-group" data-dsgo-group-value="...">…</section>`.
+
+**Step 4: Verify tests pass**
+
+```bash
+composer test -- --filter=GroupByTest
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/blocks/query/block.json src/blocks/query/render-helpers.php src/blocks/query/render-posts.php tests/integration/blocks/query/GroupByTest.php
+git commit -m "feat(query): partition items by taxonomy/meta/date with group headers"
+```
+
+---
+
+### Task D3: Group-by inspector control + editor preview
+
+**Files:**
+- Modify: `src/blocks/query/components/QuerySourcePanel.js` (add group-by control to existing panel)
+- Modify: `src/blocks/query/edit-template.js` (render group headers in preview)
+- Test: `tests/unit/blocks/query/edit.test.js` (new describe block)
+
+**Step 1: Write failing test**
+
+```js
+describe('QueryEdit — Group-by', () => {
+    it('renders the group-by type select', () => {
+        renderWith();
+        expect(screen.getByLabelText(/group by/i)).toBeInTheDocument();
+    });
+
+    it('shows a taxonomy picker when groupBy.field is taxonomy', () => {
+        renderWith({ groupBy: { field: 'taxonomy', key: 'category' } });
+        expect(screen.getByLabelText(/group taxonomy/i)).toBeInTheDocument();
+    });
+});
+```
+
+**Step 2: Run and verify fails**
+
+```bash
+npm run test:unit -- --testPathPattern=query/edit.test
+```
+
+**Step 3: Implement the inspector control**
+
+`SelectControl` for `groupBy.field` with options `none` / `taxonomy` / `meta` / `date`. When field changes to non-null, render a second `SelectControl` or `TextControl` for `groupBy.key`.
+
+Wire `setAttributes({ groupBy: { field, key } })` or `setAttributes({ groupBy: null })` depending on the field pick.
+
+**Step 4: Verify tests pass**
+
+```bash
+npm run test:unit -- --testPathPattern=query/edit.test
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/blocks/query/components/QuerySourcePanel.js src/blocks/query/edit-template.js tests/unit/blocks/query/edit.test.js
+git commit -m "feat(query): group-by inspector + editor preview"
+```
+
+---
+
+### Task D4: Group-by manual QA + CSS
+
+**Files:**
+- Modify: `src/blocks/query/style.scss` (basic `.dsgo-query-group` gap rules)
+- Modify: `src/styles/style.scss` + `src/styles/editor.scss` (if not already autoloaded)
+
+**Steps:**
+
+1. `npm run build`
+2. Create posts in two categories (News, Events). Add a Dynamic Query block, enable Group-by → Taxonomy → Category.
+3. Insert a Query Group Header inner block. Put a heading inside bound to a meta field that expands to the group name (for now, hard-code "Section").
+4. Save. Verify frontend renders two `<section class="dsgo-query-group">` blocks with interleaved headers.
+5. Commit CSS with message: `style(query): spacing + structure for .dsgo-query-group`
+
+---
+
+## Phase E — Docs, CHANGELOG, CI, PR
+
+### Task E1: Update the Query guide
+
+**Files:**
+- Modify: `.claude/docs/QUERY-BLOCK-GUIDE.md` (extend Recipes section)
+- Modify: `.claude/CLAUDE.md` (add v2.3 subsection under "Query block family")
+
+Add:
+- Recipe: "Show posts linked via an ACF relationship field".
+- Recipe: "Hide the 'Featured' badge on non-featured posts".
+- Recipe: "Group posts by category with custom group headers".
+- Recipe: "Nested loops — for each post, show its 3 latest sibling posts".
+- Extension point: `designsetgo_visibility_rule` filter for custom rule types.
+
+**Commit:**
+
+```bash
+git add .claude/docs/QUERY-BLOCK-GUIDE.md .claude/CLAUDE.md
+git commit -m "docs: v2.3 recipes + extension points"
+```
+
+---
+
+### Task E2: Update CHANGELOG + plugin header
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `designsetgo.php` (`* Version: 2.3.0`)
+- Modify: `package.json` (`"version": "2.3.0"`)
+
+```markdown
+## [2.3.0] — 2026-04-19
+### Added
+- Dynamic Query: relationship source reads a parent-context field (meta or ACF) and iterates referenced posts.
+- Dynamic Query: nested loops — outer Query's current item is available to inner Queries via `designsetgo/parentItem` context and the new `scope: 'parent' | 'root'` arg on DSGo bindings.
+- Dynamic Query: conditional inner-block visibility via the `dsgoVisibility` attribute, with inspector UI and shared evaluator (meta / taxonomy / index / auth rule types).
+- Dynamic Query: `groupBy` partitions items by taxonomy / meta / date; new `designsetgo/query-group-header` sibling block renders once per group.
+
+### Changed
+- `designsetgo/post-meta` + `designsetgo/acf` bindings accept an optional `scope` arg (defaults to `'self'`).
+
+### Migration
+No breaking changes — all new attributes default to null / `'self'`.
+```
+
+**Commit:**
+
+```bash
+git add CHANGELOG.md designsetgo.php package.json
+git commit -m "chore(release): bump to 2.3.0"
+```
+
+---
+
+### Task E3: Run all checks + push branch + open PR
+
+**Steps:**
+
+1. Run:
+
+```bash
+npm run build
+npm run lint:js
+npm run lint:css
+npm run lint:php
+npm run test:unit
+composer test
+composer analyse
+```
+
+All green.
+
+2. Start wp-env and sanity-check the four features (relationship, visibility, nested, group-by) on `http://localhost:9451/`.
+
+3. Push:
+
+```bash
+git push -u origin claude/query-v2.3-nested
+```
+
+4. Open PR against `main`:
+
+```bash
+gh pr create --title "feat(query): Dynamic Query v2.3 — nested loops, relationships, visibility, group-by" --body "$(cat <<'EOF'
+## Summary
+- Relationship source reads a parent-context field and iterates referenced posts.
+- Nested loops: outer item flows into inner queries via the new `designsetgo/parentItem` context + `scope` arg on DSGo bindings.
+- Conditional visibility: `dsgoVisibility` attribute on every block; shared evaluator; inspector UI.
+- Group-by: `groupBy` attribute + `designsetgo/query-group-header` sibling block partitions results.
+
+## Test plan
+- [ ] `composer test` 100% green.
+- [ ] `npm run test:unit` 100% green.
+- [ ] Manual: relationship source renders referenced posts on frontend + editor preview.
+- [ ] Manual: visibility rule hides a paragraph on non-featured posts.
+- [ ] Manual: nested Query resolves `scope: parent` binding to outer post meta.
+- [ ] Manual: group-by=category renders one header per category.
+- [ ] Manual: infinite scroll + filters still work inside a grouped query (regression).
+
+Follow-up: v2.4 (JetEngine / Meta Box / Pods bindings, PHP escape-hatch UI, JSON export/import).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+5. Return the PR URL.
+
+---
+
+## Out of scope (v2.4+)
+
+- JetEngine / Meta Box / Pods bindings.
+- PHP escape-hatch UI for advanced users.
+- JSON export/import of query configurations.
+- Date-query UI, multi-level AND/OR tree, hierarchical taxonomy drilldown → v2.5+.
+
+---
+
+## Verification checklist (ship gate)
+
+- [ ] `composer test` — all suites green.
+- [ ] `npm run test:unit` — all suites green.
+- [ ] `composer analyse` — phpstan clean.
+- [ ] `npm run lint:js` / `lint:css` / `lint:php` — clean.
+- [ ] `npm run build` — no warnings.
+- [ ] WP admin at `localhost:9451/wp-admin/` — all four headline features work.
+- [ ] Regression: infinite scroll, filters, load-more, editor live preview still work.
+- [ ] CHANGELOG + plugin header updated to 2.3.0.

--- a/includes/blocks/class-query-bindings.php
+++ b/includes/blocks/class-query-bindings.php
@@ -56,6 +56,17 @@ class Bindings {
 				)
 			);
 		}
+
+		if ( ! get_block_bindings_source( 'designsetgo/group-context' ) ) {
+			register_block_bindings_source(
+				'designsetgo/group-context',
+				array(
+					'label'              => __( 'Group Context (DesignSetGo)', 'designsetgo' ),
+					'get_value_callback' => array( $this, 'get_group_context_value' ),
+					'uses_context'       => array( 'designsetgo/groupLabel', 'designsetgo/groupValue' ),
+				)
+			);
+		}
 	}
 
 	/**
@@ -158,10 +169,65 @@ class Bindings {
 	}
 
 	/**
+	 * Returns a group-context value for a block inside a query-group-header.
+	 *
+	 * Supported keys: 'groupLabel' (human-readable term/meta/date label),
+	 * 'groupValue' (slug/key — use this when comparing, rendering links, etc.).
+	 *
+	 * The parent query pushes both keys into the header's context before calling
+	 * render(), but the consuming block (core/heading, core/paragraph, etc.)
+	 * only exposes `$block->context` for keys it declared in `usesContext`. We
+	 * fall back to the block's full `available_context` via Reflection so
+	 * authors don't have to modify core blocks.
+	 *
+	 * @param array          $args           Binding args (expects 'key').
+	 * @param \WP_Block|null $block          The current block instance.
+	 * @param string         $attribute_name The bound attribute name.
+	 * @return string|null
+	 */
+	public function get_group_context_value( array $args, $block = null, $attribute_name = 'content' ) {
+		$key = isset( $args['key'] ) ? (string) $args['key'] : 'groupLabel';
+		if ( 'groupValue' !== $key ) {
+			$key = 'groupLabel';
+		}
+		$context_key = 'designsetgo/' . $key;
+
+		if ( $block && isset( $block->context[ $context_key ] ) ) {
+			$value = (string) $block->context[ $context_key ];
+			return '' === $value ? null : $value;
+		}
+
+		// Fallback: read the full available_context (protected property) via Reflection.
+		// Inner blocks like core/heading don't declare usesContext for the group keys,
+		// so $block->context would be empty even though available_context has the values.
+		if ( $block instanceof \WP_Block ) {
+			try {
+				$prop = new \ReflectionProperty( \WP_Block::class, 'available_context' );
+				$prop->setAccessible( true );
+				$available = $prop->getValue( $block );
+				if ( isset( $available[ $context_key ] ) ) {
+					$value = (string) $available[ $context_key ];
+					return '' === $value ? null : $value;
+				}
+			} catch ( \ReflectionException $e ) {
+				// Property not accessible — nothing to do.
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * Resolves the post ID to read from, taking the 'scope' arg into account.
 	 *
-	 * - 'parent': reads the most-recently-pushed item from $GLOBALS['designsetgo_parent_stack'].
-	 * - 'root':   reads the first (outermost) item from the same stack.
+	 * The parent stack maintained by `designsetgo_query_render_item()` pushes the
+	 * CURRENT item before rendering its innerBlocks, so at binding-resolution time
+	 * the stack looks like `[...ancestors, self]`. 'parent' therefore means the
+	 * penultimate entry (ancestor one level up), not the top.
+	 *
+	 * - 'parent': reads the ancestor one level up (penultimate stack entry). Returns 0
+	 *   when no outer query is iterating.
+	 * - 'root':   reads the outermost (first) entry. Returns 0 when the stack is empty.
 	 * - 'self' (default): reads from the block's own context, with a Reflection fallback.
 	 *
 	 * @param array          $args  Binding args (optional 'scope': 'self'|'parent'|'root').
@@ -172,8 +238,10 @@ class Bindings {
 		$scope = isset( $args['scope'] ) ? (string) $args['scope'] : 'self';
 
 		if ( 'parent' === $scope ) {
-			$stack  = isset( $GLOBALS['designsetgo_parent_stack'] ) && is_array( $GLOBALS['designsetgo_parent_stack'] ) ? $GLOBALS['designsetgo_parent_stack'] : array();
-			$parent = empty( $stack ) ? null : end( $stack );
+			$stack = isset( $GLOBALS['designsetgo_parent_stack'] ) && is_array( $GLOBALS['designsetgo_parent_stack'] ) ? $GLOBALS['designsetgo_parent_stack'] : array();
+			$count = count( $stack );
+			// Skip the top entry — that's the current item (same as 'self').
+			$parent = $count >= 2 ? $stack[ $count - 2 ] : null;
 			if ( is_array( $parent ) && ! empty( $parent['postId'] ) ) {
 				return (int) $parent['postId'];
 			}

--- a/includes/blocks/class-query-bindings.php
+++ b/includes/blocks/class-query-bindings.php
@@ -74,25 +74,7 @@ class Bindings {
 			return null;
 		}
 
-		$scope = isset( $args['scope'] ) ? (string) $args['scope'] : 'self';
-
-		$post_id = 0;
-		if ( 'parent' === $scope ) {
-			$stack  = isset( $GLOBALS['designsetgo_parent_stack'] ) && is_array( $GLOBALS['designsetgo_parent_stack'] ) ? $GLOBALS['designsetgo_parent_stack'] : array();
-			$parent = empty( $stack ) ? null : end( $stack );
-			if ( is_array( $parent ) && ! empty( $parent['postId'] ) ) {
-				$post_id = (int) $parent['postId'];
-			}
-		} elseif ( 'root' === $scope ) {
-			$stack = isset( $GLOBALS['designsetgo_parent_stack'] ) && is_array( $GLOBALS['designsetgo_parent_stack'] ) ? $GLOBALS['designsetgo_parent_stack'] : array();
-			$root  = empty( $stack ) ? null : reset( $stack );
-			if ( is_array( $root ) && ! empty( $root['postId'] ) ) {
-				$post_id = (int) $root['postId'];
-			}
-		} else {
-			$post_id = self::resolve_post_id_from_block( $block );
-		}
-
+		$post_id = $this->resolve_scoped_post_id( $args, $block );
 		if ( ! $post_id ) {
 			$post_id = get_the_ID();
 		}
@@ -140,25 +122,7 @@ class Bindings {
 			return null;
 		}
 
-		$scope = isset( $args['scope'] ) ? (string) $args['scope'] : 'self';
-
-		$post_id = 0;
-		if ( 'parent' === $scope ) {
-			$stack  = isset( $GLOBALS['designsetgo_parent_stack'] ) && is_array( $GLOBALS['designsetgo_parent_stack'] ) ? $GLOBALS['designsetgo_parent_stack'] : array();
-			$parent = empty( $stack ) ? null : end( $stack );
-			if ( is_array( $parent ) && ! empty( $parent['postId'] ) ) {
-				$post_id = (int) $parent['postId'];
-			}
-		} elseif ( 'root' === $scope ) {
-			$stack = isset( $GLOBALS['designsetgo_parent_stack'] ) && is_array( $GLOBALS['designsetgo_parent_stack'] ) ? $GLOBALS['designsetgo_parent_stack'] : array();
-			$root  = empty( $stack ) ? null : reset( $stack );
-			if ( is_array( $root ) && ! empty( $root['postId'] ) ) {
-				$post_id = (int) $root['postId'];
-			}
-		} else {
-			$post_id = self::resolve_post_id_from_block( $block );
-		}
-
+		$post_id = $this->resolve_scoped_post_id( $args, $block );
 		if ( ! $post_id ) {
 			$post_id = get_the_ID();
 		}
@@ -194,6 +158,46 @@ class Bindings {
 	}
 
 	/**
+	 * Resolves the post ID to read from, taking the 'scope' arg into account.
+	 *
+	 * - 'parent': reads the most-recently-pushed item from $GLOBALS['designsetgo_parent_stack'].
+	 * - 'root':   reads the first (outermost) item from the same stack.
+	 * - 'self' (default): reads from the block's own context, with a Reflection fallback.
+	 *
+	 * @param array          $args  Binding args (optional 'scope': 'self'|'parent'|'root').
+	 * @param \WP_Block|null $block The current block instance.
+	 * @return int Post ID, or 0 if not resolvable.
+	 */
+	private function resolve_scoped_post_id( array $args, $block ) {
+		$scope = isset( $args['scope'] ) ? (string) $args['scope'] : 'self';
+
+		if ( 'parent' === $scope ) {
+			$stack  = isset( $GLOBALS['designsetgo_parent_stack'] ) && is_array( $GLOBALS['designsetgo_parent_stack'] ) ? $GLOBALS['designsetgo_parent_stack'] : array();
+			$parent = empty( $stack ) ? null : end( $stack );
+			if ( is_array( $parent ) && ! empty( $parent['postId'] ) ) {
+				return (int) $parent['postId'];
+			}
+			return 0;
+		}
+
+		if ( 'root' === $scope ) {
+			$stack = isset( $GLOBALS['designsetgo_parent_stack'] ) && is_array( $GLOBALS['designsetgo_parent_stack'] ) ? $GLOBALS['designsetgo_parent_stack'] : array();
+			$root  = empty( $stack ) ? null : reset( $stack );
+			if ( is_array( $root ) && ! empty( $root['postId'] ) ) {
+				return (int) $root['postId'];
+			}
+			return 0;
+		}
+
+		// 'self' (default) — read from block context (with the existing reflection fallback).
+		if ( $block && isset( $block->context['postId'] ) ) {
+			return (int) $block->context['postId'];
+		}
+		// Reflection fallback — preserve the existing logic.
+		return $this->resolve_post_id_from_block_reflection( $block );
+	}
+
+	/**
 	 * Resolves the post ID from a block's context.
 	 *
 	 * First checks `$block->context['postId']` (populated when the block type
@@ -206,7 +210,7 @@ class Bindings {
 	 * @param \WP_Block|null $block The current block instance.
 	 * @return int Post ID, or 0 if not resolvable.
 	 */
-	private static function resolve_post_id_from_block( $block ) {
+	private function resolve_post_id_from_block_reflection( $block ) {
 		if ( ! $block instanceof \WP_Block ) {
 			return 0;
 		}

--- a/includes/blocks/class-query-bindings.php
+++ b/includes/blocks/class-query-bindings.php
@@ -210,7 +210,9 @@ class Bindings {
 					return '' === $value ? null : $value;
 				}
 			} catch ( \ReflectionException $e ) {
-				// Property not accessible — nothing to do.
+				// WP_Block::$available_context is no longer reflectable on this WP
+				// version — fall through to returning null. No recovery possible.
+				unset( $e );
 			}
 		}
 
@@ -298,7 +300,9 @@ class Bindings {
 				return (int) $available['postId'];
 			}
 		} catch ( \ReflectionException $e ) {
-			// Property not accessible — nothing to do.
+			// WP_Block::$available_context is no longer reflectable on this WP
+			// version — fall through to returning 0. No recovery possible.
+			unset( $e );
 		}
 
 		return 0;

--- a/includes/blocks/class-query-bindings.php
+++ b/includes/blocks/class-query-bindings.php
@@ -61,7 +61,7 @@ class Bindings {
 	/**
 	 * Returns a single post-meta value for the bound block.
 	 *
-	 * @param array          $args           Binding args (expects 'key').
+	 * @param array          $args           Binding args (expects 'key'; optional 'scope': 'self'|'parent'|'root').
 	 * @param \WP_Block|null $block          The current block instance.
 	 * @param string         $attribute_name The bound attribute name.
 	 * @return string|null
@@ -74,10 +74,25 @@ class Bindings {
 			return null;
 		}
 
+		$scope = isset( $args['scope'] ) ? (string) $args['scope'] : 'self';
+
 		$post_id = 0;
-		if ( $block && isset( $block->context['postId'] ) ) {
-			$post_id = (int) $block->context['postId'];
+		if ( 'parent' === $scope ) {
+			$stack  = isset( $GLOBALS['designsetgo_parent_stack'] ) && is_array( $GLOBALS['designsetgo_parent_stack'] ) ? $GLOBALS['designsetgo_parent_stack'] : array();
+			$parent = empty( $stack ) ? null : end( $stack );
+			if ( is_array( $parent ) && ! empty( $parent['postId'] ) ) {
+				$post_id = (int) $parent['postId'];
+			}
+		} elseif ( 'root' === $scope ) {
+			$stack = isset( $GLOBALS['designsetgo_parent_stack'] ) && is_array( $GLOBALS['designsetgo_parent_stack'] ) ? $GLOBALS['designsetgo_parent_stack'] : array();
+			$root  = empty( $stack ) ? null : reset( $stack );
+			if ( is_array( $root ) && ! empty( $root['postId'] ) ) {
+				$post_id = (int) $root['postId'];
+			}
+		} else {
+			$post_id = self::resolve_post_id_from_block( $block );
 		}
+
 		if ( ! $post_id ) {
 			$post_id = get_the_ID();
 		}
@@ -108,7 +123,7 @@ class Bindings {
 	/**
 	 * Returns a single ACF field value for the bound block.
 	 *
-	 * @param array          $args           Binding args (expects 'key').
+	 * @param array          $args           Binding args (expects 'key'; optional 'scope': 'self'|'parent'|'root').
 	 * @param \WP_Block|null $block          The current block instance.
 	 * @param string         $attribute_name The bound attribute name.
 	 * @return string|null
@@ -125,10 +140,25 @@ class Bindings {
 			return null;
 		}
 
+		$scope = isset( $args['scope'] ) ? (string) $args['scope'] : 'self';
+
 		$post_id = 0;
-		if ( $block && isset( $block->context['postId'] ) ) {
-			$post_id = (int) $block->context['postId'];
+		if ( 'parent' === $scope ) {
+			$stack  = isset( $GLOBALS['designsetgo_parent_stack'] ) && is_array( $GLOBALS['designsetgo_parent_stack'] ) ? $GLOBALS['designsetgo_parent_stack'] : array();
+			$parent = empty( $stack ) ? null : end( $stack );
+			if ( is_array( $parent ) && ! empty( $parent['postId'] ) ) {
+				$post_id = (int) $parent['postId'];
+			}
+		} elseif ( 'root' === $scope ) {
+			$stack = isset( $GLOBALS['designsetgo_parent_stack'] ) && is_array( $GLOBALS['designsetgo_parent_stack'] ) ? $GLOBALS['designsetgo_parent_stack'] : array();
+			$root  = empty( $stack ) ? null : reset( $stack );
+			if ( is_array( $root ) && ! empty( $root['postId'] ) ) {
+				$post_id = (int) $root['postId'];
+			}
+		} else {
+			$post_id = self::resolve_post_id_from_block( $block );
 		}
+
 		if ( ! $post_id ) {
 			$post_id = get_the_ID();
 		}
@@ -161,5 +191,44 @@ class Bindings {
 			return null;
 		}
 		return (string) $value;
+	}
+
+	/**
+	 * Resolves the post ID from a block's context.
+	 *
+	 * First checks `$block->context['postId']` (populated when the block type
+	 * declares `uses_context: ['postId']`). Falls back to reading the
+	 * protected `available_context` via Reflection, which always holds the full
+	 * ancestor context regardless of the block type's `uses_context` declaration.
+	 * This fallback is used in tests and edge-cases where block type registration
+	 * is absent or incomplete.
+	 *
+	 * @param \WP_Block|null $block The current block instance.
+	 * @return int Post ID, or 0 if not resolvable.
+	 */
+	private static function resolve_post_id_from_block( $block ) {
+		if ( ! $block instanceof \WP_Block ) {
+			return 0;
+		}
+
+		if ( isset( $block->context['postId'] ) ) {
+			return (int) $block->context['postId'];
+		}
+
+		// Fallback: read the full available_context (protected property) via Reflection.
+		// WP_Block filters context to only keys declared in uses_context, but the unfiltered
+		// available_context always carries the full ancestor context.
+		try {
+			$prop = new \ReflectionProperty( \WP_Block::class, 'available_context' );
+			$prop->setAccessible( true );
+			$available = $prop->getValue( $block );
+			if ( isset( $available['postId'] ) ) {
+				return (int) $available['postId'];
+			}
+		} catch ( \ReflectionException $e ) {
+			// Property not accessible — nothing to do.
+		}
+
+		return 0;
 	}
 }

--- a/includes/class-block-visibility.php
+++ b/includes/class-block-visibility.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Shared rule evaluator for the dsgoVisibility attribute.
+ *
+ * Pure static methods — no WordPress hooks, no state. Consumers
+ * (render helpers, REST endpoints) pass a rules array and a
+ * per-item context; the evaluator returns bool.
+ *
+ * @package DesignSetGo
+ * @since   2.3.0
+ */
+
+namespace DesignSetGo;
+
+defined( 'ABSPATH' ) || exit;
+
+class BlockVisibility {
+
+	/**
+	 * Evaluate a dsgoVisibility rules object against per-item context.
+	 *
+	 * Returns true when the block should be rendered; false to suppress it.
+	 * An empty or null rules value is treated as "always visible".
+	 *
+	 * @param array|null $rules   The dsgoVisibility attribute value.
+	 * @param array      $context Per-item context: postId, postType, index, etc.
+	 * @return bool Whether the block should render.
+	 */
+	public static function matches( $rules, array $context ) {
+		if ( empty( $rules ) || ! is_array( $rules ) || empty( $rules['rules'] ) ) {
+			return true;
+		}
+
+		$operator = isset( $rules['operator'] ) && 'OR' === strtoupper( (string) $rules['operator'] ) ? 'OR' : 'AND';
+
+		foreach ( (array) $rules['rules'] as $rule ) {
+			$matched = self::evaluate_rule( (array) $rule, $context );
+			if ( 'OR' === $operator && $matched ) {
+				return true;
+			}
+			if ( 'AND' === $operator && ! $matched ) {
+				return false;
+			}
+		}
+		return 'AND' === $operator;
+	}
+
+	/**
+	 * Dispatch a single rule to its type handler.
+	 *
+	 * @param array $rule    Rule definition array.
+	 * @param array $context Per-item context.
+	 * @return bool Whether the rule matches.
+	 */
+	private static function evaluate_rule( array $rule, array $context ) {
+		$type = isset( $rule['type'] ) ? (string) $rule['type'] : '';
+		switch ( $type ) {
+			case 'meta':
+				return self::evaluate_meta( $rule, $context );
+			case 'taxonomy':
+				return self::evaluate_taxonomy( $rule, $context );
+			case 'index':
+				return self::evaluate_index( $rule, $context );
+			case 'auth':
+				return self::evaluate_auth( $rule );
+		}
+
+		/**
+		 * Filter to add custom rule types.
+		 *
+		 * @param bool|null $match   Return bool to short-circuit; null to fall through (returns false).
+		 * @param array     $rule    The rule definition.
+		 * @param array     $context The per-item context.
+		 */
+		$filtered = apply_filters( 'designsetgo_visibility_rule', null, $rule, $context );
+		return (bool) $filtered;
+	}
+
+	/**
+	 * Evaluate a post-meta rule.
+	 *
+	 * @param array $rule    Rule definition: key, op, value.
+	 * @param array $context Per-item context: postId.
+	 * @return bool
+	 */
+	private static function evaluate_meta( array $rule, array $context ) {
+		$post_id = isset( $context['postId'] ) ? (int) $context['postId'] : 0;
+		$key     = isset( $rule['key'] ) ? sanitize_text_field( (string) $rule['key'] ) : '';
+		if ( ! $post_id || '' === $key ) {
+			return false;
+		}
+		$actual = get_post_meta( $post_id, $key, true );
+		return self::compare( $actual, $rule['op'] ?? 'equals', $rule['value'] ?? '' );
+	}
+
+	/**
+	 * Evaluate a taxonomy membership rule.
+	 *
+	 * @param array $rule    Rule definition: taxonomy, op (has|not_has), value (slug).
+	 * @param array $context Per-item context: postId.
+	 * @return bool
+	 */
+	private static function evaluate_taxonomy( array $rule, array $context ) {
+		$post_id  = isset( $context['postId'] ) ? (int) $context['postId'] : 0;
+		$taxonomy = isset( $rule['taxonomy'] ) ? sanitize_key( (string) $rule['taxonomy'] ) : '';
+		if ( ! $post_id || '' === $taxonomy ) {
+			return false;
+		}
+		$terms = get_the_terms( $post_id, $taxonomy );
+		if ( empty( $terms ) || is_wp_error( $terms ) ) {
+			return 'not_has' === ( $rule['op'] ?? 'has' );
+		}
+		$slugs    = wp_list_pluck( $terms, 'slug' );
+		$needle   = sanitize_title( (string) ( $rule['value'] ?? '' ) );
+		$contains = in_array( $needle, $slugs, true );
+		return 'not_has' === ( $rule['op'] ?? 'has' ) ? ! $contains : $contains;
+	}
+
+	/**
+	 * Evaluate an item-index rule.
+	 *
+	 * @param array $rule    Rule definition: op, value.
+	 * @param array $context Per-item context: index (0-based).
+	 * @return bool
+	 */
+	private static function evaluate_index( array $rule, array $context ) {
+		$actual = isset( $context['index'] ) ? (int) $context['index'] : -1;
+		return self::compare( $actual, $rule['op'] ?? 'equals', (int) ( $rule['value'] ?? 0 ) );
+	}
+
+	/**
+	 * Evaluate an authentication state rule.
+	 *
+	 * @param array $rule Rule definition: value (bool — true = logged-in required).
+	 * @return bool
+	 */
+	private static function evaluate_auth( array $rule ) {
+		$expect = isset( $rule['value'] ) ? (bool) $rule['value'] : true;
+		return is_user_logged_in() === $expect;
+	}
+
+	/**
+	 * Compare an actual value to an expected value using the given operator.
+	 *
+	 * Supported operators: equals, not_equals, contains, gt, lt, empty, not_empty.
+	 *
+	 * @param mixed  $actual   The resolved value.
+	 * @param string $op       Comparison operator.
+	 * @param mixed  $expected The expected value.
+	 * @return bool
+	 */
+	private static function compare( $actual, $op, $expected ) {
+		switch ( $op ) {
+			case 'not_equals':
+				return (string) $actual !== (string) $expected;
+			case 'contains':
+				return false !== stripos( (string) $actual, (string) $expected );
+			case 'gt':
+				return (float) $actual > (float) $expected;
+			case 'lt':
+				return (float) $actual < (float) $expected;
+			case 'empty':
+				return '' === (string) $actual || null === $actual;
+			case 'not_empty':
+				return '' !== (string) $actual && null !== $actual;
+			case 'equals':
+			default:
+				return (string) $actual === (string) $expected;
+		}
+	}
+}

--- a/includes/class-block-visibility.php
+++ b/includes/class-block-visibility.php
@@ -14,6 +14,12 @@ namespace DesignSetGo;
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Evaluates `dsgoVisibility` rules against per-item context during query renders.
+ *
+ * Pure static helpers plus a single `render_block` filter registered via
+ * `register()` that gates nested inner blocks inside a query item template.
+ */
 class BlockVisibility {
 
 	/**

--- a/includes/class-block-visibility.php
+++ b/includes/class-block-visibility.php
@@ -17,6 +17,51 @@ defined( 'ABSPATH' ) || exit;
 class BlockVisibility {
 
 	/**
+	 * Register the render_block filter once at plugin bootstrap.
+	 *
+	 * Idempotent — safe to call multiple times; only hooks once.
+	 * This gates nested block rendering (inside core/group, core/columns, etc.)
+	 * by reading the top of $GLOBALS['designsetgo_parent_stack'] set by
+	 * designsetgo_query_render_item().
+	 */
+	public static function register() {
+		static $registered = false;
+		if ( $registered ) {
+			return;
+		}
+		$registered = true;
+		add_filter( 'render_block', array( __CLASS__, 'filter_render_block' ), 10, 2 );
+	}
+
+	/**
+	 * Filter callback: suppress nested blocks whose dsgoVisibility rules do not
+	 * match the current item context.
+	 *
+	 * Only active when $GLOBALS['designsetgo_parent_stack'] is non-empty, meaning
+	 * we are inside a designsetgo_query_render_item() call. Top-level template
+	 * blocks are already gated in the render_item loop (optimisation: they skip
+	 * WP_Block instantiation entirely); this filter catches blocks at deeper
+	 * nesting levels that are rendered recursively by WP_Block::render().
+	 *
+	 * @param string $block_content Rendered block HTML.
+	 * @param array  $parsed_block  Parsed block array (blockName + attrs).
+	 * @return string Empty string when rules do not match; original content otherwise.
+	 */
+	public static function filter_render_block( $block_content, $parsed_block ) {
+		if ( empty( $GLOBALS['designsetgo_parent_stack'] ) ) {
+			return $block_content;
+		}
+		$visibility = $parsed_block['attrs']['dsgoVisibility'] ?? null;
+		if ( null === $visibility ) {
+			return $block_content;
+		}
+		$ctx = end( $GLOBALS['designsetgo_parent_stack'] );
+		return self::matches( $visibility, is_array( $ctx ) ? $ctx : array() )
+			? $block_content
+			: '';
+	}
+
+	/**
 	 * Evaluate a dsgoVisibility rules object against per-item context.
 	 *
 	 * Returns true when the block should be rendered; false to suppress it.

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -518,6 +518,7 @@ class Plugin {
 	 * Load required files.
 	 */
 	private function load_dependencies() {
+		require_once DESIGNSETGO_PATH . 'includes/class-block-visibility.php';
 		require_once DESIGNSETGO_PATH . 'includes/class-assets.php';
 		require_once DESIGNSETGO_PATH . 'includes/blocks/class-loader.php';
 		require_once DESIGNSETGO_PATH . 'includes/blocks/class-form-security.php';

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -519,6 +519,7 @@ class Plugin {
 	 */
 	private function load_dependencies() {
 		require_once DESIGNSETGO_PATH . 'includes/class-block-visibility.php';
+		BlockVisibility::register();
 		require_once DESIGNSETGO_PATH . 'includes/class-assets.php';
 		require_once DESIGNSETGO_PATH . 'includes/blocks/class-loader.php';
 		require_once DESIGNSETGO_PATH . 'includes/blocks/class-form-security.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "designsetgo",
-  "version": "2.3.0",
+  "version": "2.1.0",
   "description": "Professional Gutenberg block library with 46 blocks and 14 extensions - complete Form Builder, container system, interactive elements, scroll effects, and animations. Built with WordPress standards.",
   "author": "DesignSetGo",
   "license": "GPL-2.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "designsetgo",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Professional Gutenberg block library with 46 blocks and 14 extensions - complete Form Builder, container system, interactive elements, scroll effects, and animations. Built with WordPress standards.",
   "author": "DesignSetGo",
   "license": "GPL-2.0-or-later",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,9 @@
 		<testsuite name="DesignSetGo">
 			<directory suffix="-test.php">./tests/phpunit</directory>
 		</testsuite>
+		<testsuite name="DesignSetGo Integration">
+			<directory suffix="Test.php">./tests/integration</directory>
+		</testsuite>
 	</testsuites>
 	<coverage>
 		<include>

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -16,7 +16,7 @@ process.env.STORAGE_STATE_PATH =
 	path.join(process.env.WP_ARTIFACTS_PATH, 'storage-states/admin.json');
 
 // WordPress environment URL (matches port in .wp-env.json)
-const WP_BASE_URL = process.env.WP_BASE_URL || 'http://localhost:9449';
+const WP_BASE_URL = process.env.WP_BASE_URL || 'http://localhost:9451';
 const baseUrl = new URL(WP_BASE_URL);
 
 module.exports = defineConfig({

--- a/src/blocks/query-group-header/block.json
+++ b/src/blocks/query-group-header/block.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 3,
+  "name": "designsetgo/query-group-header",
+  "version": "1.0.0",
+  "title": "Query Group Header",
+  "category": "designsetgo",
+  "description": "Renders once per group inside a Query with group-by enabled. Use block bindings or context to display the group label.",
+  "keywords": ["query", "group", "header", "section"],
+  "textdomain": "designsetgo",
+  "icon": "list-view",
+  "parent": ["designsetgo/query"],
+  "usesContext": ["designsetgo/queryId", "designsetgo/groupLabel", "designsetgo/groupValue"],
+  "supports": {
+    "anchor": true,
+    "html": false,
+    "spacing": {
+      "margin": true,
+      "padding": true,
+      "blockGap": true
+    },
+    "typography": {
+      "fontSize": true,
+      "lineHeight": true
+    }
+  },
+  "attributes": {
+    "tagName": { "type": "string", "default": "header" }
+  },
+  "example": { "attributes": {} },
+  "editorScript": "file:./index.js",
+  "render": "file:./render.php"
+}

--- a/src/blocks/query-group-header/edit.js
+++ b/src/blocks/query-group-header/edit.js
@@ -1,0 +1,15 @@
+import { __ } from '@wordpress/i18n';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+const TEMPLATE = [
+	[ 'core/heading', { level: 3, placeholder: __( 'Group header', 'designsetgo' ) } ],
+];
+
+export default function Edit() {
+	const blockProps = useBlockProps( { className: 'dsgo-query-group-header' } );
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		template: TEMPLATE,
+		templateLock: false,
+	} );
+	return <div { ...innerBlocksProps } />;
+}

--- a/src/blocks/query-group-header/index.js
+++ b/src/blocks/query-group-header/index.js
@@ -1,0 +1,29 @@
+import { registerBlockType } from '@wordpress/blocks';
+import edit from './edit';
+import save from './save';
+import metadata from './block.json';
+import { ICON_COLOR } from '../shared/constants';
+
+registerBlockType( metadata.name, {
+	...metadata,
+	icon: {
+		src: (
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			>
+				<rect x="3" y="3" width="18" height="5" rx="1" />
+				<line x1="3" y1="12" x2="21" y2="12" />
+				<line x1="3" y1="17" x2="15" y2="17" />
+			</svg>
+		),
+		foreground: ICON_COLOR,
+	},
+	edit,
+	save,
+} );

--- a/src/blocks/query-group-header/render.php
+++ b/src/blocks/query-group-header/render.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Query Group Header — server-side render.
+ *
+ * Wraps parsed inner content in the configured tag element.
+ * The parent Query's group-by logic (Task D2) controls whether this block
+ * is actually emitted for each group; this file only handles the HTML wrapper.
+ *
+ * @package DesignSetGo
+ * @since   2.3.0
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Parsed inner content (WP has already rendered innerBlocks).
+ * @param WP_Block $block      Block instance.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$allowed_tags = array( 'header', 'div', 'section' );
+$tag          = isset( $attributes['tagName'] ) && in_array( $attributes['tagName'], $allowed_tags, true )
+	? $attributes['tagName']
+	: 'header';
+
+$wrapper = get_block_wrapper_attributes( array( 'class' => 'dsgo-query-group-header' ) );
+
+printf(
+	'<%1$s %2$s>%3$s</%1$s>',
+	$tag, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- validated against allowlist above.
+	$wrapper, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	$content  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- innerBlocks HTML is WP-sanitized on save.
+);

--- a/src/blocks/query-group-header/save.js
+++ b/src/blocks/query-group-header/save.js
@@ -1,0 +1,12 @@
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+export default function save() {
+	const blockProps = useBlockProps.save( {
+		className: 'dsgo-query-group-header',
+	} );
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks.Content />
+		</div>
+	);
+}

--- a/src/blocks/query-group-header/save.js
+++ b/src/blocks/query-group-header/save.js
@@ -1,12 +1,7 @@
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 
+// render.php wraps innerBlocks in the configured tag (header/div/section).
+// Returning an InnerBlocks.Content wrapper here would double-wrap the output.
 export default function save() {
-	const blockProps = useBlockProps.save( {
-		className: 'dsgo-query-group-header',
-	} );
-	return (
-		<div { ...blockProps }>
-			<InnerBlocks.Content />
-		</div>
-	);
+	return <InnerBlocks.Content />;
 }

--- a/src/blocks/query/block.json
+++ b/src/blocks/query/block.json
@@ -31,6 +31,7 @@
       "__experimentalDefaultControls": { "fontSize": true }
     }
   },
+  "usesContext": ["postId", "postType", "designsetgo/parentItem"],
   "providesContext": {
     "designsetgo/queryId": "queryId",
     "designsetgo/querySource": "source",

--- a/src/blocks/query/block.json
+++ b/src/blocks/query/block.json
@@ -38,7 +38,9 @@
   },
   "attributes": {
     "queryId": { "type": "string", "default": "" },
-    "source": { "type": "string", "default": "posts", "enum": ["posts", "users", "terms", "manual", "current"] },
+    "source": { "type": "string", "default": "posts", "enum": ["posts", "users", "terms", "manual", "current", "relationship"] },
+    "relationshipField": { "type": "string", "default": "" },
+    "relationshipFallback": { "type": "string", "default": "empty", "enum": ["empty", "all", "parent"] },
     "postType": { "type": "string", "default": "post" },
     "perPage": { "type": "number", "default": 6 },
     "offset": { "type": "number", "default": 0 },

--- a/src/blocks/query/block.json
+++ b/src/blocks/query/block.json
@@ -69,7 +69,8 @@
     "columnsMobile": { "type": "number", "default": 0 },
     "columnGap": { "type": "string", "default": "" },
     "showPlaceholder": { "type": "boolean", "default": true },
-    "emitSchema": { "type": "boolean", "default": true }
+    "emitSchema": { "type": "boolean", "default": true },
+    "groupBy": { "type": "object", "default": null }
   },
   "example": { "attributes": { "perPage": 3 } },
   "viewScriptModule": "file:./view.js",

--- a/src/blocks/query/components/EditorPreviewList.js
+++ b/src/blocks/query/components/EditorPreviewList.js
@@ -29,11 +29,14 @@ import { addQueryArgs } from '@wordpress/url';
  * @param {Object} props.innerBlocksProps Props from useInnerBlocksProps in edit.js —
  *                                        spread onto item 0's container so the block
  *                                        editor "owns" the inner blocks slot correctly.
+ * @param {Object} [props.context]        Block context passed from edit.js (may include
+ *                                        designsetgo/parentItem from an outer Query).
  */
 export default function EditorPreviewList({
 	attributes,
 	innerBlocks,
 	innerBlocksProps,
+	context,
 }) {
 	const source = attributes.source || 'posts';
 	const isPosts = source === 'posts';
@@ -68,7 +71,7 @@ export default function EditorPreviewList({
 	return (
 		<ul className="dsgo-query__editor-preview-list">
 			{records.map((item, idx) => {
-				const context = buildContext(item, source);
+				const itemContext = buildContext(item, source, idx, context);
 				return (
 					<li
 						key={item.id}
@@ -78,7 +81,7 @@ export default function EditorPreviewList({
 								: 'dsgo-query__editor-preview-item is-read-only'
 						}
 					>
-						<BlockContextProvider value={context}>
+						<BlockContextProvider value={itemContext}>
 							{idx === 0 ? (
 								<EditableTemplate
 									innerBlocksProps={innerBlocksProps}
@@ -245,36 +248,99 @@ function useRemotePreview(attributes, enabled) {
 // ---------------------------------------------------------------------------
 
 /**
+ * Build a taxonomy → term-slug-array map from a preview item.
+ *
+ * WP REST post objects expose embedded terms under `_embedded['wp:term']`
+ * as an array of taxonomy arrays. We flatten these into a plain object
+ * so inner blocks (and the visibility gate) can filter by taxonomy slug.
+ *
+ * @param {Object} item WP REST post object (may have _embedded or taxonomies).
+ * @return {Object} e.g. { category: ['news'], post_tag: ['js'] }
+ */
+function buildTermsMap(item) {
+	const map = {};
+	const embedded = item?._embedded?.['wp:term'];
+	if (!Array.isArray(embedded)) {
+		return map;
+	}
+	embedded.forEach((taxTerms) => {
+		if (!Array.isArray(taxTerms) || taxTerms.length === 0) {
+			return;
+		}
+		const taxonomy = taxTerms[0]?.taxonomy;
+		if (!taxonomy) {
+			return;
+		}
+		map[taxonomy] = taxTerms.map((t) => t.slug).filter(Boolean);
+	});
+	return map;
+}
+
+/**
  * Build the BlockContextProvider value for a single preview item.
  *
  * Posts use the native `postId` + `postType` shape that core Block Bindings
  * (post-meta etc.) understand. Users and Terms use the designsetgo custom
  * context keys.
  *
- * @param {Object} item   Preview item: { id, type, ... }.
- * @param {string} source The query block source attribute value.
+ * Extends the base context with:
+ * - `designsetgo/itemIndex`  — zero-based position in the result set.
+ * - `designsetgo/itemMeta`   — post meta map (if available from REST embed).
+ * - `designsetgo/itemTerms`  — taxonomy → slug-array map.
+ * - `designsetgo/parentItem` — the outer Query's current item (when nested),
+ *   or a self-referencing fallback for root-level Queries so inner Query
+ *   blocks always receive a defined value.
+ *
+ * @param {Object} item      Preview item: { id, type, ... }.
+ * @param {string} source    The query block source attribute value.
+ * @param {number} index     Zero-based item index in the current result set.
+ * @param {Object} outerCtx  The block's `context` prop from edit.js. May carry
+ *                           `designsetgo/parentItem` when this Query is nested.
  * @return {Object} Context object for BlockContextProvider.
  */
-function buildContext(item, source) {
+function buildContext(item, source, index, outerCtx) {
+	// Common enrichment applied regardless of source type.
+	const enrichment = {
+		'designsetgo/itemIndex': index,
+		'designsetgo/itemMeta': item.meta || {},
+		'designsetgo/itemTerms': buildTermsMap(item),
+	};
+
+	let base;
 	if (source === 'posts' || source === 'manual' || source === 'current') {
-		return {
+		base = {
 			postId: item.id,
 			postType: item.type || 'post',
 		};
-	}
-	if (source === 'users') {
-		return {
+	} else if (source === 'users') {
+		base = {
 			'designsetgo/currentItemId': item.id,
 			'designsetgo/currentItemType': 'user',
 		};
-	}
-	if (source === 'terms') {
-		return {
+	} else if (source === 'terms') {
+		base = {
 			'designsetgo/currentItemId': item.id,
 			'designsetgo/currentItemType': 'term',
 		};
+	} else {
+		base = {};
 	}
-	return {};
+
+	// `designsetgo/parentItem` propagates the outer Query's current item so a
+	// nested Query block can identify its parent. For root-level Queries the
+	// outer context has no parentItem, so we fall back to the current item
+	// itself — ensuring the key is always defined for inner blocks.
+	const parentItem =
+		outerCtx?.['designsetgo/parentItem'] ??
+		(base.postId !== undefined
+			? { postId: base.postId, postType: base.postType }
+			: { postId: item.id, postType: item.type || 'post' });
+
+	return {
+		...base,
+		...enrichment,
+		'designsetgo/parentItem': parentItem,
+	};
 }
 
 /**

--- a/src/blocks/query/components/EditorPreviewList.js
+++ b/src/blocks/query/components/EditorPreviewList.js
@@ -17,6 +17,7 @@ import { BlockPreview, BlockContextProvider } from '@wordpress/block-editor';
 import { Spinner, Placeholder } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
+import useQueryPreview from '../hooks/useQueryPreview';
 
 // ---------------------------------------------------------------------------
 // Main component
@@ -40,12 +41,25 @@ export default function EditorPreviewList({
 }) {
 	const source = attributes.source || 'posts';
 	const isPosts = source === 'posts';
+	const isRelationship = source === 'relationship';
 
-	// Choose the data-fetching path based on source.
+	// All three hooks must be called unconditionally (Rules of Hooks).
+	// Each hook no-ops cheaply when its source doesn't match via its `enabled`
+	// guard or its internal isRelationship branch.
 	const postsData = usePosts(attributes, isPosts);
-	const remoteData = useRemotePreview(attributes, !isPosts);
+	const remoteData = useRemotePreview(attributes, !isPosts && !isRelationship);
+	const relationshipData = useQueryPreview({
+		source,
+		relationshipField: attributes.relationshipField || '',
+		perPage: attributes.perPage || 6,
+	});
 
-	const { records, hasResolved } = isPosts ? postsData : remoteData;
+	// Select the active data path.
+	const { records, hasResolved } = isPosts
+		? postsData
+		: isRelationship
+		? relationshipData
+		: remoteData;
 
 	if (!hasResolved) {
 		return (

--- a/src/blocks/query/components/EditorPreviewList.js
+++ b/src/blocks/query/components/EditorPreviewList.js
@@ -227,57 +227,63 @@ function GroupedPreviewList({
 
 	return (
 		<div className="dsgo-query__editor-preview-list is-grouped">
-			{groups.map((group) => (
-				<section
-					key={group.label}
-					className="dsgo-query__editor-preview-group"
-				>
-					<div
-						className="dsgo-query-group-label"
-						aria-hidden="true"
+			{groups.map((group) => {
+				let groupItemIdx = 0;
+				return (
+					<section
+						key={group.label}
+						className="dsgo-query__editor-preview-group"
 					>
-						{group.label}
-					</div>
-					<ul className="dsgo-query__editor-preview-list">
-						{group.items.map((item) => {
-							const idx = globalIdx;
-							globalIdx++;
-							const itemContext = buildContext(
-								item,
-								source,
-								idx,
-								context
-							);
-							return (
-								<li
-									key={item.id}
-									className={
-										idx === 0
-											? 'dsgo-query__editor-preview-item is-template-source'
-											: 'dsgo-query__editor-preview-item is-read-only'
-									}
-								>
-									<BlockContextProvider value={itemContext}>
-										{idx === 0 ? (
-											<EditableTemplate
-												innerBlocksProps={
-													innerBlocksProps
-												}
-											/>
-										) : (
-											<BlockPreview
-												blocks={innerBlocks}
-												viewportWidth={1000}
-												additionalStyles={[]}
-											/>
-										)}
-									</BlockContextProvider>
-								</li>
-							);
-						})}
-					</ul>
-				</section>
-			))}
+						<div
+							className="dsgo-query-group-label"
+							aria-hidden="true"
+						>
+							{group.label}
+						</div>
+						<ul className="dsgo-query__editor-preview-list">
+							{group.items.map((item) => {
+								const idx = globalIdx;
+								const groupIdx = groupItemIdx;
+								globalIdx++;
+								groupItemIdx++;
+								const itemContext = buildContext(
+									item,
+									source,
+									idx,
+									context,
+									groupIdx
+								);
+								return (
+									<li
+										key={item.id}
+										className={
+											idx === 0
+												? 'dsgo-query__editor-preview-item is-template-source'
+												: 'dsgo-query__editor-preview-item is-read-only'
+										}
+									>
+										<BlockContextProvider value={itemContext}>
+											{idx === 0 ? (
+												<EditableTemplate
+													innerBlocksProps={
+														innerBlocksProps
+													}
+												/>
+											) : (
+												<BlockPreview
+													blocks={innerBlocks}
+													viewportWidth={1000}
+													additionalStyles={[]}
+												/>
+											)}
+										</BlockContextProvider>
+									</li>
+								);
+							})}
+						</ul>
+					</section>
+				);
+			})}
 		</div>
 	);
 }
@@ -472,14 +478,15 @@ function buildTermsMap(item) {
  *   or a self-referencing fallback for root-level Queries so inner Query
  *   blocks always receive a defined value.
  *
- * @param {Object} item      Preview item: { id, type, ... }.
- * @param {string} source    The query block source attribute value.
- * @param {number} index     Zero-based item index in the current result set.
- * @param {Object} outerCtx  The block's `context` prop from edit.js. May carry
- *                           `designsetgo/parentItem` when this Query is nested.
+ * @param {Object} item           Preview item: { id, type, ... }.
+ * @param {string} source         The query block source attribute value.
+ * @param {number} index          Zero-based item index in the current result set (flat/cross-group).
+ * @param {Object} outerCtx       The block's `context` prop from edit.js. May carry
+ *                                `designsetgo/parentItem` when this Query is nested.
+ * @param {number} [groupItemIndex] Zero-based position within the current group (grouped queries only).
  * @return {Object} Context object for BlockContextProvider.
  */
-function buildContext(item, source, index, outerCtx) {
+function buildContext(item, source, index, outerCtx, groupItemIndex) {
 	// Common enrichment applied regardless of source type.
 	const enrichment = {
 		'designsetgo/itemIndex': index,
@@ -489,6 +496,11 @@ function buildContext(item, source, index, outerCtx) {
 		// This ensures auth-rule "show for logged-in users" works correctly
 		// in the editor preview without requiring server-side context.
 		'designsetgo/isAuthenticated': true,
+		// Per-group index (0-based within the group). Omitted for non-grouped
+		// queries (undefined); present when groupItemIndex is supplied.
+		...(groupItemIndex !== undefined
+			? { 'designsetgo/groupItemIndex': groupItemIndex }
+			: {}),
 	};
 
 	let base;

--- a/src/blocks/query/components/EditorPreviewList.js
+++ b/src/blocks/query/components/EditorPreviewList.js
@@ -130,12 +130,27 @@ function buildGroupLabel(item, groupBy) {
 	const { field, key } = groupBy;
 
 	if (field === 'taxonomy') {
+		// Prefer the term name from embedded REST data (_embedded['wp:term'])
+		// so the editor label matches the server-side label produced by
+		// designsetgo_query_partition_items() via wp_list_pluck( $terms, 'name' ).
+		const embedded = item?._embedded?.['wp:term'];
+		if (Array.isArray(embedded)) {
+			for (const taxTerms of embedded) {
+				const match = Array.isArray(taxTerms)
+					? taxTerms.find((t) => t.taxonomy === key)
+					: null;
+				if (match) {
+					return match.name || match.slug;
+				}
+			}
+		}
+		// Fall back to slug via the flat terms map when embedded data is absent.
 		const termsMap = buildTermsMap(item);
 		const slugs = termsMap[key];
 		if (slugs && slugs.length > 0) {
-			return slugs[0]; // Use first term slug as group key.
+			return slugs[0];
 		}
-		return __('Uncategorised', 'designsetgo');
+		return __('Uncategorized', 'designsetgo');
 	}
 
 	if (field === 'meta') {

--- a/src/blocks/query/components/EditorPreviewList.js
+++ b/src/blocks/query/components/EditorPreviewList.js
@@ -471,6 +471,10 @@ function buildContext(item, source, index, outerCtx) {
 		'designsetgo/itemIndex': index,
 		'designsetgo/itemMeta': item.meta || {},
 		'designsetgo/itemTerms': buildTermsMap(item),
+		// Editor sessions are always authenticated — the admin is logged in.
+		// This ensures auth-rule "show for logged-in users" works correctly
+		// in the editor preview without requiring server-side context.
+		'designsetgo/isAuthenticated': true,
 	};
 
 	let base;

--- a/src/blocks/query/components/EditorPreviewList.js
+++ b/src/blocks/query/components/EditorPreviewList.js
@@ -68,6 +68,20 @@ export default function EditorPreviewList({
 		);
 	}
 
+	const groupBy = attributes.groupBy || null;
+	if (groupBy) {
+		return (
+			<GroupedPreviewList
+				records={records}
+				attributes={attributes}
+				innerBlocks={innerBlocks}
+				innerBlocksProps={innerBlocksProps}
+				context={context}
+				groupBy={groupBy}
+			/>
+		);
+	}
+
 	return (
 		<ul className="dsgo-query__editor-preview-list">
 			{records.map((item, idx) => {
@@ -98,6 +112,144 @@ export default function EditorPreviewList({
 				);
 			})}
 		</ul>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Grouped preview (when groupBy is set)
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a group label string from a record given the groupBy config.
+ *
+ * @param {Object} item    Preview record.
+ * @param {Object} groupBy { field, key } attribute value.
+ * @return {string} Group label.
+ */
+function buildGroupLabel(item, groupBy) {
+	const { field, key } = groupBy;
+
+	if (field === 'taxonomy') {
+		const termsMap = buildTermsMap(item);
+		const slugs = termsMap[key];
+		if (slugs && slugs.length > 0) {
+			return slugs[0]; // Use first term slug as group key.
+		}
+		return __('Uncategorised', 'designsetgo');
+	}
+
+	if (field === 'meta') {
+		const val = item?.meta?.[key];
+		return val !== undefined && val !== null && val !== ''
+			? String(val)
+			: __('(no value)', 'designsetgo');
+	}
+
+	if (field === 'date') {
+		const date = item?.date;
+		if (!date) {
+			return __('(no date)', 'designsetgo');
+		}
+		// date is ISO 8601 e.g. "2024-03-15T12:00:00".
+		const [year, month, day] = date.split('T')[0].split('-');
+		if (key === 'Y-M-D') {
+			return `${year}-${month}-${day}`;
+		}
+		if (key === 'Y-M') {
+			return `${year}-${month}`;
+		}
+		return year;
+	}
+
+	return '';
+}
+
+/**
+ * Render records partitioned by their groupBy value, with a simple placeholder
+ * heading for each group.
+ *
+ * @param {Object} props
+ */
+function GroupedPreviewList({
+	records,
+	attributes,
+	innerBlocks,
+	innerBlocksProps,
+	context,
+	groupBy,
+}) {
+	const source = attributes.source || 'posts';
+
+	// Partition records into ordered groups preserving first-seen order.
+	const groups = [];
+	const groupIndex = {};
+	records.forEach((item) => {
+		const label = buildGroupLabel(item, groupBy);
+		if (!Object.prototype.hasOwnProperty.call(groupIndex, label)) {
+			groupIndex[label] = groups.length;
+			groups.push({ label, items: [] });
+		}
+		groups[groupIndex[label]].items.push(item);
+	});
+
+	// Track the first-ever item index across all groups so item 0 gets
+	// the editable InnerBlocks slot.
+	let globalIdx = 0;
+
+	return (
+		<div className="dsgo-query__editor-preview-list is-grouped">
+			{groups.map((group) => (
+				<section
+					key={group.label}
+					className="dsgo-query__editor-preview-group"
+				>
+					<div
+						className="dsgo-query-group-label"
+						aria-hidden="true"
+					>
+						{group.label}
+					</div>
+					<ul className="dsgo-query__editor-preview-list">
+						{group.items.map((item) => {
+							const idx = globalIdx;
+							globalIdx++;
+							const itemContext = buildContext(
+								item,
+								source,
+								idx,
+								context
+							);
+							return (
+								<li
+									key={item.id}
+									className={
+										idx === 0
+											? 'dsgo-query__editor-preview-item is-template-source'
+											: 'dsgo-query__editor-preview-item is-read-only'
+									}
+								>
+									<BlockContextProvider value={itemContext}>
+										{idx === 0 ? (
+											<EditableTemplate
+												innerBlocksProps={
+													innerBlocksProps
+												}
+											/>
+										) : (
+											<BlockPreview
+												blocks={innerBlocks}
+												viewportWidth={1000}
+												additionalStyles={[]}
+											/>
+										)}
+									</BlockContextProvider>
+								</li>
+							);
+						})}
+					</ul>
+				</section>
+			))}
+		</div>
 	);
 }
 

--- a/src/blocks/query/components/QuerySourcePanel.js
+++ b/src/blocks/query/components/QuerySourcePanel.js
@@ -10,6 +10,19 @@ import {
 } from '@wordpress/components';
 import { DsgoInspectorPanel } from '../../../components/shared';
 
+const GROUP_BY_OPTIONS = [
+	{ value: 'none', label: __('None', 'designsetgo') },
+	{ value: 'taxonomy', label: __('Taxonomy', 'designsetgo') },
+	{ value: 'meta', label: __('Meta field', 'designsetgo') },
+	{ value: 'date', label: __('Date', 'designsetgo') },
+];
+
+const DATE_PRECISION_OPTIONS = [
+	{ value: 'Y', label: __('Year', 'designsetgo') },
+	{ value: 'Y-M', label: __('Year + Month', 'designsetgo') },
+	{ value: 'Y-M-D', label: __('Year + Month + Day', 'designsetgo') },
+];
+
 const SOURCES = [
 	{ value: 'posts', label: __('Posts', 'designsetgo') },
 	{ value: 'users', label: __('Users', 'designsetgo') },
@@ -62,10 +75,16 @@ export default function QuerySourcePanel({
 		columnGap,
 		relationshipField,
 		relationshipFallback,
+		groupBy,
 	} = attributes;
 
 	const postTypes = useSelect(
 		(select) => select(coreStore).getPostTypes({ per_page: -1 }) || [],
+		[]
+	);
+
+	const taxonomies = useSelect(
+		(select) => select(coreStore).getTaxonomies({ per_page: -1 }) || [],
 		[]
 	);
 
@@ -76,9 +95,28 @@ export default function QuerySourcePanel({
 			value: pt.slug,
 		}));
 
+	const taxonomyOptions = (taxonomies || []).map((t) => ({
+		label: t.labels?.singular_name || t.slug,
+		value: t.slug,
+	}));
+
 	const showPostType = source === 'posts';
 	const showRelationship = source === 'relationship';
 	const showMetaKey = ['meta_value', 'meta_value_num'].includes(orderBy);
+
+	// Group-by derived state.
+	const groupByField = groupBy?.field || 'none';
+	const showGroupTaxonomy = groupByField === 'taxonomy';
+	const showGroupMeta = groupByField === 'meta';
+	const showGroupDate = groupByField === 'date';
+
+	const handleGroupByFieldChange = (value) => {
+		if (value === 'none') {
+			setAttributes({ groupBy: null });
+		} else {
+			setAttributes({ groupBy: { field: value, key: '' } });
+		}
+	};
 
 	return (
 		<DsgoInspectorPanel
@@ -343,6 +381,90 @@ export default function QuerySourcePanel({
 					__nextHasNoMarginBottom
 				/>
 			</DsgoInspectorPanel.Item>
+
+			<DsgoInspectorPanel.Item
+				label={__('Group by', 'designsetgo')}
+				hasValue={() => groupBy !== null}
+				onDeselect={() => setAttributes({ groupBy: null })}
+				isShownByDefault
+			>
+				<SelectControl
+					label={__('Group by', 'designsetgo')}
+					value={groupByField}
+					options={GROUP_BY_OPTIONS}
+					onChange={handleGroupByFieldChange}
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+			</DsgoInspectorPanel.Item>
+
+			{showGroupTaxonomy && (
+				<DsgoInspectorPanel.Item
+					label={__('Group taxonomy', 'designsetgo')}
+					hasValue={() => (groupBy?.key || '') !== ''}
+					onDeselect={() =>
+						setAttributes({ groupBy: { ...groupBy, key: '' } })
+					}
+					isShownByDefault
+				>
+					<SelectControl
+						label={__('Group taxonomy', 'designsetgo')}
+						value={groupBy?.key || ''}
+						options={[
+							{ value: '', label: __('— Select —', 'designsetgo') },
+							...taxonomyOptions,
+						]}
+						onChange={(value) =>
+							setAttributes({ groupBy: { ...groupBy, key: value } })
+						}
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				</DsgoInspectorPanel.Item>
+			)}
+
+			{showGroupMeta && (
+				<DsgoInspectorPanel.Item
+					label={__('Group meta key', 'designsetgo')}
+					hasValue={() => (groupBy?.key || '') !== ''}
+					onDeselect={() =>
+						setAttributes({ groupBy: { ...groupBy, key: '' } })
+					}
+					isShownByDefault
+				>
+					<TextControl
+						label={__('Group meta key', 'designsetgo')}
+						value={groupBy?.key || ''}
+						onChange={(value) =>
+							setAttributes({ groupBy: { ...groupBy, key: value } })
+						}
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				</DsgoInspectorPanel.Item>
+			)}
+
+			{showGroupDate && (
+				<DsgoInspectorPanel.Item
+					label={__('Date precision', 'designsetgo')}
+					hasValue={() => (groupBy?.key || '') !== '' && groupBy?.key !== 'Y'}
+					onDeselect={() =>
+						setAttributes({ groupBy: { ...groupBy, key: 'Y' } })
+					}
+					isShownByDefault
+				>
+					<SelectControl
+						label={__('Date precision', 'designsetgo')}
+						value={groupBy?.key || 'Y'}
+						options={DATE_PRECISION_OPTIONS}
+						onChange={(value) =>
+							setAttributes({ groupBy: { ...groupBy, key: value } })
+						}
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				</DsgoInspectorPanel.Item>
+			)}
 		</DsgoInspectorPanel>
 	);
 }

--- a/src/blocks/query/components/QuerySourcePanel.js
+++ b/src/blocks/query/components/QuerySourcePanel.js
@@ -16,6 +16,13 @@ const SOURCES = [
 	{ value: 'terms', label: __('Terms', 'designsetgo') },
 	{ value: 'manual', label: __('Manual picks', 'designsetgo') },
 	{ value: 'current', label: __('Current archive', 'designsetgo') },
+	{ value: 'relationship', label: __('Related items (field-driven)', 'designsetgo') },
+];
+
+const RELATIONSHIP_FALLBACK_OPTIONS = [
+	{ value: 'empty', label: __('Render no items', 'designsetgo') },
+	{ value: 'all', label: __('Fall back to all posts', 'designsetgo') },
+	{ value: 'parent', label: __('Render the parent item', 'designsetgo') },
 ];
 
 const ORDER_BY_OPTIONS = [
@@ -53,6 +60,8 @@ export default function QuerySourcePanel({
 		columnsTablet,
 		columnsMobile,
 		columnGap,
+		relationshipField,
+		relationshipFallback,
 	} = attributes;
 
 	const postTypes = useSelect(
@@ -68,6 +77,7 @@ export default function QuerySourcePanel({
 		}));
 
 	const showPostType = source === 'posts';
+	const showRelationship = source === 'relationship';
 	const showMetaKey = ['meta_value', 'meta_value_num'].includes(orderBy);
 
 	return (
@@ -121,6 +131,45 @@ export default function QuerySourcePanel({
 						onChange={(value) => setAttributes({ postType: value })}
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
+					/>
+				</DsgoInspectorPanel.Item>
+			)}
+
+			{showRelationship && (
+				<DsgoInspectorPanel.Item
+					label={__('Relationship field', 'designsetgo')}
+					hasValue={() => (relationshipField || '') !== ''}
+					onDeselect={() => setAttributes({ relationshipField: '' })}
+					isShownByDefault
+				>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={__('Relationship field', 'designsetgo')}
+						help={__(
+							'Meta key or ACF field on the parent item that holds the related post IDs.',
+							'designsetgo'
+						)}
+						value={relationshipField || ''}
+						onChange={(v) => setAttributes({ relationshipField: v })}
+					/>
+				</DsgoInspectorPanel.Item>
+			)}
+
+			{showRelationship && (
+				<DsgoInspectorPanel.Item
+					label={__('When no related items', 'designsetgo')}
+					hasValue={() => (relationshipFallback || 'empty') !== 'empty'}
+					onDeselect={() => setAttributes({ relationshipFallback: 'empty' })}
+					isShownByDefault
+				>
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={__('When no related items', 'designsetgo')}
+						value={relationshipFallback || 'empty'}
+						onChange={(v) => setAttributes({ relationshipFallback: v })}
+						options={RELATIONSHIP_FALLBACK_OPTIONS}
 					/>
 				</DsgoInspectorPanel.Item>
 			)}

--- a/src/blocks/query/edit.js
+++ b/src/blocks/query/edit.js
@@ -24,7 +24,7 @@ import { DEFAULT_TEMPLATE } from './edit-template';
 // console with "`useSelect` returns different values" warnings.
 const EMPTY_BLOCKS = Object.freeze([]);
 
-export default function QueryEdit({ attributes, setAttributes, clientId }) {
+export default function QueryEdit({ attributes, setAttributes, clientId, context }) {
 	useQueryId({ clientId, queryId: attributes.queryId, setAttributes });
 
 	// Two narrow selectors instead of one composite object: hasInnerBlocks is
@@ -148,6 +148,7 @@ export default function QueryEdit({ attributes, setAttributes, clientId }) {
 							attributes={attributes}
 							innerBlocks={innerBlocks}
 							innerBlocksProps={innerBlocksProps}
+							context={context}
 						/>
 					) : (
 						<>

--- a/src/blocks/query/editor.scss
+++ b/src/blocks/query/editor.scss
@@ -112,3 +112,9 @@
 	margin-block-end: 0.5rem;
 	opacity: 0.7;
 }
+
+// Visibility gate placeholder — keeps the React slot in the tree while
+// hiding the block visually. display:none ensures no layout space is consumed.
+.dsgo-visibility-hidden {
+	display: none;
+}

--- a/src/blocks/query/editor.scss
+++ b/src/blocks/query/editor.scss
@@ -104,3 +104,11 @@
 		}
 	}
 }
+
+.dsgo-query-group-label {
+	font-size: 0.85em;
+	font-weight: 600;
+	color: var(--wp--preset--color--contrast, #555);
+	margin-block-end: 0.5rem;
+	opacity: 0.7;
+}

--- a/src/blocks/query/hooks/useQueryPreview.js
+++ b/src/blocks/query/hooks/useQueryPreview.js
@@ -18,12 +18,12 @@ import { useSelect } from '@wordpress/data';
  *   attribute changes coalesce into a single request.
  *   Returns `{ loading, totalItems, error }`.
  *
- * @param {Object} root0                    The hook options object.
- * @param {string} [root0.source]           Query source ('posts', 'relationship', …).
+ * @param {Object} root0                     The hook options object.
+ * @param {string} [root0.source]            Query source ('posts', 'relationship', …).
  * @param {string} [root0.relationshipField] Meta/ACF key when source is 'relationship'.
- * @param {number} [root0.perPage]          Maximum number of items to fetch.
- * @param {Object} [root0.attributes]       Full query block attributes (non-relationship path).
- * @param {string} [root0.queryId]          The unique query ID (non-relationship path).
+ * @param {number} [root0.perPage]           Maximum number of items to fetch.
+ * @param {Object} [root0.attributes]        Full query block attributes (non-relationship path).
+ * @param {string} [root0.queryId]           The unique query ID (non-relationship path).
  */
 export default function useQueryPreview({
 	source,
@@ -48,19 +48,34 @@ export default function useQueryPreview({
 		[isRelationship]
 	);
 
+	const parentPostType = useSelect(
+		(s) => {
+			if (!isRelationship) {
+				return null;
+			}
+			return s('core/editor')?.getCurrentPostType?.() ?? null;
+		},
+		[isRelationship]
+	);
+
 	const fieldValue = useSelect(
 		(s) => {
-			if (!isRelationship || !parentId || !relationshipField) {
+			if (
+				!isRelationship ||
+				!parentId ||
+				!relationshipField ||
+				!parentPostType
+			) {
 				return null;
 			}
 			const record = s('core').getEntityRecord(
 				'postType',
-				'post',
+				parentPostType,
 				parentId
 			);
-			return record?.meta?.[ relationshipField ] ?? null;
+			return record?.meta?.[relationshipField] ?? null;
 		},
-		[isRelationship, parentId, relationshipField]
+		[isRelationship, parentId, parentPostType, relationshipField]
 	);
 
 	// Normalize the raw field value into an array of integer post IDs.
@@ -74,15 +89,11 @@ export default function useQueryPreview({
 	// useEntityRecords must always be called (rules of hooks). When not in
 	// relationship mode, or when ids is empty, we pass a sentinel [0] so
 	// the call is valid but returns nothing useful.
-	const entityResult = useEntityRecords(
-		'postType',
-		'any',
-		{
-			include: ids.length ? ids : [0],
-			per_page: Math.max(1, perPage),
-			orderby: 'include',
-		}
-	);
+	const entityResult = useEntityRecords('postType', 'any', {
+		include: ids.length ? ids : [0],
+		per_page: Math.max(1, perPage),
+		orderby: 'include',
+	});
 
 	// ── Non-relationship: REST-based totalItems badge ─────────────────────────
 	const [restState, setRestState] = useState({

--- a/src/blocks/query/hooks/useQueryPreview.js
+++ b/src/blocks/query/hooks/useQueryPreview.js
@@ -25,6 +25,50 @@ import { useSelect } from '@wordpress/data';
  * @param {Object} [root0.attributes]        Full query block attributes (non-relationship path).
  * @param {string} [root0.queryId]           The unique query ID (non-relationship path).
  */
+/**
+ * Normalize an ACF/postmeta relationship field value to an array of post IDs.
+ *
+ * Mirrors PHP's `designsetgo_query_relationship_normalize_ids()` in
+ * `render-relationship.php`. Handles every storage shape the WP REST API
+ * can surface for meta fields:
+ *  - Array of ints:          [12, 34]
+ *  - Array of post objects:  [{ id: 12 }, { ID: 34 }]
+ *  - Comma-separated string: "12, 34, 56"
+ *  - Single numeric string:  "12"
+ *  - Plain number:           12
+ *
+ * PHP's `maybe_unserialize()` branch is intentionally omitted — the WP
+ * REST API always pre-deserializes meta values before exposing them.
+ *
+ * @param {*} value Raw field value from the REST response.
+ * @return {number[]} Filtered, non-zero integer post IDs.
+ */
+export function normalizeRelationshipIds(value) {
+	if (Array.isArray(value)) {
+		return value
+			.map((v) =>
+				typeof v === 'object' && v !== null
+					? Number(v.id ?? v.ID)
+					: Number(v)
+			)
+			.filter(Boolean);
+	}
+	if (typeof value === 'string' && value !== '') {
+		if (value.includes(',')) {
+			return value
+				.split(',')
+				.map((s) => Number(s.trim()))
+				.filter(Boolean);
+		}
+		const n = Number(value);
+		return Number.isFinite(n) && n > 0 ? [n] : [];
+	}
+	if (typeof value === 'number' && value > 0) {
+		return [Math.floor(value)];
+	}
+	return [];
+}
+
 export default function useQueryPreview({
 	source,
 	relationshipField = '',
@@ -79,17 +123,23 @@ export default function useQueryPreview({
 	);
 
 	// Normalize the raw field value into an array of integer post IDs.
-	const ids =
-		isRelationship && Array.isArray(fieldValue)
-			? fieldValue
-					.map((v) => (typeof v === 'object' ? v.ID : Number(v)))
-					.filter(Boolean)
-			: [];
+	// Mirrors PHP's designsetgo_query_relationship_normalize_ids() in
+	// render-relationship.php, covering all storage shapes ACF/postmeta can
+	// produce. PHP's maybe_unserialize() branch is omitted — the WP REST
+	// API always pre-deserializes meta values before exposing them.
+	const ids = isRelationship
+		? normalizeRelationshipIds(fieldValue)
+		: [];
 
 	// useEntityRecords must always be called (rules of hooks). When not in
 	// relationship mode, or when ids is empty, we pass a sentinel [0] so
 	// the call is valid but returns nothing useful.
-	const entityResult = useEntityRecords('postType', 'any', {
+	//
+	// TODO(v2.4): Add a `relationshipPostType` block attribute so CPT
+	// relationship fields (e.g. product, event) can be fetched correctly.
+	// For now we default to 'post', which covers the common case. Passing
+	// 'any' is invalid — there is no /wp/v2/any REST endpoint.
+	const entityResult = useEntityRecords('postType', 'post', {
 		include: ids.length ? ids : [0],
 		per_page: Math.max(1, perPage),
 		orderby: 'include',

--- a/src/blocks/query/hooks/useQueryPreview.js
+++ b/src/blocks/query/hooks/useQueryPreview.js
@@ -1,18 +1,91 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useState, useEffect } from '@wordpress/element';
+import { useEntityRecords } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 
 /**
- * Runs the same render helper server-side via REST so the editor can show
- * a live "N matches" badge without reimplementing WP_Query in the browser.
+ * Unified query preview hook.
  *
- * Debounced by React re-render cadence + JSON.stringify key so rapid attribute
- * changes coalesce into a single request.
- * @param {Object} root0            The hook options object.
- * @param {Object} root0.attributes The query block attributes to send to the server.
- * @param {string} root0.queryId    The unique query ID used to scope the REST request.
+ * For `source === 'relationship'`:
+ *   Reads the field value from the editor's current post, normalizes it to an
+ *   array of post IDs, then fetches those posts via useEntityRecords. Returns
+ *   `{ records, hasResolved }`.
+ *
+ * For all other sources:
+ *   Runs the same render helper server-side via REST so the editor can show
+ *   a live "N matches" badge without reimplementing WP_Query in the browser.
+ *   Debounced by React re-render cadence + JSON.stringify key so rapid
+ *   attribute changes coalesce into a single request.
+ *   Returns `{ loading, totalItems, error }`.
+ *
+ * @param {Object} root0                    The hook options object.
+ * @param {string} [root0.source]           Query source ('posts', 'relationship', …).
+ * @param {string} [root0.relationshipField] Meta/ACF key when source is 'relationship'.
+ * @param {number} [root0.perPage]          Maximum number of items to fetch.
+ * @param {Object} [root0.attributes]       Full query block attributes (non-relationship path).
+ * @param {string} [root0.queryId]          The unique query ID (non-relationship path).
  */
-export default function useQueryPreview({ attributes, queryId }) {
-	const [state, setState] = useState({
+export default function useQueryPreview({
+	source,
+	relationshipField = '',
+	perPage = 6,
+	attributes,
+	queryId,
+}) {
+	const isRelationship = source === 'relationship';
+
+	// ── Relationship: read parent post's field value ──────────────────────────
+	// These selectors run unconditionally (rules of hooks). They return null
+	// when not applicable (no editor context, or wrong source).
+
+	const parentId = useSelect(
+		(s) => {
+			if (!isRelationship) {
+				return null;
+			}
+			return s('core/editor')?.getCurrentPostId?.() ?? null;
+		},
+		[isRelationship]
+	);
+
+	const fieldValue = useSelect(
+		(s) => {
+			if (!isRelationship || !parentId || !relationshipField) {
+				return null;
+			}
+			const record = s('core').getEntityRecord(
+				'postType',
+				'post',
+				parentId
+			);
+			return record?.meta?.[ relationshipField ] ?? null;
+		},
+		[isRelationship, parentId, relationshipField]
+	);
+
+	// Normalize the raw field value into an array of integer post IDs.
+	const ids =
+		isRelationship && Array.isArray(fieldValue)
+			? fieldValue
+					.map((v) => (typeof v === 'object' ? v.ID : Number(v)))
+					.filter(Boolean)
+			: [];
+
+	// useEntityRecords must always be called (rules of hooks). When not in
+	// relationship mode, or when ids is empty, we pass a sentinel [0] so
+	// the call is valid but returns nothing useful.
+	const entityResult = useEntityRecords(
+		'postType',
+		'any',
+		{
+			include: ids.length ? ids : [0],
+			per_page: Math.max(1, perPage),
+			orderby: 'include',
+		}
+	);
+
+	// ── Non-relationship: REST-based totalItems badge ─────────────────────────
+	const [restState, setRestState] = useState({
 		loading: false,
 		totalItems: null,
 		error: null,
@@ -21,11 +94,11 @@ export default function useQueryPreview({ attributes, queryId }) {
 	const payloadKey = JSON.stringify(attributes);
 
 	useEffect(() => {
-		if (!queryId) {
+		if (isRelationship || !queryId) {
 			return undefined;
 		}
 		let cancelled = false;
-		setState((s) => ({ ...s, loading: true }));
+		setRestState((s) => ({ ...s, loading: true }));
 
 		apiFetch({
 			path: '/designsetgo/v1/query/render',
@@ -41,7 +114,7 @@ export default function useQueryPreview({ attributes, queryId }) {
 				if (cancelled) {
 					return;
 				}
-				setState({
+				setRestState({
 					loading: false,
 					totalItems:
 						typeof res?.totalItems === 'number'
@@ -54,7 +127,7 @@ export default function useQueryPreview({ attributes, queryId }) {
 				if (cancelled) {
 					return;
 				}
-				setState({ loading: false, totalItems: null, error: err });
+				setRestState({ loading: false, totalItems: null, error: err });
 			});
 
 		return () => {
@@ -62,7 +135,16 @@ export default function useQueryPreview({ attributes, queryId }) {
 		};
 		// payloadKey makes the effect rerun on attribute changes (cheaper than deep compare).
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [payloadKey, queryId]);
+	}, [payloadKey, queryId, isRelationship]);
 
-	return state;
+	// ── Return the appropriate shape for the active source ────────────────────
+
+	if (isRelationship) {
+		return {
+			records: ids.length ? entityResult.records : [],
+			hasResolved: entityResult.hasResolved,
+		};
+	}
+
+	return restState;
 }

--- a/src/blocks/query/render-helpers.php
+++ b/src/blocks/query/render-helpers.php
@@ -121,8 +121,66 @@ if ( ! function_exists( 'designsetgo_query_render' ) ) :
 			'emitSchema'           => true,
 			'relationshipField'    => '',
 			'relationshipFallback' => 'empty', // empty | all | parent
+			'groupBy'              => null,
 		);
 		return wp_parse_args( $attributes, $defaults );
+	}
+
+	/**
+	 * Partition an array of post IDs into labelled groups for grouped rendering.
+	 *
+	 * Supported fields: 'taxonomy' (by term slug), 'meta' (by meta value),
+	 * 'date' (by Y, Y-m, or Y-m-d depending on $group_spec['key']).
+	 *
+	 * Posts with multiple terms (taxonomy field) appear in ALL matching groups.
+	 * Posts with no matching term land in the '__none__' / Uncategorized bucket.
+	 *
+	 * @param int[]  $post_ids   Ordered list of post IDs to partition.
+	 * @param array  $group_spec { field: string, key: string }
+	 * @return array[] Array of groups: each { label: string, value: string, ids: int[] }
+	 */
+	function designsetgo_query_partition_items( array $post_ids, array $group_spec ) {
+		if ( empty( $group_spec['field'] ) || empty( $group_spec['key'] ) ) {
+			return array( array( 'label' => '', 'value' => '', 'ids' => $post_ids ) );
+		}
+		$field = (string) $group_spec['field'];
+		$key   = (string) $group_spec['key'];
+
+		$groups = array();
+		foreach ( $post_ids as $pid ) {
+			$values = array();
+			$labels = array();
+			if ( 'taxonomy' === $field ) {
+				$terms = get_the_terms( $pid, $key );
+				if ( empty( $terms ) || is_wp_error( $terms ) ) {
+					$values = array( '__none__' );
+					$labels = array( __( 'Uncategorized', 'designsetgo' ) );
+				} else {
+					$values = wp_list_pluck( $terms, 'slug' );
+					$labels = wp_list_pluck( $terms, 'name' );
+				}
+			} elseif ( 'meta' === $field ) {
+				$v      = (string) get_post_meta( $pid, $key, true );
+				$values = array( $v );
+				$labels = array( $v );
+			} elseif ( 'date' === $field ) {
+				$d      = get_post_field( 'post_date', $pid );
+				$ts     = $d ? strtotime( $d ) : 0;
+				$format = 'Y-M-D' === $key ? 'Y-m-d' : ( 'Y-M' === $key ? 'Y-m' : 'Y' );
+				$values = array( gmdate( $format, $ts ) );
+				$labels = $values;
+			} else {
+				$values = array( '' );
+				$labels = array( '' );
+			}
+			foreach ( $values as $i => $v ) {
+				if ( ! isset( $groups[ $v ] ) ) {
+					$groups[ $v ] = array( 'label' => $labels[ $i ] ?? $v, 'value' => $v, 'ids' => array() );
+				}
+				$groups[ $v ]['ids'][] = $pid;
+			}
+		}
+		return array_values( $groups );
 	}
 
 	/**

--- a/src/blocks/query/render-helpers.php
+++ b/src/blocks/query/render-helpers.php
@@ -276,21 +276,41 @@ if ( ! function_exists( 'designsetgo_query_render' ) ) :
 
 		$html   = '';
 		$parsed = parse_blocks( $inner_html );
-		foreach ( $parsed as $parsed_block ) {
-			if ( empty( $parsed_block['blockName'] ) ) {
-				continue;
+
+		// Push this item's context onto the global parent stack so that nested
+		// Query blocks (and Task C2's `scope` arg on bindings) can walk the
+		// ancestor chain. The stack is keyed by depth, so parallel items from
+		// different queries never collide — each item fully completes before the
+		// next begins (PHP is single-threaded, no async interleaving).
+		if ( ! isset( $GLOBALS['designsetgo_parent_stack'] ) || ! is_array( $GLOBALS['designsetgo_parent_stack'] ) ) {
+			$GLOBALS['designsetgo_parent_stack'] = array();
+		}
+		array_push( $GLOBALS['designsetgo_parent_stack'], $item_context );
+
+		try {
+			foreach ( $parsed as $parsed_block ) {
+				if ( empty( $parsed_block['blockName'] ) ) {
+					continue;
+				}
+				// Skip blocks whose dsgoVisibility rules don't match the current item context.
+				$visibility = isset( $parsed_block['attrs']['dsgoVisibility'] ) ? $parsed_block['attrs']['dsgoVisibility'] : null;
+				if ( ! \DesignSetGo\BlockVisibility::matches( $visibility, $item_context ) ) {
+					continue;
+				}
+				// WP_Block's constructor signature is ( $block, $available_context, $registry ).
+				// The $available_context arg is what gets filtered through child blocks'
+				// usesContext declarations. Passing it via render_block()'s parsed-block
+				// 'context' key would NOT work — that key is not read by WP_Block.
+				$block_instance = new WP_Block( $parsed_block, $item_context );
+				$html          .= $block_instance->render();
 			}
-			// Skip blocks whose dsgoVisibility rules don't match the current item context.
-			$visibility = isset( $parsed_block['attrs']['dsgoVisibility'] ) ? $parsed_block['attrs']['dsgoVisibility'] : null;
-			if ( ! \DesignSetGo\BlockVisibility::matches( $visibility, $item_context ) ) {
-				continue;
+		} finally {
+			// Always pop — even if render() throws — so the stack stays consistent
+			// for any outer Query block that is still iterating.
+			array_pop( $GLOBALS['designsetgo_parent_stack'] );
+			if ( empty( $GLOBALS['designsetgo_parent_stack'] ) ) {
+				unset( $GLOBALS['designsetgo_parent_stack'] );
 			}
-			// WP_Block's constructor signature is ( $block, $available_context, $registry ).
-			// The $available_context arg is what gets filtered through child blocks'
-			// usesContext declarations. Passing it via render_block()'s parsed-block
-			// 'context' key would NOT work — that key is not read by WP_Block.
-			$block_instance = new WP_Block( $parsed_block, $item_context );
-			$html          .= $block_instance->render();
 		}
 
 		return sprintf( '<%1$s class="dsgo-query__item">%2$s</%1$s>', $tag, $html );

--- a/src/blocks/query/render-helpers.php
+++ b/src/blocks/query/render-helpers.php
@@ -64,6 +64,12 @@ if ( ! function_exists( 'designsetgo_query_render' ) ) :
 					return designsetgo_query_render_terms( $attributes, $context );
 				}
 				break;
+			case 'relationship':
+				require_once __DIR__ . '/render-relationship.php';
+				if ( function_exists( 'designsetgo_query_render_relationship' ) ) {
+					return designsetgo_query_render_relationship( $attributes, $context );
+				}
+				break;
 			case 'posts':
 			case 'manual':
 			case 'current':
@@ -110,9 +116,11 @@ if ( ! function_exists( 'designsetgo_query_render' ) ) :
 				'relation' => 'AND',
 				'clauses'  => array(),
 			),
-			'tagName'        => 'ul',
-			'itemTagName'    => 'li',
-			'emitSchema'     => true,
+			'tagName'              => 'ul',
+			'itemTagName'          => 'li',
+			'emitSchema'           => true,
+			'relationshipField'    => '',
+			'relationshipFallback' => 'empty', // empty | all | parent
 		);
 		return wp_parse_args( $attributes, $defaults );
 	}

--- a/src/blocks/query/render-helpers.php
+++ b/src/blocks/query/render-helpers.php
@@ -266,12 +266,23 @@ if ( ! function_exists( 'designsetgo_query_render' ) ) :
 	 * @return string
 	 */
 	function designsetgo_query_render_item( $inner_html, array $item_context, $item_tag ) {
+		// Ensure BlockVisibility is available when this file is required directly
+		// (e.g. in integration tests) before the plugin bootstrap has run.
+		if ( ! class_exists( '\\DesignSetGo\\BlockVisibility' ) ) {
+			require_once DESIGNSETGO_PATH . 'includes/class-block-visibility.php';
+		}
+
 		$tag = in_array( $item_tag, array( 'li', 'div', 'article' ), true ) ? $item_tag : 'li';
 
 		$html   = '';
 		$parsed = parse_blocks( $inner_html );
 		foreach ( $parsed as $parsed_block ) {
 			if ( empty( $parsed_block['blockName'] ) ) {
+				continue;
+			}
+			// Skip blocks whose dsgoVisibility rules don't match the current item context.
+			$visibility = isset( $parsed_block['attrs']['dsgoVisibility'] ) ? $parsed_block['attrs']['dsgoVisibility'] : null;
+			if ( ! \DesignSetGo\BlockVisibility::matches( $visibility, $item_context ) ) {
 				continue;
 			}
 			// WP_Block's constructor signature is ( $block, $available_context, $registry ).

--- a/src/blocks/query/render-posts.php
+++ b/src/blocks/query/render-posts.php
@@ -133,9 +133,12 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 					);
 					$header_html_out .= $header_block->render();
 				}
-				// Render items in this group using the original flat result-set
-				// indices so visibility rules behave the same grouped or ungrouped.
-				$group_items_html = '';
+				// Render items in this group.
+				// Pass both the flat cross-group index (designsetgo/itemIndex) and a
+				// per-group zero-based index (designsetgo/groupItemIndex) so authors
+				// can target either in custom bindings or visibility rules.
+				$group_items_html  = '';
+				$group_item_index  = 0;
 				foreach ( $group['ids'] as $gid ) {
 					$post_obj = get_post( $gid );
 					if ( ! $post_obj ) {
@@ -145,13 +148,15 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 					$group_items_html .= designsetgo_query_render_item(
 						$item_template_html,
 						array(
-							'postId'                => (int) $gid,
-							'postType'              => $post_obj->post_type,
-							'index'                 => $item_index,
-							'designsetgo/itemIndex' => $item_index,
+							'postId'                         => (int) $gid,
+							'postType'                       => $post_obj->post_type,
+							'index'                          => $item_index,
+							'designsetgo/itemIndex'          => $item_index,
+							'designsetgo/groupItemIndex'     => $group_item_index,
 						),
 						$atts['itemTagName']
 					);
+					$group_item_index++;
 				}
 				$items_html .= sprintf(
 					'<section class="dsgo-query-group" data-dsgo-group-value="%s">%s%s</section>',

--- a/src/blocks/query/render-posts.php
+++ b/src/blocks/query/render-posts.php
@@ -80,10 +80,11 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 
 		$use_groups = ! empty( $atts['groupBy'] ) && ! empty( $group_header_blocks );
 
-		$items_html    = '';
-		$post_urls     = array();
-		$collected_ids = array();
-		$flat_counter  = 0;
+		$items_html        = '';
+		$post_urls         = array();
+		$collected_ids     = array();
+		$collected_indexes = array();
+		$flat_counter      = 0;
 
 		try {
 			while ( $query->have_posts() ) {
@@ -92,17 +93,22 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 				$post_urls[] = get_permalink();
 				if ( $use_groups ) {
 					$collected_ids[] = $post_id;
+					if ( ! isset( $collected_indexes[ $post_id ] ) ) {
+						$collected_indexes[ $post_id ] = $flat_counter;
+					}
 				} else {
 					$items_html .= designsetgo_query_render_item(
 						$item_template_html,
 						array(
-							'postId'   => $post_id,
-							'postType' => get_post_type(),
-							'index'    => $flat_counter++,
+							'postId'                => $post_id,
+							'postType'              => get_post_type(),
+							'index'                 => $flat_counter,
+							'designsetgo/itemIndex' => $flat_counter,
 						),
 						$atts['itemTagName']
 					);
 				}
+				$flat_counter++;
 			}
 		} finally {
 			wp_reset_postdata();
@@ -127,21 +133,22 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 					);
 					$header_html_out .= $header_block->render();
 				}
-				// Render items in this group using the stripped template.
-				// Counter resets per group so "index 0" means "first in group".
-				$group_items_html  = '';
-				$group_item_index  = 0;
+				// Render items in this group using the original flat result-set
+				// indices so visibility rules behave the same grouped or ungrouped.
+				$group_items_html = '';
 				foreach ( $group['ids'] as $gid ) {
 					$post_obj = get_post( $gid );
 					if ( ! $post_obj ) {
 						continue;
 					}
+					$item_index = isset( $collected_indexes[ $gid ] ) ? (int) $collected_indexes[ $gid ] : 0;
 					$group_items_html .= designsetgo_query_render_item(
 						$item_template_html,
 						array(
-							'postId'   => (int) $gid,
-							'postType' => $post_obj->post_type,
-							'index'    => $group_item_index++,
+							'postId'                => (int) $gid,
+							'postType'              => $post_obj->post_type,
+							'index'                 => $item_index,
+							'designsetgo/itemIndex' => $item_index,
 						),
 						$atts['itemTagName']
 					);
@@ -296,7 +303,9 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 				$args['post__in']       = $ids;
 				$args['orderby']        = 'post__in';
 				$args['post_type']      = 'any';
-				$args['posts_per_page'] = count( $ids );
+				if ( empty( $atts['manualPaginated'] ) ) {
+					$args['posts_per_page'] = count( $ids );
+				}
 			}
 		}
 

--- a/src/blocks/query/render-posts.php
+++ b/src/blocks/query/render-posts.php
@@ -83,6 +83,7 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 		$items_html    = '';
 		$post_urls     = array();
 		$collected_ids = array();
+		$flat_counter  = 0;
 
 		try {
 			while ( $query->have_posts() ) {
@@ -97,6 +98,7 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 						array(
 							'postId'   => $post_id,
 							'postType' => get_post_type(),
+							'index'    => $flat_counter++,
 						),
 						$atts['itemTagName']
 					);
@@ -126,7 +128,9 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 					$header_html_out .= $header_block->render();
 				}
 				// Render items in this group using the stripped template.
-				$group_items_html = '';
+				// Counter resets per group so "index 0" means "first in group".
+				$group_items_html  = '';
+				$group_item_index  = 0;
 				foreach ( $group['ids'] as $gid ) {
 					$post_obj = get_post( $gid );
 					if ( ! $post_obj ) {
@@ -137,6 +141,7 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 						array(
 							'postId'   => (int) $gid,
 							'postType' => $post_obj->post_type,
+							'index'    => $group_item_index++,
 						),
 						$atts['itemTagName']
 					);

--- a/src/blocks/query/render-posts.php
+++ b/src/blocks/query/render-posts.php
@@ -56,24 +56,98 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 
 		$query = new WP_Query( $args );
 
-		$items_html = '';
-		$post_urls  = array();
+		// Determine whether grouped rendering is requested.
+		// Parse inner_html to split group-header blocks from the item template.
+		$group_header_blocks = array();
+		$item_template_html  = (string) $context['inner_html'];
+		if ( ! empty( $atts['groupBy'] ) && is_array( $atts['groupBy'] ) ) {
+			$parsed_inner = parse_blocks( $item_template_html );
+			$template_parts = array();
+			foreach ( $parsed_inner as $pb ) {
+				if ( empty( $pb['blockName'] ) ) {
+					continue;
+				}
+				if ( 'designsetgo/query-group-header' === $pb['blockName'] ) {
+					$group_header_blocks[] = $pb;
+				} else {
+					$template_parts[] = serialize_block( $pb );
+				}
+			}
+			if ( ! empty( $group_header_blocks ) ) {
+				$item_template_html = implode( '', $template_parts );
+			}
+		}
+
+		$use_groups = ! empty( $atts['groupBy'] ) && ! empty( $group_header_blocks );
+
+		$items_html    = '';
+		$post_urls     = array();
+		$collected_ids = array();
+
 		try {
 			while ( $query->have_posts() ) {
 				$query->the_post();
+				$post_id   = get_the_ID();
 				$post_urls[] = get_permalink();
-				$items_html .= designsetgo_query_render_item(
-					(string) $context['inner_html'],
-					array(
-						'postId'   => get_the_ID(),
-						'postType' => get_post_type(),
-					),
-					$atts['itemTagName']
-				);
+				if ( $use_groups ) {
+					$collected_ids[] = $post_id;
+				} else {
+					$items_html .= designsetgo_query_render_item(
+						$item_template_html,
+						array(
+							'postId'   => $post_id,
+							'postType' => get_post_type(),
+						),
+						$atts['itemTagName']
+					);
+				}
 			}
 		} finally {
 			wp_reset_postdata();
 			$post = $saved_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+
+		// If grouped, partition collected IDs and render per group.
+		if ( $use_groups && ! empty( $collected_ids ) ) {
+			require_once __DIR__ . '/render-helpers.php';
+			$groups = designsetgo_query_partition_items( $collected_ids, $atts['groupBy'] );
+			foreach ( $groups as $group ) {
+				// Render group header block(s) with group context.
+				$header_html_out = '';
+				foreach ( $group_header_blocks as $hb ) {
+					$header_block     = new WP_Block(
+						$hb,
+						array(
+							'designsetgo/queryId'    => sanitize_key( (string) ( $context['query_id'] ?? '' ) ),
+							'designsetgo/groupLabel' => (string) $group['label'],
+							'designsetgo/groupValue' => (string) $group['value'],
+						)
+					);
+					$header_html_out .= $header_block->render();
+				}
+				// Render items in this group using the stripped template.
+				$group_items_html = '';
+				foreach ( $group['ids'] as $gid ) {
+					$post_obj = get_post( $gid );
+					if ( ! $post_obj ) {
+						continue;
+					}
+					$group_items_html .= designsetgo_query_render_item(
+						$item_template_html,
+						array(
+							'postId'   => (int) $gid,
+							'postType' => $post_obj->post_type,
+						),
+						$atts['itemTagName']
+					);
+				}
+				$items_html .= sprintf(
+					'<section class="dsgo-query-group" data-dsgo-group-value="%s">%s%s</section>',
+					esc_attr( (string) $group['value'] ),
+					$header_html_out,     // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- block render() output.
+					$group_items_html     // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- assembled from designsetgo_query_render_item().
+				);
+			}
 		}
 
 		$state = array(

--- a/src/blocks/query/render-relationship.php
+++ b/src/blocks/query/render-relationship.php
@@ -28,9 +28,12 @@ if ( ! function_exists( 'designsetgo_query_render_relationship' ) ) :
 			return array( 'html' => '', 'totalPages' => 0, 'totalItems' => 0 );
 		}
 
-		$parent_stack = isset( $context['parent_stack'] ) && is_array( $context['parent_stack'] )
-			? $context['parent_stack']
-			: array();
+		$parent_stack = array();
+		if ( isset( $context['parent_stack'] ) && is_array( $context['parent_stack'] ) && ! empty( $context['parent_stack'] ) ) {
+			$parent_stack = $context['parent_stack'];
+		} elseif ( isset( $GLOBALS['designsetgo_parent_stack'] ) && is_array( $GLOBALS['designsetgo_parent_stack'] ) ) {
+			$parent_stack = $GLOBALS['designsetgo_parent_stack'];
+		}
 		$parent = empty( $parent_stack ) ? null : end( $parent_stack );
 
 		$parent_post_id = 0;
@@ -121,10 +124,13 @@ if ( ! function_exists( 'designsetgo_query_render_relationship' ) ) :
 		}
 
 		// 'parent' fallback: render a single item using the parent post itself.
-		$parent = null;
-		if ( isset( $context['parent_stack'] ) && is_array( $context['parent_stack'] ) ) {
-			$parent = end( $context['parent_stack'] );
+		$fallback_stack = array();
+		if ( isset( $context['parent_stack'] ) && is_array( $context['parent_stack'] ) && ! empty( $context['parent_stack'] ) ) {
+			$fallback_stack = $context['parent_stack'];
+		} elseif ( isset( $GLOBALS['designsetgo_parent_stack'] ) && is_array( $GLOBALS['designsetgo_parent_stack'] ) ) {
+			$fallback_stack = $GLOBALS['designsetgo_parent_stack'];
 		}
+		$parent = empty( $fallback_stack ) ? null : end( $fallback_stack );
 		if ( ! is_array( $parent ) || empty( $parent['postId'] ) ) {
 			return array( 'html' => '', 'totalPages' => 0, 'totalItems' => 0 );
 		}

--- a/src/blocks/query/render-relationship.php
+++ b/src/blocks/query/render-relationship.php
@@ -45,9 +45,13 @@ if ( ! function_exists( 'designsetgo_query_render_relationship' ) ) :
 			return designsetgo_query_relationship_fallback( $atts, $context );
 		}
 
-		$raw_value = function_exists( 'get_field' )
-			? get_field( $field, $parent_post_id )
-			: get_post_meta( $parent_post_id, $field, true );
+		$raw_value = false;
+		if ( function_exists( 'get_field' ) ) {
+			$raw_value = get_field( $field, $parent_post_id );
+		}
+		if ( false === $raw_value || null === $raw_value ) {
+			$raw_value = get_post_meta( $parent_post_id, $field, true );
+		}
 
 		$ids = designsetgo_query_relationship_normalize_ids( $raw_value );
 
@@ -63,10 +67,11 @@ if ( ! function_exists( 'designsetgo_query_render_relationship' ) ) :
 		$atts_override = array_merge(
 			$atts,
 			array(
-				'source'    => 'manual',
-				'manualIds' => $ids,
-				'postType'  => 'any',
-				'perPage'   => max( 1, min( count( $ids ), (int) $atts['perPage'] ) ),
+				'source'          => 'manual',
+				'manualIds'       => $ids,
+				'postType'        => 'any',
+				'perPage'         => max( 1, min( count( $ids ), (int) $atts['perPage'] ) ),
+				'manualPaginated' => true,
 			)
 		);
 

--- a/src/blocks/query/render-relationship.php
+++ b/src/blocks/query/render-relationship.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Dynamic Query — Relationship source renderer.
+ *
+ * Reads an ID-bearing field from the nearest parent Query item's
+ * post and iterates the referenced posts in their declared order.
+ *
+ * Supported field storage shapes:
+ *  - array of ints or WP_Post objects (ACF relationship)
+ *  - comma-separated string of ints ("12, 34, 56")
+ *  - serialized array (legacy ACF)
+ *  - single int
+ *
+ * Requires a parent_stack entry; returns empty when the Query
+ * block is used outside another Query's item template.
+ *
+ * @package DesignSetGo
+ * @since   2.3.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'designsetgo_query_render_relationship' ) ) :
+
+	function designsetgo_query_render_relationship( array $atts, array $context ) {
+		$field = isset( $atts['relationshipField'] ) ? sanitize_text_field( (string) $atts['relationshipField'] ) : '';
+		if ( '' === $field ) {
+			return array( 'html' => '', 'totalPages' => 0, 'totalItems' => 0 );
+		}
+
+		$parent_stack = isset( $context['parent_stack'] ) && is_array( $context['parent_stack'] )
+			? $context['parent_stack']
+			: array();
+		$parent = empty( $parent_stack ) ? null : end( $parent_stack );
+
+		$parent_post_id = 0;
+		if ( is_array( $parent ) && ! empty( $parent['postId'] ) ) {
+			$parent_post_id = (int) $parent['postId'];
+		}
+
+		if ( ! $parent_post_id ) {
+			return designsetgo_query_relationship_fallback( $atts, $context );
+		}
+
+		$raw_value = function_exists( 'get_field' )
+			? get_field( $field, $parent_post_id )
+			: get_post_meta( $parent_post_id, $field, true );
+
+		$ids = designsetgo_query_relationship_normalize_ids( $raw_value );
+
+		if ( empty( $ids ) ) {
+			return designsetgo_query_relationship_fallback( $atts, $context );
+		}
+
+		// Delegate to the Posts renderer — override attributes so WP_Query
+		// runs with post__in + orderby=post__in + post_type=any (relationship
+		// fields are frequently cross-type).
+		require_once __DIR__ . '/render-posts.php';
+
+		$atts_override = array_merge(
+			$atts,
+			array(
+				'source'    => 'manual',
+				'manualIds' => $ids,
+				'postType'  => 'any',
+				'perPage'   => max( 1, min( count( $ids ), (int) $atts['perPage'] ) ),
+			)
+		);
+
+		return designsetgo_query_render_posts( $atts_override, $context );
+	}
+
+	/**
+	 * Normalize ACF/meta field values to a list of post IDs.
+	 */
+	function designsetgo_query_relationship_normalize_ids( $value ) {
+		if ( is_array( $value ) ) {
+			$ids = array();
+			foreach ( $value as $v ) {
+				if ( $v instanceof \WP_Post ) {
+					$ids[] = (int) $v->ID;
+				} elseif ( is_numeric( $v ) ) {
+					$ids[] = (int) $v;
+				}
+			}
+			return array_values( array_filter( $ids ) );
+		}
+		if ( is_string( $value ) && '' !== $value ) {
+			if ( str_contains( $value, ',' ) ) {
+				return array_values( array_filter( array_map( 'absint', explode( ',', $value ) ) ) );
+			}
+			if ( is_numeric( $value ) ) {
+				return array( (int) $value );
+			}
+			$unserialized = maybe_unserialize( $value );
+			if ( is_array( $unserialized ) ) {
+				return designsetgo_query_relationship_normalize_ids( $unserialized );
+			}
+		}
+		if ( is_numeric( $value ) ) {
+			return array( (int) $value );
+		}
+		return array();
+	}
+
+	/**
+	 * Empty / all / parent fallback for no-result relationship queries.
+	 */
+	function designsetgo_query_relationship_fallback( array $atts, array $context ) {
+		$mode = isset( $atts['relationshipFallback'] ) ? (string) $atts['relationshipFallback'] : 'empty';
+
+		if ( 'empty' === $mode ) {
+			return array( 'html' => designsetgo_query_wrap( '', $atts, $context, $context['wrapper_attrs'] ?? null ), 'totalPages' => 0, 'totalItems' => 0 );
+		}
+
+		require_once __DIR__ . '/render-posts.php';
+
+		if ( 'all' === $mode ) {
+			$atts['source'] = 'posts';
+			return designsetgo_query_render_posts( $atts, $context );
+		}
+
+		// 'parent' fallback: render a single item using the parent post itself.
+		$parent = null;
+		if ( isset( $context['parent_stack'] ) && is_array( $context['parent_stack'] ) ) {
+			$parent = end( $context['parent_stack'] );
+		}
+		if ( ! is_array( $parent ) || empty( $parent['postId'] ) ) {
+			return array( 'html' => '', 'totalPages' => 0, 'totalItems' => 0 );
+		}
+		$atts['source']    = 'manual';
+		$atts['manualIds'] = array( (int) $parent['postId'] );
+		$atts['perPage']   = 1;
+		return designsetgo_query_render_posts( $atts, $context );
+	}
+
+endif;

--- a/src/blocks/query/render-terms.php
+++ b/src/blocks/query/render-terms.php
@@ -72,6 +72,7 @@ if ( ! function_exists( 'designsetgo_query_render_terms' ) ) :
 		$total_terms          = (int) get_terms( $count_args );
 
 		$items_html = '';
+		$item_index = 0;
 		foreach ( (array) $terms as $term ) {
 			if ( ! $term instanceof WP_Term ) {
 				continue;
@@ -81,9 +82,12 @@ if ( ! function_exists( 'designsetgo_query_render_terms' ) ) :
 				array(
 					'designsetgo/currentItemId'   => (int) $term->term_id,
 					'designsetgo/currentItemType' => 'term:' . $term->taxonomy,
+					'index'                       => $item_index,
+					'designsetgo/itemIndex'       => $item_index,
 				),
 				$atts['itemTagName']
 			);
+			$item_index++;
 		}
 
 		$state = array(

--- a/src/blocks/query/render-users.php
+++ b/src/blocks/query/render-users.php
@@ -45,16 +45,20 @@ if ( ! function_exists( 'designsetgo_query_render_users' ) ) :
 		$users       = (array) $query->get_results();
 		$total_users = (int) $query->get_total();
 
-		$items_html = '';
+		$items_html  = '';
+		$item_index  = 0;
 		foreach ( $users as $user ) {
 			$items_html .= designsetgo_query_render_item(
 				(string) $context['inner_html'],
 				array(
 					'designsetgo/currentItemId'   => (int) $user->ID,
 					'designsetgo/currentItemType' => 'user',
+					'index'                       => $item_index,
+					'designsetgo/itemIndex'       => $item_index,
 				),
 				$atts['itemTagName']
 			);
+			$item_index++;
 		}
 
 		$state = array(

--- a/src/blocks/query/style.scss
+++ b/src/blocks/query/style.scss
@@ -40,3 +40,16 @@
 		transition: none;
 	}
 }
+
+.dsgo-query-group {
+	display: block;
+	margin-block-end: var(--wp--preset--spacing--40, 1.5rem);
+
+	&:last-child {
+		margin-block-end: 0;
+	}
+}
+
+.wp-block-designsetgo-query-group-header {
+	margin-block-end: var(--wp--preset--spacing--20, 0.75rem);
+}

--- a/src/blocks/query/view.js
+++ b/src/blocks/query/view.js
@@ -41,179 +41,11 @@ store('designsetgo/query', {
 		// ----------------------------------------------------------------
 		// Pagination
 		// ----------------------------------------------------------------
-		*loadMore() {
+		*loadMore(event) {
+			dsgoMarkHandledEvent(event);
 			const ctx = getContext();
-			if (ctx.busy) {
-				return;
-			}
-			ctx.busy = true;
-
 			const { ref } = getElement(); // the button itself
-			const idleLabel =
-				ref instanceof HTMLElement
-					? ref.getAttribute('data-dsgo-label-idle') ||
-						ref.textContent
-					: '';
-			const loadingLabel =
-				ref instanceof HTMLElement
-					? ref.getAttribute('data-dsgo-label-loading') || ''
-					: '';
-
-			if (ref instanceof HTMLElement && loadingLabel) {
-				ref.textContent = loadingLabel;
-				ref.setAttribute('aria-busy', 'true');
-				ref.disabled = true;
-			}
-
-			// Fix 1: exclude elements with [data-dsgo-pagination] so we find the
-			// query list, not the pagination wrapper (both carry data-dsgo-query-id).
-			const container =
-				ref.closest(
-					'[data-dsgo-query-id]:not([data-dsgo-pagination])'
-				) ||
-				document.querySelector(
-					`[data-dsgo-query-id="${ctx.queryId}"]:not([data-dsgo-pagination])`
-				);
-
-			if (!container) {
-				if (ref instanceof HTMLElement) {
-					ref.textContent = idleLabel;
-					ref.disabled = false;
-					ref.removeAttribute('aria-busy');
-				}
-				ctx.busy = false;
-				return;
-			}
-
-			container.setAttribute('aria-busy', 'true');
-
-			try {
-				// Fix 4: blobs now live in a preceding-sibling hidden div with
-				// data-dsgo-blobs-for, not inside the list element.
-				const blobsHost = document.querySelector(
-					`[data-dsgo-blobs-for="${ctx.queryId}"]`
-				);
-				const attrsEl = blobsHost?.querySelector(
-					'script[data-dsgo-attrs]'
-				);
-				const innerEl = blobsHost?.querySelector(
-					'script[data-dsgo-inner]'
-				);
-
-				if (!attrsEl || !innerEl) {
-					ctx.busy = false;
-					container.setAttribute('aria-busy', 'false');
-					return;
-				}
-
-				const attributes = JSON.parse(attrsEl.textContent);
-				const innerBlocks = JSON.parse(innerEl.textContent);
-				const nextPage = (ctx.page || 1) + 1;
-
-				// ctx.restUrl + ctx.nonce are seeded by render-helpers.php so we
-				// don't rely on wpApiSettings (admin-only) or /wp-json/ rewrites
-				// (not guaranteed on plain-permalink installs).
-				const restUrl =
-					ctx.restUrl ||
-					(window.wpApiSettings?.root || '/wp-json/') +
-						'designsetgo/v1/query/render';
-				const restNonce =
-					ctx.nonce || window.wpApiSettings?.nonce || '';
-				const res = yield fetch(restUrl, {
-					method: 'POST',
-					credentials: 'same-origin',
-					headers: {
-						'Content-Type': 'application/json',
-						'X-WP-Nonce': restNonce,
-					},
-					body: JSON.stringify({
-						queryId: ctx.queryId,
-						attributes,
-						page: nextPage,
-						innerBlocks,
-						currentUrl: window.location.href,
-					}),
-				});
-
-				if (!res.ok) {
-					// 401 typically means the nonce expired (page open > 12h).
-					// Surface this to devtools so "load more does nothing" is
-					// debuggable without the user having to inspect network.
-					// eslint-disable-next-line no-console
-					console.warn(
-						`[designsetgo/query] load-more request failed (${res.status}). If 401, the nonce has likely expired — reload the page.`
-					);
-					return;
-				}
-
-				const data = yield res.json();
-
-				// Parse the returned HTML and append .dsgo-query__item nodes.
-				const parser = new DOMParser();
-				const doc = parser.parseFromString(
-					data.html || '',
-					'text/html'
-				);
-				const newItems = doc.querySelectorAll('.dsgo-query__item');
-
-				if (newItems.length) {
-					// Focus management: move focus to the first newly-appended item.
-					const firstNew = newItems[0];
-					newItems.forEach((el) => container.appendChild(el));
-
-					// Refresh feed positions for the now-longer set and announce
-					// the running count if the server reported a total.
-					dsgoStampFeedPositions(container);
-					if (Number.isFinite(data.totalItems)) {
-						dsgoAnnounceResultCount(ctx.queryId, data.totalItems);
-					}
-
-					// Fix 2: only stamp tabindex="-1" when falling back to the item
-					// wrapper itself (no naturally focusable child found). This avoids
-					// permanently evicting <a>/<button>/<input> from the tab order.
-					const naturallyFocusable = firstNew.querySelector(
-						'a, button, input, [tabindex]:not([tabindex="-1"])'
-					);
-					const focusable = naturallyFocusable || firstNew;
-
-					if (focusable instanceof HTMLElement) {
-						if (!naturallyFocusable) {
-							focusable.setAttribute('tabindex', '-1');
-							focusable.addEventListener(
-								'blur',
-								() => focusable.removeAttribute('tabindex'),
-								{ once: true }
-							);
-						}
-						focusable.focus();
-					}
-				}
-
-				ctx.page = nextPage;
-
-				// Remove pagination controls once we've fetched the last page.
-				// Covers both load-more buttons and the infinite-scroll sentinel
-				// wrapper (removing the wrapper also garbage-collects any
-				// IntersectionObserver attached to the sentinel inside it).
-				if (data.totalPages && nextPage >= data.totalPages) {
-					document
-						.querySelectorAll(
-							`[data-dsgo-query-id="${ctx.queryId}"][data-dsgo-pagination="loadmore"] button, ` +
-								`[data-dsgo-query-id="${ctx.queryId}"][data-dsgo-pagination="infinite"]`
-						)
-						.forEach((el) => el.remove());
-				}
-			} finally {
-				ctx.busy = false;
-				container.setAttribute('aria-busy', 'false');
-				// Restore button label and state (button may have been removed
-				// when we reached the last page, so guard with isConnected).
-				if (ref instanceof HTMLElement && ref.isConnected) {
-					ref.textContent = idleLabel;
-					ref.disabled = false;
-					ref.removeAttribute('aria-busy');
-				}
-			}
+			yield dsgoLoadMorePlain(ctx, ref);
 		},
 
 		// ----------------------------------------------------------------
@@ -396,120 +228,7 @@ store('designsetgo/query', {
 		 */
 		initInfiniteObserver() {
 			const { ref } = getElement(); // sentinel div
-
-			const wrapper = ref.closest('[data-dsgo-pagination="infinite"]');
-			if (!wrapper) {
-				return;
-			}
-
-			// Disconnect any prior observer for this sentinel. IAPI may
-			// re-run callbacks.initInfiniteObserver on the same element if
-			// a refresh swaps innerHTML and the sentinel is rebuilt, and
-			// leftover observers from previous mounts would keep firing.
-			const prior = dsgoSentinelObservers.get(ref);
-			if (prior) {
-				prior.disconnect();
-			}
-
-			// Promote the list to role="feed" + stamp positions so AT users
-			// can navigate the incrementally-loaded items structurally. Done
-			// here (not in render.php) so markup stays correct under plain
-			// (non-infinite) pagination modes.
-			const queryId = wrapper.getAttribute('data-dsgo-query-id') || '';
-			const feedContainer = queryId
-				? document.querySelector(
-						`[data-dsgo-query-id="${queryId}"][data-dsgo-query-role="container"]`
-					)
-				: null;
-			if (
-				feedContainer &&
-				feedContainer.getAttribute('role') !== 'feed'
-			) {
-				feedContainer.setAttribute('role', 'feed');
-				feedContainer.setAttribute('aria-busy', 'false');
-				dsgoStampFeedPositions(feedContainer);
-			}
-
-			const button = wrapper.querySelector(
-				'.dsgo-query-pagination__loadmore'
-			);
-
-			// Reduced-motion: reveal the button and skip auto-advance entirely.
-			const prefersReduced = window.matchMedia(
-				'(prefers-reduced-motion: reduce)'
-			).matches;
-			if (prefersReduced) {
-				if (button) {
-					button.hidden = false;
-				}
-				return;
-			}
-
-			const ctx = getContext();
-
-			const threshold = parseInt(
-				wrapper.dataset.dsgoAutoPauseAfter || '3',
-				10
-			);
-			const offset = parseInt(
-				wrapper.dataset.dsgoSentinelOffset || '200',
-				10
-			);
-
-			// Initialise the auto-load counter on the context if not already set.
-			if (typeof ctx.autoLoadCount !== 'number') {
-				ctx.autoLoadCount = 0;
-			}
-
-			const observer = new IntersectionObserver(
-				(entries) => {
-					entries.forEach((entry) => {
-						if (!entry.isIntersecting) {
-							return;
-						}
-
-						// Don't count or fire if a load is already in-flight.
-						if (ctx.busy) {
-							return;
-						}
-
-						if (ctx.autoLoadCount >= threshold) {
-							// Auto-pause threshold reached — reveal button,
-							// disconnect observer, let the user opt in to more.
-							if (button) {
-								button.hidden = false;
-							}
-							observer.disconnect();
-							dsgoSentinelObservers.delete(ref);
-							return;
-						}
-
-						ctx.autoLoadCount++;
-
-						// Fire a synthetic click on the button so the existing
-						// loadMore generator action handles the full fetch/append
-						// cycle (including busy-guard, aria-busy, focus management).
-						// The button stays hidden visually during auto-loads;
-						// we briefly un-hide it so the IAPI click event resolves
-						// the correct element reference, then re-hide immediately.
-						if (button) {
-							button.hidden = false;
-							button.click();
-							// Re-hide after the microtask tick so the click event
-							// is dispatched with the button visible, then restore.
-							Promise.resolve().then(() => {
-								if (button.isConnected) {
-									button.hidden = true;
-								}
-							});
-						}
-					});
-				},
-				{ rootMargin: `${offset}px` }
-			);
-
-			observer.observe(ref);
-			dsgoSentinelObservers.set(ref, observer);
+			dsgoSetupInfiniteObserver(ref, getContext());
 		},
 	},
 });
@@ -542,15 +261,25 @@ store('designsetgo/query', {
  * @param {Object} ctx Parsed context ({ queryId, ...}).
  * @param {URL}    url Target URL.
  */
-function dsgoDelegatedRefresh(ctx, url) {
+function dsgoMarkHandledEvent(event) {
+	if (event && typeof event === 'object') {
+		dsgoHandledEvents.add(event);
+	}
+}
+
+function dsgoRunDelegated(ctx, callback) {
 	const queryId = ctx && ctx.queryId;
 	if (!queryId || dsgoDelegatedBusy.has(queryId)) {
 		return;
 	}
 	dsgoDelegatedBusy.add(queryId);
-	Promise.resolve(dsgoQueryRefreshPlain(ctx, url)).finally(() => {
+	Promise.resolve(callback()).finally(() => {
 		dsgoDelegatedBusy.delete(queryId);
 	});
+}
+
+function dsgoDelegatedRefresh(ctx, url) {
+	dsgoRunDelegated(ctx, () => dsgoQueryRefreshPlain(ctx, url));
 }
 
 /**
@@ -569,6 +298,235 @@ function dsgoGetContextFromDom(el) {
 	} catch (err) {
 		return null;
 	}
+}
+
+function dsgoGetQueryContainer(queryId, el) {
+	return (
+		el?.closest('[data-dsgo-query-id]:not([data-dsgo-pagination])') ||
+		document.querySelector(
+			`[data-dsgo-query-id="${queryId}"]:not([data-dsgo-pagination])`
+		)
+	);
+}
+
+function dsgoGetRestConfig(ctx) {
+	return {
+		restUrl:
+			ctx.restUrl ||
+			(window.wpApiSettings?.root || '/wp-json/') +
+				'designsetgo/v1/query/render',
+		restNonce: ctx.nonce || window.wpApiSettings?.nonce || '',
+	};
+}
+
+async function dsgoLoadMorePlain(ctx, button) {
+	if (!ctx?.queryId || ctx.busy || !(button instanceof HTMLElement)) {
+		return;
+	}
+
+	ctx.busy = true;
+
+	const idleLabel =
+		button.getAttribute('data-dsgo-label-idle') || button.textContent;
+	const loadingLabel = button.getAttribute('data-dsgo-label-loading') || '';
+	if (loadingLabel) {
+		button.textContent = loadingLabel;
+		button.setAttribute('aria-busy', 'true');
+	}
+	button.disabled = true;
+
+	const container = dsgoGetQueryContainer(ctx.queryId, button);
+	if (!container) {
+		button.textContent = idleLabel;
+		button.disabled = false;
+		button.removeAttribute('aria-busy');
+		ctx.busy = false;
+		return;
+	}
+
+	container.setAttribute('aria-busy', 'true');
+
+	try {
+		const blobsHost = document.querySelector(
+			`[data-dsgo-blobs-for="${ctx.queryId}"]`
+		);
+		const attrsEl = blobsHost?.querySelector('script[data-dsgo-attrs]');
+		const innerEl = blobsHost?.querySelector('script[data-dsgo-inner]');
+
+		if (!attrsEl || !innerEl) {
+			return;
+		}
+
+		const attributes = JSON.parse(attrsEl.textContent);
+		const innerBlocks = JSON.parse(innerEl.textContent);
+		const nextPage = (ctx.page || 1) + 1;
+		const { restUrl, restNonce } = dsgoGetRestConfig(ctx);
+		const res = await fetch(restUrl, {
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-WP-Nonce': restNonce,
+			},
+			body: JSON.stringify({
+				queryId: ctx.queryId,
+				attributes,
+				page: nextPage,
+				innerBlocks,
+				currentUrl: window.location.href,
+			}),
+		});
+
+		if (!res.ok) {
+			// eslint-disable-next-line no-console
+			console.warn(
+				`[designsetgo/query] load-more request failed (${res.status}). If 401, the nonce has likely expired — reload the page.`
+			);
+			return;
+		}
+
+		const data = await res.json();
+		const doc = new DOMParser().parseFromString(data.html || '', 'text/html');
+		const newItems = doc.querySelectorAll('.dsgo-query__item');
+
+		if (newItems.length) {
+			const firstNew = newItems[0];
+			newItems.forEach((el) => container.appendChild(el));
+
+			dsgoStampFeedPositions(container);
+			if (Number.isFinite(data.totalItems)) {
+				dsgoAnnounceResultCount(ctx.queryId, data.totalItems);
+			}
+
+			const naturallyFocusable = firstNew.querySelector(
+				'a, button, input, [tabindex]:not([tabindex="-1"])'
+			);
+			const focusable = naturallyFocusable || firstNew;
+
+			if (focusable instanceof HTMLElement) {
+				if (!naturallyFocusable) {
+					focusable.setAttribute('tabindex', '-1');
+					focusable.addEventListener(
+						'blur',
+						() => focusable.removeAttribute('tabindex'),
+						{ once: true }
+					);
+				}
+				focusable.focus();
+			}
+		}
+
+		ctx.page = nextPage;
+
+		if (data.totalPages && nextPage >= data.totalPages) {
+			document
+				.querySelectorAll(
+					`[data-dsgo-query-id="${ctx.queryId}"][data-dsgo-pagination="loadmore"] button, ` +
+						`[data-dsgo-query-id="${ctx.queryId}"][data-dsgo-pagination="infinite"]`
+				)
+				.forEach((el) => el.remove());
+		}
+	} finally {
+		ctx.busy = false;
+		container.setAttribute('aria-busy', 'false');
+		if (button.isConnected) {
+			button.textContent = idleLabel;
+			button.disabled = false;
+			button.removeAttribute('aria-busy');
+		}
+	}
+}
+
+function dsgoSetupInfiniteObserver(sentinel, ctx) {
+	if (!(sentinel instanceof HTMLElement) || !ctx?.queryId) {
+		return;
+	}
+
+	const wrapper = sentinel.closest('[data-dsgo-pagination="infinite"]');
+	if (!wrapper) {
+		return;
+	}
+
+	const prior = dsgoSentinelObservers.get(sentinel);
+	if (prior) {
+		prior.disconnect();
+	}
+
+	const feedContainer = dsgoGetQueryContainer(ctx.queryId, wrapper);
+	if (feedContainer && feedContainer.getAttribute('role') !== 'feed') {
+		feedContainer.setAttribute('role', 'feed');
+		feedContainer.setAttribute('aria-busy', 'false');
+		dsgoStampFeedPositions(feedContainer);
+	}
+
+	const button = wrapper.querySelector('.dsgo-query-pagination__loadmore');
+	const prefersReduced = window.matchMedia(
+		'(prefers-reduced-motion: reduce)'
+	).matches;
+	if (prefersReduced) {
+		if (button) {
+			button.hidden = false;
+		}
+		return;
+	}
+
+	const threshold = parseInt(wrapper.dataset.dsgoAutoPauseAfter || '3', 10);
+	const offset = parseInt(wrapper.dataset.dsgoSentinelOffset || '200', 10);
+	if (typeof ctx.autoLoadCount !== 'number') {
+		ctx.autoLoadCount = 0;
+	}
+
+	const observer = new IntersectionObserver(
+		(entries) => {
+			entries.forEach((entry) => {
+				if (!entry.isIntersecting || ctx.busy) {
+					return;
+				}
+
+				if (ctx.autoLoadCount >= threshold) {
+					if (button) {
+						button.hidden = false;
+					}
+					observer.disconnect();
+					dsgoSentinelObservers.delete(sentinel);
+					return;
+				}
+
+				ctx.autoLoadCount++;
+
+				if (button) {
+					button.hidden = false;
+					button.click();
+					Promise.resolve().then(() => {
+						if (button.isConnected) {
+							button.hidden = true;
+						}
+					});
+				}
+			});
+		},
+		{ rootMargin: `${offset}px` }
+	);
+
+	observer.observe(sentinel);
+	dsgoSentinelObservers.set(sentinel, observer);
+}
+
+function dsgoInitInfiniteObservers(root = document) {
+	if (!root?.querySelectorAll) {
+		return;
+	}
+
+	root
+		.querySelectorAll(
+			'[data-dsgo-pagination="infinite"] [data-wp-init*="initInfiniteObserver"]'
+		)
+		.forEach((sentinel) => {
+			const ctx = dsgoGetContextFromDom(sentinel);
+			if (ctx) {
+				dsgoSetupInfiniteObserver(sentinel, ctx);
+			}
+		});
 }
 
 /**
@@ -704,6 +662,17 @@ function dsgoDelegatedClick(event) {
 	if (!(target instanceof HTMLElement)) {
 		return;
 	}
+	const loadMoreButton = target.closest('.dsgo-query-pagination__loadmore');
+	if (loadMoreButton) {
+		const ctx = dsgoGetContextFromDom(loadMoreButton);
+		if (!ctx) {
+			return;
+		}
+
+		event.preventDefault();
+		dsgoRunDelegated(ctx, () => dsgoLoadMorePlain(ctx, loadMoreButton));
+		return;
+	}
 	const chip = target.closest(
 		'.dsgo-query-filter--active .dsgo-query-filter__chip, .dsgo-query-filter--reset .dsgo-query-filter__reset, .dsgo-query-filter--reset a'
 	);
@@ -729,6 +698,13 @@ function dsgoDelegatedClick(event) {
 document.addEventListener('change', dsgoDelegatedChange);
 document.addEventListener('input', dsgoDelegatedInput);
 document.addEventListener('click', dsgoDelegatedClick);
+if (document.readyState === 'loading') {
+	document.addEventListener('DOMContentLoaded', () =>
+		dsgoInitInfiniteObservers(document)
+	);
+} else {
+	dsgoInitInfiniteObservers(document);
+}
 
 // ---------------------------------------------------------------------------
 // Shared refresh helpers
@@ -845,6 +821,7 @@ function* dsgoQueryRefresh(ctx, url) {
 			// Server-rendered HTML assembled from esc_attr / esc_html /
 			// block-render output in designsetgo_query_render_region().
 			region.innerHTML = newRegion.innerHTML;
+			dsgoInitInfiniteObservers(region);
 		}
 
 		// Sync the browser URL without a page reload.
@@ -963,6 +940,7 @@ async function dsgoQueryRefreshPlain(ctx, url) {
 			// Server-rendered HTML assembled from esc_attr / esc_html /
 			// block-render output in designsetgo_query_render_region().
 			region.innerHTML = newRegion.innerHTML;
+			dsgoInitInfiniteObservers(region);
 		}
 
 		window.history.replaceState({}, '', url.toString());

--- a/src/blocks/query/view.js
+++ b/src/blocks/query/view.js
@@ -251,15 +251,9 @@ store('designsetgo/query', {
 // URL-manipulation + dsgoQueryRefreshPlain() path.
 
 /**
- * Serialise delegated-path refreshes per queryId.
+ * Mark a native event as already handled by the Interactivity API store.
  *
- * Two rapid filter changes after the IAPI swap produce two calls to
- * dsgoQueryRefreshPlain, each with a freshly-parsed ctx — so ctx.busy cannot
- * guard them. Track in-flight refreshes in the module-level Set and drop new
- * requests while one is already running, mirroring the IAPI reactive guard.
- *
- * @param {Object} ctx Parsed context ({ queryId, ...}).
- * @param {URL}    url Target URL.
+ * @param {Event} event Native event object.
  */
 function dsgoMarkHandledEvent(event) {
 	if (event && typeof event === 'object') {
@@ -267,6 +261,16 @@ function dsgoMarkHandledEvent(event) {
 	}
 }
 
+/**
+ * Serialise delegated-path network work per queryId.
+ *
+ * Two rapid interactions after the IAPI swap produce fresh ctx objects, so
+ * ctx.busy cannot guard them. Track in-flight work in a module-level Set and
+ * drop new requests while one is already running.
+ *
+ * @param {Object}   ctx      Parsed context ({ queryId, ... }).
+ * @param {Function} callback Promise-returning runner.
+ */
 function dsgoRunDelegated(ctx, callback) {
 	const queryId = ctx && ctx.queryId;
 	if (!queryId || dsgoDelegatedBusy.has(queryId)) {
@@ -386,7 +390,10 @@ async function dsgoLoadMorePlain(ctx, button) {
 		}
 
 		const data = await res.json();
-		const doc = new DOMParser().parseFromString(data.html || '', 'text/html');
+		const doc = new DOMParser().parseFromString(
+			data.html || '',
+			'text/html'
+		);
 		const newItems = doc.querySelectorAll('.dsgo-query__item');
 
 		if (newItems.length) {
@@ -517,16 +524,14 @@ function dsgoInitInfiniteObservers(root = document) {
 		return;
 	}
 
-	root
-		.querySelectorAll(
-			'[data-dsgo-pagination="infinite"] [data-wp-init*="initInfiniteObserver"]'
-		)
-		.forEach((sentinel) => {
-			const ctx = dsgoGetContextFromDom(sentinel);
-			if (ctx) {
-				dsgoSetupInfiniteObserver(sentinel, ctx);
-			}
-		});
+	root.querySelectorAll(
+		'[data-dsgo-pagination="infinite"] [data-wp-init*="initInfiniteObserver"]'
+	).forEach((sentinel) => {
+		const ctx = dsgoGetContextFromDom(sentinel);
+		if (ctx) {
+			dsgoSetupInfiniteObserver(sentinel, ctx);
+		}
+	});
 }
 
 /**

--- a/src/extensions/visibility/RuleRow.js
+++ b/src/extensions/visibility/RuleRow.js
@@ -16,8 +16,9 @@ const TYPE_OPTIONS = [
 const META_OP_OPTIONS = [
 	{ value: 'equals', label: __( 'equals', 'designsetgo' ) },
 	{ value: 'not_equals', label: __( 'does not equal', 'designsetgo' ) },
-	{ value: 'exists', label: __( 'exists', 'designsetgo' ) },
-	{ value: 'not_exists', label: __( 'does not exist', 'designsetgo' ) },
+	{ value: 'contains', label: __( 'contains', 'designsetgo' ) },
+	{ value: 'not_empty', label: __( 'is set', 'designsetgo' ) },
+	{ value: 'empty', label: __( 'is not set', 'designsetgo' ) },
 ];
 
 const TAXONOMY_OP_OPTIONS = [
@@ -26,11 +27,10 @@ const TAXONOMY_OP_OPTIONS = [
 ];
 
 const INDEX_OP_OPTIONS = [
-	{ value: 'equals', label: __( 'equals', 'designsetgo' ) },
-	{ value: 'less_than', label: __( 'less than', 'designsetgo' ) },
-	{ value: 'greater_than', label: __( 'greater than', 'designsetgo' ) },
-	{ value: 'even', label: __( 'is even', 'designsetgo' ) },
-	{ value: 'odd', label: __( 'is odd', 'designsetgo' ) },
+	{ value: 'equals', label: __( 'is', 'designsetgo' ) },
+	{ value: 'not_equals', label: __( 'is not', 'designsetgo' ) },
+	{ value: 'lt', label: __( 'less than', 'designsetgo' ) },
+	{ value: 'gt', label: __( 'greater than', 'designsetgo' ) },
 ];
 
 const AUTH_OP_OPTIONS = [
@@ -63,7 +63,7 @@ function MetaControls( { rule, onChange } ) {
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
-			{ ( rule.op === 'equals' || rule.op === 'not_equals' || ! rule.op ) && (
+			{ ! [ 'empty', 'not_empty' ].includes( rule.op ) && (
 				<TextControl
 					label={ __( 'Value', 'designsetgo' ) }
 					value={ rule.value ?? '' }
@@ -120,7 +120,7 @@ function TaxonomyControls( { rule, onChange } ) {
  * @param {Function} props.onChange
  */
 function IndexControls( { rule, onChange } ) {
-	const showValue = [ 'equals', 'less_than', 'greater_than' ].includes( rule.op ?? 'equals' );
+	const showValue = [ 'equals', 'not_equals', 'lt', 'gt' ].includes( rule.op ?? 'equals' );
 	return (
 		<>
 			<SelectControl
@@ -165,6 +165,27 @@ function AuthControls( { rule, onChange } ) {
 }
 
 /**
+ * Returns the default rule shape for a given type.
+ *
+ * @param {string} type Rule type.
+ * @return {Object} Default rule object.
+ */
+function getDefaultRule( type ) {
+	switch ( type ) {
+		case 'meta':
+			return { type: 'meta', key: '', op: 'equals', value: '' };
+		case 'taxonomy':
+			return { type: 'taxonomy', taxonomy: '', op: 'has', value: '' };
+		case 'index':
+			return { type: 'index', op: 'equals', value: 0 };
+		case 'auth':
+			return { type: 'auth', value: true };
+		default:
+			return { type, op: 'equals', value: '' };
+	}
+}
+
+/**
  * A single visibility rule row.
  *
  * @param {Object}   props
@@ -181,7 +202,7 @@ export default function RuleRow( { rule, onChange, onRemove } ) {
 						label={ __( 'Rule Type', 'designsetgo' ) }
 						value={ rule.type ?? 'meta' }
 						options={ TYPE_OPTIONS }
-						onChange={ ( type ) => onChange( { ...rule, type } ) }
+						onChange={ ( type ) => onChange( getDefaultRule( type ) ) }
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
 					/>

--- a/src/extensions/visibility/RuleRow.js
+++ b/src/extensions/visibility/RuleRow.js
@@ -1,0 +1,212 @@
+import { __ } from '@wordpress/i18n';
+import {
+	SelectControl,
+	TextControl,
+	Button,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+
+const TYPE_OPTIONS = [
+	{ value: 'meta', label: __( 'Post Meta', 'designsetgo' ) },
+	{ value: 'taxonomy', label: __( 'Taxonomy', 'designsetgo' ) },
+	{ value: 'index', label: __( 'Item Index', 'designsetgo' ) },
+	{ value: 'auth', label: __( 'Auth State', 'designsetgo' ) },
+];
+
+const META_OP_OPTIONS = [
+	{ value: 'equals', label: __( 'equals', 'designsetgo' ) },
+	{ value: 'not_equals', label: __( 'does not equal', 'designsetgo' ) },
+	{ value: 'exists', label: __( 'exists', 'designsetgo' ) },
+	{ value: 'not_exists', label: __( 'does not exist', 'designsetgo' ) },
+];
+
+const TAXONOMY_OP_OPTIONS = [
+	{ value: 'has', label: __( 'has term', 'designsetgo' ) },
+	{ value: 'not_has', label: __( 'does not have term', 'designsetgo' ) },
+];
+
+const INDEX_OP_OPTIONS = [
+	{ value: 'equals', label: __( 'equals', 'designsetgo' ) },
+	{ value: 'less_than', label: __( 'less than', 'designsetgo' ) },
+	{ value: 'greater_than', label: __( 'greater than', 'designsetgo' ) },
+	{ value: 'even', label: __( 'is even', 'designsetgo' ) },
+	{ value: 'odd', label: __( 'is odd', 'designsetgo' ) },
+];
+
+const AUTH_OP_OPTIONS = [
+	{ value: 'logged_in', label: __( 'logged in', 'designsetgo' ) },
+	{ value: 'logged_out', label: __( 'logged out', 'designsetgo' ) },
+];
+
+/**
+ * Renders the extra controls for a meta-type rule.
+ *
+ * @param {Object} props
+ * @param {Object} props.rule
+ * @param {Function} props.onChange
+ */
+function MetaControls( { rule, onChange } ) {
+	return (
+		<>
+			<TextControl
+				label={ __( 'Meta Key', 'designsetgo' ) }
+				value={ rule.key ?? '' }
+				onChange={ ( key ) => onChange( { ...rule, key } ) }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+			<SelectControl
+				label={ __( 'Condition', 'designsetgo' ) }
+				value={ rule.op ?? 'equals' }
+				options={ META_OP_OPTIONS }
+				onChange={ ( op ) => onChange( { ...rule, op } ) }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+			{ ( rule.op === 'equals' || rule.op === 'not_equals' || ! rule.op ) && (
+				<TextControl
+					label={ __( 'Value', 'designsetgo' ) }
+					value={ rule.value ?? '' }
+					onChange={ ( value ) => onChange( { ...rule, value } ) }
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+			) }
+		</>
+	);
+}
+
+/**
+ * Renders the extra controls for a taxonomy-type rule.
+ *
+ * @param {Object} props
+ * @param {Object} props.rule
+ * @param {Function} props.onChange
+ */
+function TaxonomyControls( { rule, onChange } ) {
+	return (
+		<>
+			<TextControl
+				label={ __( 'Taxonomy Slug', 'designsetgo' ) }
+				value={ rule.taxonomy ?? '' }
+				onChange={ ( taxonomy ) => onChange( { ...rule, taxonomy } ) }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+			<SelectControl
+				label={ __( 'Condition', 'designsetgo' ) }
+				value={ rule.op ?? 'has' }
+				options={ TAXONOMY_OP_OPTIONS }
+				onChange={ ( op ) => onChange( { ...rule, op } ) }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+			<TextControl
+				label={ __( 'Term Slug', 'designsetgo' ) }
+				value={ rule.value ?? '' }
+				onChange={ ( value ) => onChange( { ...rule, value } ) }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+		</>
+	);
+}
+
+/**
+ * Renders the extra controls for an index-type rule.
+ *
+ * @param {Object} props
+ * @param {Object} props.rule
+ * @param {Function} props.onChange
+ */
+function IndexControls( { rule, onChange } ) {
+	const showValue = [ 'equals', 'less_than', 'greater_than' ].includes( rule.op ?? 'equals' );
+	return (
+		<>
+			<SelectControl
+				label={ __( 'Condition', 'designsetgo' ) }
+				value={ rule.op ?? 'equals' }
+				options={ INDEX_OP_OPTIONS }
+				onChange={ ( op ) => onChange( { ...rule, op } ) }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+			{ showValue && (
+				<TextControl
+					label={ __( 'Index Value', 'designsetgo' ) }
+					value={ String( rule.value ?? '' ) }
+					onChange={ ( value ) => onChange( { ...rule, value } ) }
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+			) }
+		</>
+	);
+}
+
+/**
+ * Renders the extra controls for an auth-type rule.
+ *
+ * @param {Object} props
+ * @param {Object} props.rule
+ * @param {Function} props.onChange
+ */
+function AuthControls( { rule, onChange } ) {
+	return (
+		<SelectControl
+			label={ __( 'Auth State', 'designsetgo' ) }
+			value={ rule.op ?? 'logged_in' }
+			options={ AUTH_OP_OPTIONS }
+			onChange={ ( op ) => onChange( { ...rule, op } ) }
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+		/>
+	);
+}
+
+/**
+ * A single visibility rule row.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.rule      Rule object.
+ * @param {Function} props.onChange  Called with updated rule object.
+ * @param {Function} props.onRemove  Called when the rule is removed.
+ */
+export default function RuleRow( { rule, onChange, onRemove } ) {
+	return (
+		<div className="dsgo-visibility-rule-row">
+			<HStack alignment="top">
+				<div className="dsgo-visibility-rule-row__controls">
+					<SelectControl
+						label={ __( 'Rule Type', 'designsetgo' ) }
+						value={ rule.type ?? 'meta' }
+						options={ TYPE_OPTIONS }
+						onChange={ ( type ) => onChange( { ...rule, type } ) }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+					{ ( rule.type === 'meta' || ! rule.type ) && (
+						<MetaControls rule={ rule } onChange={ onChange } />
+					) }
+					{ rule.type === 'taxonomy' && (
+						<TaxonomyControls rule={ rule } onChange={ onChange } />
+					) }
+					{ rule.type === 'index' && (
+						<IndexControls rule={ rule } onChange={ onChange } />
+					) }
+					{ rule.type === 'auth' && (
+						<AuthControls rule={ rule } onChange={ onChange } />
+					) }
+				</div>
+				<Button
+					variant="tertiary"
+					isDestructive
+					onClick={ onRemove }
+					aria-label={ __( 'Remove rule', 'designsetgo' ) }
+				>
+					{ __( 'Remove', 'designsetgo' ) }
+				</Button>
+			</HStack>
+		</div>
+	);
+}

--- a/src/extensions/visibility/RuleRow.js
+++ b/src/extensions/visibility/RuleRow.js
@@ -115,7 +115,6 @@ function TaxonomyControls( { rule, onChange } ) {
  * @param {Function} props.onChange
  */
 function IndexControls( { rule, onChange } ) {
-	const showValue = [ 'equals', 'not_equals', 'lt', 'gt' ].includes( rule.op ?? 'equals' );
 	return (
 		<>
 			<SelectControl
@@ -126,15 +125,13 @@ function IndexControls( { rule, onChange } ) {
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
-			{ showValue && (
-				<TextControl
-					label={ __( 'Index Value', 'designsetgo' ) }
-					value={ String( rule.value ?? '' ) }
-					onChange={ ( value ) => onChange( { ...rule, value } ) }
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-				/>
-			) }
+			<TextControl
+				label={ __( 'Index Value', 'designsetgo' ) }
+				value={ String( rule.value ?? '' ) }
+				onChange={ ( value ) => onChange( { ...rule, value } ) }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
 		</>
 	);
 }

--- a/src/extensions/visibility/RuleRow.js
+++ b/src/extensions/visibility/RuleRow.js
@@ -33,11 +33,6 @@ const INDEX_OP_OPTIONS = [
 	{ value: 'gt', label: __( 'greater than', 'designsetgo' ) },
 ];
 
-const AUTH_OP_OPTIONS = [
-	{ value: 'logged_in', label: __( 'logged in', 'designsetgo' ) },
-	{ value: 'logged_out', label: __( 'logged out', 'designsetgo' ) },
-];
-
 /**
  * Renders the extra controls for a meta-type rule.
  *
@@ -154,10 +149,13 @@ function IndexControls( { rule, onChange } ) {
 function AuthControls( { rule, onChange } ) {
 	return (
 		<SelectControl
-			label={ __( 'Auth State', 'designsetgo' ) }
-			value={ rule.op ?? 'logged_in' }
-			options={ AUTH_OP_OPTIONS }
-			onChange={ ( op ) => onChange( { ...rule, op } ) }
+			label={ __( 'Visibility requires', 'designsetgo' ) }
+			value={ JSON.stringify( !! rule.value ) }
+			options={ [
+				{ value: 'true', label: __( 'Logged-in user', 'designsetgo' ) },
+				{ value: 'false', label: __( 'Logged-out visitor', 'designsetgo' ) },
+			] }
+			onChange={ ( v ) => onChange( { ...rule, value: JSON.parse( v ) } ) }
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom
 		/>

--- a/src/extensions/visibility/VisibilityPanel.js
+++ b/src/extensions/visibility/VisibilityPanel.js
@@ -1,0 +1,89 @@
+import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	SelectControl,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import RuleRow from './RuleRow';
+
+const DEFAULT_RULE = { type: 'meta', key: '', op: 'equals', value: '' };
+
+const OPERATOR_OPTIONS = [
+	{ value: 'AND', label: __( 'All rules must match (AND)', 'designsetgo' ) },
+	{ value: 'OR', label: __( 'Any rule must match (OR)', 'designsetgo' ) },
+];
+
+/**
+ * Inspector panel for configuring block visibility rules.
+ *
+ * @param {Object}        props
+ * @param {Object|null}   props.value     Current visibility config ({ operator, rules }) or null.
+ * @param {Function}      props.onChange  Called with the new visibility config.
+ */
+export default function VisibilityPanel( { value, onChange } ) {
+	const rules = value?.rules ?? [];
+	const operator = value?.operator ?? 'AND';
+	const hasRules = rules.length > 0;
+
+	function handleAddRule() {
+		onChange( {
+			operator,
+			rules: [ ...rules, { ...DEFAULT_RULE } ],
+		} );
+	}
+
+	function handleOperatorChange( newOperator ) {
+		onChange( { ...value, operator: newOperator } );
+	}
+
+	function handleRuleChange( index, updatedRule ) {
+		const newRules = rules.map( ( r, i ) => ( i === index ? updatedRule : r ) );
+		onChange( { operator, rules: newRules } );
+	}
+
+	function handleRuleRemove( index ) {
+		const newRules = rules.filter( ( _, i ) => i !== index );
+		if ( newRules.length === 0 ) {
+			onChange( null );
+		} else {
+			onChange( { operator, rules: newRules } );
+		}
+	}
+
+	return (
+		<VStack spacing={ 3 } className="dsgo-visibility-panel">
+			{ ! hasRules && (
+				<p className="dsgo-visibility-panel__empty-state">
+					{ __( 'Always visible', 'designsetgo' ) }
+				</p>
+			) }
+
+			{ hasRules && rules.length > 1 && (
+				<SelectControl
+					label={ __( 'Combine Rules', 'designsetgo' ) }
+					value={ operator }
+					options={ OPERATOR_OPTIONS }
+					onChange={ handleOperatorChange }
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+			) }
+
+			{ hasRules && rules.map( ( rule, index ) => (
+				<RuleRow
+					key={ index }
+					rule={ rule }
+					onChange={ ( updated ) => handleRuleChange( index, updated ) }
+					onRemove={ () => handleRuleRemove( index ) }
+				/>
+			) ) }
+
+			<Button
+				variant="secondary"
+				onClick={ handleAddRule }
+			>
+				{ __( 'Add rule', 'designsetgo' ) }
+			</Button>
+		</VStack>
+	);
+}

--- a/src/extensions/visibility/context-filter.js
+++ b/src/extensions/visibility/context-filter.js
@@ -40,6 +40,7 @@ const CONTEXT_KEYS = [
 	'designsetgo/itemMeta',
 	'designsetgo/itemTerms',
 	'designsetgo/isAuthenticated',
+	'designsetgo/groupItemIndex',
 ];
 
 /**

--- a/src/extensions/visibility/context-filter.js
+++ b/src/extensions/visibility/context-filter.js
@@ -1,0 +1,45 @@
+/**
+ * context-filter.js
+ *
+ * Appends item-context keys to every block's `usesContext` so the visibility
+ * gate (Task B5) can read designsetgo/itemIndex, designsetgo/itemMeta, and
+ * designsetgo/itemTerms from any block inside a Dynamic Query template.
+ *
+ * @since 2.3.0
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Blocks whose usesContext should NOT be touched (no runtime, or special
+ * blocks that don't participate in the editor block-tree context system).
+ */
+const BLOCKED = new Set(['core/freeform', 'core/missing', 'core/template-part']);
+
+/** Context keys provided by the Dynamic Query block per rendered item. */
+const CONTEXT_KEYS = [
+	'designsetgo/itemIndex',
+	'designsetgo/itemMeta',
+	'designsetgo/itemTerms',
+];
+
+/**
+ * Filter callback — appends CONTEXT_KEYS to settings.usesContext, deduped.
+ *
+ * @param {Object} settings Block type settings.
+ * @param {string} name     Block type name.
+ * @return {Object} Updated settings.
+ */
+function addItemContextUses(settings, name) {
+	if (BLOCKED.has(name)) {
+		return settings;
+	}
+	const existing = settings.usesContext ?? [];
+	const merged = [...new Set([...existing, ...CONTEXT_KEYS])];
+	return { ...settings, usesContext: merged };
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'designsetgo/visibility/uses-context',
+	addItemContextUses
+);

--- a/src/extensions/visibility/context-filter.js
+++ b/src/extensions/visibility/context-filter.js
@@ -39,6 +39,7 @@ const CONTEXT_KEYS = [
 	'designsetgo/itemIndex',
 	'designsetgo/itemMeta',
 	'designsetgo/itemTerms',
+	'designsetgo/isAuthenticated',
 ];
 
 /**

--- a/src/extensions/visibility/context-filter.js
+++ b/src/extensions/visibility/context-filter.js
@@ -10,10 +10,29 @@
 import { addFilter } from '@wordpress/hooks';
 
 /**
- * Blocks whose usesContext should NOT be touched (no runtime, or special
- * blocks that don't participate in the editor block-tree context system).
+ * Blocks whose usesContext should NOT be touched.
+ *
+ * Container/query-family blocks never appear inside a query item template,
+ * so they never need the item-context keys.
  */
-const BLOCKED = new Set(['core/freeform', 'core/missing', 'core/template-part']);
+const BLOCKED = new Set([
+	'core/freeform',
+	'core/missing',
+	'core/template-part',
+	'core/query',
+	'core/query-loop',
+	'core/query-pagination',
+	'core/query-pagination-next',
+	'core/query-pagination-previous',
+	'core/query-pagination-numbers',
+	'core/query-no-results',
+	'core/post-template',
+	'designsetgo/query',
+	'designsetgo/query-pagination',
+	'designsetgo/query-filter',
+	'designsetgo/query-no-results',
+	'designsetgo/query-group-header',
+]);
 
 /** Context keys provided by the Dynamic Query block per rendered item. */
 const CONTEXT_KEYS = [

--- a/src/extensions/visibility/evaluateRules.js
+++ b/src/extensions/visibility/evaluateRules.js
@@ -1,0 +1,51 @@
+/**
+ * JS mirror of DesignSetGo\BlockVisibility::matches — keep in sync.
+ *
+ * Pure function: no React imports, no WordPress imports.
+ *
+ * @param {object|null} rules   The dsgoVisibility attribute.
+ * @param {object}      context Per-item context: { postId, postType, index, meta, terms, isAuthenticated }.
+ * @return {boolean} Whether the block should be visible.
+ */
+export default function evaluateRules( rules, context = {} ) {
+	if ( ! rules || ! rules.rules?.length ) return true;
+	const op = ( rules.operator || 'AND' ).toUpperCase();
+	for ( const rule of rules.rules ) {
+		const ok = evaluate( rule, context );
+		if ( op === 'OR' && ok ) return true;
+		if ( op === 'AND' && ! ok ) return false;
+	}
+	return op === 'AND';
+}
+
+function evaluate( rule, ctx ) {
+	const { type, op = 'equals', value } = rule;
+	switch ( type ) {
+		case 'meta':
+			return compare( ctx.meta?.[ rule.key ], op, value );
+		case 'taxonomy': {
+			const slugs = ctx.terms?.[ rule.taxonomy ] || [];
+			const has = slugs.includes( String( value ) );
+			return op === 'not_has' ? ! has : has;
+		}
+		case 'index':
+			return compare( ctx.index, op, Number( value ) );
+		case 'auth':
+			return !! ctx.isAuthenticated === !! value;
+		default:
+			return false;
+	}
+}
+
+function compare( actual, op, expected ) {
+	switch ( op ) {
+		case 'not_equals': return String( actual ) !== String( expected );
+		case 'contains':   return String( actual ).toLowerCase().includes( String( expected ).toLowerCase() );
+		case 'gt':         return Number( actual ) > Number( expected );
+		case 'lt':         return Number( actual ) < Number( expected );
+		case 'empty':      return actual === '' || actual == null;
+		case 'not_empty':  return actual !== '' && actual != null;
+		case 'equals':
+		default:           return String( actual ) === String( expected );
+	}
+}

--- a/src/extensions/visibility/filters.js
+++ b/src/extensions/visibility/filters.js
@@ -8,9 +8,13 @@ const BLOCKED = new Set([
 
 function addVisibilityAttribute(settings, name) {
 	if (BLOCKED.has(name)) return settings;
-	if (!settings.attributes) settings.attributes = {};
-	settings.attributes.dsgoVisibility = { type: 'object', default: null };
-	return settings;
+	return {
+		...settings,
+		attributes: {
+			...(settings.attributes ?? {}),
+			dsgoVisibility: { type: 'object', default: null },
+		},
+	};
 }
 
 addFilter(

--- a/src/extensions/visibility/filters.js
+++ b/src/extensions/visibility/filters.js
@@ -57,11 +57,6 @@ addFilter(
  *   2. The block context explicitly provides `designsetgo/itemIndex`
  *      (meaning we are inside a query-item preview, not the main canvas), AND
  *   3. evaluateRules() returns false for the current item context.
- *
- * NOTE: This gate is inert until Task C3 wires `designsetgo/itemIndex`,
- * `designsetgo/itemMeta`, and `designsetgo/itemTerms` into query-item
- * preview context. Until then `props.context['designsetgo/itemIndex']`
- * will always be undefined and every block will pass through unchanged.
  */
 const withVisibilityGate = createHigherOrderComponent( ( BlockListBlock ) => ( props ) => {
 	const visibility = props.attributes?.dsgoVisibility;

--- a/src/extensions/visibility/filters.js
+++ b/src/extensions/visibility/filters.js
@@ -86,7 +86,16 @@ const withVisibilityGate = createHigherOrderComponent( ( BlockListBlock ) => ( p
 	};
 
 	if ( ! evaluateRules( visibility, evalCtx ) ) {
-		return null;
+		// Return a hidden placeholder rather than null so the React tree stays
+		// stable. Returning null from editor.BlockListBlock can break tree
+		// diffing because Gutenberg expects a stable DOM node per slot.
+		return (
+			<div
+				className="dsgo-visibility-hidden"
+				style={ { display: 'none' } }
+				aria-hidden="true"
+			/>
+		);
 	}
 
 	return <BlockListBlock { ...props } />;

--- a/src/extensions/visibility/filters.js
+++ b/src/extensions/visibility/filters.js
@@ -3,6 +3,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { InspectorControls } from '@wordpress/block-editor';
 import { Fragment } from '@wordpress/element';
 import VisibilityPanel from './VisibilityPanel';
+import evaluateRules from './evaluateRules';
 
 const BLOCKED = new Set( [
 	'core/freeform',
@@ -46,4 +47,53 @@ addFilter(
 	'editor.BlockEdit',
 	'designsetgo/visibility/inspector',
 	withVisibilityPanel
+);
+
+/**
+ * Gate HOC for editor.BlockListBlock.
+ *
+ * Short-circuits rendering (returns null) when:
+ *   1. The block carries a dsgoVisibility attribute, AND
+ *   2. The block context explicitly provides `designsetgo/itemIndex`
+ *      (meaning we are inside a query-item preview, not the main canvas), AND
+ *   3. evaluateRules() returns false for the current item context.
+ *
+ * NOTE: This gate is inert until Task C3 wires `designsetgo/itemIndex`,
+ * `designsetgo/itemMeta`, and `designsetgo/itemTerms` into query-item
+ * preview context. Until then `props.context['designsetgo/itemIndex']`
+ * will always be undefined and every block will pass through unchanged.
+ */
+const withVisibilityGate = createHigherOrderComponent( ( BlockListBlock ) => ( props ) => {
+	const visibility = props.attributes?.dsgoVisibility;
+	// props.context is populated by the editor.BlockListBlock filter in
+	// Gutenberg >= 16.x (WP 6.5+). It carries any context values declared
+	// via `usesContext` in the block's block.json.
+	const ctx = props.context || {};
+
+	// Only gate inside query-item previews. If the item index context key is
+	// absent we are on the main canvas and must not hide anything.
+	if ( ctx[ 'designsetgo/itemIndex' ] == null ) {
+		return <BlockListBlock { ...props } />;
+	}
+
+	const evalCtx = {
+		index:           ctx[ 'designsetgo/itemIndex' ],
+		meta:            ctx[ 'designsetgo/itemMeta' ]  || {},
+		terms:           ctx[ 'designsetgo/itemTerms' ] || {},
+		postId:          ctx.postId,
+		postType:        ctx.postType,
+		isAuthenticated: ctx[ 'designsetgo/isAuthenticated' ] || false,
+	};
+
+	if ( ! evaluateRules( visibility, evalCtx ) ) {
+		return null;
+	}
+
+	return <BlockListBlock { ...props } />;
+}, 'withDsgoVisibilityGate' );
+
+addFilter(
+	'editor.BlockListBlock',
+	'designsetgo/visibility/gate',
+	withVisibilityGate
 );

--- a/src/extensions/visibility/filters.js
+++ b/src/extensions/visibility/filters.js
@@ -1,17 +1,21 @@
 import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { InspectorControls } from '@wordpress/block-editor';
+import { Fragment } from '@wordpress/element';
+import VisibilityPanel from './VisibilityPanel';
 
-const BLOCKED = new Set([
+const BLOCKED = new Set( [
 	'core/freeform',
 	'core/missing',
 	'core/template-part',
-]);
+] );
 
-function addVisibilityAttribute(settings, name) {
-	if (BLOCKED.has(name)) return settings;
+function addVisibilityAttribute( settings, name ) {
+	if ( BLOCKED.has( name ) ) return settings;
 	return {
 		...settings,
 		attributes: {
-			...(settings.attributes ?? {}),
+			...( settings.attributes ?? {} ),
 			dsgoVisibility: { type: 'object', default: null },
 		},
 	};
@@ -21,4 +25,25 @@ addFilter(
 	'blocks.registerBlockType',
 	'designsetgo/visibility/add-attribute',
 	addVisibilityAttribute
+);
+
+const withVisibilityPanel = createHigherOrderComponent( ( BlockEdit ) => ( props ) => {
+	if ( BLOCKED.has( props.name ) ) return <BlockEdit { ...props } />;
+	return (
+		<Fragment>
+			<BlockEdit { ...props } />
+			<InspectorControls group="advanced">
+				<VisibilityPanel
+					value={ props.attributes.dsgoVisibility }
+					onChange={ ( value ) => props.setAttributes( { dsgoVisibility: value } ) }
+				/>
+			</InspectorControls>
+		</Fragment>
+	);
+}, 'withDsgoVisibilityPanel' );
+
+addFilter(
+	'editor.BlockEdit',
+	'designsetgo/visibility/inspector',
+	withVisibilityPanel
 );

--- a/src/extensions/visibility/filters.js
+++ b/src/extensions/visibility/filters.js
@@ -1,0 +1,20 @@
+import { addFilter } from '@wordpress/hooks';
+
+const BLOCKED = new Set([
+	'core/freeform',
+	'core/missing',
+	'core/template-part',
+]);
+
+function addVisibilityAttribute(settings, name) {
+	if (BLOCKED.has(name)) return settings;
+	if (!settings.attributes) settings.attributes = {};
+	settings.attributes.dsgoVisibility = { type: 'object', default: null };
+	return settings;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'designsetgo/visibility/add-attribute',
+	addVisibilityAttribute
+);

--- a/src/extensions/visibility/index.js
+++ b/src/extensions/visibility/index.js
@@ -1,0 +1,1 @@
+import './filters';

--- a/src/extensions/visibility/index.js
+++ b/src/extensions/visibility/index.js
@@ -1,1 +1,2 @@
 import './filters';
+import './context-filter';

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,9 @@ import './extensions/vertical-scroll-parallax';
 // Draft Mode - adds "draft mode" functionality for published pages
 import './extensions/draft-mode';
 
+// Conditional Visibility - registers dsgoVisibility attribute for query-driven inner-block visibility
+import './extensions/visibility';
+
 // ===== RICH TEXT FORMATS =====
 // Text Style - adds inline text styling (color, gradient, size) to selected text
 import './formats/text-style';

--- a/tests/e2e/auth.setup.js
+++ b/tests/e2e/auth.setup.js
@@ -14,7 +14,7 @@ const http = require('http');
 const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
 const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
 
-const WP_BASE_URL = process.env.WP_BASE_URL || 'http://localhost:9449';
+const WP_BASE_URL = process.env.WP_BASE_URL || 'http://localhost:9451';
 
 /**
  * Wait for the WordPress server to be ready by polling the login page.

--- a/tests/integration/BlockVisibilityTest.php
+++ b/tests/integration/BlockVisibilityTest.php
@@ -1,0 +1,68 @@
+<?php
+// tests/integration/BlockVisibilityTest.php
+namespace DesignSetGo\Tests\Integration;
+
+use DesignSetGo\BlockVisibility;
+use WP_UnitTestCase;
+
+class BlockVisibilityTest extends WP_UnitTestCase {
+
+	public function test_null_rules_always_visible() {
+		$this->assertTrue( BlockVisibility::matches( null, array( 'postId' => 1 ) ) );
+		$this->assertTrue( BlockVisibility::matches( array(), array() ) );
+	}
+
+	public function test_meta_equals_rule() {
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, 'featured', '1' );
+
+		$rules = array(
+			'operator' => 'AND',
+			'rules'    => array(
+				array( 'type' => 'meta', 'key' => 'featured', 'op' => 'equals', 'value' => '1' ),
+			),
+		);
+		$this->assertTrue( BlockVisibility::matches( $rules, array( 'postId' => $post_id ) ) );
+
+		update_post_meta( $post_id, 'featured', '0' );
+		$this->assertFalse( BlockVisibility::matches( $rules, array( 'postId' => $post_id ) ) );
+	}
+
+	public function test_taxonomy_has_rule() {
+		$post_id = self::factory()->post->create();
+		$term_id = self::factory()->term->create( array( 'taxonomy' => 'category', 'slug' => 'news' ) );
+		wp_set_post_terms( $post_id, array( $term_id ), 'category' );
+
+		$rules = array(
+			'operator' => 'AND',
+			'rules'    => array(
+				array( 'type' => 'taxonomy', 'taxonomy' => 'category', 'op' => 'has', 'value' => 'news' ),
+			),
+		);
+		$this->assertTrue( BlockVisibility::matches( $rules, array( 'postId' => $post_id ) ) );
+	}
+
+	public function test_index_rule() {
+		$rules = array(
+			'operator' => 'AND',
+			'rules'    => array(
+				array( 'type' => 'index', 'op' => 'equals', 'value' => 0 ),
+			),
+		);
+		$this->assertTrue( BlockVisibility::matches( $rules, array( 'postId' => 1, 'index' => 0 ) ) );
+		$this->assertFalse( BlockVisibility::matches( $rules, array( 'postId' => 1, 'index' => 3 ) ) );
+	}
+
+	public function test_or_relation() {
+		$rules = array(
+			'operator' => 'OR',
+			'rules'    => array(
+				array( 'type' => 'index', 'op' => 'equals', 'value' => 0 ),
+				array( 'type' => 'index', 'op' => 'equals', 'value' => 2 ),
+			),
+		);
+		$this->assertTrue( BlockVisibility::matches( $rules, array( 'index' => 0 ) ) );
+		$this->assertTrue( BlockVisibility::matches( $rules, array( 'index' => 2 ) ) );
+		$this->assertFalse( BlockVisibility::matches( $rules, array( 'index' => 1 ) ) );
+	}
+}

--- a/tests/integration/blocks/query/BindingsScopeTest.php
+++ b/tests/integration/blocks/query/BindingsScopeTest.php
@@ -7,13 +7,18 @@ use WP_UnitTestCase;
 
 class BindingsScopeTest extends WP_UnitTestCase {
 
-	public function test_parent_scope_reads_from_parent_stack() {
+	public function test_parent_scope_reads_ancestor_not_current_item() {
 		$parent_id = self::factory()->post->create();
 		$child_id  = self::factory()->post->create();
 		update_post_meta( $parent_id, 'parent_label', 'HELLO-PARENT' );
+		update_post_meta( $child_id, 'parent_label', 'WRONG-CHILD' );
 
+		// designsetgo_query_render_item() pushes the CURRENT item onto the
+		// stack before innerBlocks render, so 'parent' must skip the top entry
+		// (self) and read the ancestor one level up.
 		$GLOBALS['designsetgo_parent_stack'] = array(
 			array( 'postId' => $parent_id, 'postType' => 'post' ),
+			array( 'postId' => $child_id,  'postType' => 'post' ),
 		);
 
 		$bindings = new Bindings();
@@ -28,6 +33,30 @@ class BindingsScopeTest extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( 'HELLO-PARENT', $value );
+		unset( $GLOBALS['designsetgo_parent_stack'] );
+	}
+
+	public function test_parent_scope_returns_null_when_no_outer_loop() {
+		$only_id = self::factory()->post->create();
+		update_post_meta( $only_id, 'label', 'ONLY' );
+
+		// Single-level query — stack has just the current item, no ancestor.
+		$GLOBALS['designsetgo_parent_stack'] = array(
+			array( 'postId' => $only_id, 'postType' => 'post' ),
+		);
+
+		$bindings = new Bindings();
+		$block    = new WP_Block(
+			array( 'blockName' => 'core/paragraph' ),
+			array( 'postId' => $only_id, 'postType' => 'post' )
+		);
+		$value = $bindings->get_post_meta_value(
+			array( 'key' => 'label', 'scope' => 'parent' ),
+			$block,
+			'content'
+		);
+
+		$this->assertNull( $value );
 		unset( $GLOBALS['designsetgo_parent_stack'] );
 	}
 
@@ -50,9 +79,12 @@ class BindingsScopeTest extends WP_UnitTestCase {
 		$leaf_id  = self::factory()->post->create();
 		update_post_meta( $root_id, 'root_label', 'ROOT' );
 
+		// Three-level stack matches the real render pipeline: root → mid → leaf
+		// (leaf is the current item, pushed by designsetgo_query_render_item()).
 		$GLOBALS['designsetgo_parent_stack'] = array(
 			array( 'postId' => $root_id, 'postType' => 'post' ),
 			array( 'postId' => $mid_id,  'postType' => 'post' ),
+			array( 'postId' => $leaf_id, 'postType' => 'post' ),
 		);
 
 		$bindings = new Bindings();

--- a/tests/integration/blocks/query/BindingsScopeTest.php
+++ b/tests/integration/blocks/query/BindingsScopeTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace DesignSetGo\Tests\Integration\Blocks\Query;
+
+use DesignSetGo\Blocks\Query\Bindings;
+use WP_Block;
+use WP_UnitTestCase;
+
+class BindingsScopeTest extends WP_UnitTestCase {
+
+	public function test_parent_scope_reads_from_parent_stack() {
+		$parent_id = self::factory()->post->create();
+		$child_id  = self::factory()->post->create();
+		update_post_meta( $parent_id, 'parent_label', 'HELLO-PARENT' );
+
+		$GLOBALS['designsetgo_parent_stack'] = array(
+			array( 'postId' => $parent_id, 'postType' => 'post' ),
+		);
+
+		$bindings = new Bindings();
+		$block    = new WP_Block(
+			array( 'blockName' => 'core/paragraph' ),
+			array( 'postId' => $child_id, 'postType' => 'post' )
+		);
+		$value = $bindings->get_post_meta_value(
+			array( 'key' => 'parent_label', 'scope' => 'parent' ),
+			$block,
+			'content'
+		);
+
+		$this->assertSame( 'HELLO-PARENT', $value );
+		unset( $GLOBALS['designsetgo_parent_stack'] );
+	}
+
+	public function test_self_scope_is_default() {
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, 'label', 'ME' );
+
+		$bindings = new Bindings();
+		$block    = new WP_Block(
+			array( 'blockName' => 'core/paragraph' ),
+			array( 'postId' => $post_id, 'postType' => 'post' )
+		);
+		$value = $bindings->get_post_meta_value( array( 'key' => 'label' ), $block, 'content' );
+		$this->assertSame( 'ME', $value );
+	}
+
+	public function test_root_scope_reads_from_stack_bottom() {
+		$root_id  = self::factory()->post->create();
+		$mid_id   = self::factory()->post->create();
+		$leaf_id  = self::factory()->post->create();
+		update_post_meta( $root_id, 'root_label', 'ROOT' );
+
+		$GLOBALS['designsetgo_parent_stack'] = array(
+			array( 'postId' => $root_id, 'postType' => 'post' ),
+			array( 'postId' => $mid_id,  'postType' => 'post' ),
+		);
+
+		$bindings = new Bindings();
+		$block    = new WP_Block(
+			array( 'blockName' => 'core/paragraph' ),
+			array( 'postId' => $leaf_id, 'postType' => 'post' )
+		);
+		$value = $bindings->get_post_meta_value(
+			array( 'key' => 'root_label', 'scope' => 'root' ),
+			$block,
+			'content'
+		);
+
+		$this->assertSame( 'ROOT', $value );
+		unset( $GLOBALS['designsetgo_parent_stack'] );
+	}
+}

--- a/tests/integration/blocks/query/GroupByTest.php
+++ b/tests/integration/blocks/query/GroupByTest.php
@@ -1,0 +1,40 @@
+<?php
+namespace DesignSetGo\Tests\Integration\Blocks\Query;
+
+use WP_UnitTestCase;
+
+class GroupByTest extends WP_UnitTestCase {
+
+	public function test_partitions_by_taxonomy() {
+		$news_term   = self::factory()->term->create( array( 'taxonomy' => 'category', 'slug' => 'news' ) );
+		$events_term = self::factory()->term->create( array( 'taxonomy' => 'category', 'slug' => 'events' ) );
+
+		$news_post_ids = self::factory()->post->create_many( 2 );
+		foreach ( $news_post_ids as $pid ) wp_set_post_terms( $pid, array( $news_term ), 'category' );
+
+		$events_post_ids = self::factory()->post->create_many( 1 );
+		wp_set_post_terms( $events_post_ids[0], array( $events_term ), 'category' );
+
+		require_once DESIGNSETGO_PATH . 'src/blocks/query/render-helpers.php';
+
+		$header_html = '<!-- wp:designsetgo/query-group-header -->'
+					  . '<div class="wp-block-designsetgo-query-group-header"><h3>Group</h3></div>'
+					  . '<!-- /wp:designsetgo/query-group-header -->';
+		$inner       = $header_html . '<!-- wp:paragraph --><p>x</p><!-- /wp:paragraph -->';
+
+		$html = designsetgo_query_render(
+			array(
+				'source'      => 'posts',
+				'postType'    => 'post',
+				'perPage'     => 10,
+				'tagName'     => 'ul',
+				'itemTagName' => 'li',
+				'groupBy'     => array( 'field' => 'taxonomy', 'key' => 'category' ),
+			),
+			array( 'query_id' => 'g1', 'page' => 1, 'inner_html' => $inner, 'params' => array() )
+		)['html'];
+
+		// Two groups → two headers in output.
+		$this->assertSame( 2, substr_count( $html, 'dsgo-query-group-header' ) );
+	}
+}

--- a/tests/integration/blocks/query/NestedVisibilityTest.php
+++ b/tests/integration/blocks/query/NestedVisibilityTest.php
@@ -1,0 +1,36 @@
+<?php
+namespace DesignSetGo\Tests\Integration\Blocks\Query;
+
+use WP_UnitTestCase;
+
+class NestedVisibilityTest extends WP_UnitTestCase {
+
+	public function test_visibility_applies_to_nested_blocks() {
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, 'featured', '0' );
+
+		require_once DESIGNSETGO_PATH . 'src/blocks/query/render-helpers.php';
+
+		// Register the render_block filter so nested block visibility is gated.
+		\DesignSetGo\BlockVisibility::register();
+
+		// Paragraph with dsgoVisibility nested inside a core/group.
+		$inner_html = '<!-- wp:group -->'
+			. '<div class="wp-block-group">'
+			. '<!-- wp:paragraph {"dsgoVisibility":{"operator":"AND","rules":[{"type":"meta","key":"featured","op":"equals","value":"1"}]}} -->'
+			. '<p>Nested featured badge</p>'
+			. '<!-- /wp:paragraph -->'
+			. '<!-- wp:paragraph --><p>Always shown nested</p><!-- /wp:paragraph -->'
+			. '</div>'
+			. '<!-- /wp:group -->';
+
+		$html = designsetgo_query_render_item(
+			$inner_html,
+			array( 'postId' => $post_id, 'postType' => 'post', 'index' => 0 ),
+			'li'
+		);
+
+		$this->assertStringNotContainsString( 'Nested featured badge', $html );
+		$this->assertStringContainsString( 'Always shown nested', $html );
+	}
+}

--- a/tests/integration/blocks/query/ParentStackTest.php
+++ b/tests/integration/blocks/query/ParentStackTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace DesignSetGo\Tests\Integration\Blocks\Query;
+
+use WP_UnitTestCase;
+
+class ParentStackTest extends WP_UnitTestCase {
+
+	public function test_stack_is_pushed_and_popped_per_item() {
+		$posts = self::factory()->post->create_many( 2 );
+
+		$GLOBALS['dsgo_stack_capture'] = array();
+		add_action( 'render_block', function ( $html, $block ) {
+			if ( ! empty( $block['blockName'] ) && 'core/paragraph' === $block['blockName'] ) {
+				$GLOBALS['dsgo_stack_capture'][] = $GLOBALS['designsetgo_parent_stack'] ?? array();
+			}
+			return $html;
+		}, 10, 2 );
+
+		require_once DESIGNSETGO_PATH . 'src/blocks/query/render-helpers.php';
+		designsetgo_query_render(
+			array( 'source' => 'posts', 'postType' => 'post', 'perPage' => 2, 'tagName' => 'ul', 'itemTagName' => 'li' ),
+			array( 'query_id' => 'c1', 'page' => 1, 'inner_html' => '<!-- wp:paragraph --><p>x</p><!-- /wp:paragraph -->', 'params' => array() )
+		);
+
+		$this->assertCount( 2, $GLOBALS['dsgo_stack_capture'] );
+		// WP_Query defaults to date DESC (newest first), so the second-created post
+		// (higher ID) renders first. Sort the captured IDs to assert both are present
+		// without depending on query ordering.
+		$captured_ids = array(
+			$GLOBALS['dsgo_stack_capture'][0][0]['postId'],
+			$GLOBALS['dsgo_stack_capture'][1][0]['postId'],
+		);
+		sort( $captured_ids );
+		$expected_ids = $posts;
+		sort( $expected_ids );
+		$this->assertSame( $expected_ids, $captured_ids );
+		$this->assertArrayNotHasKey( 'designsetgo_parent_stack', $GLOBALS ); // popped after render
+	}
+}

--- a/tests/integration/blocks/query/RelationshipRenderTest.php
+++ b/tests/integration/blocks/query/RelationshipRenderTest.php
@@ -1,0 +1,49 @@
+<?php
+// tests/integration/blocks/query/RelationshipRenderTest.php
+namespace DesignSetGo\Tests\Integration\Blocks\Query;
+
+use WP_UnitTestCase;
+
+class RelationshipRenderTest extends WP_UnitTestCase {
+
+	public function test_resolves_parent_meta_to_post_ids() {
+		$parent  = self::factory()->post->create( array( 'post_title' => 'Parent' ) );
+		$child_a = self::factory()->post->create( array( 'post_title' => 'Child A' ) );
+		$child_b = self::factory()->post->create( array( 'post_title' => 'Child B' ) );
+		update_post_meta( $parent, 'related_posts', array( $child_a, $child_b ) );
+
+		require_once DESIGNSETGO_PATH . 'src/blocks/query/render-helpers.php';
+
+		$result = designsetgo_query_render(
+			array(
+				'source'            => 'relationship',
+				'relationshipField' => 'related_posts',
+				'postType'          => 'post',
+				'perPage'           => 10,
+				'tagName'           => 'ul',
+				'itemTagName'       => 'li',
+			),
+			array(
+				'query_id'     => 'rel-1',
+				'page'         => 1,
+				'inner_html'   => '<!-- wp:paragraph --><p>x</p><!-- /wp:paragraph -->',
+				'params'       => array(),
+				'parent_stack' => array(
+					array( 'postId' => $parent, 'postType' => 'post' ),
+				),
+			)
+		);
+
+		$this->assertSame( 2, $result['totalItems'] );
+		$this->assertStringContainsString( 'dsgo-query__item', $result['html'] );
+	}
+
+	public function test_returns_empty_when_parent_stack_missing() {
+		$result = designsetgo_query_render(
+			array( 'source' => 'relationship', 'relationshipField' => 'x' ),
+			array( 'query_id' => 'rel-2', 'page' => 1, 'inner_html' => '', 'params' => array() )
+		);
+		$this->assertSame( 0, $result['totalItems'] );
+		$this->assertSame( '', trim( wp_strip_all_tags( $result['html'] ) ) );
+	}
+}

--- a/tests/integration/blocks/query/RelationshipRenderTest.php
+++ b/tests/integration/blocks/query/RelationshipRenderTest.php
@@ -47,6 +47,59 @@ class RelationshipRenderTest extends WP_UnitTestCase {
 		$this->assertSame( '', trim( wp_strip_all_tags( $result['html'] ) ) );
 	}
 
+	public function test_relationship_honors_per_page_and_total_pages() {
+		$parent   = self::factory()->post->create( array( 'post_title' => 'Parent' ) );
+		$children = self::factory()->post->create_many( 3 );
+		update_post_meta( $parent, 'related_posts', $children );
+
+		require_once DESIGNSETGO_PATH . 'src/blocks/query/render-helpers.php';
+
+		$page_one = designsetgo_query_render(
+			array(
+				'source'            => 'relationship',
+				'relationshipField' => 'related_posts',
+				'postType'          => 'post',
+				'perPage'           => 2,
+				'tagName'           => 'ul',
+				'itemTagName'       => 'li',
+			),
+			array(
+				'query_id'     => 'rel-paginated',
+				'page'         => 1,
+				'inner_html'   => '<!-- wp:paragraph --><p>child</p><!-- /wp:paragraph -->',
+				'params'       => array(),
+				'parent_stack' => array(
+					array( 'postId' => $parent, 'postType' => 'post' ),
+				),
+			)
+		);
+
+		$page_two = designsetgo_query_render(
+			array(
+				'source'            => 'relationship',
+				'relationshipField' => 'related_posts',
+				'postType'          => 'post',
+				'perPage'           => 2,
+				'tagName'           => 'ul',
+				'itemTagName'       => 'li',
+			),
+			array(
+				'query_id'     => 'rel-paginated',
+				'page'         => 2,
+				'inner_html'   => '<!-- wp:paragraph --><p>child</p><!-- /wp:paragraph -->',
+				'params'       => array(),
+				'parent_stack' => array(
+					array( 'postId' => $parent, 'postType' => 'post' ),
+				),
+			)
+		);
+
+		$this->assertSame( 3, $page_one['totalItems'] );
+		$this->assertSame( 2, $page_one['totalPages'] );
+		$this->assertSame( 2, substr_count( $page_one['html'], 'dsgo-query__item' ) );
+		$this->assertSame( 1, substr_count( $page_two['html'], 'dsgo-query__item' ) );
+	}
+
 	/**
 	 * Production path: no manual context injection — parent stack comes from
 	 * $GLOBALS['designsetgo_parent_stack'] pushed by designsetgo_query_render_item().
@@ -58,7 +111,6 @@ class RelationshipRenderTest extends WP_UnitTestCase {
 		update_post_meta( $parent, 'related_posts', array( $child_a, $child_b ) );
 
 		require_once DESIGNSETGO_PATH . 'src/blocks/query/render-helpers.php';
-		require_once DESIGNSETGO_PATH . 'src/blocks/query/render-relationship.php';
 
 		// Simulate the production path: push the parent item onto $GLOBALS directly,
 		// as designsetgo_query_render_item() does, then call the relationship renderer
@@ -68,7 +120,8 @@ class RelationshipRenderTest extends WP_UnitTestCase {
 		);
 
 		try {
-			$result = designsetgo_query_render_relationship(
+			// Use designsetgo_query_render() so defaults are applied (avoids "Undefined array key" notices).
+			$result = designsetgo_query_render(
 				array(
 					'source'               => 'relationship',
 					'relationshipField'    => 'related_posts',

--- a/tests/integration/blocks/query/RelationshipRenderTest.php
+++ b/tests/integration/blocks/query/RelationshipRenderTest.php
@@ -46,4 +46,51 @@ class RelationshipRenderTest extends WP_UnitTestCase {
 		$this->assertSame( 0, $result['totalItems'] );
 		$this->assertSame( '', trim( wp_strip_all_tags( $result['html'] ) ) );
 	}
+
+	/**
+	 * Production path: no manual context injection — parent stack comes from
+	 * $GLOBALS['designsetgo_parent_stack'] pushed by designsetgo_query_render_item().
+	 */
+	public function test_relationship_uses_globals_parent_stack_fallback() {
+		$parent  = self::factory()->post->create( array( 'post_title' => 'Parent Post' ) );
+		$child_a = self::factory()->post->create( array( 'post_title' => 'Child One' ) );
+		$child_b = self::factory()->post->create( array( 'post_title' => 'Child Two' ) );
+		update_post_meta( $parent, 'related_posts', array( $child_a, $child_b ) );
+
+		require_once DESIGNSETGO_PATH . 'src/blocks/query/render-helpers.php';
+		require_once DESIGNSETGO_PATH . 'src/blocks/query/render-relationship.php';
+
+		// Simulate the production path: push the parent item onto $GLOBALS directly,
+		// as designsetgo_query_render_item() does, then call the relationship renderer
+		// WITHOUT injecting parent_stack into $context (which is what production does).
+		$GLOBALS['designsetgo_parent_stack'] = array(
+			array( 'postId' => $parent, 'postType' => 'post', 'index' => 0 ),
+		);
+
+		try {
+			$result = designsetgo_query_render_relationship(
+				array(
+					'source'               => 'relationship',
+					'relationshipField'    => 'related_posts',
+					'relationshipFallback' => 'empty',
+					'postType'             => 'post',
+					'perPage'              => 10,
+					'tagName'              => 'ul',
+					'itemTagName'          => 'li',
+				),
+				array(
+					'query_id'   => 'rel-globals',
+					'page'       => 1,
+					'inner_html' => '<!-- wp:paragraph --><p>child</p><!-- /wp:paragraph -->',
+					'params'     => array(),
+					// Intentionally NO parent_stack key — exercises the GLOBALS fallback.
+				)
+			);
+		} finally {
+			unset( $GLOBALS['designsetgo_parent_stack'] );
+		}
+
+		$this->assertSame( 2, $result['totalItems'], 'Relationship renderer must resolve IDs via $GLOBALS parent stack when context key is absent.' );
+		$this->assertStringContainsString( 'dsgo-query__item', $result['html'] );
+	}
 }

--- a/tests/integration/blocks/query/VisibilityIntegrationTest.php
+++ b/tests/integration/blocks/query/VisibilityIntegrationTest.php
@@ -25,4 +25,38 @@ class VisibilityIntegrationTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'Featured badge', $html );
 		$this->assertStringContainsString( 'Always shown', $html );
 	}
+
+	public function test_index_rule_is_applied_during_full_query_render() {
+		$first_post  = self::factory()->post->create( array( 'post_title' => 'First Item' ) );
+		$second_post = self::factory()->post->create( array( 'post_title' => 'Second Item' ) );
+
+		require_once DESIGNSETGO_PATH . 'src/blocks/query/render-helpers.php';
+
+		$inner_html = '<!-- wp:paragraph {"dsgoVisibility":{"operator":"AND","rules":[{"type":"index","op":"equals","value":0}]}} -->'
+					. '<p>First only</p>'
+					. '<!-- /wp:paragraph -->';
+
+		$result = designsetgo_query_render(
+			array(
+				'source'      => 'manual',
+				'manualIds'   => array( $first_post, $second_post ),
+				'perPage'     => 2,
+				'tagName'     => 'ul',
+				'itemTagName' => 'li',
+			),
+			array(
+				'query_id'   => 'visibility-index',
+				'page'       => 1,
+				'inner_html' => $inner_html,
+				'params'     => array(),
+			)
+		);
+
+		// 'First only' appears once in the rendered list items.
+		// It also appears in the JSON blob (the raw template stored for IAPI refreshes) as
+		// a JSON-encoded, HTML-entity-escaped string inside <script type="application/json">.
+		// Strip the blob scripts before counting, so we only assert on rendered output.
+		$list_html = preg_replace( '/<script type="application\/json"[^>]*>.*?<\/script>/s', '', $result['html'] );
+		$this->assertSame( 1, substr_count( $list_html, 'First only' ) );
+	}
 }

--- a/tests/integration/blocks/query/VisibilityIntegrationTest.php
+++ b/tests/integration/blocks/query/VisibilityIntegrationTest.php
@@ -1,0 +1,28 @@
+<?php
+namespace DesignSetGo\Tests\Integration\Blocks\Query;
+
+use WP_UnitTestCase;
+
+class VisibilityIntegrationTest extends WP_UnitTestCase {
+
+	public function test_hides_block_when_rule_does_not_match() {
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, 'featured', '0' );
+
+		require_once DESIGNSETGO_PATH . 'src/blocks/query/render-helpers.php';
+
+		$inner_html = '<!-- wp:paragraph {"dsgoVisibility":{"operator":"AND","rules":[{"type":"meta","key":"featured","op":"equals","value":"1"}]}} -->'
+					. '<p>Featured badge</p>'
+					. '<!-- /wp:paragraph -->'
+					. '<!-- wp:paragraph --><p>Always shown</p><!-- /wp:paragraph -->';
+
+		$html = designsetgo_query_render_item(
+			$inner_html,
+			array( 'postId' => $post_id, 'postType' => 'post', 'index' => 0 ),
+			'li'
+		);
+
+		$this->assertStringNotContainsString( 'Featured badge', $html );
+		$this->assertStringContainsString( 'Always shown', $html );
+	}
+}

--- a/tests/unit/blocks/query-group-header/edit.test.js
+++ b/tests/unit/blocks/query-group-header/edit.test.js
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock( '@wordpress/i18n', () => ( { __: ( t ) => t } ) );
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: () => ( { className: 'dsgo-query-group-header' } ),
+	useInnerBlocksProps: ( p = {} ) => ( {
+		...p,
+		children: <div data-testid="inner-blocks" />,
+	} ),
+} ) );
+
+import Edit from '../../../../src/blocks/query-group-header/edit';
+
+describe( 'QueryGroupHeader edit', () => {
+	it( 'renders an InnerBlocks wrapper', () => {
+		render( <Edit attributes={ {} } context={ {} } clientId="g1" /> );
+		expect( screen.getByTestId( 'inner-blocks' ) ).toBeInTheDocument();
+	} );
+
+	it( 'applies the block class to the wrapper', () => {
+		const { container } = render(
+			<Edit attributes={ {} } context={ {} } clientId="g2" />
+		);
+		const wrapper = container.firstChild;
+		expect( wrapper ).toHaveClass( 'dsgo-query-group-header' );
+	} );
+} );

--- a/tests/unit/blocks/query/NestedPreview.test.js
+++ b/tests/unit/blocks/query/NestedPreview.test.js
@@ -1,0 +1,336 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// ─── WordPress module mocks ───────────────────────────────────────────────────
+// All mocks must be declared before the component import so Jest hoists them.
+
+jest.mock('@wordpress/i18n', () => ({
+	__: (text) => text,
+	_n: (singular, plural, count) => (count === 1 ? singular : plural),
+	sprintf: (template, ...args) => {
+		let result = template;
+		args.forEach((arg) => {
+			result = result.replace(/%d/, String(arg));
+		});
+		return result;
+	},
+}));
+
+// Mock @wordpress/api-fetch — never-resolving to avoid async act() warnings.
+jest.mock('@wordpress/api-fetch', () => jest.fn(() => new Promise(() => {})));
+
+// Mock @wordpress/data — same as edit.test.js.
+jest.mock('@wordpress/data', () => ({
+	useSelect: (cb) =>
+		cb((storeName) => {
+			if (storeName === 'core/block-editor') {
+				return {
+					getBlock: () => ({ innerBlocks: [] }),
+				};
+			}
+			if (storeName !== 'core') {
+				return {};
+			}
+			return {
+				getPostTypes: () => [
+					{
+						slug: 'post',
+						labels: { singular_name: 'Post' },
+						viewable: true,
+					},
+				],
+				getTaxonomies: () => [],
+				getEntityRecords: () => [],
+			};
+		}),
+	useDispatch: () => ({
+		insertBlocks: jest.fn(),
+	}),
+}));
+
+// Stub @wordpress/core-data — return a real record so BlockContextProvider fires.
+jest.mock('@wordpress/core-data', () => ({
+	store: 'core',
+	useEntityRecords: () => ({
+		records: [{ id: 42, type: 'post', meta: {} }],
+		hasResolved: true,
+	}),
+}));
+
+// Capture array — populated by the BlockContextProvider mock below.
+// Must be declared here (module scope) so it is accessible inside the mock
+// factory closure AND inside the test assertions.
+const ctxCapture = [];
+
+// Block-editor mock — capture BlockContextProvider values.
+jest.mock('@wordpress/block-editor', () => ({
+	useBlockProps: () => ({ className: 'wp-block-designsetgo-query' }),
+	useInnerBlocksProps: (p = {}) => ({ ...p, children: null }),
+	InspectorControls: ({ children }) => (
+		<div data-testid="inspector">{children}</div>
+	),
+	InnerBlocks: () => <div data-testid="inner-blocks" />,
+	BlockPreview: () => <div data-testid="block-preview" />,
+	BlockContextProvider: ({ value, children }) => {
+		ctxCapture.push(value);
+		return <>{children}</>;
+	},
+	store: 'core/block-editor',
+}));
+
+// @wordpress/blocks stub.
+jest.mock('@wordpress/blocks', () => ({
+	createBlocksFromInnerBlocksTemplate: jest.fn((t) => t),
+	createBlock: jest.fn((name, attrs) => ({ name, attributes: attrs || {} })),
+}));
+
+// Minimal @wordpress/components stubs — same as edit.test.js.
+jest.mock('@wordpress/components', () => {
+	const SelectControl = ({ label, value, options, onChange }) => (
+		<label>
+			{label}
+			<select
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				aria-label={label}
+			>
+				{(options || []).map((opt) => (
+					<option key={opt.value} value={opt.value}>
+						{opt.label}
+					</option>
+				))}
+			</select>
+		</label>
+	);
+
+	const RangeControl = ({ label, value, onChange }) => (
+		<label>
+			{label}
+			<input
+				type="range"
+				value={value}
+				onChange={(e) => onChange(Number(e.target.value))}
+				aria-label={label}
+			/>
+		</label>
+	);
+
+	const TextControl = ({ label, value, onChange }) => (
+		<label>
+			{label}
+			<input
+				type="text"
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				aria-label={label}
+			/>
+		</label>
+	);
+
+	const NumberControl = ({ label, value, onChange }) => (
+		<label>
+			{label}
+			<input
+				type="number"
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				aria-label={label}
+			/>
+		</label>
+	);
+
+	const FormTokenField = ({
+		label,
+		value,
+		suggestions: _suggestions,
+		onChange,
+	}) => (
+		<label>
+			{label}
+			<input
+				type="text"
+				aria-label={label}
+				value={(value || []).join(', ')}
+				onChange={(e) =>
+					onChange(e.target.value.split(', ').filter(Boolean))
+				}
+			/>
+		</label>
+	);
+
+	const ToolsPanelItem = ({ children, isShownByDefault }) =>
+		isShownByDefault !== false ? <>{children}</> : null;
+
+	const ToolsPanel = ({ children, label }) => (
+		<fieldset aria-label={label}>{children}</fieldset>
+	);
+
+	const Placeholder = ({ label, instructions }) => (
+		<div data-testid="placeholder">
+			<span>{label}</span>
+			<span>{instructions}</span>
+		</div>
+	);
+
+	const TextareaControl = ({ label, value, onChange }) => (
+		<label>
+			{label}
+			<textarea
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				aria-label={label}
+			/>
+		</label>
+	);
+
+	const ToggleControl = ({ label, checked, onChange }) => (
+		<label>
+			{label}
+			<input
+				type="checkbox"
+				checked={checked}
+				onChange={(e) => onChange(e.target.checked)}
+				aria-label={label}
+			/>
+		</label>
+	);
+
+	const VStack = ({ children }) => <div>{children}</div>;
+	const HStack = ({ children }) => <div>{children}</div>;
+
+	return {
+		SelectControl,
+		RangeControl,
+		TextControl,
+		TextareaControl,
+		ToggleControl,
+		FormTokenField,
+		__experimentalNumberControl: NumberControl,
+		__experimentalToolsPanel: ToolsPanel,
+		__experimentalToolsPanelItem: ToolsPanelItem,
+		__experimentalHStack: HStack,
+		__experimentalVStack: VStack,
+		Placeholder,
+		Button: ({ children, onClick, disabled, 'aria-label': ariaLabel }) => (
+			<button
+				type="button"
+				onClick={onClick}
+				disabled={disabled}
+				aria-label={ariaLabel}
+			>
+				{children}
+			</button>
+		),
+		Icon: ({ icon }) => <span>{icon}</span>,
+		Spinner: () => <span data-testid="spinner" />,
+	};
+});
+
+// @wordpress/element — real React so hooks work correctly.
+jest.mock('@wordpress/element', () => jest.requireActual('@wordpress/element'));
+
+// ─── Component under test ─────────────────────────────────────────────────────
+import QueryEdit from '../../../../src/blocks/query/edit';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_ATTRIBUTES = {
+	queryId: 'nested-1',
+	source: 'posts',
+	postType: 'post',
+	perPage: 1,
+	offset: 0,
+	orderBy: 'date',
+	orderByMetaKey: '',
+	order: 'DESC',
+	taxQuery: { relation: 'AND', clauses: [] },
+	metaQuery: { relation: 'AND', clauses: [] },
+	search: '',
+	bindSearchTo: '',
+	excludeCurrent: false,
+	ignoreSticky: true,
+	manualIds: [],
+	tagName: 'ul',
+	itemTagName: 'li',
+	relationshipField: '',
+	relationshipFallback: 'empty',
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('QueryEdit nested preview', () => {
+	beforeEach(() => {
+		ctxCapture.length = 0;
+	});
+
+	it('provides parent context to BlockContextProvider when nested inside an outer Query', () => {
+		render(
+			<QueryEdit
+				attributes={DEFAULT_ATTRIBUTES}
+				setAttributes={jest.fn()}
+				clientId="cli-1"
+				context={{ 'designsetgo/parentItem': { postId: 99, postType: 'post' } }}
+			/>
+		);
+		// At least one BlockContextProvider must have received the outer parentItem.
+		expect(
+			ctxCapture.some(
+				(c) => c?.['designsetgo/parentItem']?.postId === 99
+			)
+		).toBe(true);
+	});
+
+	it('provides a self-referencing parentItem fallback for root-level Queries', () => {
+		render(
+			<QueryEdit
+				attributes={DEFAULT_ATTRIBUTES}
+				setAttributes={jest.fn()}
+				clientId="cli-2"
+				context={{}}
+			/>
+		);
+		// No outer parentItem — the provider should fall back to the current item
+		// (id: 42, as returned by the useEntityRecords mock).
+		expect(
+			ctxCapture.some(
+				(c) =>
+					c?.['designsetgo/parentItem'] !== undefined &&
+					c?.['designsetgo/parentItem']?.postId === 42
+			)
+		).toBe(true);
+	});
+
+	it('always provides designsetgo/itemIndex in BlockContextProvider', () => {
+		render(
+			<QueryEdit
+				attributes={DEFAULT_ATTRIBUTES}
+				setAttributes={jest.fn()}
+				clientId="cli-3"
+				context={{}}
+			/>
+		);
+		expect(
+			ctxCapture.some(
+				(c) => typeof c?.['designsetgo/itemIndex'] === 'number'
+			)
+		).toBe(true);
+	});
+
+	it('always provides designsetgo/itemMeta in BlockContextProvider', () => {
+		render(
+			<QueryEdit
+				attributes={DEFAULT_ATTRIBUTES}
+				setAttributes={jest.fn()}
+				clientId="cli-4"
+				context={{}}
+			/>
+		);
+		expect(
+			ctxCapture.some(
+				(c) =>
+					c?.['designsetgo/itemMeta'] !== undefined &&
+					typeof c?.['designsetgo/itemMeta'] === 'object'
+			)
+		).toBe(true);
+	});
+});

--- a/tests/unit/blocks/query/NestedPreview.test.js
+++ b/tests/unit/blocks/query/NestedPreview.test.js
@@ -333,4 +333,22 @@ describe('QueryEdit nested preview', () => {
 			)
 		).toBe(true);
 	});
+
+	it('provides designsetgo/isAuthenticated=true in BlockContextProvider', () => {
+		render(
+			<QueryEdit
+				attributes={DEFAULT_ATTRIBUTES}
+				setAttributes={jest.fn()}
+				clientId="cli-5"
+				context={{}}
+			/>
+		);
+		// Editor sessions are always authenticated; auth visibility rules should
+		// never hide content from the admin in the editor preview.
+		expect(
+			ctxCapture.some(
+				(c) => c?.['designsetgo/isAuthenticated'] === true
+			)
+		).toBe(true);
+	});
 });

--- a/tests/unit/blocks/query/edit.test.js
+++ b/tests/unit/blocks/query/edit.test.js
@@ -259,6 +259,8 @@ const DEFAULT_ATTRIBUTES = {
 	manualIds: [],
 	tagName: 'ul',
 	itemTagName: 'li',
+	relationshipField: '',
+	relationshipFallback: 'empty',
 };
 
 function renderWith(attributeOverrides = {}, propOverrides = {}) {
@@ -299,6 +301,21 @@ describe('QueryEdit — Settings panel', () => {
 	it('renders the Items per page control', () => {
 		renderWith();
 		expect(screen.getByLabelText(/items per page/i)).toBeInTheDocument();
+	});
+
+	it('renders the relationship field input when source is relationship', () => {
+		renderWith({ source: 'relationship' });
+		expect(screen.getByLabelText(/relationship field/i)).toBeInTheDocument();
+	});
+
+	it('renders the fallback select when source is relationship', () => {
+		renderWith({ source: 'relationship' });
+		expect(screen.getByLabelText(/when no related items/i)).toBeInTheDocument();
+	});
+
+	it('does not render relationship field input when source is posts', () => {
+		renderWith({ source: 'posts' });
+		expect(screen.queryByLabelText(/relationship field/i)).not.toBeInTheDocument();
 	});
 
 	it('shows the meta-key input only when orderBy is meta_value', () => {

--- a/tests/unit/blocks/query/edit.test.js
+++ b/tests/unit/blocks/query/edit.test.js
@@ -261,6 +261,7 @@ const DEFAULT_ATTRIBUTES = {
 	itemTagName: 'li',
 	relationshipField: '',
 	relationshipFallback: 'empty',
+	groupBy: null,
 };
 
 function renderWith(attributeOverrides = {}, propOverrides = {}) {
@@ -336,5 +337,17 @@ describe('QueryEdit — Settings panel', () => {
 			/>
 		);
 		expect(screen.getByLabelText(/meta key/i)).toBeInTheDocument();
+	});
+});
+
+describe('QueryEdit — Group-by', () => {
+	it('renders the group-by type select', () => {
+		renderWith();
+		expect(screen.getByLabelText(/group by/i)).toBeInTheDocument();
+	});
+
+	it('shows a taxonomy picker when groupBy.field is taxonomy', () => {
+		renderWith({ groupBy: { field: 'taxonomy', key: 'category' } });
+		expect(screen.getByLabelText(/group taxonomy/i)).toBeInTheDocument();
 	});
 });

--- a/tests/unit/blocks/query/useQueryPreview.test.js
+++ b/tests/unit/blocks/query/useQueryPreview.test.js
@@ -1,5 +1,7 @@
 import { renderHook } from '@testing-library/react';
-import useQueryPreview from '../../../../src/blocks/query/hooks/useQueryPreview';
+import useQueryPreview, {
+	normalizeRelationshipIds,
+} from '../../../../src/blocks/query/hooks/useQueryPreview';
 
 jest.mock('@wordpress/core-data', () => ({
 	store: 'core',
@@ -11,6 +13,72 @@ jest.mock('@wordpress/data', () => ({
 
 const { useEntityRecords } = require('@wordpress/core-data');
 const { useSelect } = require('@wordpress/data');
+
+// ---------------------------------------------------------------------------
+// normalizeRelationshipIds — unit tests for each storage shape
+// ---------------------------------------------------------------------------
+
+describe('normalizeRelationshipIds', () => {
+	it('handles array of plain integers', () => {
+		expect(normalizeRelationshipIds([12, 34, 56])).toEqual([12, 34, 56]);
+	});
+
+	it('filters out zero / falsy ints in an array', () => {
+		expect(normalizeRelationshipIds([0, 12, null, 34])).toEqual([12, 34]);
+	});
+
+	it('handles array of WP_Post-style objects with .ID', () => {
+		expect(
+			normalizeRelationshipIds([{ ID: 12 }, { ID: 34 }])
+		).toEqual([12, 34]);
+	});
+
+	it('handles array of REST-style objects with .id (lowercase)', () => {
+		expect(
+			normalizeRelationshipIds([{ id: 12 }, { id: 34 }])
+		).toEqual([12, 34]);
+	});
+
+	it('handles comma-separated string', () => {
+		expect(normalizeRelationshipIds('12, 34, 56')).toEqual([12, 34, 56]);
+	});
+
+	it('handles single numeric string', () => {
+		expect(normalizeRelationshipIds('42')).toEqual([42]);
+	});
+
+	it('returns empty array for non-numeric string', () => {
+		expect(normalizeRelationshipIds('not-a-number')).toEqual([]);
+	});
+
+	it('handles plain number', () => {
+		expect(normalizeRelationshipIds(99)).toEqual([99]);
+	});
+
+	it('returns empty array for zero', () => {
+		expect(normalizeRelationshipIds(0)).toEqual([]);
+	});
+
+	it('returns empty array for null', () => {
+		expect(normalizeRelationshipIds(null)).toEqual([]);
+	});
+
+	it('returns empty array for undefined', () => {
+		expect(normalizeRelationshipIds(undefined)).toEqual([]);
+	});
+
+	it('returns empty array for empty string', () => {
+		expect(normalizeRelationshipIds('')).toEqual([]);
+	});
+
+	it('returns empty array for empty array', () => {
+		expect(normalizeRelationshipIds([])).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// useQueryPreview hook — relationship source
+// ---------------------------------------------------------------------------
 
 describe('useQueryPreview — relationship source', () => {
 	beforeEach(() => {
@@ -74,7 +142,8 @@ describe('useQueryPreview — relationship source', () => {
 			})
 		);
 
-		expect(useEntityRecords).toHaveBeenCalledWith('postType', 'any', {
+		// Must use 'post' — 'any' is not a valid WP REST entity type.
+		expect(useEntityRecords).toHaveBeenCalledWith('postType', 'post', {
 			include: [101, 202],
 			per_page: 3,
 			orderby: 'include',

--- a/tests/unit/blocks/query/useQueryPreview.test.js
+++ b/tests/unit/blocks/query/useQueryPreview.test.js
@@ -10,16 +10,74 @@ jest.mock('@wordpress/data', () => ({
 }));
 
 const { useEntityRecords } = require('@wordpress/core-data');
+const { useSelect } = require('@wordpress/data');
 
 describe('useQueryPreview — relationship source', () => {
-	beforeEach(() => useEntityRecords.mockReset());
+	beforeEach(() => {
+		useEntityRecords.mockReset();
+		useSelect.mockReset();
+		useSelect.mockImplementation(() => null);
+	});
 
 	it('returns empty state when relationshipField is empty', () => {
 		useEntityRecords.mockReturnValue({ records: [], hasResolved: true });
 		const { result } = renderHook(() =>
-			useQueryPreview({ source: 'relationship', relationshipField: '', perPage: 3 })
+			useQueryPreview({
+				source: 'relationship',
+				relationshipField: '',
+				perPage: 3,
+			})
 		);
 		expect(result.current.records).toEqual([]);
 		expect(result.current.hasResolved).toBe(true);
+	});
+
+	it('reads relationship meta from the current editor post type', () => {
+		useEntityRecords.mockReturnValue({ records: [], hasResolved: true });
+		useSelect.mockImplementation((selector) =>
+			selector((store) => {
+				if (store === 'core/editor') {
+					return {
+						getCurrentPostId: () => 42,
+						getCurrentPostType: () => 'page',
+					};
+				}
+
+				if (store === 'core') {
+					return {
+						getEntityRecord: (kind, name, id) => {
+							if (
+								kind === 'postType' &&
+								name === 'page' &&
+								id === 42
+							) {
+								return {
+									meta: {
+										related_posts: [101, 202],
+									},
+								};
+							}
+							return null;
+						},
+					};
+				}
+
+				return {};
+			})
+		);
+
+		renderHook(() =>
+			useQueryPreview({
+				source: 'relationship',
+				relationshipField: 'related_posts',
+				perPage: 3,
+			})
+		);
+
+		expect(useEntityRecords).toHaveBeenCalledWith('postType', 'any', {
+			include: [101, 202],
+			per_page: 3,
+			orderby: 'include',
+		});
 	});
 });

--- a/tests/unit/blocks/query/useQueryPreview.test.js
+++ b/tests/unit/blocks/query/useQueryPreview.test.js
@@ -1,0 +1,25 @@
+import { renderHook } from '@testing-library/react';
+import useQueryPreview from '../../../../src/blocks/query/hooks/useQueryPreview';
+
+jest.mock('@wordpress/core-data', () => ({
+	store: 'core',
+	useEntityRecords: jest.fn(),
+}));
+jest.mock('@wordpress/data', () => ({
+	useSelect: jest.fn(() => null),
+}));
+
+const { useEntityRecords } = require('@wordpress/core-data');
+
+describe('useQueryPreview — relationship source', () => {
+	beforeEach(() => useEntityRecords.mockReset());
+
+	it('returns empty state when relationshipField is empty', () => {
+		useEntityRecords.mockReturnValue({ records: [], hasResolved: true });
+		const { result } = renderHook(() =>
+			useQueryPreview({ source: 'relationship', relationshipField: '', perPage: 3 })
+		);
+		expect(result.current.records).toEqual([]);
+		expect(result.current.hasResolved).toBe(true);
+	});
+});

--- a/tests/unit/extensions/visibility/VisibilityPanel.test.js
+++ b/tests/unit/extensions/visibility/VisibilityPanel.test.js
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import VisibilityPanel from '../../../../src/extensions/visibility/VisibilityPanel';
+
+jest.mock('@wordpress/i18n', () => ({ __: (t) => t, sprintf: (t, a) => String(t).replace('%s', a) }));
+jest.mock('@wordpress/components', () => ({
+	SelectControl: ({ label, value, onChange, options }) => (
+		<label>{label}<select value={value} onChange={(e) => onChange(e.target.value)}>{(options || []).map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}</select></label>
+	),
+	TextControl: ({ label, value, onChange }) => (
+		<label>{label}<input value={value || ''} onChange={(e) => onChange(e.target.value)} /></label>
+	),
+	Button: ({ children, onClick }) => <button type="button" onClick={onClick}>{children}</button>,
+	__experimentalVStack: ({ children }) => <div>{children}</div>,
+	__experimentalHStack: ({ children }) => <div>{children}</div>,
+}));
+
+describe('VisibilityPanel', () => {
+	it('shows empty state when no rules exist', () => {
+		render(<VisibilityPanel value={null} onChange={jest.fn()} />);
+		expect(screen.getByText(/always visible/i)).toBeInTheDocument();
+	});
+
+	it('renders a row per rule', () => {
+		const value = {
+			operator: 'AND',
+			rules: [{ type: 'meta', key: 'foo', op: 'equals', value: 'bar' }],
+		};
+		render(<VisibilityPanel value={value} onChange={jest.fn()} />);
+		expect(screen.getByDisplayValue('foo')).toBeInTheDocument();
+	});
+
+	it('calls onChange with a new rule when Add clicked', () => {
+		const onChange = jest.fn();
+		render(<VisibilityPanel value={null} onChange={onChange} />);
+		fireEvent.click(screen.getByText(/add rule/i));
+		expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+			operator: 'AND',
+			rules: expect.arrayContaining([expect.objectContaining({ type: 'meta' })]),
+		}));
+	});
+});

--- a/tests/unit/extensions/visibility/attribute.test.js
+++ b/tests/unit/extensions/visibility/attribute.test.js
@@ -1,0 +1,25 @@
+import { applyFilters } from '@wordpress/hooks';
+import '../../../../src/extensions/visibility';
+
+describe('dsgoVisibility attribute filter', () => {
+	it('adds the attribute to an allowed block', () => {
+		const settings = applyFilters(
+			'blocks.registerBlockType',
+			{ attributes: {} },
+			'core/paragraph'
+		);
+		expect(settings.attributes.dsgoVisibility).toEqual({
+			type: 'object',
+			default: null,
+		});
+	});
+
+	it('leaves unsupported blocks untouched', () => {
+		const settings = applyFilters(
+			'blocks.registerBlockType',
+			{ attributes: {} },
+			'core/freeform'
+		);
+		expect(settings.attributes.dsgoVisibility).toBeUndefined();
+	});
+});

--- a/tests/unit/extensions/visibility/evaluateRules.test.js
+++ b/tests/unit/extensions/visibility/evaluateRules.test.js
@@ -1,0 +1,82 @@
+import evaluateRules from '../../../../src/extensions/visibility/evaluateRules';
+
+describe( 'evaluateRules', () => {
+	it( 'defaults visible when rules null', () => {
+		expect( evaluateRules( null, { postId: 1 } ) ).toBe( true );
+	} );
+
+	it( 'defaults visible when rules has empty array', () => {
+		expect( evaluateRules( { operator: 'AND', rules: [] }, {} ) ).toBe( true );
+	} );
+
+	it( 'meta equals', () => {
+		const ctx = { meta: { featured: '1' } };
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'featured', op: 'equals', value: '1' } ] }, ctx ) ).toBe( true );
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'featured', op: 'equals', value: '0' } ] }, ctx ) ).toBe( false );
+	} );
+
+	it( 'meta not_equals', () => {
+		const ctx = { meta: { status: 'active' } };
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'status', op: 'not_equals', value: 'inactive' } ] }, ctx ) ).toBe( true );
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'status', op: 'not_equals', value: 'active' } ] }, ctx ) ).toBe( false );
+	} );
+
+	it( 'meta contains', () => {
+		const ctx = { meta: { title: 'Hello World' } };
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'title', op: 'contains', value: 'world' } ] }, ctx ) ).toBe( true );
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'title', op: 'contains', value: 'foo' } ] }, ctx ) ).toBe( false );
+	} );
+
+	it( 'meta empty / not_empty', () => {
+		const ctx = { meta: { filled: 'yes', blank: '' } };
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'blank', op: 'empty' } ] }, ctx ) ).toBe( true );
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'filled', op: 'not_empty' } ] }, ctx ) ).toBe( true );
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'filled', op: 'empty' } ] }, ctx ) ).toBe( false );
+	} );
+
+	it( 'index equals', () => {
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'index', op: 'equals', value: 0 } ] }, { index: 0 } ) ).toBe( true );
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'index', op: 'equals', value: 0 } ] }, { index: 1 } ) ).toBe( false );
+	} );
+
+	it( 'index gt / lt', () => {
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'index', op: 'gt', value: 2 } ] }, { index: 5 } ) ).toBe( true );
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'index', op: 'lt', value: 3 } ] }, { index: 1 } ) ).toBe( true );
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'index', op: 'gt', value: 5 } ] }, { index: 3 } ) ).toBe( false );
+	} );
+
+	it( 'taxonomy has / not_has', () => {
+		const ctx = { terms: { category: [ 'news', 'featured' ] } };
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'taxonomy', taxonomy: 'category', op: 'has', value: 'news' } ] }, ctx ) ).toBe( true );
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'taxonomy', taxonomy: 'category', op: 'not_has', value: 'sports' } ] }, ctx ) ).toBe( true );
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'taxonomy', taxonomy: 'category', op: 'has', value: 'sports' } ] }, ctx ) ).toBe( false );
+	} );
+
+	it( 'auth rule', () => {
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'auth', value: true } ] }, { isAuthenticated: true } ) ).toBe( true );
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'auth', value: true } ] }, { isAuthenticated: false } ) ).toBe( false );
+	} );
+
+	it( 'unknown rule type returns false', () => {
+		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'unknown_type', op: 'equals', value: '1' } ] }, {} ) ).toBe( false );
+	} );
+
+	it( 'OR relation', () => {
+		const rules = { operator: 'OR', rules: [ { type: 'index', op: 'equals', value: 0 }, { type: 'index', op: 'equals', value: 1 } ] };
+		expect( evaluateRules( rules, { index: 1 } ) ).toBe( true );
+		expect( evaluateRules( rules, { index: 5 } ) ).toBe( false );
+	} );
+
+	it( 'AND relation requires all rules', () => {
+		const ctx = { index: 0, meta: { featured: '1' } };
+		const rules = {
+			operator: 'AND',
+			rules: [
+				{ type: 'index', op: 'equals', value: 0 },
+				{ type: 'meta', key: 'featured', op: 'equals', value: '1' },
+			],
+		};
+		expect( evaluateRules( rules, ctx ) ).toBe( true );
+		expect( evaluateRules( rules, { index: 0, meta: { featured: '0' } } ) ).toBe( false );
+	} );
+} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -294,6 +294,11 @@ module.exports = [
 						to: 'blocks/query/render-terms.php',
 						noErrorOnMissing: true,
 					},
+					{
+						from: 'src/blocks/query/render-relationship.php',
+						to: 'blocks/query/render-relationship.php',
+						noErrorOnMissing: true,
+					},
 				],
 			}),
 			// Bundle analyzer - run with: ANALYZE=true npm run build


### PR DESCRIPTION
## Summary

v2.3 closes the remaining headline gap with Bricks / Elementor Pro / JetEngine by adding four features to the Dynamic Query family:

- **Relationship source** reads a parent-context field (meta or ACF relationship) and iterates referenced posts via `post__in`; fallback modes for when no IDs resolve.
- **Nested loops with parent context** — outer Query's current item flows into inner Queries via a new `designsetgo/parentItem` block context. DSGo bindings (`designsetgo/post-meta`, `designsetgo/acf`) now accept a `scope` arg (`'self'` default / `'parent'` / `'root'`) that reads from the parent-stack maintained by `designsetgo_query_render_item()`.
- **Conditional inner-block visibility** — every block now carries a `dsgoVisibility` attribute with an inspector panel under Advanced → Visibility. Rule types: meta / taxonomy / index / auth, combined with AND/OR relations. Server evaluator (`DesignSetGo\BlockVisibility::matches()`) and JS mirror (`src/extensions/visibility/evaluateRules.js`) stay in sync so editor previews match frontend output.
- **Group-by partitioning** — new `groupBy` attribute on the Query block partitions items by taxonomy / meta / date (with year / year-month / year-month-day precision). New sibling block `designsetgo/query-group-header` renders once per group inside a `<section class=\"dsgo-query-group\">` wrapper.

No breaking changes — all new attributes default to `null` / `'self'`. Plugin version stays at 2.1.0 since v2.2 was also unreleased; v2.3 entries land under `[Unreleased]` in the CHANGELOG.

Plan lives at [\`docs/plans/2026-04-19-dynamic-query-v2.3-nested.md\`](docs/plans/2026-04-19-dynamic-query-v2.3-nested.md).

## Test plan
- [ ] Jest unit tests green (1952/1952 on last local run)
- [ ] PHPUnit integration tests green (RelationshipRenderTest, BlockVisibilityTest, VisibilityIntegrationTest, ParentStackTest, BindingsScopeTest, GroupByTest)
- [ ] `npm run build`, `npm run lint:js`, `npm run lint:css` clean
- [ ] Manual: relationship source renders referenced posts on frontend + editor preview (matches `related_posts` meta/ACF)
- [ ] Manual: set a `dsgoVisibility` rule (meta = \"featured\" equals \"1\") on a paragraph inside a query item — verify it's hidden on non-featured posts in both the editor preview and frontend
- [ ] Manual: outer Query iterates posts; inside the item template add an inner Query; a paragraph bound with `scope: 'parent'` resolves to the outer post's meta
- [ ] Manual: Query → Group by = Taxonomy, Group taxonomy = category → frontend shows one `<section class=\"dsgo-query-group\">` per category with a Query Group Header above each group
- [ ] Regression: infinite scroll + filters + load-more + editor live preview still work inside both a flat and a grouped query

Follow-up: v2.4 (JetEngine / Meta Box / Pods bindings, PHP escape-hatch UI, JSON export/import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)