### PR TITLE
fix(sticky-header): smooth logo shrink transition in both scroll directions

### DIFF
--- a/src/styles/utilities/_sticky-header.scss
+++ b/src/styles/utilities/_sticky-header.scss
@@ -76,6 +76,11 @@ body:not(.block-editor-page).admin-bar .wp-block-template-part.dsgo-sticky-heade
  * --dsgo-sticky-logo-original-width / -height come from each image inline.
  */
 .dsgo-sticky-shrink-logo.wp-block-template-part :where(.wp-block-image img, .wp-block-site-logo img) {
+	// Set explicit px values so the transition animates in both directions.
+	// Without this, the non-scrolled state has max-width: none (∞), and
+	// CSS cannot interpolate ∞ → px, causing an instant snap on scroll-down.
+	max-width: var(--dsgo-sticky-logo-original-width);
+	max-height: var(--dsgo-sticky-logo-original-height);
 	transition:
 		max-width var(--dsgo-sticky-header-transition-speed, 300ms) ease-in-out,
 		max-height var(--dsgo-sticky-header-transition-speed, 300ms) ease-in-out;


### PR DESCRIPTION
## Summary

- The logo shrink-on-scroll feature was jolting (instant snap) when scrolling **down** but animating correctly when scrolling **up**
- Root cause: CSS cannot interpolate between `max-width: none` (treated as ∞) and a pixel value — the constraint only kicks in at the very last frame, making it look instant
- Fix: explicitly set `max-width`/`max-height` in the base (non-scrolled) rule using the JS-measured `--dsgo-sticky-logo-original-width` / `--dsgo-sticky-logo-original-height` custom properties so both scroll states carry numeric pixel values and the transition animates smoothly in both directions

## Test Plan

- [ ] Enable sticky header with shrink logo on scroll
- [ ] Scroll down past the threshold — logo should shrink with a smooth transition (no jolt)
- [ ] Scroll back to top — logo should grow with a smooth transition (unchanged from before)
- [ ] Verify at multiple logo sizes and with both `wp-block-site-logo` and `wp-block-image` logos

🤖 Generated with [Claude Code](https://claude.com/claude-code)