### PR TITLE
feat(query): Dynamic Query v2.5 — advanced filters, QM panel, style bindings

### DIFF
--- a/.claude/claude.md
+++ b/.claude/claude.md
@@ -84,6 +84,15 @@ For sibling blocks that already exist and meet the "1–3 attribute difference +
 - Inspector → Settings panel → Template I/O section exposes Export + Import buttons backed by those routes.
 - `designsetgo/post-meta` and `designsetgo/acf` sources (v2.1) refactored to use the new helper internally — output is identical.
 
+### Query block family (Dynamic Query v2.5)
+
+- `dateQuery` attribute on `designsetgo/query` — shape `{ relation, clauses: [{ column, mode, after, before, inclusive }] }`. Supported modes: `after`, `before`, `between`. Date values: ISO `YYYY-MM-DD` or PHP relative expressions (`-30 days`, `today`).
+- `taxQuery.clauses[]` entries may now be leaf clauses OR nested groups (`{ relation, clauses: [...] }`). PHP builder: `designsetgo_build_tax_query_entry()` (recursive). Same pattern for `metaQuery` via `designsetgo_build_meta_query_entry()`.
+- `include_children` field on each `taxQuery` leaf clause — boolean, defaults `true`. Pass-through to WP_Query `tax_query`.
+- `<ClauseGroupShell>` (`src/blocks/query/components/ClauseGroupShell.js`) — shared recursive group chrome (relation selector, + Clause, + Group, Remove group). Used by both TaxQueryBuilder and MetaQueryBuilder via `renderClause` render prop.
+- Query Monitor panel: `includes/class-query-qm-collector.php` + `includes/class-query-qm-output.php`. Loaded only when `defined('QM_VERSION')`. Collects data via `designsetgo_query_did_render` action fired from `render-posts.php` after each WP_Query.
+- Dynamic CSS style bindings: `dsgoStyleBinding` global attribute (`src/extensions/style-binding/filters.js`) maps CSS property names (including custom properties `--foo`) → binding source+key. PHP: `DesignSetGo\StyleBinding` (`includes/class-style-binding.php`) resolves via `designsetgo_style_binding_resolve` filter and injects via `WP_HTML_Tag_Processor`. Honours `$GLOBALS['designsetgo_parent_stack']` for nested loop context. Dangerous values (`url(`, `expression(`, `javascript:`) rejected.
+
 ### Inspector IA (Theme 3)
 
 Three panels per block, in this order: **Settings** → **Style** → **Advanced**. Use `<DsgoInspectorPanel>` (the `ToolsPanel` wrapper) for all custom inspector controls; never reach for `PanelBody` directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Query Group Header** - Sibling block for the Dynamic Query that renders once per group when group-by is enabled; hosts an InnerBlocks area for a heading or any custom content, and receives `designsetgo/groupLabel` + `designsetgo/groupValue` context so bindings can display the current group's name
 
 ### Added
+- Date Query Builder: inspector UI for `before`/`after`/`between` date filters with relative expression support (`-30 days`, `today`).
+- Multi-level AND/OR filter groups: TaxQueryBuilder and MetaQueryBuilder now support nested `{relation, clauses}` groups at any depth.
+- Hierarchical taxonomy drilldown: per-clause `include_children` toggle in TaxQueryBuilder (defaults `true`).
+- Query Monitor panel: when QM is active, a "DSGo (N)" panel in the QM toolbar shows per-render query args, found-posts count, duration, and SQL.
+- Dynamic CSS style bindings: `dsgoStyleBinding` attribute on every block maps CSS property names → DSGo binding source + key. Values injected as inline styles on the block root element via `render_block` filter.
 - **Dynamic Query — Relationship source** - New `source: 'relationship'` reads a parent-context field (meta or ACF relationship) and iterates the referenced posts via `post__in`; configurable fallback when no IDs are resolved (render nothing, all posts, or the parent item)
 - **Dynamic Query — Nested loops with parent context** - Outer Query's current item flows into inner Queries via the `designsetgo/parentItem` block context; DSGo bindings (`designsetgo/post-meta`, `designsetgo/acf`) accept a new optional `scope` arg of `'self'` (default), `'parent'`, or `'root'` — reading from a parent-stack maintained by `designsetgo_query_render_item()`
 - **Conditional inner-block visibility** - Every block now carries a `dsgoVisibility` attribute with an inspector panel under Advanced → Visibility. Rule types: meta / taxonomy / index / auth, combined with AND/OR relations and ops (`equals`, `not_equals`, `contains`, `gt`, `lt`, `empty`, `not_empty`, `has`, `not_has`). Editor previews mirror server-side evaluation so authors see what will ship

--- a/docs/plans/2026-04-20-dynamic-query-v2.5-advanced-filters.md
+++ b/docs/plans/2026-04-20-dynamic-query-v2.5-advanced-filters.md
@@ -1,0 +1,1973 @@
+# Dynamic Query v2.5 — Advanced Filters Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extend the Dynamic Query block with four capabilities: an `include_children` toggle for taxonomy clauses, a Date Query UI, multi-level AND/OR nested groups in both tax and meta query builders, and a Query Monitor debug panel.
+
+**Architecture:** Hierarchical taxonomy and date-query are additive — new attributes + new/modified components + PHP builder additions with no breaking schema changes. The multi-level AND/OR tree refactors TaxQueryBuilder and MetaQueryBuilder to use a shared recursive `ClauseGroupShell` component and updates the PHP builders to recurse into nested groups. The QM panel is a completely standalone PHP addition guarded by `defined('QM_VERSION')`.
+
+**Tech Stack:** React/JSX (`@wordpress/components`, `@wordpress/block-editor`), PHP 7.4+ (WP_Query `tax_query`/`meta_query`/`date_query` arrays), PHPUnit 9, Jest, QM_Collector/QM_Output_Html (Query Monitor 3.x API).
+
+---
+
+## Context: existing architecture
+
+- **`src/blocks/query/block.json`** — `taxQuery` and `metaQuery` are opaque `type: object` attributes with `{relation, clauses:[]}` defaults. No `dateQuery` exists yet.
+- **`src/blocks/query/components/TaxQueryBuilder.js`** — flat clause list + top-level `relation` selector. Each clause: `{taxonomy, terms[], operator}`. No `include_children` field.
+- **`src/blocks/query/components/MetaQueryBuilder.js`** — same flat pattern. Each clause: `{key, compare, value, type}`.
+- **`src/blocks/query/render-posts.php`** — `designsetgo_query_build_posts_args()` builds tax/meta query arrays at lines ~260-302. No `date_query` block. No `include_children` pass-through (WP defaults it `true` when absent).
+- **`src/blocks/query/edit.js`** — inspector mounts `<TaxQueryBuilder>` and `<MetaQueryBuilder>` when `source === 'posts'`. A new `<DateQueryBuilder>` follows the same gate.
+- **Tests:** `tests/phpunit/blocks/query/render-posts-test.php`, `tests/unit/blocks/query/tax-query-builder.test.js`, `tests/unit/blocks/query/meta-query-builder.test.js`.
+
+---
+
+## Task 1: `include_children` toggle in TaxQueryBuilder
+
+Adds a per-clause "Include child terms" toggle (defaults `true` to preserve existing behavior).
+
+**Files:**
+- Modify: `src/blocks/query/components/TaxQueryBuilder.js`
+- Modify: `src/blocks/query/render-posts.php` (lines ~265–278)
+- Modify: `tests/phpunit/blocks/query/render-posts-test.php`
+- Modify: `tests/unit/blocks/query/tax-query-builder.test.js`
+
+**Step 1: Write the failing PHP test**
+
+Add to `tests/phpunit/blocks/query/render-posts-test.php` inside the test class:
+
+```php
+public function test_tax_clause_defaults_include_children_true() {
+    $atts = [
+        'source'   => 'posts',
+        'taxQuery' => [
+            'relation' => 'AND',
+            'clauses'  => [ [ 'taxonomy' => 'category', 'terms' => [ 1 ], 'operator' => 'IN' ] ],
+        ],
+    ];
+    $args = designsetgo_query_build_posts_args( $atts, null );
+    $this->assertTrue( $args['tax_query'][0]['include_children'] );
+}
+
+public function test_tax_clause_include_children_false() {
+    $atts = [
+        'source'   => 'posts',
+        'taxQuery' => [
+            'relation' => 'AND',
+            'clauses'  => [ [
+                'taxonomy'         => 'category',
+                'terms'            => [ 1 ],
+                'operator'         => 'IN',
+                'include_children' => false,
+            ] ],
+        ],
+    ];
+    $args = designsetgo_query_build_posts_args( $atts, null );
+    $this->assertFalse( $args['tax_query'][0]['include_children'] );
+}
+```
+
+**Step 2: Run to confirm failure**
+
+```bash
+cd /path/to/worktree
+npx wp-env run tests-cli vendor/bin/phpunit tests/phpunit/blocks/query/render-posts-test.php --filter=test_tax_clause
+```
+
+Expected: FAIL — `include_children` key missing from `$args['tax_query'][0]`.
+
+**Step 3: Update PHP builder**
+
+In `src/blocks/query/render-posts.php`, inside the `foreach ( $tax_clauses as $clause )` loop (lines ~269–274), add `include_children` to the clause array:
+
+```php
+$tax_query[] = array(
+    'taxonomy'         => sanitize_key( (string) $clause['taxonomy'] ),
+    'terms'            => array_map( 'absint', (array) $clause['terms'] ),
+    'operator'         => in_array( ( $clause['operator'] ?? 'IN' ), array( 'IN', 'NOT IN', 'AND' ), true ) ? $clause['operator'] : 'IN',
+    'include_children' => isset( $clause['include_children'] ) ? (bool) $clause['include_children'] : true,
+);
+```
+
+**Step 4: Run PHP tests — expect pass**
+
+```bash
+npx wp-env run tests-cli vendor/bin/phpunit tests/phpunit/blocks/query/render-posts-test.php --filter=test_tax_clause
+```
+
+Expected: PASS.
+
+**Step 5: Write failing JS test**
+
+In `tests/unit/blocks/query/tax-query-builder.test.js`, add tests verifying `addClause` seeds `include_children: true` and that a toggle renders per clause. Use the existing test file's import pattern. The test should call the `addClause` logic (extract it or spy on `setAttributes`) and assert `include_children: true` is present in the new clause.
+
+```js
+it('seeds include_children: true when adding a clause', () => {
+    const setAttributes = jest.fn();
+    const { getByRole } = render(
+        <TaxQueryBuilder
+            attributes={{ taxQuery: { relation: 'AND', clauses: [] }, postType: 'post' }}
+            setAttributes={setAttributes}
+            clientId="test-id"
+        />
+    );
+    fireEvent.click( getByRole( 'button', { name: /add/i } ) );
+    expect( setAttributes ).toHaveBeenCalledWith(
+        expect.objectContaining({
+            taxQuery: expect.objectContaining({
+                clauses: expect.arrayContaining([
+                    expect.objectContaining({ include_children: true }),
+                ]),
+            }),
+        })
+    );
+} );
+```
+
+**Step 6: Run JS test — expect failure**
+
+```bash
+npx wp-scripts test-unit-js tests/unit/blocks/query/tax-query-builder.test.js --testNamePattern="include_children"
+```
+
+Expected: FAIL.
+
+**Step 7: Update TaxQueryBuilder.js**
+
+Three changes:
+
+1. In `addClause()`, add `include_children: true` to the seeded clause object.
+
+2. Add `import { ToggleControl } from '@wordpress/components';` if not already imported.
+
+3. Inside the clause render (the `<VStack>` per clause, after the operator `<SelectControl>`), add:
+
+```jsx
+<ToggleControl
+    label={ __( 'Include child terms', 'designsetgo' ) }
+    checked={ clause.include_children ?? true }
+    onChange={ ( val ) => updateClause( idx, { include_children: val } ) }
+    __nextHasNoMarginBottom
+/>
+```
+
+**Step 8: Run JS tests — expect pass**
+
+```bash
+npx wp-scripts test-unit-js tests/unit/blocks/query/tax-query-builder.test.js
+```
+
+**Step 9: Build and verify no console errors**
+
+```bash
+npm run build
+npm run lint:js
+```
+
+**Step 10: Commit**
+
+```bash
+git add src/blocks/query/components/TaxQueryBuilder.js \
+        src/blocks/query/render-posts.php \
+        tests/phpunit/blocks/query/render-posts-test.php \
+        tests/unit/blocks/query/tax-query-builder.test.js
+git commit -m "feat(query): add include_children toggle to taxonomy clause builder"
+```
+
+---
+
+## Task 2: Date Query UI
+
+Adds a new `dateQuery` attribute and a `DateQueryBuilder` inspector component. Supports `before`, `after`, and `between` modes with ISO date strings or relative expressions (`-30 days`, `-1 year`).
+
+**Date clause shape:**
+```js
+{
+    column:    'post_date' | 'post_modified' | 'post_date_gmt' | 'post_modified_gmt',
+    mode:      'after' | 'before' | 'between',
+    after:     string,   // ISO date 'YYYY-MM-DD' or relative '-30 days'
+    before:    string,   // ISO date 'YYYY-MM-DD' or relative
+    inclusive: boolean,
+}
+```
+
+**Files:**
+- Modify: `src/blocks/query/block.json`
+- Create: `src/blocks/query/components/DateQueryBuilder.js`
+- Modify: `src/blocks/query/edit.js`
+- Modify: `src/blocks/query/render-posts.php`
+- Create: `tests/unit/blocks/query/date-query-builder.test.js`
+- Modify: `tests/phpunit/blocks/query/render-posts-test.php`
+
+**Step 1: Add `dateQuery` attribute to block.json**
+
+In `src/blocks/query/block.json`, after the `metaQuery` attribute (currently at lines ~62–64), add:
+
+```json
+"dateQuery": {
+  "type": "object",
+  "default": { "relation": "AND", "clauses": [] }
+}
+```
+
+**Step 2: Write failing PHP tests**
+
+Add to `tests/phpunit/blocks/query/render-posts-test.php`:
+
+```php
+public function test_date_query_after_builds_correctly() {
+    $atts = [
+        'source'    => 'posts',
+        'dateQuery' => [
+            'relation' => 'AND',
+            'clauses'  => [ [
+                'column'    => 'post_date',
+                'mode'      => 'after',
+                'after'     => '-30 days',
+                'before'    => '',
+                'inclusive' => false,
+            ] ],
+        ],
+    ];
+    $args = designsetgo_query_build_posts_args( $atts, null );
+    $this->assertArrayHasKey( 'date_query', $args );
+    $this->assertEquals( 'post_date', $args['date_query'][0]['column'] );
+    $this->assertEquals( '-30 days', $args['date_query'][0]['after'] );
+    $this->assertArrayNotHasKey( 'before', $args['date_query'][0] );
+}
+
+public function test_date_query_between_includes_both_bounds() {
+    $atts = [
+        'source'    => 'posts',
+        'dateQuery' => [
+            'relation' => 'AND',
+            'clauses'  => [ [
+                'column'    => 'post_date',
+                'mode'      => 'between',
+                'after'     => '2024-01-01',
+                'before'    => '2024-12-31',
+                'inclusive' => true,
+            ] ],
+        ],
+    ];
+    $args = designsetgo_query_build_posts_args( $atts, null );
+    $this->assertEquals( '2024-01-01', $args['date_query'][0]['after'] );
+    $this->assertEquals( '2024-12-31', $args['date_query'][0]['before'] );
+    $this->assertTrue( $args['date_query'][0]['inclusive'] );
+}
+
+public function test_date_query_skips_empty_clauses() {
+    $atts = [
+        'source'    => 'posts',
+        'dateQuery' => [
+            'relation' => 'AND',
+            'clauses'  => [ [ 'column' => 'post_date', 'mode' => 'after', 'after' => '', 'before' => '' ] ],
+        ],
+    ];
+    $args = designsetgo_query_build_posts_args( $atts, null );
+    $this->assertArrayNotHasKey( 'date_query', $args );
+}
+```
+
+**Step 3: Run PHP tests — expect failure**
+
+```bash
+npx wp-env run tests-cli vendor/bin/phpunit tests/phpunit/blocks/query/render-posts-test.php --filter=test_date_query
+```
+
+Expected: FAIL — `date_query` key absent.
+
+**Step 4: Add PHP date_query builder**
+
+In `src/blocks/query/render-posts.php`, after the `meta_query` block (~line 302) and before any `manual` source handling (~line 305), add:
+
+```php
+// Date query.
+$date_clauses = isset( $atts['dateQuery']['clauses'] ) ? (array) $atts['dateQuery']['clauses'] : array();
+if ( ! empty( $date_clauses ) ) {
+    $valid_columns = array( 'post_date', 'post_modified', 'post_date_gmt', 'post_modified_gmt' );
+    $date_query    = array(
+        'relation' => ( 'OR' === ( $atts['dateQuery']['relation'] ?? 'AND' ) ) ? 'OR' : 'AND',
+    );
+    foreach ( $date_clauses as $clause ) {
+        $mode   = $clause['mode'] ?? 'after';
+        $after  = sanitize_text_field( (string) ( $clause['after'] ?? '' ) );
+        $before = sanitize_text_field( (string) ( $clause['before'] ?? '' ) );
+
+        // Skip clauses with no date value.
+        if ( 'between' === $mode && ( '' === $after || '' === $before ) ) {
+            continue;
+        }
+        if ( 'after' === $mode && '' === $after ) {
+            continue;
+        }
+        if ( 'before' === $mode && '' === $before ) {
+            continue;
+        }
+
+        $entry = array(
+            'column'    => in_array( ( $clause['column'] ?? 'post_date' ), $valid_columns, true ) ? $clause['column'] : 'post_date',
+            'inclusive' => ! empty( $clause['inclusive'] ),
+        );
+        if ( 'after' === $mode || 'between' === $mode ) {
+            $entry['after'] = $after;
+        }
+        if ( 'before' === $mode || 'between' === $mode ) {
+            $entry['before'] = $before;
+        }
+        $date_query[] = $entry;
+    }
+    if ( count( $date_query ) > 1 ) {
+        $args['date_query'] = $date_query;
+    }
+}
+```
+
+**Step 5: Run PHP tests — expect pass**
+
+```bash
+npx wp-env run tests-cli vendor/bin/phpunit tests/phpunit/blocks/query/render-posts-test.php --filter=test_date_query
+```
+
+**Step 6: Write failing JS test**
+
+Create `tests/unit/blocks/query/date-query-builder.test.js`:
+
+```js
+import { render, screen, fireEvent } from '@testing-library/react';
+import DateQueryBuilder from '../../../src/blocks/query/components/DateQueryBuilder';
+
+const defaultAttrs = {
+    dateQuery: { relation: 'AND', clauses: [] },
+};
+
+describe( 'DateQueryBuilder', () => {
+    it( 'renders empty state with an Add button', () => {
+        render(
+            <DateQueryBuilder
+                attributes={ defaultAttrs }
+                setAttributes={ jest.fn() }
+                clientId="test"
+            />
+        );
+        expect( screen.getByRole( 'button', { name: /add date clause/i } ) ).toBeInTheDocument();
+    } );
+
+    it( 'seeds new clause with post_date / after / inclusive:true defaults', () => {
+        const setAttributes = jest.fn();
+        render(
+            <DateQueryBuilder
+                attributes={ defaultAttrs }
+                setAttributes={ setAttributes }
+                clientId="test"
+            />
+        );
+        fireEvent.click( screen.getByRole( 'button', { name: /add date clause/i } ) );
+        expect( setAttributes ).toHaveBeenCalledWith(
+            expect.objectContaining( {
+                dateQuery: expect.objectContaining( {
+                    clauses: [ expect.objectContaining( {
+                        column: 'post_date',
+                        mode: 'after',
+                        inclusive: true,
+                    } ) ],
+                } ),
+            } )
+        );
+    } );
+} );
+```
+
+**Step 7: Run JS test — expect failure**
+
+```bash
+npx wp-scripts test-unit-js tests/unit/blocks/query/date-query-builder.test.js
+```
+
+Expected: FAIL — module not found.
+
+**Step 8: Create DateQueryBuilder.js**
+
+Create `src/blocks/query/components/DateQueryBuilder.js`:
+
+```jsx
+import { __ } from '@wordpress/i18n';
+import {
+    SelectControl,
+    TextControl,
+    ToggleControl,
+    Button,
+    VStack,
+    HStack,
+} from '@wordpress/components';
+import { DsgoInspectorPanel } from '../../../components/shared/DsgoInspectorPanel';
+
+const COLUMN_OPTIONS = [
+    { label: __( 'Publish date', 'designsetgo' ), value: 'post_date' },
+    { label: __( 'Modified date', 'designsetgo' ), value: 'post_modified' },
+    { label: __( 'Publish date (GMT)', 'designsetgo' ), value: 'post_date_gmt' },
+    { label: __( 'Modified date (GMT)', 'designsetgo' ), value: 'post_modified_gmt' },
+];
+
+const MODE_OPTIONS = [
+    { label: __( 'After', 'designsetgo' ), value: 'after' },
+    { label: __( 'Before', 'designsetgo' ), value: 'before' },
+    { label: __( 'Between', 'designsetgo' ), value: 'between' },
+];
+
+const DEFAULT_CLAUSE = {
+    column: 'post_date',
+    mode: 'after',
+    after: '',
+    before: '',
+    inclusive: true,
+};
+
+export default function DateQueryBuilder( { attributes, setAttributes, clientId } ) {
+    const { dateQuery = { relation: 'AND', clauses: [] } } = attributes;
+    const { relation, clauses } = dateQuery;
+
+    const updateQuery = ( patch ) =>
+        setAttributes( { dateQuery: { ...dateQuery, ...patch } } );
+
+    const addClause = () =>
+        updateQuery( { clauses: [ ...clauses, { ...DEFAULT_CLAUSE } ] } );
+
+    const updateClause = ( idx, patch ) => {
+        const next = clauses.map( ( c, i ) => ( i === idx ? { ...c, ...patch } : c ) );
+        updateQuery( { clauses: next } );
+    };
+
+    const removeClause = ( idx ) =>
+        updateQuery( { clauses: clauses.filter( ( _, i ) => i !== idx ) } );
+
+    return (
+        <DsgoInspectorPanel
+            title={ __( 'Date filters', 'designsetgo' ) }
+            panelName="settings"
+            panelId={ clientId }
+            onDeselect={ () => updateQuery( { relation: 'AND', clauses: [] } ) }
+            hasValue={ clauses.length > 0 }
+            isShownByDefault
+        >
+            <DsgoInspectorPanel.Item
+                label={ __( 'Date clauses', 'designsetgo' ) }
+                hasValue={ clauses.length > 0 }
+                onDeselect={ () => updateQuery( { relation: 'AND', clauses: [] } ) }
+                isShownByDefault
+            >
+                { clauses.length > 1 && (
+                    <SelectControl
+                        label={ __( 'Match', 'designsetgo' ) }
+                        value={ relation }
+                        options={ [
+                            { label: __( 'All (AND)', 'designsetgo' ), value: 'AND' },
+                            { label: __( 'Any (OR)', 'designsetgo' ), value: 'OR' },
+                        ] }
+                        onChange={ ( val ) => updateQuery( { relation: val } ) }
+                        __nextHasNoMarginBottom
+                    />
+                ) }
+                { clauses.map( ( clause, idx ) => (
+                    <VStack key={ idx } spacing={ 2 } className="dsgo-query-date-clause">
+                        <SelectControl
+                            label={ __( 'Date column', 'designsetgo' ) }
+                            value={ clause.column }
+                            options={ COLUMN_OPTIONS }
+                            onChange={ ( val ) => updateClause( idx, { column: val } ) }
+                            __nextHasNoMarginBottom
+                        />
+                        <SelectControl
+                            label={ __( 'Mode', 'designsetgo' ) }
+                            value={ clause.mode }
+                            options={ MODE_OPTIONS }
+                            onChange={ ( val ) => updateClause( idx, { mode: val } ) }
+                            __nextHasNoMarginBottom
+                        />
+                        { ( clause.mode === 'after' || clause.mode === 'between' ) && (
+                            <TextControl
+                                label={ clause.mode === 'between' ? __( 'After', 'designsetgo' ) : __( 'Date', 'designsetgo' ) }
+                                value={ clause.after }
+                                placeholder="2024-01-01 or -30 days"
+                                onChange={ ( val ) => updateClause( idx, { after: val } ) }
+                                __nextHasNoMarginBottom
+                            />
+                        ) }
+                        { ( clause.mode === 'before' || clause.mode === 'between' ) && (
+                            <TextControl
+                                label={ __( 'Before', 'designsetgo' ) }
+                                value={ clause.before }
+                                placeholder="2024-12-31 or today"
+                                onChange={ ( val ) => updateClause( idx, { before: val } ) }
+                                __nextHasNoMarginBottom
+                            />
+                        ) }
+                        <HStack justify="space-between">
+                            <ToggleControl
+                                label={ __( 'Inclusive', 'designsetgo' ) }
+                                checked={ clause.inclusive }
+                                onChange={ ( val ) => updateClause( idx, { inclusive: val } ) }
+                                __nextHasNoMarginBottom
+                            />
+                            <Button
+                                variant="tertiary"
+                                isDestructive
+                                size="small"
+                                onClick={ () => removeClause( idx ) }
+                            >
+                                { __( 'Remove', 'designsetgo' ) }
+                            </Button>
+                        </HStack>
+                    </VStack>
+                ) ) }
+                <Button variant="secondary" size="small" onClick={ addClause } __next40pxDefaultSize>
+                    { __( 'Add date clause', 'designsetgo' ) }
+                </Button>
+            </DsgoInspectorPanel.Item>
+        </DsgoInspectorPanel>
+    );
+}
+```
+
+**Step 9: Wire DateQueryBuilder into edit.js**
+
+In `src/blocks/query/edit.js`:
+
+1. Add import at the top alongside the other builders:
+```js
+import DateQueryBuilder from './components/DateQueryBuilder';
+```
+
+2. Inside the inspector, after `<MetaQueryBuilder>` and before `<AdvancedPanel>`:
+```jsx
+{ showPostsOnlyPanels && (
+    <DateQueryBuilder attributes={attributes} setAttributes={setAttributes} clientId={clientId} />
+) }
+```
+
+**Step 10: Run all tests**
+
+```bash
+npx wp-scripts test-unit-js tests/unit/blocks/query/date-query-builder.test.js
+npx wp-env run tests-cli vendor/bin/phpunit tests/phpunit/blocks/query/render-posts-test.php
+```
+
+Both expected: PASS.
+
+**Step 11: Build**
+
+```bash
+npm run build && npm run lint:js && npm run lint:css
+```
+
+**Step 12: Commit**
+
+```bash
+git add src/blocks/query/block.json \
+        src/blocks/query/components/DateQueryBuilder.js \
+        src/blocks/query/edit.js \
+        src/blocks/query/render-posts.php \
+        tests/unit/blocks/query/date-query-builder.test.js \
+        tests/phpunit/blocks/query/render-posts-test.php
+git commit -m "feat(query): add date query builder with after/before/between modes"
+```
+
+---
+
+## Task 3: Multi-level AND/OR groups (shared shell component)
+
+Extracts a reusable `ClauseGroupShell` component so both TaxQueryBuilder and MetaQueryBuilder can support nested groups. Each entry in a `clauses` array is either a leaf clause or a group (detected by presence of a `clauses` key).
+
+**Nested group shape:**
+```js
+// Leaf (tax):
+{ taxonomy: 'category', terms: [1], operator: 'IN', include_children: true }
+
+// Group (any depth):
+{ clauses: [...], relation: 'AND' | 'OR' }
+```
+
+**Files:**
+- Create: `src/blocks/query/components/ClauseGroupShell.js`
+- Modify: `src/blocks/query/components/TaxQueryBuilder.js`
+- Modify: `src/blocks/query/render-posts.php`
+- Modify: `tests/phpunit/blocks/query/render-posts-test.php`
+- Modify: `tests/unit/blocks/query/tax-query-builder.test.js`
+
+### Step 1: Write failing PHP tests for nested tax groups
+
+Add to `tests/phpunit/blocks/query/render-posts-test.php`:
+
+```php
+public function test_nested_tax_group_builds_correctly() {
+    $atts = [
+        'source'   => 'posts',
+        'taxQuery' => [
+            'relation' => 'AND',
+            'clauses'  => [
+                [
+                    'relation' => 'OR',
+                    'clauses'  => [
+                        [ 'taxonomy' => 'category', 'terms' => [ 1 ], 'operator' => 'IN', 'include_children' => true ],
+                        [ 'taxonomy' => 'category', 'terms' => [ 2 ], 'operator' => 'IN', 'include_children' => true ],
+                    ],
+                ],
+                [ 'taxonomy' => 'post_tag', 'terms' => [ 5 ], 'operator' => 'IN', 'include_children' => false ],
+            ],
+        ],
+    ];
+    $args = designsetgo_query_build_posts_args( $atts, null );
+    $this->assertEquals( 'AND', $args['tax_query']['relation'] );
+    $sub = $args['tax_query'][0];
+    $this->assertEquals( 'OR', $sub['relation'] );
+    $this->assertEquals( 'category', $sub[0]['taxonomy'] );
+    $this->assertEquals( 'category', $sub[1]['taxonomy'] );
+    $leaf = $args['tax_query'][1];
+    $this->assertEquals( 'post_tag', $leaf['taxonomy'] );
+    $this->assertFalse( $leaf['include_children'] );
+}
+```
+
+### Step 2: Run to confirm failure
+
+```bash
+npx wp-env run tests-cli vendor/bin/phpunit tests/phpunit/blocks/query/render-posts-test.php --filter=test_nested_tax_group
+```
+
+Expected: FAIL.
+
+### Step 3: Refactor PHP tax_query builder to be recursive
+
+In `src/blocks/query/render-posts.php`, replace the existing `$tax_clauses` block (lines ~260–279) with a recursive helper function and updated caller.
+
+Add the private helper function **above** `designsetgo_query_build_posts_args()`:
+
+```php
+/**
+ * Recursively builds a WP_Query tax_query clause or nested group.
+ *
+ * @param array $entry Clause or group from block attributes.
+ * @return array|null WP_Query tax_query entry, or null if invalid.
+ */
+function designsetgo_build_tax_query_entry( array $entry ) {
+    if ( isset( $entry['clauses'] ) ) {
+        // Nested group.
+        $sub = array(
+            'relation' => ( 'OR' === ( $entry['relation'] ?? 'AND' ) ) ? 'OR' : 'AND',
+        );
+        foreach ( (array) $entry['clauses'] as $child ) {
+            $built = designsetgo_build_tax_query_entry( $child );
+            if ( null !== $built ) {
+                $sub[] = $built;
+            }
+        }
+        return count( $sub ) > 1 ? $sub : null;
+    }
+    // Leaf clause.
+    if ( empty( $entry['taxonomy'] ) || empty( $entry['terms'] ) ) {
+        return null;
+    }
+    return array(
+        'taxonomy'         => sanitize_key( (string) $entry['taxonomy'] ),
+        'terms'            => array_map( 'absint', (array) $entry['terms'] ),
+        'operator'         => in_array( ( $entry['operator'] ?? 'IN' ), array( 'IN', 'NOT IN', 'AND' ), true ) ? $entry['operator'] : 'IN',
+        'include_children' => isset( $entry['include_children'] ) ? (bool) $entry['include_children'] : true,
+    );
+}
+```
+
+Then replace the `$tax_clauses` block in `designsetgo_query_build_posts_args()`:
+
+```php
+// Tax query (supports nested AND/OR groups).
+$tax_clauses = isset( $atts['taxQuery']['clauses'] ) ? (array) $atts['taxQuery']['clauses'] : array();
+if ( ! empty( $tax_clauses ) ) {
+    $tax_query = array(
+        'relation' => ( 'OR' === ( $atts['taxQuery']['relation'] ?? 'AND' ) ) ? 'OR' : 'AND',
+    );
+    foreach ( $tax_clauses as $entry ) {
+        $built = designsetgo_build_tax_query_entry( $entry );
+        if ( null !== $built ) {
+            $tax_query[] = $built;
+        }
+    }
+    if ( count( $tax_query ) > 1 ) {
+        $args['tax_query'] = $tax_query;
+    }
+}
+```
+
+### Step 4: Run PHP tests — expect pass
+
+```bash
+npx wp-env run tests-cli vendor/bin/phpunit tests/phpunit/blocks/query/render-posts-test.php
+```
+
+All existing + new tests expected: PASS.
+
+### Step 5: Create ClauseGroupShell.js
+
+Create `src/blocks/query/components/ClauseGroupShell.js`:
+
+```jsx
+import { __ } from '@wordpress/i18n';
+import { Button, SelectControl, VStack } from '@wordpress/components';
+
+/**
+ * Reusable recursive group shell for tax/meta clause builders.
+ *
+ * Props:
+ *   group        - { relation, clauses }
+ *   onChange     - (patch) => void — called with { relation?, clauses? }
+ *   onRemove     - () => void | undefined — present on nested groups, absent on root
+ *   depth        - number (0 = root)
+ *   renderClause - (clause, idx, update, remove) => JSX — renders one leaf clause
+ *   newClause    - object — default shape for a new leaf clause
+ */
+export default function ClauseGroupShell( {
+    group,
+    onChange,
+    onRemove,
+    depth = 0,
+    renderClause,
+    newClause,
+} ) {
+    const { relation = 'AND', clauses = [] } = group;
+
+    const updateEntry = ( idx, patch ) => {
+        const next = clauses.map( ( c, i ) => ( i === idx ? { ...c, ...patch } : c ) );
+        onChange( { clauses: next } );
+    };
+
+    const replaceEntry = ( idx, entry ) => {
+        const next = clauses.map( ( c, i ) => ( i === idx ? entry : c ) );
+        onChange( { clauses: next } );
+    };
+
+    const removeEntry = ( idx ) =>
+        onChange( { clauses: clauses.filter( ( _, i ) => i !== idx ) } );
+
+    const addClause = () =>
+        onChange( { clauses: [ ...clauses, { ...newClause } ] } );
+
+    const addGroup = () =>
+        onChange( {
+            clauses: [ ...clauses, { relation: 'AND', clauses: [ { ...newClause } ] } ],
+        } );
+
+    return (
+        <VStack
+            spacing={ 2 }
+            className={ `dsgo-clause-group dsgo-clause-group--depth-${ depth }` }
+            style={ depth > 0 ? { paddingLeft: '12px', borderLeft: '2px solid var(--wp-admin-theme-color-darker-10, #ccc)' } : undefined }
+        >
+            { ( clauses.length > 1 || depth > 0 ) && (
+                <SelectControl
+                    label={ __( 'Match', 'designsetgo' ) }
+                    value={ relation }
+                    options={ [
+                        { label: __( 'All (AND)', 'designsetgo' ), value: 'AND' },
+                        { label: __( 'Any (OR)', 'designsetgo' ), value: 'OR' },
+                    ] }
+                    onChange={ ( val ) => onChange( { relation: val } ) }
+                    __nextHasNoMarginBottom
+                />
+            ) }
+
+            { clauses.map( ( entry, idx ) =>
+                Array.isArray( entry.clauses ) ? (
+                    <ClauseGroupShell
+                        key={ idx }
+                        group={ entry }
+                        onChange={ ( patch ) => replaceEntry( idx, { ...entry, ...patch } ) }
+                        onRemove={ () => removeEntry( idx ) }
+                        depth={ depth + 1 }
+                        renderClause={ renderClause }
+                        newClause={ newClause }
+                    />
+                ) : (
+                    renderClause( entry, idx, updateEntry, removeEntry )
+                )
+            ) }
+
+            <div className="dsgo-clause-group__actions">
+                <Button variant="secondary" size="small" onClick={ addClause } __next40pxDefaultSize>
+                    { __( '+ Clause', 'designsetgo' ) }
+                </Button>
+                <Button variant="secondary" size="small" onClick={ addGroup } __next40pxDefaultSize>
+                    { __( '+ Group', 'designsetgo' ) }
+                </Button>
+                { onRemove && (
+                    <Button variant="tertiary" isDestructive size="small" onClick={ onRemove }>
+                        { __( 'Remove group', 'designsetgo' ) }
+                    </Button>
+                ) }
+            </div>
+        </VStack>
+    );
+}
+```
+
+### Step 6: Refactor TaxQueryBuilder to use ClauseGroupShell
+
+In `src/blocks/query/components/TaxQueryBuilder.js`:
+
+1. Import `ClauseGroupShell`:
+```js
+import ClauseGroupShell from './ClauseGroupShell';
+```
+
+2. Replace the existing clause-list rendering and buttons with a single `<ClauseGroupShell>` call. The `renderClause` prop receives one leaf clause and renders the existing per-clause VStack (taxonomy select, TermPicker, operator select, include_children toggle, remove button).
+
+3. Remove the old `addClause` standalone button and the flat `clauses.map(...)` block — ClauseGroupShell owns that loop now.
+
+4. Keep `TermPicker` as an internal sub-component — it is still needed by `renderClause`.
+
+The final return inside `TaxQueryBuilder` should look like:
+
+```jsx
+return (
+    <DsgoInspectorPanel
+        title={ __( 'Taxonomy filters', 'designsetgo' ) }
+        panelName="settings"
+        panelId={ clientId }
+        onDeselect={ () => setAttributes( { taxQuery: { relation: 'AND', clauses: [] } } ) }
+        hasValue={ taxQuery.clauses.length > 0 }
+        isShownByDefault
+    >
+        <DsgoInspectorPanel.Item
+            label={ __( 'Taxonomy clauses', 'designsetgo' ) }
+            hasValue={ taxQuery.clauses.length > 0 }
+            onDeselect={ () => setAttributes( { taxQuery: { relation: 'AND', clauses: [] } } ) }
+            isShownByDefault
+        >
+            <ClauseGroupShell
+                group={ taxQuery }
+                onChange={ ( patch ) =>
+                    setAttributes( { taxQuery: { ...taxQuery, ...patch } } )
+                }
+                depth={ 0 }
+                newClause={ { taxonomy: relevant[0]?.slug ?? 'category', terms: [], operator: 'IN', include_children: true } }
+                renderClause={ ( clause, idx, updateEntry, removeEntry ) => (
+                    <VStack key={ idx } spacing={ 2 } className="dsgo-query-tax-clause">
+                        <SelectControl
+                            label={ __( 'Taxonomy', 'designsetgo' ) }
+                            value={ clause.taxonomy }
+                            options={ relevant.map( ( t ) => ( { label: t.name, value: t.slug } ) ) }
+                            onChange={ ( val ) => updateEntry( idx, { taxonomy: val, terms: [] } ) }
+                            __nextHasNoMarginBottom
+                        />
+                        <TermPicker
+                            taxonomy={ clause.taxonomy }
+                            selected={ clause.terms }
+                            onChange={ ( val ) => updateEntry( idx, { terms: val } ) }
+                        />
+                        <HStack>
+                            <SelectControl
+                                label={ __( 'Operator', 'designsetgo' ) }
+                                value={ clause.operator }
+                                options={ [
+                                    { label: 'IN', value: 'IN' },
+                                    { label: 'NOT IN', value: 'NOT IN' },
+                                    { label: 'AND', value: 'AND' },
+                                ] }
+                                onChange={ ( val ) => updateEntry( idx, { operator: val } ) }
+                                __nextHasNoMarginBottom
+                            />
+                            <Button
+                                variant="tertiary"
+                                isDestructive
+                                size="small"
+                                onClick={ () => removeEntry( idx ) }
+                            >
+                                { __( 'Remove', 'designsetgo' ) }
+                            </Button>
+                        </HStack>
+                        <ToggleControl
+                            label={ __( 'Include child terms', 'designsetgo' ) }
+                            checked={ clause.include_children ?? true }
+                            onChange={ ( val ) => updateEntry( idx, { include_children: val } ) }
+                            __nextHasNoMarginBottom
+                        />
+                    </VStack>
+                ) }
+            />
+        </DsgoInspectorPanel.Item>
+    </DsgoInspectorPanel>
+);
+```
+
+### Step 7: Write JS test for nested group
+
+In `tests/unit/blocks/query/tax-query-builder.test.js`, add:
+
+```js
+it( 'adds a nested group when clicking + Group', () => {
+    const setAttributes = jest.fn();
+    const { getByRole } = render(
+        <TaxQueryBuilder
+            attributes={ { taxQuery: { relation: 'AND', clauses: [] }, postType: 'post' } }
+            setAttributes={ setAttributes }
+            clientId="test"
+        />
+    );
+    fireEvent.click( getByRole( 'button', { name: /\+ group/i } ) );
+    const call = setAttributes.mock.calls[0][0];
+    expect( call.taxQuery.clauses[0] ).toHaveProperty( 'clauses' );
+    expect( call.taxQuery.clauses[0].relation ).toBe( 'AND' );
+} );
+```
+
+### Step 8: Run all tests
+
+```bash
+npx wp-scripts test-unit-js tests/unit/blocks/query/tax-query-builder.test.js
+npx wp-env run tests-cli vendor/bin/phpunit tests/phpunit/blocks/query/render-posts-test.php
+```
+
+Both expected: PASS.
+
+### Step 9: Build
+
+```bash
+npm run build && npm run lint:js
+```
+
+### Step 10: Commit
+
+```bash
+git add src/blocks/query/components/ClauseGroupShell.js \
+        src/blocks/query/components/TaxQueryBuilder.js \
+        src/blocks/query/render-posts.php \
+        tests/phpunit/blocks/query/render-posts-test.php \
+        tests/unit/blocks/query/tax-query-builder.test.js
+git commit -m "feat(query): add multi-level AND/OR groups to taxonomy clause builder"
+```
+
+---
+
+## Task 4: Multi-level AND/OR groups in MetaQueryBuilder
+
+Mirrors Task 3 but for `metaQuery`. Uses the `ClauseGroupShell` created in Task 3, so the recursive PHP builder needs the same treatment. Meta clauses are leaves only (no sub-taxonomy pickers needed).
+
+**Files:**
+- Modify: `src/blocks/query/components/MetaQueryBuilder.js`
+- Modify: `src/blocks/query/render-posts.php`
+- Modify: `tests/phpunit/blocks/query/render-posts-test.php`
+- Modify: `tests/unit/blocks/query/meta-query-builder.test.js`
+
+### Step 1: Write failing PHP test
+
+Add to `tests/phpunit/blocks/query/render-posts-test.php`:
+
+```php
+public function test_nested_meta_group_builds_correctly() {
+    $atts = [
+        'source'    => 'posts',
+        'metaQuery' => [
+            'relation' => 'AND',
+            'clauses'  => [
+                [
+                    'relation' => 'OR',
+                    'clauses'  => [
+                        [ 'key' => 'status', 'compare' => '=', 'value' => 'featured', 'type' => 'CHAR' ],
+                        [ 'key' => 'featured', 'compare' => '=', 'value' => '1', 'type' => 'NUMERIC' ],
+                    ],
+                ],
+                [ 'key' => 'active', 'compare' => '=', 'value' => '1', 'type' => 'CHAR' ],
+            ],
+        ],
+    ];
+    $args = designsetgo_query_build_posts_args( $atts, null );
+    $this->assertEquals( 'AND', $args['meta_query']['relation'] );
+    $sub = $args['meta_query'][0];
+    $this->assertEquals( 'OR', $sub['relation'] );
+    $this->assertEquals( 'status', $sub[0]['key'] );
+    $this->assertEquals( 'active', $args['meta_query'][1]['key'] );
+}
+```
+
+### Step 2: Run to confirm failure
+
+```bash
+npx wp-env run tests-cli vendor/bin/phpunit tests/phpunit/blocks/query/render-posts-test.php --filter=test_nested_meta_group
+```
+
+### Step 3: Add recursive meta_query helper to render-posts.php
+
+Add above `designsetgo_query_build_posts_args()` (alongside `designsetgo_build_tax_query_entry`):
+
+```php
+/**
+ * Recursively builds a WP_Query meta_query clause or nested group.
+ *
+ * @param array $entry Clause or group from block attributes.
+ * @return array|null WP_Query meta_query entry, or null if invalid.
+ */
+function designsetgo_build_meta_query_entry( array $entry ) {
+    if ( isset( $entry['clauses'] ) ) {
+        $sub = array(
+            'relation' => ( 'OR' === ( $entry['relation'] ?? 'AND' ) ) ? 'OR' : 'AND',
+        );
+        foreach ( (array) $entry['clauses'] as $child ) {
+            $built = designsetgo_build_meta_query_entry( $child );
+            if ( null !== $built ) {
+                $sub[] = $built;
+            }
+        }
+        return count( $sub ) > 1 ? $sub : null;
+    }
+    if ( empty( $entry['key'] ) ) {
+        return null;
+    }
+    $valid_compare = array( '=', '!=', '>', '>=', '<', '<=', 'LIKE', 'NOT LIKE', 'IN', 'NOT IN', 'EXISTS', 'NOT EXISTS' );
+    $valid_type    = array( 'CHAR', 'NUMERIC', 'DATE' );
+    return array(
+        'key'     => sanitize_text_field( (string) $entry['key'] ),
+        'value'   => sanitize_text_field( (string) ( $entry['value'] ?? '' ) ),
+        'compare' => in_array( ( $entry['compare'] ?? '=' ), $valid_compare, true ) ? $entry['compare'] : '=',
+        'type'    => in_array( ( $entry['type'] ?? 'CHAR' ), $valid_type, true ) ? $entry['type'] : 'CHAR',
+    );
+}
+```
+
+Replace the `$meta_clauses` block in `designsetgo_query_build_posts_args()`:
+
+```php
+// Meta query (supports nested AND/OR groups).
+$meta_clauses = isset( $atts['metaQuery']['clauses'] ) ? (array) $atts['metaQuery']['clauses'] : array();
+if ( ! empty( $meta_clauses ) ) {
+    $meta_query = array(
+        'relation' => ( 'OR' === ( $atts['metaQuery']['relation'] ?? 'AND' ) ) ? 'OR' : 'AND',
+    );
+    foreach ( $meta_clauses as $entry ) {
+        $built = designsetgo_build_meta_query_entry( $entry );
+        if ( null !== $built ) {
+            $meta_query[] = $built;
+        }
+    }
+    if ( count( $meta_query ) > 1 ) {
+        $args['meta_query'] = $meta_query;
+    }
+}
+```
+
+### Step 4: Run PHP tests — expect pass
+
+```bash
+npx wp-env run tests-cli vendor/bin/phpunit tests/phpunit/blocks/query/render-posts-test.php
+```
+
+### Step 5: Refactor MetaQueryBuilder to use ClauseGroupShell
+
+In `src/blocks/query/components/MetaQueryBuilder.js`:
+
+1. Import `ClauseGroupShell`.
+2. Replace the flat clause list + add button with `<ClauseGroupShell>`, passing `renderClause` that renders the existing per-clause VStack (key TextControl, compare SelectControl, type SelectControl, value TextControl, remove Button).
+3. `newClause` prop: `{ key: '', compare: '=', value: '', type: 'CHAR' }`.
+
+### Step 6: Write and run JS test
+
+In `tests/unit/blocks/query/meta-query-builder.test.js`, add a test mirroring the TaxQueryBuilder group test:
+
+```js
+it( 'adds a nested group when clicking + Group', () => {
+    const setAttributes = jest.fn();
+    const { getByRole } = render(
+        <MetaQueryBuilder
+            attributes={ { metaQuery: { relation: 'AND', clauses: [] } } }
+            setAttributes={ setAttributes }
+            clientId="test"
+        />
+    );
+    fireEvent.click( getByRole( 'button', { name: /\+ group/i } ) );
+    const call = setAttributes.mock.calls[0][0];
+    expect( call.metaQuery.clauses[0] ).toHaveProperty( 'clauses' );
+} );
+```
+
+```bash
+npx wp-scripts test-unit-js tests/unit/blocks/query/meta-query-builder.test.js
+npx wp-env run tests-cli vendor/bin/phpunit tests/phpunit/blocks/query/render-posts-test.php
+```
+
+Both expected: PASS.
+
+### Step 7: Build and commit
+
+```bash
+npm run build && npm run lint:js
+git add src/blocks/query/components/MetaQueryBuilder.js \
+        src/blocks/query/render-posts.php \
+        tests/phpunit/blocks/query/render-posts-test.php \
+        tests/unit/blocks/query/meta-query-builder.test.js
+git commit -m "feat(query): add multi-level AND/OR groups to meta clause builder"
+```
+
+---
+
+## Task 5: Query Monitor debug panel
+
+Adds a DSGo panel to Query Monitor (when active) that shows per-render query args, result count, SQL, and active filter state. Completely standalone — no changes to existing query code paths; data is captured via existing PHP action hooks.
+
+**Files:**
+- Create: `includes/class-query-qm-collector.php`
+- Create: `includes/class-query-qm-output.php`
+- Modify: `includes/class-plugin.php` (or wherever blocks are registered — load both classes conditionally)
+- Modify: `src/blocks/query/render-helpers.php` (fire a capture action)
+
+### Step 1: Write failing PHP test for collector
+
+Create `tests/phpunit/blocks/query/qm-collector-test.php`:
+
+```php
+<?php
+defined( 'ABSPATH' ) || exit;
+
+use PHPUnit\Framework\TestCase;
+
+class QMCollectorTest extends TestCase {
+
+    public function test_collector_ignores_data_when_qm_absent() {
+        // If QM is not active the collector should not be registered —
+        // calling the action should be a no-op.
+        $this->assertFalse( class_exists( 'DesignSetGo\QueryMonitor\Collector' ) );
+    }
+
+    public function test_data_structure_is_serialisable() {
+        $data = [
+            'query_id'    => 'abc123',
+            'source'      => 'posts',
+            'wp_args'     => [ 'post_type' => 'post', 'posts_per_page' => 6 ],
+            'found_posts' => 12,
+            'sql'         => 'SELECT ...',
+            'filters'     => [],
+            'duration_ms' => 14.5,
+        ];
+        $this->assertIsString( wp_json_encode( $data ) );
+    }
+}
+```
+
+### Step 2: Run to confirm expected state
+
+```bash
+npx wp-env run tests-cli vendor/bin/phpunit tests/phpunit/blocks/query/qm-collector-test.php
+```
+
+Expected: PASS (test_collector_ignores_data_when_qm_absent passes because QM is not loaded in the test environment; test_data_structure_is_serialisable passes trivially).
+
+This test serves as a smoke check — the real value is integration.
+
+### Step 3: Add capture action to render-helpers.php
+
+In `src/blocks/query/render-helpers.php`, inside `designsetgo_query_render_item()` (or `designsetgo_query_render()`) — after the WP_Query runs and results are known — fire:
+
+```php
+/**
+ * Fires after a DSGo query executes. Consumed by the Query Monitor panel
+ * when QM is active; no-op otherwise.
+ *
+ * @param array    $capture {
+ *     @type string $query_id    Block queryId attribute.
+ *     @type string $source      Query source (posts/users/terms/…).
+ *     @type array  $wp_args     WP_Query args array.
+ *     @type int    $found_posts Total matching posts before pagination.
+ *     @type string $sql         Last query executed by wpdb.
+ *     @type array  $filters     Active filter state from IAPI store (empty on first render).
+ *     @type float  $duration_ms Milliseconds the WP_Query took.
+ * }
+ */
+do_action( 'designsetgo_query_did_render', $capture );
+```
+
+Build `$capture` immediately after `$query = new WP_Query( $args )`:
+
+```php
+$t_start = microtime( true );
+$query   = new WP_Query( $args );
+$duration_ms = ( microtime( true ) - $t_start ) * 1000;
+
+$capture = array(
+    'query_id'    => $atts['queryId'] ?? '',
+    'source'      => $atts['source'] ?? 'posts',
+    'wp_args'     => $args,
+    'found_posts' => $query->found_posts,
+    'sql'         => $GLOBALS['wpdb']->last_query ?? '',
+    'filters'     => array(),
+    'duration_ms' => round( $duration_ms, 2 ),
+);
+do_action( 'designsetgo_query_did_render', $capture );
+```
+
+### Step 4: Create the QM Collector
+
+Create `includes/class-query-qm-collector.php`:
+
+```php
+<?php
+defined( 'ABSPATH' ) || exit;
+
+namespace DesignSetGo\QueryMonitor;
+
+if ( ! class_exists( '\QM_Collector' ) ) {
+    return;
+}
+
+/**
+ * Query Monitor data collector for DesignSetGo queries.
+ */
+class Collector extends \QM_Collector {
+
+    public $id = 'dsgo_queries';
+
+    /** @var array[] */
+    private array $renders = [];
+
+    public function __construct() {
+        parent::__construct();
+        add_action( 'designsetgo_query_did_render', [ $this, 'capture' ] );
+    }
+
+    public function capture( array $data ): void {
+        $this->renders[] = $data;
+    }
+
+    public function process(): void {
+        $this->data['renders'] = $this->renders;
+        $this->data['count']   = count( $this->renders );
+    }
+
+    public function name(): string {
+        return __( 'DSGo Queries', 'designsetgo' );
+    }
+}
+
+add_filter(
+    'qm/collectors',
+    static function ( array $collectors ) {
+        $collectors['dsgo_queries'] = new Collector();
+        return $collectors;
+    }
+);
+```
+
+### Step 5: Create the QM Output panel
+
+Create `includes/class-query-qm-output.php`:
+
+```php
+<?php
+defined( 'ABSPATH' ) || exit;
+
+namespace DesignSetGo\QueryMonitor;
+
+if ( ! class_exists( '\QM_Output_Html' ) ) {
+    return;
+}
+
+/**
+ * Query Monitor HTML output for DesignSetGo queries.
+ */
+class OutputHtml extends \QM_Output_Html {
+
+    public function __construct( \QM_Collector $collector ) {
+        parent::__construct( $collector );
+        add_filter( 'qm/output/menus', [ $this, 'admin_menu' ], 80 );
+    }
+
+    public function name(): string {
+        return __( 'DSGo Queries', 'designsetgo' );
+    }
+
+    public function output(): void {
+        $data    = $this->collector->get_data();
+        $renders = $data['renders'] ?? [];
+
+        $this->before_non_tabular_output();
+
+        if ( empty( $renders ) ) {
+            echo '<p>' . esc_html__( 'No DSGo queries ran on this request.', 'designsetgo' ) . '</p>';
+            $this->after_non_tabular_output();
+            return;
+        }
+
+        echo '<p>' . esc_html( sprintf(
+            /* translators: %d: number of queries */
+            _n( '%d DSGo query ran on this request.', '%d DSGo queries ran on this request.', count( $renders ), 'designsetgo' ),
+            count( $renders )
+        ) ) . '</p>';
+
+        foreach ( $renders as $i => $r ) {
+            echo '<h3>' . esc_html( sprintf( '#%d — %s (%s)', $i + 1, $r['query_id'], $r['source'] ) ) . '</h3>';
+            echo '<table class="qm-sortable"><thead><tr>';
+            echo '<th>' . esc_html__( 'Property', 'designsetgo' ) . '</th>';
+            echo '<th>' . esc_html__( 'Value', 'designsetgo' ) . '</th>';
+            echo '</tr></thead><tbody>';
+
+            $rows = [
+                __( 'Found posts', 'designsetgo' ) => $r['found_posts'],
+                __( 'Duration (ms)', 'designsetgo' ) => $r['duration_ms'],
+                __( 'WP_Query args', 'designsetgo' ) => '<pre style="margin:0;white-space:pre-wrap">' . esc_html( wp_json_encode( $r['wp_args'], JSON_PRETTY_PRINT ) ) . '</pre>',
+                __( 'SQL', 'designsetgo' ) => '<code>' . esc_html( $r['sql'] ) . '</code>',
+            ];
+
+            foreach ( $rows as $label => $value ) {
+                echo '<tr><td>' . esc_html( $label ) . '</td><td>' . wp_kses_post( $value ) . '</td></tr>';
+            }
+
+            echo '</tbody></table>';
+        }
+
+        $this->after_non_tabular_output();
+    }
+
+    public function admin_menu( array $menu ): array {
+        $data  = $this->collector->get_data();
+        $count = $data['count'] ?? 0;
+
+        $menu[ $this->collector->id ] = $this->menu( [
+            'title' => esc_html( sprintf(
+                /* translators: %d: query count */
+                _n( 'DSGo (%d)', 'DSGo (%d)', $count, 'designsetgo' ),
+                $count
+            ) ),
+        ] );
+
+        return $menu;
+    }
+}
+
+add_filter(
+    'qm/outputter/html',
+    static function ( array $outputters, array $collectors ) {
+        if ( isset( $collectors['dsgo_queries'] ) ) {
+            $outputters['dsgo_queries'] = new OutputHtml( $collectors['dsgo_queries'] );
+        }
+        return $outputters;
+    },
+    80,
+    2
+);
+```
+
+### Step 6: Load QM classes conditionally in Plugin bootstrap
+
+In `includes/class-plugin.php` (or whatever file bootstraps the plugin), in the constructor or `init()` method, add after the block classes are loaded:
+
+```php
+// Query Monitor integration — loads only when QM is active.
+if ( defined( 'QM_VERSION' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . 'class-query-qm-collector.php';
+    require_once plugin_dir_path( __FILE__ ) . 'class-query-qm-output.php';
+}
+```
+
+### Step 7: Run PHP lint
+
+```bash
+npm run lint:php
+```
+
+Fix any PHPCS warnings before committing.
+
+### Step 8: Manual verification
+
+With `wp-env` running and Query Monitor active (install via `npx wp-env install-plugin query-monitor` or drop the plugin zip in `wp-content/plugins/`):
+
+1. Load a page that has a Dynamic Query block.
+2. Open QM's toolbar → look for the "DSGo (N)" menu item.
+3. Confirm the panel shows query_id, source, found_posts, duration_ms, WP_Query args JSON, SQL.
+4. Without QM active, confirm no errors in PHP logs.
+
+### Step 9: Commit
+
+```bash
+git add includes/class-query-qm-collector.php \
+        includes/class-query-qm-output.php \
+        includes/class-plugin.php \
+        src/blocks/query/render-helpers.php \
+        tests/phpunit/blocks/query/qm-collector-test.php
+git commit -m "feat(query): add Query Monitor debug panel for DSGo queries"
+```
+
+---
+
+## Task 6: Dynamic CSS from meta (style bindings)
+
+Adds a `dsgoStyleBinding` attribute to every block (registered as a global extension like `dsgoVisibility`). Authors map CSS property names → a DSGo binding source + key. The server-side `render_block` filter resolves the value and injects it as an inline `style` attribute on the block's root element. The editor shows a visual indicator badge in the inspector when bindings are active and provides add/remove UI in the Advanced controls.
+
+**Supported sources:** `designsetgo/post-meta`, `designsetgo/acf`, `designsetgo/metabox`, `designsetgo/pods`, `designsetgo/jetengine` (same set as v2.4 bindings).
+
+**Attribute shape:**
+```json
+{
+  "dsgoStyleBinding": {
+    "--brand-color": { "source": "designsetgo/post-meta", "args": { "key": "brand_color" } },
+    "background-color": { "source": "designsetgo/acf", "args": { "name": "bg_color" } }
+  }
+}
+```
+
+Valid CSS property names: custom properties (`--[a-zA-Z][a-zA-Z0-9-_]*`) or standard CSS properties (`[a-z][a-z-]*`). Values with `url(`, `expression(`, or `javascript:` are rejected.
+
+**Files:**
+- Create: `src/extensions/style-binding/filters.js`
+- Create: `src/extensions/style-binding/index.js`
+- Modify: `src/index.js` (add import)
+- Create: `includes/class-style-binding.php`
+- Modify: `includes/class-plugin.php` (require the new class)
+- Create: `tests/phpunit/extensions/style-binding-test.php`
+- Create: `tests/unit/extensions/style-binding.test.js`
+
+### Step 1: Write failing PHP tests
+
+Create `tests/phpunit/extensions/style-binding-test.php`:
+
+```php
+<?php
+defined( 'ABSPATH' ) || exit;
+
+use PHPUnit\Framework\TestCase;
+
+class StyleBindingTest extends TestCase {
+
+    private function make_block( array $attrs ): array {
+        return [
+            'blockName' => 'core/paragraph',
+            'attrs'     => $attrs,
+            'innerBlocks' => [],
+            'innerHTML'   => '',
+        ];
+    }
+
+    public function test_no_binding_returns_html_unchanged() {
+        $sb   = new DesignSetGo\StyleBinding();
+        $html = '<p class="wp-block">Hello</p>';
+        $this->assertSame( $html, $sb->apply_style_bindings( $html, $this->make_block( [] ) ) );
+    }
+
+    public function test_invalid_css_prop_is_skipped() {
+        // Props with spaces or dangerous chars are invalid.
+        $sb = new DesignSetGo\StyleBinding();
+        // Return value should be unchanged because the prop is invalid.
+        $html = '<p>Hello</p>';
+        $block = $this->make_block( [
+            'dsgoStyleBinding' => [
+                'bad prop!' => [ 'source' => 'designsetgo/post-meta', 'args' => [ 'key' => 'x' ] ],
+            ],
+        ] );
+        $this->assertStringNotContainsString( 'bad prop!', $sb->apply_style_bindings( $html, $block ) );
+    }
+
+    public function test_dangerous_value_is_rejected() {
+        $sb = new DesignSetGo\StyleBinding();
+        add_filter( 'designsetgo_style_binding_resolve', function( $val, $source, $args ) {
+            return 'url(javascript:alert(1))';
+        }, 10, 3 );
+        $html  = '<div class="wp-block">X</div>';
+        $block = $this->make_block( [
+            'dsgoStyleBinding' => [
+                '--color' => [ 'source' => 'designsetgo/post-meta', 'args' => [ 'key' => 'c' ] ],
+            ],
+        ] );
+        $result = $sb->apply_style_bindings( $html, $block );
+        $this->assertStringNotContainsString( 'javascript', $result );
+        remove_all_filters( 'designsetgo_style_binding_resolve' );
+    }
+
+    public function test_valid_binding_injects_style_attribute() {
+        $sb = new DesignSetGo\StyleBinding();
+        add_filter( 'designsetgo_style_binding_resolve', function( $val, $source, $args ) {
+            return '#ff0000';
+        }, 10, 3 );
+        $html  = '<div class="wp-block">X</div>';
+        $block = $this->make_block( [
+            'dsgoStyleBinding' => [
+                '--brand' => [ 'source' => 'designsetgo/post-meta', 'args' => [ 'key' => 'color' ] ],
+            ],
+        ] );
+        $result = $sb->apply_style_bindings( $html, $block );
+        $this->assertStringContainsString( '--brand:#ff0000', $result );
+        remove_all_filters( 'designsetgo_style_binding_resolve' );
+    }
+
+    public function test_existing_style_attribute_is_preserved() {
+        $sb = new DesignSetGo\StyleBinding();
+        add_filter( 'designsetgo_style_binding_resolve', fn() => 'blue', 10, 3 );
+        $html  = '<div style="color:red">X</div>';
+        $block = $this->make_block( [
+            'dsgoStyleBinding' => [
+                'background-color' => [ 'source' => 'designsetgo/post-meta', 'args' => [ 'key' => 'bg' ] ],
+            ],
+        ] );
+        $result = $sb->apply_style_bindings( $html, $block );
+        $this->assertStringContainsString( 'color:red', $result );
+        $this->assertStringContainsString( 'background-color:blue', $result );
+        remove_all_filters( 'designsetgo_style_binding_resolve' );
+    }
+}
+```
+
+### Step 2: Run to confirm failure
+
+```bash
+npx wp-env run tests-cli vendor/bin/phpunit tests/phpunit/extensions/style-binding-test.php
+```
+
+Expected: FAIL — class `DesignSetGo\StyleBinding` not found.
+
+### Step 3: Create the PHP StyleBinding class
+
+Create `includes/class-style-binding.php`:
+
+```php
+<?php
+defined( 'ABSPATH' ) || exit;
+
+namespace DesignSetGo;
+
+/**
+ * Applies dsgoStyleBinding attribute values as inline CSS on block root elements.
+ *
+ * Resolves each bound property via the `designsetgo_style_binding_resolve` filter
+ * so third-party code can supply custom sources. Built-in sources: post-meta, acf,
+ * metabox, pods, jetengine — resolved directly against the current item's post ID
+ * (honours $GLOBALS['designsetgo_parent_stack'] for nested query loops).
+ */
+class StyleBinding {
+
+    public function __construct() {
+        add_filter( 'render_block', [ $this, 'apply_style_bindings' ], 5, 2 );
+    }
+
+    /**
+     * @param string $html  Rendered block HTML.
+     * @param array  $block Parsed block array.
+     * @return string
+     */
+    public function apply_style_bindings( string $html, array $block ): string {
+        $binding = $block['attrs']['dsgoStyleBinding'] ?? null;
+        if ( empty( $binding ) || ! is_array( $binding ) ) {
+            return $html;
+        }
+
+        $styles = [];
+        foreach ( $binding as $prop => $config ) {
+            if ( ! is_string( $prop ) || ! preg_match( '/^--[a-zA-Z][a-zA-Z0-9\-_]*$|^[a-z][a-z\-]*$/', $prop ) ) {
+                continue;
+            }
+            $source = sanitize_key( (string) ( $config['source'] ?? '' ) );
+            $args   = is_array( $config['args'] ?? null ) ? $config['args'] : [];
+
+            /**
+             * Filters the resolved value for a style binding.
+             *
+             * @param string|null $value  Resolved value, or null to skip.
+             * @param string      $source Binding source slug.
+             * @param array       $args   Binding args.
+             */
+            $value = apply_filters( 'designsetgo_style_binding_resolve', $this->resolve( $source, $args ), $source, $args );
+
+            if ( null === $value || '' === $value ) {
+                continue;
+            }
+            // Reject dangerous CSS values.
+            if ( preg_match( '/url\s*\(|expression\s*\(|javascript:/i', $value ) ) {
+                continue;
+            }
+            $styles[] = esc_attr( $prop ) . ':' . esc_attr( $value );
+        }
+
+        if ( empty( $styles ) ) {
+            return $html;
+        }
+
+        $processor = new \WP_HTML_Tag_Processor( $html );
+        if ( ! $processor->next_tag() ) {
+            return $html;
+        }
+        $existing = (string) ( $processor->get_attribute( 'style' ) ?? '' );
+        $sep      = ( '' !== $existing && ! str_ends_with( rtrim( $existing ), ';' ) ) ? ';' : '';
+        $processor->set_attribute( 'style', $existing . $sep . implode( ';', $styles ) );
+
+        return $processor->get_updated_html();
+    }
+
+    /**
+     * Resolves a binding source+args to a scalar string value.
+     * Returns null when the source is unsupported or returns no value.
+     *
+     * @param string $source Binding source slug.
+     * @param array  $args   Binding args.
+     * @return string|null
+     */
+    private function resolve( string $source, array $args ): ?string {
+        $post_id = $this->current_post_id();
+
+        switch ( $source ) {
+            case 'designsetgo/post-meta':
+                $key = sanitize_key( (string) ( $args['key'] ?? '' ) );
+                if ( ! $key || ! $post_id ) {
+                    return null;
+                }
+                $val = get_post_meta( $post_id, $key, true );
+                return is_scalar( $val ) ? (string) $val : null;
+
+            case 'designsetgo/acf':
+                if ( ! function_exists( 'get_field' ) ) {
+                    return null;
+                }
+                $name = sanitize_text_field( (string) ( $args['name'] ?? '' ) );
+                if ( ! $name || ! $post_id ) {
+                    return null;
+                }
+                $val = get_field( $name, $post_id );
+                return is_scalar( $val ) ? (string) $val : null;
+
+            case 'designsetgo/metabox':
+                if ( ! function_exists( 'rwmb_meta' ) ) {
+                    return null;
+                }
+                $id  = sanitize_key( (string) ( $args['id'] ?? '' ) );
+                $val = $id && $post_id ? rwmb_meta( $id, [], $post_id ) : null;
+                return is_scalar( $val ) ? (string) $val : null;
+
+            case 'designsetgo/pods':
+                if ( ! function_exists( 'pods_field' ) ) {
+                    return null;
+                }
+                $field = sanitize_text_field( (string) ( $args['field'] ?? '' ) );
+                $val   = $field && $post_id ? pods_field( $field, $post_id ) : null;
+                return is_scalar( $val ) ? (string) $val : null;
+
+            case 'designsetgo/jetengine':
+                if ( ! isset( jet_engine()->listings->data ) ) {
+                    return null;
+                }
+                $key = sanitize_key( (string) ( $args['key'] ?? '' ) );
+                if ( ! $key || ! $post_id ) {
+                    return null;
+                }
+                $val = jet_engine()->listings->data->get_meta( $key )
+                    ?? get_post_meta( $post_id, $key, true );
+                return is_scalar( $val ) ? (string) $val : null;
+
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Returns the post ID for the current rendering context, honouring nested query loops.
+     *
+     * @return int|null
+     */
+    private function current_post_id(): ?int {
+        $stack = $GLOBALS['designsetgo_parent_stack'] ?? [];
+        if ( ! empty( $stack ) ) {
+            $top = end( $stack );
+            return (int) ( $top['postId'] ?? 0 ) ?: null;
+        }
+        $id = get_the_ID();
+        return $id ? (int) $id : null;
+    }
+}
+```
+
+### Step 4: Register the class in class-plugin.php
+
+In `includes/class-plugin.php`, after the other block/extension requires, add:
+
+```php
+require_once plugin_dir_path( __FILE__ ) . 'class-style-binding.php';
+```
+
+And instantiate it in the constructor or `init()`:
+
+```php
+new \DesignSetGo\StyleBinding();
+```
+
+### Step 5: Run PHP tests — expect pass
+
+```bash
+npx wp-env run tests-cli vendor/bin/phpunit tests/phpunit/extensions/style-binding-test.php
+```
+
+All expected: PASS.
+
+### Step 6: Write failing JS test
+
+Create `tests/unit/extensions/style-binding.test.js`:
+
+```js
+import { dispatch } from '@wordpress/data';
+
+// Mock @wordpress/blocks getBlockType
+jest.mock( '@wordpress/blocks', () => ( {
+    getBlockTypes: () => [],
+} ) );
+
+describe( 'style-binding extension', () => {
+    it( 'registers dsgoStyleBinding attribute on block registration', () => {
+        // Import triggers the addFilter hook
+        require( '../../../src/extensions/style-binding/filters' );
+
+        // The filter must be registered (we can verify the hook exists)
+        const hooks = require( '@wordpress/hooks' );
+        // filters.js adds to 'blocks.registerBlockType'
+        // Verify by calling the registered filter with a mock block settings object
+        const result = wp.hooks.applyFilters(
+            'blocks.registerBlockType',
+            { attributes: {} },
+            'core/paragraph'
+        );
+        expect( result.attributes ).toHaveProperty( 'dsgoStyleBinding' );
+        expect( result.attributes.dsgoStyleBinding.type ).toBe( 'object' );
+    } );
+} );
+```
+
+### Step 7: Run JS test — expect failure
+
+```bash
+npx wp-scripts test-unit-js tests/unit/extensions/style-binding.test.js
+```
+
+Expected: FAIL — module not found.
+
+### Step 8: Create the JS extension files
+
+Create `src/extensions/style-binding/filters.js`:
+
+```js
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, Button, SelectControl, TextControl, HStack, VStack } from '@wordpress/components';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { Fragment } from '@wordpress/element';
+
+const SOURCE_OPTIONS = [
+    { label: __( 'Post meta', 'designsetgo' ), value: 'designsetgo/post-meta' },
+    { label: __( 'ACF', 'designsetgo' ), value: 'designsetgo/acf' },
+    { label: __( 'Meta Box', 'designsetgo' ), value: 'designsetgo/metabox' },
+    { label: __( 'Pods', 'designsetgo' ), value: 'designsetgo/pods' },
+    { label: __( 'JetEngine', 'designsetgo' ), value: 'designsetgo/jetengine' },
+];
+
+// 1. Register dsgoStyleBinding attribute on every block type.
+addFilter(
+    'blocks.registerBlockType',
+    'designsetgo/style-binding-attribute',
+    ( settings ) => {
+        if ( ! settings.attributes ) {
+            settings.attributes = {};
+        }
+        settings.attributes.dsgoStyleBinding = {
+            type: 'object',
+            default: {},
+        };
+        return settings;
+    }
+);
+
+// 2. Add inspector UI under Advanced controls.
+const withStyleBindingInspector = createHigherOrderComponent( ( BlockEdit ) => {
+    return function WithStyleBindingInspector( props ) {
+        const { attributes, setAttributes } = props;
+        const binding = attributes.dsgoStyleBinding ?? {};
+        const entries = Object.entries( binding );
+
+        const updateEntry = ( oldProp, newProp, config ) => {
+            const next = { ...binding };
+            if ( oldProp !== newProp ) {
+                delete next[ oldProp ];
+            }
+            next[ newProp ] = config;
+            setAttributes( { dsgoStyleBinding: next } );
+        };
+
+        const removeEntry = ( prop ) => {
+            const next = { ...binding };
+            delete next[ prop ];
+            setAttributes( { dsgoStyleBinding: next } );
+        };
+
+        const addEntry = () => {
+            const key = `--dsgo-binding-${ Date.now() }`;
+            setAttributes( {
+                dsgoStyleBinding: {
+                    ...binding,
+                    [ key ]: { source: 'designsetgo/post-meta', args: { key: '' } },
+                },
+            } );
+        };
+
+        return (
+            <Fragment>
+                <BlockEdit { ...props } />
+                <InspectorControls group="advanced">
+                    <PanelBody
+                        title={ __( 'Style Bindings', 'designsetgo' ) }
+                        initialOpen={ entries.length > 0 }
+                    >
+                        { entries.map( ( [ prop, config ] ) => (
+                            <VStack key={ prop } spacing={ 1 } style={ { marginBottom: '12px' } }>
+                                <HStack>
+                                    <TextControl
+                                        label={ __( 'CSS property', 'designsetgo' ) }
+                                        value={ prop }
+                                        placeholder="--brand-color"
+                                        onChange={ ( val ) => updateEntry( prop, val, config ) }
+                                        __nextHasNoMarginBottom
+                                    />
+                                    <Button
+                                        variant="tertiary"
+                                        isDestructive
+                                        size="small"
+                                        onClick={ () => removeEntry( prop ) }
+                                        style={ { alignSelf: 'flex-end' } }
+                                    >
+                                        { __( 'Remove', 'designsetgo' ) }
+                                    </Button>
+                                </HStack>
+                                <SelectControl
+                                    label={ __( 'Source', 'designsetgo' ) }
+                                    value={ config.source }
+                                    options={ SOURCE_OPTIONS }
+                                    onChange={ ( val ) => updateEntry( prop, prop, { ...config, source: val } ) }
+                                    __nextHasNoMarginBottom
+                                />
+                                <TextControl
+                                    label={ __( 'Field key / name', 'designsetgo' ) }
+                                    value={ config.args?.key ?? config.args?.name ?? config.args?.id ?? config.args?.field ?? '' }
+                                    onChange={ ( val ) => {
+                                        const argKey = [ 'designsetgo/acf' ].includes( config.source ) ? 'name'
+                                            : [ 'designsetgo/pods' ].includes( config.source ) ? 'field'
+                                            : 'key';
+                                        updateEntry( prop, prop, { ...config, args: { [ argKey ]: val } } );
+                                    } }
+                                    __nextHasNoMarginBottom
+                                />
+                            </VStack>
+                        ) ) }
+                        <Button variant="secondary" size="small" onClick={ addEntry } __next40pxDefaultSize>
+                            { __( '+ Add style binding', 'designsetgo' ) }
+                        </Button>
+                    </PanelBody>
+                </InspectorControls>
+            </Fragment>
+        );
+    };
+}, 'withStyleBindingInspector' );
+
+addFilter(
+    'editor.BlockEdit',
+    'designsetgo/style-binding-inspector',
+    withStyleBindingInspector
+);
+```
+
+Create `src/extensions/style-binding/index.js`:
+
+```js
+import './filters';
+```
+
+### Step 9: Import in src/index.js
+
+In `src/index.js`, add alongside the other extension imports:
+
+```js
+import './extensions/style-binding';
+```
+
+### Step 10: Run JS test — expect pass
+
+```bash
+npx wp-scripts test-unit-js tests/unit/extensions/style-binding.test.js
+```
+
+### Step 11: Build and lint
+
+```bash
+npm run build && npm run lint:js && npm run lint:php
+```
+
+### Step 12: Commit
+
+```bash
+git add src/extensions/style-binding/filters.js \
+        src/extensions/style-binding/index.js \
+        src/index.js \
+        includes/class-style-binding.php \
+        includes/class-plugin.php \
+        tests/phpunit/extensions/style-binding-test.php \
+        tests/unit/extensions/style-binding.test.js
+git commit -m "feat(query): add dynamic CSS style bindings from meta/ACF/MetaBox/Pods/JetEngine"
+```
+
+---
+
+## Task 7: CHANGELOG + CLAUDE.md update
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `.claude/CLAUDE.md`
+
+**Step 1: Update CHANGELOG.md**
+
+Under `[Unreleased]`, add:
+
+```markdown
+### Added
+- Date Query Builder: inspector UI for `before`/`after`/`between` date filters with relative expression support (`-30 days`, `today`).
+- Multi-level AND/OR filter groups: TaxQueryBuilder and MetaQueryBuilder now support nested `{relation, clauses}` groups at any depth.
+- Hierarchical taxonomy drilldown: per-clause `include_children` toggle in TaxQueryBuilder (defaults `true`).
+- Query Monitor panel: when QM is active, a "DSGo (N)" panel in the QM toolbar shows per-render query args, found-posts count, duration, and SQL.
+- Dynamic CSS style bindings: `dsgoStyleBinding` attribute on every block maps CSS property names → DSGo binding source + key. Values injected as inline styles on the block root element via `render_block` filter.
+```
+
+**Step 2: Update CLAUDE.md**
+
+In the `### Query block family (Dynamic Query v2.5)` section (add it), document:
+
+```markdown
+### Query block family (Dynamic Query v2.5)
+
+- `dateQuery` attribute on `designsetgo/query` — shape `{ relation, clauses: [{ column, mode, after, before, inclusive }] }`. Supported modes: `after`, `before`, `between`. Date values: ISO `YYYY-MM-DD` or PHP relative expressions (`-30 days`, `today`).
+- `taxQuery.clauses[]` entries may now be leaf clauses OR nested groups (`{ relation, clauses: [...] }`). PHP builder: `designsetgo_build_tax_query_entry()` (recursive). Same pattern for `metaQuery` via `designsetgo_build_meta_query_entry()`.
+- `include_children` field on each `taxQuery` leaf clause — boolean, defaults `true`. Pass-through to WP_Query `tax_query`.
+- `<ClauseGroupShell>` (`src/blocks/query/components/ClauseGroupShell.js`) — shared recursive group chrome (relation selector, + Clause, + Group, Remove group). Used by both TaxQueryBuilder and MetaQueryBuilder via `renderClause` render prop.
+- Query Monitor panel: `includes/class-query-qm-collector.php` + `includes/class-query-qm-output.php`. Loaded only when `defined('QM_VERSION')`. Collects data via `designsetgo_query_did_render` action fired from `render-helpers.php` after each WP_Query.
+- Dynamic CSS style bindings: `dsgoStyleBinding` global attribute (`src/extensions/style-binding/filters.js`) maps CSS property names (including custom properties `--foo`) → binding source+key. PHP: `DesignSetGo\StyleBinding` (`includes/class-style-binding.php`) resolves via `designsetgo_style_binding_resolve` filter and injects via `WP_HTML_Tag_Processor`. Honours `$GLOBALS['designsetgo_parent_stack']` for nested loop context. Dangerous values (`url(`, `expression(`, `javascript:`) rejected.
+```
+
+**Step 3: Commit**
+
+```bash
+git add CHANGELOG.md .claude/CLAUDE.md
+git commit -m "docs: update CHANGELOG and CLAUDE.md for Dynamic Query v2.5"
+```
+
+---
+
+## Verification checklist (ship gate)
+
+- [ ] `npm run build` — no errors, only the pre-existing slider/modal size warnings
+- [ ] `npm run lint:js && npm run lint:css && npm run lint:php` — all clean
+- [ ] `npx wp-env run tests-cli vendor/bin/phpunit tests/phpunit/blocks/query/` — all pass
+- [ ] `npx wp-scripts test-unit-js tests/unit/blocks/query/` — all pass
+- [ ] TaxQueryBuilder: `include_children` toggle visible per clause, PHP sends correct value
+- [ ] TaxQueryBuilder: "Add Group" button creates a nested group; nested group renders relation selector + its own clauses
+- [ ] MetaQueryBuilder: same nested group behavior
+- [ ] DateQueryBuilder: `between` mode shows both After and Before fields; `after`/`before` modes show only the relevant field
+- [ ] QM panel appears in QM toolbar when Query Monitor is active and page renders a DSGo query block
+- [ ] QM panel absent (no errors) when Query Monitor is not installed
+- [ ] Style binding: `dsgoStyleBinding` attribute visible in Advanced inspector for every block
+- [ ] Style binding: Add/remove binding rows work; CSS prop + source + key inputs save correctly
+- [ ] Style binding: PHP injects inline style on block root element with resolved meta value
+- [ ] Style binding: dangerous values (`url()`, `expression()`, `javascript:`) silently rejected
+- [ ] Style binding: existing `style` attribute preserved when new bindings are appended
+- [ ] CHANGELOG entry lives under `[Unreleased]`; plugin version stays at 2.1.0

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -553,11 +553,20 @@ class Plugin {
 			Blocks\Query\FilterIndexCLI::register();
 		}
 
-		// Query Monitor integration — loads only when QM is active.
-		if ( defined( 'QM_VERSION' ) ) {
-			require_once DESIGNSETGO_PATH . 'includes/class-query-qm-collector.php';
-			require_once DESIGNSETGO_PATH . 'includes/class-query-qm-output.php';
-		}
+		// Query Monitor integration — deferred to plugins_loaded so QM has finished
+		// loading regardless of plugin order; the files themselves bail if the QM
+		// base classes still aren't present at the deferred point.
+		add_action(
+			'plugins_loaded',
+			static function () {
+				if ( ! class_exists( '\QM_Collector' ) ) {
+					return;
+				}
+				require_once DESIGNSETGO_PATH . 'includes/class-query-qm-collector.php';
+				require_once DESIGNSETGO_PATH . 'includes/class-query-qm-output.php';
+			},
+			20
+		);
 
 		require_once DESIGNSETGO_PATH . 'includes/patterns/class-loader.php';
 		require_once DESIGNSETGO_PATH . 'includes/admin/class-global-styles.php';

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -459,6 +459,13 @@ class Plugin {
 	public $extension_attrs;
 
 	/**
+	 * Style Binding instance.
+	 *
+	 * @var StyleBinding
+	 */
+	public $style_binding;
+
+	/**
 	 * Query Block Controller instance.
 	 *
 	 * @var Blocks\Query\Controller
@@ -572,6 +579,7 @@ class Plugin {
 		require_once DESIGNSETGO_PATH . 'includes/class-icon-injector.php';
 		require_once DESIGNSETGO_PATH . 'includes/class-button-global-styles.php';
 		require_once DESIGNSETGO_PATH . 'includes/class-extension-attributes.php';
+		require_once DESIGNSETGO_PATH . 'includes/class-style-binding.php';
 		require_once DESIGNSETGO_PATH . 'includes/svg-pattern-data.php';
 		require_once DESIGNSETGO_PATH . 'includes/class-svg-pattern-renderer.php';
 
@@ -617,6 +625,7 @@ class Plugin {
 		$this->assets              = new Assets();
 		$this->blocks              = new Blocks\Loader();
 		$this->extension_attrs     = new Extension_Attributes();
+		$this->style_binding       = new StyleBinding();
 		$this->modal_hooks         = new Blocks\Modal_Hooks();
 		$this->form_handler        = new Blocks\Form_Handler();
 		$this->form_submissions    = new Blocks\Form_Submissions();

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -545,6 +545,13 @@ class Plugin {
 			require_once DESIGNSETGO_PATH . 'includes/blocks/class-query-filter-index-cli.php';
 			Blocks\Query\FilterIndexCLI::register();
 		}
+
+		// Query Monitor integration — loads only when QM is active.
+		if ( defined( 'QM_VERSION' ) ) {
+			require_once DESIGNSETGO_PATH . 'includes/class-query-qm-collector.php';
+			require_once DESIGNSETGO_PATH . 'includes/class-query-qm-output.php';
+		}
+
 		require_once DESIGNSETGO_PATH . 'includes/patterns/class-loader.php';
 		require_once DESIGNSETGO_PATH . 'includes/admin/class-global-styles.php';
 		require_once DESIGNSETGO_PATH . 'includes/admin/class-settings.php';

--- a/includes/class-query-qm-collector.php
+++ b/includes/class-query-qm-collector.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Query Monitor collector for DesignSetGo Dynamic Query.
+ *
+ * @package DesignSetGo
+ * @since 2.5.0
+ */
+
+namespace DesignSetGo\QueryMonitor;
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( '\QM_Collector' ) ) {
+	return;
+}
+
+/**
+ * Query Monitor data collector for DesignSetGo queries.
+ */
+class Collector extends \QM_Collector {
+
+	/**
+	 * Collector ID used by QM to reference this collector.
+	 *
+	 * @var string
+	 */
+	public $id = 'dsgo_queries';
+
+	/**
+	 * Captured query render data entries.
+	 *
+	 * @var array[]
+	 */
+	private array $renders = array();
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+		add_action( 'designsetgo_query_did_render', array( $this, 'capture' ) );
+	}
+
+	/**
+	 * Capture a query render data snapshot.
+	 *
+	 * @param array $data Associative array with keys: query_id, source, wp_args,
+	 *                    found_posts, sql, filters, duration_ms.
+	 * @return void
+	 */
+	public function capture( array $data ): void {
+		$this->renders[] = $data;
+	}
+
+	/**
+	 * Process captured data before output.
+	 *
+	 * @return void
+	 */
+	public function process(): void {
+		$this->data['renders'] = $this->renders;
+		$this->data['count']   = count( $this->renders );
+	}
+
+	/**
+	 * Human-readable collector name shown in the QM panel list.
+	 *
+	 * @return string
+	 */
+	public function name(): string {
+		return __( 'DSGo Queries', 'designsetgo' );
+	}
+}
+
+add_filter(
+	'qm/collectors',
+	static function ( array $collectors ) {
+		$collectors['dsgo_queries'] = new Collector();
+		return $collectors;
+	}
+);

--- a/includes/class-query-qm-output.php
+++ b/includes/class-query-qm-output.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Query Monitor HTML output for DesignSetGo Dynamic Query.
+ *
+ * @package DesignSetGo
+ * @since 2.5.0
+ */
+
+namespace DesignSetGo\QueryMonitor;
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( '\QM_Output_Html' ) ) {
+	return;
+}
+
+/**
+ * Query Monitor HTML output for DesignSetGo queries.
+ */
+class OutputHtml extends \QM_Output_Html {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param \QM_Collector $collector The data collector instance.
+	 */
+	public function __construct( \QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 80 );
+	}
+
+	/**
+	 * Human-readable panel name shown in QM UI.
+	 *
+	 * @return string
+	 */
+	public function name(): string {
+		return __( 'DSGo Queries', 'designsetgo' );
+	}
+
+	/**
+	 * Render the QM panel HTML.
+	 *
+	 * @return void
+	 */
+	public function output(): void {
+		$data    = $this->collector->get_data();
+		$renders = $data['renders'] ?? array();
+
+		$this->before_non_tabular_output();
+
+		if ( empty( $renders ) ) {
+			echo '<p>' . esc_html__( 'No DSGo queries ran on this request.', 'designsetgo' ) . '</p>';
+			$this->after_non_tabular_output();
+			return;
+		}
+
+		echo '<p>' . esc_html(
+			sprintf(
+				/* translators: %d: number of queries */
+				_n( '%d DSGo query ran on this request.', '%d DSGo queries ran on this request.', count( $renders ), 'designsetgo' ),
+				count( $renders )
+			)
+		) . '</p>';
+
+		echo '<style>.dsgo-qm-pre{margin:0;white-space:pre-wrap}</style>';
+
+		foreach ( $renders as $i => $r ) {
+			echo '<h3>' . esc_html( sprintf( '#%d — %s (%s)', $i + 1, $r['query_id'], $r['source'] ) ) . '</h3>';
+			echo '<table class="qm-sortable"><thead><tr>';
+			echo '<th>' . esc_html__( 'Property', 'designsetgo' ) . '</th>';
+			echo '<th>' . esc_html__( 'Value', 'designsetgo' ) . '</th>';
+			echo '</tr></thead><tbody>';
+
+			$rows = array(
+				__( 'Found posts', 'designsetgo' )   => $r['found_posts'],
+				__( 'Duration (ms)', 'designsetgo' ) => $r['duration_ms'],
+				__( 'WP_Query args', 'designsetgo' ) => '<pre class="dsgo-qm-pre">' . esc_html( wp_json_encode( $r['wp_args'], JSON_PRETTY_PRINT ) ) . '</pre>',
+				__( 'SQL', 'designsetgo' )            => '<code>' . esc_html( $r['sql'] ) . '</code>',
+			);
+
+			foreach ( $rows as $label => $value ) {
+				echo '<tr><td>' . esc_html( $label ) . '</td><td>' . wp_kses_post( $value ) . '</td></tr>';
+			}
+
+			echo '</tbody></table>';
+		}
+
+		$this->after_non_tabular_output();
+	}
+
+	/**
+	 * Register this panel in the QM admin bar menu.
+	 *
+	 * @param array $menu Existing QM menu entries.
+	 * @return array Modified menu entries.
+	 */
+	public function admin_menu( array $menu ): array {
+		$data  = $this->collector->get_data();
+		$count = $data['count'] ?? 0;
+
+		$menu[ $this->collector->id ] = $this->menu(
+			array(
+				'title' => esc_html(
+					sprintf(
+						/* translators: %d: query count */
+						_n( 'DSGo (%d)', 'DSGo (%d)', $count, 'designsetgo' ),
+						$count
+					)
+				),
+			)
+		);
+
+		return $menu;
+	}
+}
+
+add_filter(
+	'qm/outputter/html',
+	static function ( array $outputters, array $collectors ) {
+		if ( isset( $collectors['dsgo_queries'] ) ) {
+			$outputters['dsgo_queries'] = new OutputHtml( $collectors['dsgo_queries'] );
+		}
+		return $outputters;
+	},
+	80,
+	2
+);

--- a/includes/class-style-binding.php
+++ b/includes/class-style-binding.php
@@ -110,13 +110,14 @@ class StyleBinding {
 	 */
 	private function resolve( string $source, array $args ): ?string {
 		$post_id = $this->current_post_id();
+		$key     = sanitize_text_field( (string) ( $args['key'] ?? '' ) );
+
+		if ( ! $key || ! $post_id ) {
+			return null;
+		}
 
 		switch ( $source ) {
 			case 'designsetgo/post-meta':
-				$key = sanitize_text_field( (string) ( $args['key'] ?? '' ) );
-				if ( ! $key || ! $post_id ) {
-					return null;
-				}
 				$val = get_post_meta( $post_id, $key, true );
 				return is_scalar( $val ) ? (string) $val : null;
 
@@ -124,39 +125,29 @@ class StyleBinding {
 				if ( ! function_exists( 'get_field' ) ) {
 					return null;
 				}
-				$name = sanitize_text_field( (string) ( $args['name'] ?? '' ) );
-				if ( ! $name || ! $post_id ) {
-					return null;
-				}
-				$val = get_field( $name, $post_id );
+				$val = get_field( $key, $post_id );
 				return is_scalar( $val ) ? (string) $val : null;
 
 			case 'designsetgo/metabox':
 				if ( ! function_exists( 'rwmb_meta' ) ) {
 					return null;
 				}
-				$id  = sanitize_key( (string) ( $args['id'] ?? '' ) );
-				$val = $id && $post_id ? rwmb_meta( $id, array(), $post_id ) : null;
+				$val = rwmb_meta( $key, array(), $post_id );
 				return is_scalar( $val ) ? (string) $val : null;
 
 			case 'designsetgo/pods':
 				if ( ! function_exists( 'pods_field' ) ) {
 					return null;
 				}
-				$field = sanitize_text_field( (string) ( $args['field'] ?? '' ) );
-				$val   = $field && $post_id ? pods_field( $field, $post_id ) : null;
+				$val = pods_field( $key, $post_id );
 				return is_scalar( $val ) ? (string) $val : null;
 
 			case 'designsetgo/jetengine':
-				if ( ! function_exists( 'jet_engine' ) || ! isset( jet_engine()->listings->data ) ) {
-					return null;
+				if ( function_exists( 'jet_engine' ) && isset( jet_engine()->listings->data ) && method_exists( jet_engine()->listings->data, 'get_meta' ) ) {
+					$val = jet_engine()->listings->data->get_meta( $key, $post_id );
+				} else {
+					$val = get_post_meta( $post_id, $key, true );
 				}
-				$key = sanitize_text_field( (string) ( $args['key'] ?? '' ) );
-				if ( ! $key || ! $post_id ) {
-					return null;
-				}
-				$val = jet_engine()->listings->data->get_meta( $key )
-					?? get_post_meta( $post_id, $key, true );
 				return is_scalar( $val ) ? (string) $val : null;
 
 			default:

--- a/includes/class-style-binding.php
+++ b/includes/class-style-binding.php
@@ -41,8 +41,9 @@ class StyleBinding {
 
 		$styles = array();
 		foreach ( $binding as $prop => $config ) {
-			// Validate CSS property: custom property or standard property.
-			if ( ! is_string( $prop ) || ! preg_match( '/^--[a-zA-Z][a-zA-Z0-9\-_]*$|^[a-z][a-z\-]*$/', $prop ) ) {
+			// Validate CSS property: custom property (--foo) or standard property
+			// including vendor prefix (-webkit-…) and digits (line2-color etc.).
+			if ( ! is_string( $prop ) || ! preg_match( '/^--[a-zA-Z][a-zA-Z0-9\-_]*$|^-?[a-z][a-z0-9\-]*$/', $prop ) ) {
 				continue;
 			}
 
@@ -73,12 +74,13 @@ class StyleBinding {
 				continue;
 			}
 
-			// Reject values that could execute code.
-			if ( preg_match( '/url\s*\(|expression\s*\(|javascript:/i', $value ) ) {
+			// Reject values that could execute code or break out of the
+			// declaration: url(), expression(), javascript:/data: schemes,
+			// CSS curly braces, and embedded semicolons.
+			if ( preg_match( '/url\s*\(|expression\s*\(|javascript:|data:/i', $value ) ) {
 				continue;
 			}
-			// Reject values containing semicolons to prevent CSS declaration injection.
-			if ( str_contains( $value, ';' ) ) {
+			if ( false !== strpbrk( $value, ';{}' ) ) {
 				continue;
 			}
 
@@ -113,6 +115,23 @@ class StyleBinding {
 		$key     = sanitize_text_field( (string) ( $args['key'] ?? '' ) );
 
 		if ( ! $key || ! $post_id ) {
+			return null;
+		}
+
+		// Apply the same security gates the v2.4 block bindings adapter uses
+		// (see includes/blocks/class-query-bindings-helpers.php) so style
+		// bindings cannot leak data block bindings would withhold.
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return null;
+		}
+		if ( post_password_required( $post ) ) {
+			return null;
+		}
+		if ( ! is_post_publicly_viewable( $post ) && ! current_user_can( 'read_post', $post_id ) ) {
+			return null;
+		}
+		if ( is_protected_meta( $key, 'post' ) ) {
 			return null;
 		}
 

--- a/includes/class-style-binding.php
+++ b/includes/class-style-binding.php
@@ -50,7 +50,7 @@ class StyleBinding {
 				continue;
 			}
 
-			$source = sanitize_key( (string) ( $config['source'] ?? '' ) );
+			$source = sanitize_text_field( (string) ( $config['source'] ?? '' ) );
 			$args   = is_array( $config['args'] ?? null ) ? $config['args'] : array();
 
 			/**
@@ -82,7 +82,7 @@ class StyleBinding {
 				continue;
 			}
 
-			$styles[] = esc_attr( $prop ) . ':' . esc_attr( $value );
+			$styles[] = $prop . ':' . $value;
 		}
 
 		if ( empty( $styles ) ) {
@@ -113,7 +113,7 @@ class StyleBinding {
 
 		switch ( $source ) {
 			case 'designsetgo/post-meta':
-				$key = sanitize_key( (string) ( $args['key'] ?? '' ) );
+				$key = sanitize_text_field( (string) ( $args['key'] ?? '' ) );
 				if ( ! $key || ! $post_id ) {
 					return null;
 				}
@@ -151,7 +151,7 @@ class StyleBinding {
 				if ( ! function_exists( 'jet_engine' ) || ! isset( jet_engine()->listings->data ) ) {
 					return null;
 				}
-				$key = sanitize_key( (string) ( $args['key'] ?? '' ) );
+				$key = sanitize_text_field( (string) ( $args['key'] ?? '' ) );
 				if ( ! $key || ! $post_id ) {
 					return null;
 				}

--- a/includes/class-style-binding.php
+++ b/includes/class-style-binding.php
@@ -77,6 +77,10 @@ class StyleBinding {
 			if ( preg_match( '/url\s*\(|expression\s*\(|javascript:/i', $value ) ) {
 				continue;
 			}
+			// Reject values containing semicolons to prevent CSS declaration injection.
+			if ( str_contains( $value, ';' ) ) {
+				continue;
+			}
 
 			$styles[] = esc_attr( $prop ) . ':' . esc_attr( $value );
 		}

--- a/includes/class-style-binding.php
+++ b/includes/class-style-binding.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Style Binding — resolves dsgoStyleBinding attribute into inline CSS.
+ *
+ * Registers a render_block filter that reads the dsgoStyleBinding attribute,
+ * resolves each CSS property → binding source → value, and injects the result
+ * as an inline style on the block's root element.
+ *
+ * @package DesignSetGo
+ * @since 2.5.0
+ */
+
+namespace DesignSetGo;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * StyleBinding class.
+ */
+class StyleBinding {
+
+	/**
+	 * Constructor — registers the render_block filter.
+	 */
+	public function __construct() {
+		add_filter( 'render_block', array( $this, 'apply_style_bindings' ), 5, 2 );
+	}
+
+	/**
+	 * Resolve dsgoStyleBinding entries and inject them as inline styles.
+	 *
+	 * @param string $html  Rendered block HTML.
+	 * @param array  $block Block data.
+	 * @return string Modified HTML.
+	 */
+	public function apply_style_bindings( string $html, array $block ): string {
+		$binding = $block['attrs']['dsgoStyleBinding'] ?? null;
+		if ( empty( $binding ) || ! is_array( $binding ) ) {
+			return $html;
+		}
+
+		$styles = array();
+		foreach ( $binding as $prop => $config ) {
+			// Validate CSS property: custom property or standard property.
+			if ( ! is_string( $prop ) || ! preg_match( '/^--[a-zA-Z][a-zA-Z0-9\-_]*$|^[a-z][a-z\-]*$/', $prop ) ) {
+				continue;
+			}
+
+			if ( ! is_array( $config ) ) {
+				continue;
+			}
+
+			$source = sanitize_key( (string) ( $config['source'] ?? '' ) );
+			$args   = is_array( $config['args'] ?? null ) ? $config['args'] : array();
+
+			/**
+			 * Filter: resolve a style binding value.
+			 *
+			 * Third-party sources can hook here to supply values for custom sources.
+			 *
+			 * @param string|null $value  Resolved value (may be null if unresolved).
+			 * @param string      $source Source identifier (e.g. 'designsetgo/post-meta').
+			 * @param array       $args   Source-specific arguments.
+			 */
+			$value = apply_filters(
+				'designsetgo_style_binding_resolve',
+				$this->resolve( $source, $args ),
+				$source,
+				$args
+			);
+
+			if ( null === $value || '' === $value ) {
+				continue;
+			}
+
+			// Reject values that could execute code.
+			if ( preg_match( '/url\s*\(|expression\s*\(|javascript:/i', $value ) ) {
+				continue;
+			}
+
+			$styles[] = esc_attr( $prop ) . ':' . esc_attr( $value );
+		}
+
+		if ( empty( $styles ) ) {
+			return $html;
+		}
+
+		$processor = new \WP_HTML_Tag_Processor( $html );
+		if ( ! $processor->next_tag() ) {
+			return $html;
+		}
+
+		$existing = (string) ( $processor->get_attribute( 'style' ) ?? '' );
+		$sep      = ( '' !== $existing && ! str_ends_with( rtrim( $existing ), ';' ) ) ? ';' : '';
+		$processor->set_attribute( 'style', $existing . $sep . implode( ';', $styles ) );
+
+		return $processor->get_updated_html();
+	}
+
+	/**
+	 * Resolve a binding value from a built-in source.
+	 *
+	 * @param string $source Source identifier.
+	 * @param array  $args   Source arguments.
+	 * @return string|null Resolved value, or null if unresolvable.
+	 */
+	private function resolve( string $source, array $args ): ?string {
+		$post_id = $this->current_post_id();
+
+		switch ( $source ) {
+			case 'designsetgo/post-meta':
+				$key = sanitize_key( (string) ( $args['key'] ?? '' ) );
+				if ( ! $key || ! $post_id ) {
+					return null;
+				}
+				$val = get_post_meta( $post_id, $key, true );
+				return is_scalar( $val ) ? (string) $val : null;
+
+			case 'designsetgo/acf':
+				if ( ! function_exists( 'get_field' ) ) {
+					return null;
+				}
+				$name = sanitize_text_field( (string) ( $args['name'] ?? '' ) );
+				if ( ! $name || ! $post_id ) {
+					return null;
+				}
+				$val = get_field( $name, $post_id );
+				return is_scalar( $val ) ? (string) $val : null;
+
+			case 'designsetgo/metabox':
+				if ( ! function_exists( 'rwmb_meta' ) ) {
+					return null;
+				}
+				$id  = sanitize_key( (string) ( $args['id'] ?? '' ) );
+				$val = $id && $post_id ? rwmb_meta( $id, array(), $post_id ) : null;
+				return is_scalar( $val ) ? (string) $val : null;
+
+			case 'designsetgo/pods':
+				if ( ! function_exists( 'pods_field' ) ) {
+					return null;
+				}
+				$field = sanitize_text_field( (string) ( $args['field'] ?? '' ) );
+				$val   = $field && $post_id ? pods_field( $field, $post_id ) : null;
+				return is_scalar( $val ) ? (string) $val : null;
+
+			case 'designsetgo/jetengine':
+				if ( ! function_exists( 'jet_engine' ) || ! isset( jet_engine()->listings->data ) ) {
+					return null;
+				}
+				$key = sanitize_key( (string) ( $args['key'] ?? '' ) );
+				if ( ! $key || ! $post_id ) {
+					return null;
+				}
+				$val = jet_engine()->listings->data->get_meta( $key )
+					?? get_post_meta( $post_id, $key, true );
+				return is_scalar( $val ) ? (string) $val : null;
+
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * Determine the current post ID, preferring the DSGo parent stack.
+	 *
+	 * @return int|null Post ID, or null if not in a post context.
+	 */
+	private function current_post_id(): ?int {
+		$stack = $GLOBALS['designsetgo_parent_stack'] ?? array();
+		if ( ! empty( $stack ) ) {
+			$top    = end( $stack );
+			$top_id = (int) ( $top['postId'] ?? 0 );
+			return $top_id ? $top_id : null;
+		}
+		$id = get_the_ID();
+		return $id ? (int) $id : null;
+	}
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,6 +15,10 @@ parameters:
 		- tests
 		- .wp-env
 		- includes/blocks/class-query-filter-index-cli.php
+		# Query Monitor integration: optional dependency, runtime-guarded with class_exists().
+		# QM stubs aren't available, so analysing extends \QM_Collector / \QM_Output_Html fails.
+		- includes/class-query-qm-collector.php
+		- includes/class-query-qm-output.php
 
 	# Bootstrap files for WordPress functions and plugin constants
 	bootstrapFiles:

--- a/src/blocks/query/block.json
+++ b/src/blocks/query/block.json
@@ -62,6 +62,10 @@
       "type": "object",
       "default": { "relation": "AND", "clauses": [] }
     },
+    "dateQuery": {
+      "type": "object",
+      "default": { "relation": "AND", "clauses": [] }
+    },
     "tagName": { "type": "string", "default": "ul" },
     "itemTagName": { "type": "string", "default": "li" },
     "columns": { "type": "number", "default": 1 },

--- a/src/blocks/query/components/ClauseGroupShell.js
+++ b/src/blocks/query/components/ClauseGroupShell.js
@@ -1,0 +1,97 @@
+import { __ } from '@wordpress/i18n';
+import { Button, SelectControl, __experimentalVStack as VStack } from '@wordpress/components';
+
+/**
+ * Reusable recursive group shell for tax/meta clause builders.
+ *
+ * Props:
+ *   group        - { relation, clauses }
+ *   onChange     - (patch) => void — called with { relation?, clauses? }
+ *   onRemove     - () => void | undefined — present on nested groups, absent on root
+ *   depth        - number (0 = root)
+ *   renderClause - (clause, idx, updateEntry, removeEntry) => JSX — renders one leaf clause
+ *   newClause    - object — default shape for a new leaf clause
+ */
+export default function ClauseGroupShell( {
+	group,
+	onChange,
+	onRemove,
+	depth = 0,
+	renderClause,
+	newClause,
+	isAddDisabled,
+} ) {
+	const { relation = 'AND', clauses = [] } = group;
+
+	const updateEntry = ( idx, patch ) => {
+		const next = clauses.map( ( c, i ) => ( i === idx ? { ...c, ...patch } : c ) );
+		onChange( { clauses: next } );
+	};
+
+	const replaceEntry = ( idx, entry ) => {
+		const next = clauses.map( ( c, i ) => ( i === idx ? entry : c ) );
+		onChange( { clauses: next } );
+	};
+
+	const removeEntry = ( idx ) =>
+		onChange( { clauses: clauses.filter( ( _, i ) => i !== idx ) } );
+
+	const addClause = () =>
+		onChange( { clauses: [ ...clauses, { ...newClause } ] } );
+
+	const addGroup = () =>
+		onChange( {
+			clauses: [ ...clauses, { relation: 'AND', clauses: [ { ...newClause } ] } ],
+		} );
+
+	return (
+		<VStack
+			spacing={ 2 }
+			className={ `dsgo-clause-group dsgo-clause-group--depth-${ depth }` }
+			style={ depth > 0 ? { paddingLeft: '12px', borderLeft: '2px solid var(--wp-admin-theme-color-darker-10, #ccc)' } : undefined }
+		>
+			{ ( clauses.length > 1 || depth > 0 ) && (
+				<SelectControl
+					label={ __( 'Match', 'designsetgo' ) }
+					value={ relation }
+					options={ [
+						{ label: __( 'All (AND)', 'designsetgo' ), value: 'AND' },
+						{ label: __( 'Any (OR)', 'designsetgo' ), value: 'OR' },
+					] }
+					onChange={ ( val ) => onChange( { relation: val } ) }
+					__nextHasNoMarginBottom
+				/>
+			) }
+
+			{ clauses.map( ( entry, idx ) =>
+				Array.isArray( entry.clauses ) ? (
+					<ClauseGroupShell
+						key={ idx }
+						group={ entry }
+						onChange={ ( patch ) => replaceEntry( idx, { ...entry, ...patch } ) }
+						onRemove={ () => removeEntry( idx ) }
+						depth={ depth + 1 }
+						renderClause={ renderClause }
+						newClause={ newClause }
+					/>
+				) : (
+					renderClause( entry, idx, updateEntry, removeEntry )
+				)
+			) }
+
+			<div className="dsgo-clause-group__actions">
+				<Button variant="secondary" size="small" onClick={ addClause } disabled={ isAddDisabled } __next40pxDefaultSize>
+					{ __( '+ Clause', 'designsetgo' ) }
+				</Button>
+				<Button variant="secondary" size="small" onClick={ addGroup } __next40pxDefaultSize>
+					{ __( '+ Group', 'designsetgo' ) }
+				</Button>
+				{ onRemove && (
+					<Button variant="tertiary" isDestructive size="small" onClick={ onRemove }>
+						{ __( 'Remove group', 'designsetgo' ) }
+					</Button>
+				) }
+			</div>
+		</VStack>
+	);
+}

--- a/src/blocks/query/components/ClauseGroupShell.js
+++ b/src/blocks/query/components/ClauseGroupShell.js
@@ -73,6 +73,7 @@ export default function ClauseGroupShell( {
 						depth={ depth + 1 }
 						renderClause={ renderClause }
 						newClause={ newClause }
+						isAddDisabled={ isAddDisabled }
 					/>
 				) : (
 					renderClause( entry, idx, updateEntry, removeEntry )
@@ -83,7 +84,7 @@ export default function ClauseGroupShell( {
 				<Button variant="secondary" size="small" onClick={ addClause } disabled={ isAddDisabled } __next40pxDefaultSize>
 					{ __( '+ Clause', 'designsetgo' ) }
 				</Button>
-				<Button variant="secondary" size="small" onClick={ addGroup } __next40pxDefaultSize>
+				<Button variant="secondary" size="small" onClick={ addGroup } disabled={ isAddDisabled } __next40pxDefaultSize>
 					{ __( '+ Group', 'designsetgo' ) }
 				</Button>
 				{ onRemove && (

--- a/src/blocks/query/components/ClauseGroupShell.js
+++ b/src/blocks/query/components/ClauseGroupShell.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Button, SelectControl, __experimentalVStack as VStack } from '@wordpress/components';
 
 /**
@@ -44,10 +44,25 @@ export default function ClauseGroupShell( {
 			clauses: [ ...clauses, { relation: 'AND', clauses: [ { ...newClause } ] } ],
 		} );
 
+	const groupLabel =
+		depth === 0
+			? __( 'top level', 'designsetgo' )
+			: sprintf(
+				/* translators: %d: nesting depth, where 1 is the first nested group. */
+				__( 'nested group level %d', 'designsetgo' ),
+				depth
+			);
+
 	return (
 		<VStack
 			spacing={ 2 }
 			className={ `dsgo-clause-group dsgo-clause-group--depth-${ depth }` }
+			role="group"
+			aria-label={ sprintf(
+				/* translators: %s: human label for the group's nesting depth. */
+				__( 'Filter clauses, %s', 'designsetgo' ),
+				groupLabel
+			) }
 			style={ depth > 0 ? { paddingLeft: '12px', borderLeft: '2px solid var(--wp-admin-theme-color-darker-10, #ccc)' } : undefined }
 		>
 			{ ( clauses.length > 1 || depth > 0 ) && (
@@ -81,14 +96,47 @@ export default function ClauseGroupShell( {
 			) }
 
 			<div className="dsgo-clause-group__actions">
-				<Button variant="secondary" size="small" onClick={ addClause } disabled={ isAddDisabled } __next40pxDefaultSize>
+				<Button
+					variant="secondary"
+					size="small"
+					onClick={ addClause }
+					disabled={ isAddDisabled }
+					aria-label={ sprintf(
+						/* translators: %s: human label for the group's nesting depth. */
+						__( 'Add clause to %s', 'designsetgo' ),
+						groupLabel
+					) }
+					__next40pxDefaultSize
+				>
 					{ __( '+ Clause', 'designsetgo' ) }
 				</Button>
-				<Button variant="secondary" size="small" onClick={ addGroup } disabled={ isAddDisabled } __next40pxDefaultSize>
+				<Button
+					variant="secondary"
+					size="small"
+					onClick={ addGroup }
+					disabled={ isAddDisabled }
+					aria-label={ sprintf(
+						/* translators: %s: human label for the group's nesting depth. */
+						__( 'Add group inside %s', 'designsetgo' ),
+						groupLabel
+					) }
+					__next40pxDefaultSize
+				>
 					{ __( '+ Group', 'designsetgo' ) }
 				</Button>
 				{ onRemove && (
-					<Button variant="tertiary" isDestructive size="small" onClick={ onRemove } __next40pxDefaultSize>
+					<Button
+						variant="tertiary"
+						isDestructive
+						size="small"
+						onClick={ onRemove }
+						aria-label={ sprintf(
+							/* translators: %s: human label for the group's nesting depth. */
+							__( 'Remove %s', 'designsetgo' ),
+							groupLabel
+						) }
+						__next40pxDefaultSize
+					>
 						{ __( 'Remove group', 'designsetgo' ) }
 					</Button>
 				) }

--- a/src/blocks/query/components/ClauseGroupShell.js
+++ b/src/blocks/query/components/ClauseGroupShell.js
@@ -87,7 +87,7 @@ export default function ClauseGroupShell( {
 					{ __( '+ Group', 'designsetgo' ) }
 				</Button>
 				{ onRemove && (
-					<Button variant="tertiary" isDestructive size="small" onClick={ onRemove }>
+					<Button variant="tertiary" isDestructive size="small" onClick={ onRemove } __next40pxDefaultSize>
 						{ __( 'Remove group', 'designsetgo' ) }
 					</Button>
 				) }

--- a/src/blocks/query/components/DateQueryBuilder.js
+++ b/src/blocks/query/components/DateQueryBuilder.js
@@ -170,6 +170,7 @@ export default function DateQueryBuilder({
 										'Remove date clause',
 										'designsetgo'
 									)}
+									__next40pxDefaultSize
 								>
 									{__('Remove', 'designsetgo')}
 								</Button>
@@ -177,7 +178,7 @@ export default function DateQueryBuilder({
 						);
 					})}
 
-					<Button variant="secondary" onClick={addClause}>
+					<Button variant="secondary" onClick={addClause} __next40pxDefaultSize>
 						{__('Add date clause', 'designsetgo')}
 					</Button>
 				</VStack>

--- a/src/blocks/query/components/DateQueryBuilder.js
+++ b/src/blocks/query/components/DateQueryBuilder.js
@@ -1,0 +1,187 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis -- experimental layout/control primitives intentionally used; stable replacements not yet available */
+import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	SelectControl,
+	TextControl,
+	ToggleControl,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { DsgoInspectorPanel } from '../../../components/shared';
+
+const COLUMN_OPTIONS = [
+	{ value: 'post_date', label: __('Post Date', 'designsetgo') },
+	{ value: 'post_modified', label: __('Post Modified', 'designsetgo') },
+	{ value: 'post_date_gmt', label: __('Post Date (GMT)', 'designsetgo') },
+	{
+		value: 'post_modified_gmt',
+		label: __('Post Modified (GMT)', 'designsetgo'),
+	},
+];
+
+const MODE_OPTIONS = [
+	{ value: 'after', label: __('After', 'designsetgo') },
+	{ value: 'before', label: __('Before', 'designsetgo') },
+	{ value: 'between', label: __('Between', 'designsetgo') },
+];
+
+const EMPTY_DEFAULT = { relation: 'AND', clauses: [] };
+
+const DEFAULT_CLAUSE = {
+	column: 'post_date',
+	mode: 'after',
+	after: '',
+	before: '',
+	inclusive: true,
+};
+
+export default function DateQueryBuilder({
+	attributes,
+	setAttributes,
+	clientId,
+}) {
+	const { dateQuery } = attributes;
+
+	const updateClause = (i, patch) => {
+		const next = [...dateQuery.clauses];
+		next[i] = { ...next[i], ...patch };
+		setAttributes({ dateQuery: { ...dateQuery, clauses: next } });
+	};
+
+	const removeClause = (i) => {
+		setAttributes({
+			dateQuery: {
+				...dateQuery,
+				clauses: dateQuery.clauses.filter((_, idx) => idx !== i),
+			},
+		});
+	};
+
+	const addClause = () => {
+		setAttributes({
+			dateQuery: {
+				...dateQuery,
+				clauses: [...dateQuery.clauses, { ...DEFAULT_CLAUSE }],
+			},
+		});
+	};
+
+	return (
+		<DsgoInspectorPanel
+			title={__('Settings', 'designsetgo')}
+			panelName="settings"
+			panelId={clientId}
+			resetAll={() => setAttributes({ dateQuery: EMPTY_DEFAULT })}
+		>
+			<DsgoInspectorPanel.Item
+				label={__('Date query', 'designsetgo')}
+				hasValue={() => dateQuery.clauses.length > 0}
+				onDeselect={() => setAttributes({ dateQuery: EMPTY_DEFAULT })}
+				isShownByDefault
+			>
+				<VStack spacing={3}>
+					{dateQuery.clauses.length > 1 && (
+						<SelectControl
+							label={__('Relation', 'designsetgo')}
+							value={dateQuery.relation}
+							options={[
+								{ value: 'AND', label: 'AND' },
+								{ value: 'OR', label: 'OR' },
+							]}
+							onChange={(v) =>
+								setAttributes({
+									dateQuery: { ...dateQuery, relation: v },
+								})
+							}
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+					)}
+
+					{dateQuery.clauses.map((clause, i) => {
+						const showAfter =
+							clause.mode === 'after' ||
+							clause.mode === 'between';
+						const showBefore =
+							clause.mode === 'before' ||
+							clause.mode === 'between';
+						return (
+							<VStack key={i} spacing={2}>
+								<HStack>
+									<SelectControl
+										label={__('Column', 'designsetgo')}
+										value={clause.column}
+										options={COLUMN_OPTIONS}
+										onChange={(v) =>
+											updateClause(i, { column: v })
+										}
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+									/>
+									<SelectControl
+										label={__('Mode', 'designsetgo')}
+										value={clause.mode}
+										options={MODE_OPTIONS}
+										onChange={(v) =>
+											updateClause(i, { mode: v })
+										}
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+									/>
+								</HStack>
+								{showAfter && (
+									<TextControl
+										label={__('After', 'designsetgo')}
+										value={clause.after}
+										placeholder="YYYY-MM-DD or -30 days"
+										onChange={(v) =>
+											updateClause(i, { after: v })
+										}
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+									/>
+								)}
+								{showBefore && (
+									<TextControl
+										label={__('Before', 'designsetgo')}
+										value={clause.before}
+										placeholder="YYYY-MM-DD or today"
+										onChange={(v) =>
+											updateClause(i, { before: v })
+										}
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+									/>
+								)}
+								<ToggleControl
+									label={__('Inclusive', 'designsetgo')}
+									checked={clause.inclusive}
+									onChange={(v) =>
+										updateClause(i, { inclusive: v })
+									}
+									__nextHasNoMarginBottom
+								/>
+								<Button
+									isDestructive
+									variant="tertiary"
+									onClick={() => removeClause(i)}
+									aria-label={__(
+										'Remove date clause',
+										'designsetgo'
+									)}
+								>
+									{__('Remove', 'designsetgo')}
+								</Button>
+							</VStack>
+						);
+					})}
+
+					<Button variant="secondary" onClick={addClause}>
+						{__('Add date clause', 'designsetgo')}
+					</Button>
+				</VStack>
+			</DsgoInspectorPanel.Item>
+		</DsgoInspectorPanel>
+	);
+}

--- a/src/blocks/query/components/DateQueryBuilder.js
+++ b/src/blocks/query/components/DateQueryBuilder.js
@@ -69,7 +69,7 @@ export default function DateQueryBuilder({
 
 	return (
 		<DsgoInspectorPanel
-			title={__('Settings', 'designsetgo')}
+			title={__('Date filters', 'designsetgo')}
 			panelName="settings"
 			panelId={clientId}
 			resetAll={() => setAttributes({ dateQuery: EMPTY_DEFAULT })}

--- a/src/blocks/query/components/DateQueryBuilder.js
+++ b/src/blocks/query/components/DateQueryBuilder.js
@@ -41,7 +41,13 @@ export default function DateQueryBuilder({
 	setAttributes,
 	clientId,
 }) {
-	const dateQuery = attributes.dateQuery ?? EMPTY_DEFAULT;
+	// Normalise both `dateQuery` and `dateQuery.clauses` so a malformed import
+	// (e.g. `{ relation: 'AND' }` with no clauses) doesn't crash the builder.
+	const rawDateQuery = attributes.dateQuery ?? EMPTY_DEFAULT;
+	const dateQuery    = {
+		relation: rawDateQuery.relation ?? 'AND',
+		clauses: Array.isArray(rawDateQuery.clauses) ? rawDateQuery.clauses : [],
+	};
 
 	const updateClause = (i, patch) => {
 		const next = [...dateQuery.clauses];

--- a/src/blocks/query/components/DateQueryBuilder.js
+++ b/src/blocks/query/components/DateQueryBuilder.js
@@ -41,7 +41,7 @@ export default function DateQueryBuilder({
 	setAttributes,
 	clientId,
 }) {
-	const { dateQuery } = attributes;
+	const dateQuery = attributes.dateQuery ?? EMPTY_DEFAULT;
 
 	const updateClause = (i, patch) => {
 		const next = [...dateQuery.clauses];

--- a/src/blocks/query/components/MetaQueryBuilder.js
+++ b/src/blocks/query/components/MetaQueryBuilder.js
@@ -94,7 +94,7 @@ export default function MetaQueryBuilder( {
 
 	return (
 		<DsgoInspectorPanel
-			title={ __( 'Settings', 'designsetgo' ) }
+			title={ __( 'Meta filters', 'designsetgo' ) }
 			panelName="settings"
 			panelId={ clientId }
 			resetAll={ () => setAttributes( { metaQuery: EMPTY_DEFAULT } ) }

--- a/src/blocks/query/components/MetaQueryBuilder.js
+++ b/src/blocks/query/components/MetaQueryBuilder.js
@@ -1,5 +1,5 @@
 /* eslint-disable @wordpress/no-unsafe-wp-apis -- experimental layout/control primitives intentionally used; stable replacements not yet available */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
 	SelectControl,
@@ -39,7 +39,11 @@ export default function MetaQueryBuilder( {
 	setAttributes,
 	clientId,
 } ) {
-	const metaQuery = attributes.metaQuery ?? EMPTY_DEFAULT;
+	const rawMetaQuery = attributes.metaQuery ?? EMPTY_DEFAULT;
+	const metaQuery = {
+		relation: rawMetaQuery.relation ?? 'AND',
+		clauses: Array.isArray( rawMetaQuery.clauses ) ? rawMetaQuery.clauses : [],
+	};
 
 	const renderClause = ( clause, idx, updateEntry, removeEntry ) => {
 		const hideValue =
@@ -84,6 +88,11 @@ export default function MetaQueryBuilder( {
 					isDestructive
 					variant="tertiary"
 					onClick={ () => removeEntry( idx ) }
+					aria-label={ sprintf(
+						/* translators: %s: meta key being removed, or "(empty)" when blank. */
+						__( 'Remove meta filter for "%s"', 'designsetgo' ),
+						clause.key || __( '(empty)', 'designsetgo' )
+					) }
 					__next40pxDefaultSize
 				>
 					{ __( 'Remove', 'designsetgo' ) }

--- a/src/blocks/query/components/MetaQueryBuilder.js
+++ b/src/blocks/query/components/MetaQueryBuilder.js
@@ -8,6 +8,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { DsgoInspectorPanel } from '../../../components/shared';
+import ClauseGroupShell from './ClauseGroupShell';
 
 const COMPARE_OPTIONS = [
 	{ value: '=', label: '=' },
@@ -25,146 +26,93 @@ const COMPARE_OPTIONS = [
 ];
 
 const TYPE_OPTIONS = [
-	{ value: 'CHAR', label: __('Text', 'designsetgo') },
-	{ value: 'NUMERIC', label: __('Numeric', 'designsetgo') },
-	{ value: 'DATE', label: __('Date', 'designsetgo') },
+	{ value: 'CHAR', label: __( 'Text', 'designsetgo' ) },
+	{ value: 'NUMERIC', label: __( 'Numeric', 'designsetgo' ) },
+	{ value: 'DATE', label: __( 'Date', 'designsetgo' ) },
 ];
 
 const EMPTY_DEFAULT = { relation: 'AND', clauses: [] };
+const NEW_CLAUSE = { key: '', compare: '=', value: '', type: 'CHAR' };
 
-export default function MetaQueryBuilder({
+export default function MetaQueryBuilder( {
 	attributes,
 	setAttributes,
 	clientId,
-}) {
-	const { metaQuery } = attributes;
+} ) {
+	const metaQuery = attributes.metaQuery ?? EMPTY_DEFAULT;
 
-	const updateClause = (i, patch) => {
-		const next = [...metaQuery.clauses];
-		next[i] = { ...next[i], ...patch };
-		setAttributes({ metaQuery: { ...metaQuery, clauses: next } });
-	};
-
-	const removeClause = (i) => {
-		setAttributes({
-			metaQuery: {
-				...metaQuery,
-				clauses: metaQuery.clauses.filter((_, idx) => idx !== i),
-			},
-		});
-	};
-
-	const addClause = () => {
-		setAttributes({
-			metaQuery: {
-				...metaQuery,
-				clauses: [
-					...metaQuery.clauses,
-					{ key: '', compare: '=', value: '', type: 'CHAR' },
-				],
-			},
-		});
+	const renderClause = ( clause, idx, updateEntry, removeEntry ) => {
+		const hideValue =
+			clause.compare === 'EXISTS' || clause.compare === 'NOT EXISTS';
+		return (
+			<VStack key={ idx } spacing={ 2 }>
+				<TextControl
+					label={ __( 'Key', 'designsetgo' ) }
+					value={ clause.key }
+					onChange={ ( v ) => updateEntry( idx, { key: v } ) }
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+				<HStack>
+					<SelectControl
+						label={ __( 'Compare', 'designsetgo' ) }
+						value={ clause.compare }
+						options={ COMPARE_OPTIONS }
+						onChange={ ( v ) => updateEntry( idx, { compare: v } ) }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+					<SelectControl
+						label={ __( 'Type', 'designsetgo' ) }
+						value={ clause.type }
+						options={ TYPE_OPTIONS }
+						onChange={ ( v ) => updateEntry( idx, { type: v } ) }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				</HStack>
+				{ ! hideValue && (
+					<TextControl
+						label={ __( 'Value', 'designsetgo' ) }
+						value={ clause.value }
+						onChange={ ( v ) => updateEntry( idx, { value: v } ) }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				) }
+				<Button
+					isDestructive
+					variant="tertiary"
+					onClick={ () => removeEntry( idx ) }
+				>
+					{ __( 'Remove', 'designsetgo' ) }
+				</Button>
+			</VStack>
+		);
 	};
 
 	return (
 		<DsgoInspectorPanel
-			title={__('Meta query', 'designsetgo')}
+			title={ __( 'Settings', 'designsetgo' ) }
 			panelName="settings"
-			panelId={clientId}
-			resetAll={() => setAttributes({ metaQuery: EMPTY_DEFAULT })}
+			panelId={ clientId }
+			resetAll={ () => setAttributes( { metaQuery: EMPTY_DEFAULT } ) }
 		>
 			<DsgoInspectorPanel.Item
-				label={__('Meta query', 'designsetgo')}
-				hasValue={() => metaQuery.clauses.length > 0}
-				onDeselect={() => setAttributes({ metaQuery: EMPTY_DEFAULT })}
+				label={ __( 'Meta query', 'designsetgo' ) }
+				hasValue={ () => metaQuery.clauses.length > 0 }
+				onDeselect={ () => setAttributes( { metaQuery: EMPTY_DEFAULT } ) }
 				isShownByDefault
 			>
-				<VStack spacing={3}>
-					{metaQuery.clauses.length > 1 && (
-						<SelectControl
-							label={__('Relation', 'designsetgo')}
-							value={metaQuery.relation}
-							options={[
-								{ value: 'AND', label: 'AND' },
-								{ value: 'OR', label: 'OR' },
-							]}
-							onChange={(v) =>
-								setAttributes({
-									metaQuery: { ...metaQuery, relation: v },
-								})
-							}
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-						/>
-					)}
-
-					{metaQuery.clauses.map((clause, i) => {
-						const hideValue =
-							clause.compare === 'EXISTS' ||
-							clause.compare === 'NOT EXISTS';
-						return (
-							<VStack key={i} spacing={2}>
-								<TextControl
-									label={__('Key', 'designsetgo')}
-									value={clause.key}
-									onChange={(v) =>
-										updateClause(i, { key: v })
-									}
-									__next40pxDefaultSize
-									__nextHasNoMarginBottom
-								/>
-								<HStack>
-									<SelectControl
-										label={__('Compare', 'designsetgo')}
-										value={clause.compare}
-										options={COMPARE_OPTIONS}
-										onChange={(v) =>
-											updateClause(i, { compare: v })
-										}
-										__next40pxDefaultSize
-										__nextHasNoMarginBottom
-									/>
-									<SelectControl
-										label={__('Type', 'designsetgo')}
-										value={clause.type}
-										options={TYPE_OPTIONS}
-										onChange={(v) =>
-											updateClause(i, { type: v })
-										}
-										__next40pxDefaultSize
-										__nextHasNoMarginBottom
-									/>
-								</HStack>
-								{!hideValue && (
-									<TextControl
-										label={__('Value', 'designsetgo')}
-										value={clause.value}
-										onChange={(v) =>
-											updateClause(i, { value: v })
-										}
-										__next40pxDefaultSize
-										__nextHasNoMarginBottom
-									/>
-								)}
-								<Button
-									isDestructive
-									variant="tertiary"
-									onClick={() => removeClause(i)}
-									aria-label={__(
-										'Remove meta condition',
-										'designsetgo'
-									)}
-								>
-									{__('Remove', 'designsetgo')}
-								</Button>
-							</VStack>
-						);
-					})}
-
-					<Button variant="secondary" onClick={addClause}>
-						{__('Add meta condition', 'designsetgo')}
-					</Button>
-				</VStack>
+				<ClauseGroupShell
+					group={ metaQuery }
+					onChange={ ( patch ) =>
+						setAttributes( { metaQuery: { ...metaQuery, ...patch } } )
+					}
+					depth={ 0 }
+					newClause={ NEW_CLAUSE }
+					renderClause={ renderClause }
+				/>
 			</DsgoInspectorPanel.Item>
 		</DsgoInspectorPanel>
 	);

--- a/src/blocks/query/components/MetaQueryBuilder.js
+++ b/src/blocks/query/components/MetaQueryBuilder.js
@@ -84,6 +84,7 @@ export default function MetaQueryBuilder( {
 					isDestructive
 					variant="tertiary"
 					onClick={ () => removeEntry( idx ) }
+					__next40pxDefaultSize
 				>
 					{ __( 'Remove', 'designsetgo' ) }
 				</Button>

--- a/src/blocks/query/components/TaxQueryBuilder.js
+++ b/src/blocks/query/components/TaxQueryBuilder.js
@@ -25,7 +25,11 @@ export default function TaxQueryBuilder( {
 	clientId,
 } ) {
 	const { postType } = attributes;
-	const taxQuery = attributes.taxQuery ?? { relation: 'AND', clauses: [] };
+	const rawTaxQuery = attributes.taxQuery ?? { relation: 'AND', clauses: [] };
+	const taxQuery = {
+		relation: rawTaxQuery.relation ?? 'AND',
+		clauses: Array.isArray( rawTaxQuery.clauses ) ? rawTaxQuery.clauses : [],
+	};
 
 	const taxonomies = useSelect(
 		( select ) => select( coreStore ).getTaxonomies( { per_page: -1 } ) || [],

--- a/src/blocks/query/components/TaxQueryBuilder.js
+++ b/src/blocks/query/components/TaxQueryBuilder.js
@@ -11,140 +11,86 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { DsgoInspectorPanel } from '../../../components/shared';
+import ClauseGroupShell from './ClauseGroupShell';
 
 const OPERATORS = [
-	{ value: 'IN', label: __('In', 'designsetgo') },
-	{ value: 'NOT IN', label: __('Not in', 'designsetgo') },
-	{ value: 'AND', label: __('All of', 'designsetgo') },
+	{ value: 'IN', label: __( 'In', 'designsetgo' ) },
+	{ value: 'NOT IN', label: __( 'Not in', 'designsetgo' ) },
+	{ value: 'AND', label: __( 'All of', 'designsetgo' ) },
 ];
 
-export default function TaxQueryBuilder({
+export default function TaxQueryBuilder( {
 	attributes,
 	setAttributes,
 	clientId,
-}) {
+} ) {
 	const { postType, taxQuery } = attributes;
 
 	const taxonomies = useSelect(
-		(select) => select(coreStore).getTaxonomies({ per_page: -1 }) || [],
+		( select ) => select( coreStore ).getTaxonomies( { per_page: -1 } ) || [],
 		[]
 	);
-	const relevant = (taxonomies || []).filter(
-		(t) => t && t.types && t.types.includes(postType)
+	const relevant = ( taxonomies || [] ).filter(
+		( t ) => t && t.types && t.types.includes( postType )
 	);
-
-	const updateClause = (idx, patch) => {
-		const next = [...taxQuery.clauses];
-		next[idx] = { ...next[idx], ...patch };
-		setAttributes({ taxQuery: { ...taxQuery, clauses: next } });
-	};
-
-	const removeClause = (idx) => {
-		setAttributes({
-			taxQuery: {
-				...taxQuery,
-				clauses: taxQuery.clauses.filter((_, i) => i !== idx),
-			},
-		});
-	};
-
-	const addClause = () => {
-		if (!relevant[0]) {
-			return;
-		}
-		setAttributes({
-			taxQuery: {
-				...taxQuery,
-				clauses: [
-					...taxQuery.clauses,
-					{ taxonomy: relevant[0].slug, terms: [], operator: 'IN', include_children: true },
-				],
-			},
-		});
-	};
 
 	return (
 		<DsgoInspectorPanel
-			title={__('Taxonomy filters', 'designsetgo')}
+			title={ __( 'Settings', 'designsetgo' ) }
 			panelName="settings"
-			panelId={clientId}
-			resetAll={() =>
-				setAttributes({ taxQuery: { relation: 'AND', clauses: [] } })
+			panelId={ clientId }
+			resetAll={ () =>
+				setAttributes( { taxQuery: { relation: 'AND', clauses: [] } } )
 			}
 		>
 			<DsgoInspectorPanel.Item
-				label={__('Taxonomy filters', 'designsetgo')}
-				hasValue={() => taxQuery.clauses.length > 0}
-				onDeselect={() =>
-					setAttributes({
-						taxQuery: { relation: 'AND', clauses: [] },
-					})
+				label={ __( 'Taxonomy filters', 'designsetgo' ) }
+				hasValue={ () => taxQuery.clauses.length > 0 }
+				onDeselect={ () =>
+					setAttributes( { taxQuery: { relation: 'AND', clauses: [] } } )
 				}
 				isShownByDefault
 			>
-				<VStack spacing={3}>
-					{taxQuery.clauses.length > 1 && (
-						<SelectControl
-							label={__('Relation', 'designsetgo')}
-							value={taxQuery.relation}
-							options={[
-								{
-									value: 'AND',
-									label: __('AND (match all)', 'designsetgo'),
-								},
-								{
-									value: 'OR',
-									label: __('OR (match any)', 'designsetgo'),
-								},
-							]}
-							onChange={(v) =>
-								setAttributes({
-									taxQuery: { ...taxQuery, relation: v },
-								})
-							}
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-						/>
-					)}
-
-					{taxQuery.clauses.map((clause, idx) => (
-						<VStack
-							key={idx}
-							spacing={2}
-							className="dsgo-query-tax-clause"
-						>
+				<ClauseGroupShell
+					group={ taxQuery }
+					onChange={ ( patch ) =>
+						setAttributes( { taxQuery: { ...taxQuery, ...patch } } )
+					}
+					depth={ 0 }
+					isAddDisabled={ relevant.length === 0 }
+					newClause={ {
+						taxonomy: relevant[ 0 ]?.slug ?? 'category',
+						terms: [],
+						operator: 'IN',
+						include_children: true,
+					} }
+					renderClause={ ( clause, idx, updateEntry, removeEntry ) => (
+						<VStack key={ idx } spacing={ 2 } className="dsgo-query-tax-clause">
 							<SelectControl
-								label={__('Taxonomy', 'designsetgo')}
-								value={clause.taxonomy}
-								options={relevant.map((t) => ({
+								label={ __( 'Taxonomy', 'designsetgo' ) }
+								value={ clause.taxonomy }
+								options={ relevant.map( ( t ) => ( {
 									label: t.labels?.singular_name || t.slug,
 									value: t.slug,
-								}))}
-								onChange={(v) =>
-									updateClause(idx, {
-										taxonomy: v,
-										terms: [],
-									})
+								} ) ) }
+								onChange={ ( val ) =>
+									updateEntry( idx, { taxonomy: val, terms: [] } )
 								}
 								__next40pxDefaultSize
 								__nextHasNoMarginBottom
 							/>
-
 							<TermPicker
-								taxonomy={clause.taxonomy}
-								selected={clause.terms}
-								onChange={(ids) =>
-									updateClause(idx, { terms: ids })
-								}
+								taxonomy={ clause.taxonomy }
+								selected={ clause.terms }
+								onChange={ ( ids ) => updateEntry( idx, { terms: ids } ) }
 							/>
-
 							<HStack>
 								<SelectControl
-									label={__('Operator', 'designsetgo')}
-									value={clause.operator || 'IN'}
-									options={OPERATORS}
-									onChange={(v) =>
-										updateClause(idx, { operator: v })
+									label={ __( 'Operator', 'designsetgo' ) }
+									value={ clause.operator || 'IN' }
+									options={ OPERATORS }
+									onChange={ ( val ) =>
+										updateEntry( idx, { operator: val } )
 									}
 									__next40pxDefaultSize
 									__nextHasNoMarginBottom
@@ -152,63 +98,55 @@ export default function TaxQueryBuilder({
 								<Button
 									isDestructive
 									variant="tertiary"
-									onClick={() => removeClause(idx)}
-									aria-label={__(
+									onClick={ () => removeEntry( idx ) }
+									aria-label={ __(
 										'Remove taxonomy filter',
 										'designsetgo'
-									)}
+									) }
 								>
-									{__('Remove', 'designsetgo')}
+									{ __( 'Remove', 'designsetgo' ) }
 								</Button>
 							</HStack>
 							<ToggleControl
-								label={__('Include child terms', 'designsetgo')}
-								checked={clause.include_children ?? true}
-								onChange={(val) =>
-									updateClause(idx, { include_children: val })
+								label={ __( 'Include child terms', 'designsetgo' ) }
+								checked={ clause.include_children ?? true }
+								onChange={ ( val ) =>
+									updateEntry( idx, { include_children: val } )
 								}
 								__nextHasNoMarginBottom
 							/>
 						</VStack>
-					))}
-
-					<Button
-						variant="secondary"
-						onClick={addClause}
-						disabled={relevant.length === 0}
-					>
-						{__('Add taxonomy filter', 'designsetgo')}
-					</Button>
-				</VStack>
+					) }
+				/>
 			</DsgoInspectorPanel.Item>
 		</DsgoInspectorPanel>
 	);
 }
 
-function TermPicker({ taxonomy, selected, onChange }) {
+function TermPicker( { taxonomy, selected, onChange } ) {
 	const terms = useSelect(
-		(select) =>
-			select(coreStore).getEntityRecords('taxonomy', taxonomy, {
+		( select ) =>
+			select( coreStore ).getEntityRecords( 'taxonomy', taxonomy, {
 				per_page: -1,
-			}) || [],
-		[taxonomy]
+			} ) || [],
+		[ taxonomy ]
 	);
-	const suggestions = (terms || []).map((t) => t.name);
-	const selectedNames = (terms || [])
-		.filter((t) => selected.includes(t.id))
-		.map((t) => t.name);
+	const suggestions = ( terms || [] ).map( ( t ) => t.name );
+	const selectedNames = ( terms || [] )
+		.filter( ( t ) => selected.includes( t.id ) )
+		.map( ( t ) => t.name );
 
 	return (
 		<FormTokenField
-			label={__('Terms', 'designsetgo')}
-			value={selectedNames}
-			suggestions={suggestions}
-			onChange={(names) => {
-				const ids = (terms || [])
-					.filter((t) => names.includes(t.name))
-					.map((t) => t.id);
-				onChange(ids);
-			}}
+			label={ __( 'Terms', 'designsetgo' ) }
+			value={ selectedNames }
+			suggestions={ suggestions }
+			onChange={ ( names ) => {
+				const ids = ( terms || [] )
+					.filter( ( t ) => names.includes( t.name ) )
+					.map( ( t ) => t.id );
+				onChange( ids );
+			} }
 			__experimentalExpandOnFocus
 			__nextHasNoMarginBottom
 		/>

--- a/src/blocks/query/components/TaxQueryBuilder.js
+++ b/src/blocks/query/components/TaxQueryBuilder.js
@@ -5,6 +5,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import {
 	Button,
 	SelectControl,
+	ToggleControl,
 	FormTokenField,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -56,7 +57,7 @@ export default function TaxQueryBuilder({
 				...taxQuery,
 				clauses: [
 					...taxQuery.clauses,
-					{ taxonomy: relevant[0].slug, terms: [], operator: 'IN' },
+					{ taxonomy: relevant[0].slug, terms: [], operator: 'IN', include_children: true },
 				],
 			},
 		});
@@ -160,6 +161,14 @@ export default function TaxQueryBuilder({
 									{__('Remove', 'designsetgo')}
 								</Button>
 							</HStack>
+							<ToggleControl
+								label={__('Include child terms', 'designsetgo')}
+								checked={clause.include_children ?? true}
+								onChange={(val) =>
+									updateClause(idx, { include_children: val })
+								}
+								__nextHasNoMarginBottom
+							/>
 						</VStack>
 					))}
 

--- a/src/blocks/query/components/TaxQueryBuilder.js
+++ b/src/blocks/query/components/TaxQueryBuilder.js
@@ -36,7 +36,7 @@ export default function TaxQueryBuilder( {
 
 	return (
 		<DsgoInspectorPanel
-			title={ __( 'Settings', 'designsetgo' ) }
+			title={ __( 'Taxonomy filters', 'designsetgo' ) }
 			panelName="settings"
 			panelId={ clientId }
 			resetAll={ () =>

--- a/src/blocks/query/components/TaxQueryBuilder.js
+++ b/src/blocks/query/components/TaxQueryBuilder.js
@@ -24,7 +24,8 @@ export default function TaxQueryBuilder( {
 	setAttributes,
 	clientId,
 } ) {
-	const { postType, taxQuery } = attributes;
+	const { postType } = attributes;
+	const taxQuery = attributes.taxQuery ?? { relation: 'AND', clauses: [] };
 
 	const taxonomies = useSelect(
 		( select ) => select( coreStore ).getTaxonomies( { per_page: -1 } ) || [],

--- a/src/blocks/query/components/TaxQueryBuilder.js
+++ b/src/blocks/query/components/TaxQueryBuilder.js
@@ -103,6 +103,7 @@ export default function TaxQueryBuilder( {
 										'Remove taxonomy filter',
 										'designsetgo'
 									) }
+									__next40pxDefaultSize
 								>
 									{ __( 'Remove', 'designsetgo' ) }
 								</Button>

--- a/src/blocks/query/edit.js
+++ b/src/blocks/query/edit.js
@@ -13,6 +13,7 @@ import useQueryPreview from './hooks/useQueryPreview';
 import QuerySourcePanel from './components/QuerySourcePanel';
 import TaxQueryBuilder from './components/TaxQueryBuilder';
 import MetaQueryBuilder from './components/MetaQueryBuilder';
+import DateQueryBuilder from './components/DateQueryBuilder';
 import AdvancedPanel from './components/AdvancedPanel';
 import ResultCountBadge from './components/ResultCountBadge';
 import EditorPreviewList from './components/EditorPreviewList';
@@ -24,7 +25,12 @@ import { DEFAULT_TEMPLATE } from './edit-template';
 // console with "`useSelect` returns different values" warnings.
 const EMPTY_BLOCKS = Object.freeze([]);
 
-export default function QueryEdit({ attributes, setAttributes, clientId, context }) {
+export default function QueryEdit({
+	attributes,
+	setAttributes,
+	clientId,
+	context,
+}) {
 	useQueryId({ clientId, queryId: attributes.queryId, setAttributes });
 
 	// Two narrow selectors instead of one composite object: hasInnerBlocks is
@@ -118,6 +124,11 @@ export default function QueryEdit({ attributes, setAttributes, clientId, context
 							clientId={clientId}
 						/>
 						<MetaQueryBuilder
+							attributes={attributes}
+							setAttributes={setAttributes}
+							clientId={clientId}
+						/>
+						<DateQueryBuilder
 							attributes={attributes}
 							setAttributes={setAttributes}
 							clientId={clientId}

--- a/src/blocks/query/render-posts.php
+++ b/src/blocks/query/render-posts.php
@@ -20,16 +20,23 @@ if ( ! function_exists( 'designsetgo_build_tax_query_entry' ) ) :
 	function designsetgo_build_tax_query_entry( array $entry ) {
 		if ( isset( $entry['clauses'] ) ) {
 			// Nested group.
-			$sub = array(
-				'relation' => ( 'OR' === ( $entry['relation'] ?? 'AND' ) ) ? 'OR' : 'AND',
-			);
+			$relation = ( 'OR' === ( $entry['relation'] ?? 'AND' ) ) ? 'OR' : 'AND';
+			$children = array();
 			foreach ( (array) $entry['clauses'] as $child ) {
 				$built = designsetgo_build_tax_query_entry( $child );
 				if ( null !== $built ) {
-					$sub[] = $built;
+					$children[] = $built;
 				}
 			}
-			return count( $sub ) > 1 ? $sub : null;
+			if ( empty( $children ) ) {
+				return null;
+			}
+			// WP_Query triggers _doing_it_wrong when a tax_query group carries
+			// `relation` with a single child — unwrap to the bare child.
+			if ( 1 === count( $children ) ) {
+				return $children[0];
+			}
+			return array_merge( array( 'relation' => $relation ), $children );
 		}
 		// Leaf clause.
 		if ( empty( $entry['taxonomy'] ) || empty( $entry['terms'] ) ) {
@@ -58,16 +65,23 @@ if ( ! function_exists( 'designsetgo_build_meta_query_entry' ) ) :
 	function designsetgo_build_meta_query_entry( array $entry ) {
 		if ( isset( $entry['clauses'] ) ) {
 			// Nested group.
-			$sub = array(
-				'relation' => ( 'OR' === ( $entry['relation'] ?? 'AND' ) ) ? 'OR' : 'AND',
-			);
+			$relation = ( 'OR' === ( $entry['relation'] ?? 'AND' ) ) ? 'OR' : 'AND';
+			$children = array();
 			foreach ( (array) $entry['clauses'] as $child ) {
 				$built = designsetgo_build_meta_query_entry( $child );
 				if ( null !== $built ) {
-					$sub[] = $built;
+					$children[] = $built;
 				}
 			}
-			return count( $sub ) > 1 ? $sub : null;
+			if ( empty( $children ) ) {
+				return null;
+			}
+			// Unwrap single-child groups to avoid WP_Meta_Query's
+			// `relation`-with-one-child _doing_it_wrong notice.
+			if ( 1 === count( $children ) ) {
+				return $children[0];
+			}
+			return array_merge( array( 'relation' => $relation ), $children );
 		}
 		// Leaf clause.
 		if ( empty( $entry['key'] ) ) {
@@ -139,21 +153,32 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 			$args = apply_filters( 'designsetgo/query/' . $query_id . '/args', $args, $atts, $context );
 		}
 
-		$t_start     = microtime( true );
-		$query       = new WP_Query( $args );
-		$last_sql    = $GLOBALS['wpdb']->last_query ?? '';
-		$duration_ms = ( microtime( true ) - $t_start ) * 1000;
+		// Capture render telemetry only when Query Monitor is loaded — otherwise
+		// the action exposes raw SQL to any third-party callback on every public
+		// page render, which is data we don't want to broadcast.
+		if ( defined( 'QM_VERSION' ) ) {
+			$t_start     = microtime( true );
+			$query       = new WP_Query( $args );
+			$duration_ms = ( microtime( true ) - $t_start ) * 1000;
 
-		$capture = array(
-			'query_id'    => $atts['queryId'] ?? '',
-			'source'      => $atts['source'] ?? 'posts',
-			'wp_args'     => $args,
-			'found_posts' => $query->found_posts,
-			'sql'         => $last_sql,
-			'filters'     => array(),
-			'duration_ms' => round( $duration_ms, 2 ),
-		);
-		do_action( 'designsetgo_query_did_render', $capture );
+			do_action(
+				'designsetgo_query_did_render',
+				array(
+					'query_id'    => $atts['queryId'] ?? '',
+					'source'      => $atts['source'] ?? 'posts',
+					'wp_args'     => $args,
+					'found_posts' => $query->found_posts,
+					// $query->request is the actual posts SELECT WP_Query just
+					// ran; $wpdb->last_query at this point would be the
+					// trailing FOUND_ROWS()/COUNT instead.
+					'sql'         => (string) ( $query->request ?? '' ),
+					'filters'     => array(),
+					'duration_ms' => round( $duration_ms, 2 ),
+				)
+			);
+		} else {
+			$query = new WP_Query( $args );
+		}
 
 		// Determine whether grouped rendering is requested.
 		// Parse inner_html to split group-header blocks from the item template.

--- a/src/blocks/query/render-posts.php
+++ b/src/blocks/query/render-posts.php
@@ -35,10 +35,14 @@ if ( ! function_exists( 'designsetgo_build_tax_query_entry' ) ) :
 		if ( empty( $entry['taxonomy'] ) || empty( $entry['terms'] ) ) {
 			return null;
 		}
+		$operator = $entry['operator'] ?? 'IN';
+		if ( ! in_array( $operator, array( 'IN', 'NOT IN', 'AND' ), true ) ) {
+			$operator = 'IN';
+		}
 		return array(
 			'taxonomy'         => sanitize_key( (string) $entry['taxonomy'] ),
 			'terms'            => array_map( 'absint', (array) $entry['terms'] ),
-			'operator'         => in_array( ( $entry['operator'] ?? 'IN' ), array( 'IN', 'NOT IN', 'AND' ), true ) ? $entry['operator'] : 'IN',
+			'operator'         => $operator,
 			'include_children' => isset( $entry['include_children'] ) ? (bool) $entry['include_children'] : true,
 		);
 	}
@@ -71,12 +75,23 @@ if ( ! function_exists( 'designsetgo_build_meta_query_entry' ) ) :
 		}
 		$valid_compare = array( '=', '!=', '>', '>=', '<', '<=', 'LIKE', 'NOT LIKE', 'IN', 'NOT IN', 'EXISTS', 'NOT EXISTS' );
 		$valid_type    = array( 'CHAR', 'NUMERIC', 'DATE' );
-		return array(
+		$compare       = $entry['compare'] ?? '=';
+		if ( ! in_array( $compare, $valid_compare, true ) ) {
+			$compare = '=';
+		}
+		$type = $entry['type'] ?? 'CHAR';
+		if ( ! in_array( $type, $valid_type, true ) ) {
+			$type = 'CHAR';
+		}
+		$result = array(
 			'key'     => sanitize_text_field( (string) $entry['key'] ),
-			'value'   => sanitize_text_field( (string) ( $entry['value'] ?? '' ) ),
-			'compare' => in_array( ( $entry['compare'] ?? '=' ), $valid_compare, true ) ? $entry['compare'] : '=',
-			'type'    => in_array( ( $entry['type'] ?? 'CHAR' ), $valid_type, true ) ? $entry['type'] : 'CHAR',
+			'compare' => $compare,
+			'type'    => $type,
 		);
+		if ( ! in_array( $compare, array( 'EXISTS', 'NOT EXISTS' ), true ) ) {
+			$result['value'] = sanitize_text_field( (string) ( $entry['value'] ?? '' ) );
+		}
+		return $result;
 	}
 endif;
 
@@ -397,8 +412,12 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 					continue;
 				}
 
+				$column = $clause['column'] ?? 'post_date';
+				if ( ! in_array( $column, $valid_columns, true ) ) {
+					$column = 'post_date';
+				}
 				$entry = array(
-					'column'    => in_array( ( $clause['column'] ?? 'post_date' ), $valid_columns, true ) ? $clause['column'] : 'post_date',
+					'column'    => $column,
 					'inclusive' => ! empty( $clause['inclusive'] ),
 				);
 				if ( 'after' === $mode || 'between' === $mode ) {

--- a/src/blocks/query/render-posts.php
+++ b/src/blocks/query/render-posts.php
@@ -10,6 +10,40 @@
 
 defined( 'ABSPATH' ) || exit;
 
+if ( ! function_exists( 'designsetgo_build_tax_query_entry' ) ) :
+	/**
+	 * Recursively builds a WP_Query tax_query clause or nested group.
+	 *
+	 * @param array $entry Clause or group from block attributes.
+	 * @return array|null WP_Query tax_query entry, or null if invalid.
+	 */
+	function designsetgo_build_tax_query_entry( array $entry ) {
+		if ( isset( $entry['clauses'] ) ) {
+			// Nested group.
+			$sub = array(
+				'relation' => ( 'OR' === ( $entry['relation'] ?? 'AND' ) ) ? 'OR' : 'AND',
+			);
+			foreach ( (array) $entry['clauses'] as $child ) {
+				$built = designsetgo_build_tax_query_entry( $child );
+				if ( null !== $built ) {
+					$sub[] = $built;
+				}
+			}
+			return count( $sub ) > 1 ? $sub : null;
+		}
+		// Leaf clause.
+		if ( empty( $entry['taxonomy'] ) || empty( $entry['terms'] ) ) {
+			return null;
+		}
+		return array(
+			'taxonomy'         => sanitize_key( (string) $entry['taxonomy'] ),
+			'terms'            => array_map( 'absint', (array) $entry['terms'] ),
+			'operator'         => in_array( ( $entry['operator'] ?? 'IN' ), array( 'IN', 'NOT IN', 'AND' ), true ) ? $entry['operator'] : 'IN',
+			'include_children' => isset( $entry['include_children'] ) ? (bool) $entry['include_children'] : true,
+		);
+	}
+endif;
+
 if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 
 	/**
@@ -256,22 +290,17 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 			}
 		}
 
-		// Taxonomy query.
+		// Tax query (supports nested AND/OR groups).
 		$tax_clauses = isset( $atts['taxQuery']['clauses'] ) ? (array) $atts['taxQuery']['clauses'] : array();
 		if ( ! empty( $tax_clauses ) ) {
 			$tax_query = array(
 				'relation' => ( 'OR' === ( $atts['taxQuery']['relation'] ?? 'AND' ) ) ? 'OR' : 'AND',
 			);
-			foreach ( $tax_clauses as $clause ) {
-				if ( empty( $clause['taxonomy'] ) || empty( $clause['terms'] ) ) {
-					continue;
+			foreach ( $tax_clauses as $entry ) {
+				$built = designsetgo_build_tax_query_entry( $entry );
+				if ( null !== $built ) {
+					$tax_query[] = $built;
 				}
-				$tax_query[] = array(
-					'taxonomy'         => sanitize_key( (string) $clause['taxonomy'] ),
-					'terms'            => array_map( 'absint', (array) $clause['terms'] ),
-					'operator'         => in_array( ( $clause['operator'] ?? 'IN' ), array( 'IN', 'NOT IN', 'AND' ), true ) ? $clause['operator'] : 'IN',
-					'include_children' => isset( $clause['include_children'] ) ? (bool) $clause['include_children'] : true,
-				);
 			}
 			if ( count( $tax_query ) > 1 ) {
 				$args['tax_query'] = $tax_query; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query

--- a/src/blocks/query/render-posts.php
+++ b/src/blocks/query/render-posts.php
@@ -124,7 +124,21 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 			$args = apply_filters( 'designsetgo/query/' . $query_id . '/args', $args, $atts, $context );
 		}
 
-		$query = new WP_Query( $args );
+		$t_start     = microtime( true );
+		$query       = new WP_Query( $args );
+		$last_sql    = $GLOBALS['wpdb']->last_query ?? '';
+		$duration_ms = ( microtime( true ) - $t_start ) * 1000;
+
+		$capture = array(
+			'query_id'    => $atts['queryId'] ?? '',
+			'source'      => $atts['source'] ?? 'posts',
+			'wp_args'     => $args,
+			'found_posts' => $query->found_posts,
+			'sql'         => $last_sql,
+			'filters'     => array(),
+			'duration_ms' => round( $duration_ms, 2 ),
+		);
+		do_action( 'designsetgo_query_did_render', $capture );
 
 		// Determine whether grouped rendering is requested.
 		// Parse inner_html to split group-header blocks from the item template.

--- a/src/blocks/query/render-posts.php
+++ b/src/blocks/query/render-posts.php
@@ -267,9 +267,10 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 					continue;
 				}
 				$tax_query[] = array(
-					'taxonomy' => sanitize_key( (string) $clause['taxonomy'] ),
-					'terms'    => array_map( 'absint', (array) $clause['terms'] ),
-					'operator' => in_array( ( $clause['operator'] ?? 'IN' ), array( 'IN', 'NOT IN', 'AND' ), true ) ? $clause['operator'] : 'IN',
+					'taxonomy'         => sanitize_key( (string) $clause['taxonomy'] ),
+					'terms'            => array_map( 'absint', (array) $clause['terms'] ),
+					'operator'         => in_array( ( $clause['operator'] ?? 'IN' ), array( 'IN', 'NOT IN', 'AND' ), true ) ? $clause['operator'] : 'IN',
+					'include_children' => isset( $clause['include_children'] ) ? (bool) $clause['include_children'] : true,
 				);
 			}
 			if ( count( $tax_query ) > 1 ) {

--- a/src/blocks/query/render-posts.php
+++ b/src/blocks/query/render-posts.php
@@ -44,6 +44,42 @@ if ( ! function_exists( 'designsetgo_build_tax_query_entry' ) ) :
 	}
 endif;
 
+if ( ! function_exists( 'designsetgo_build_meta_query_entry' ) ) :
+	/**
+	 * Recursively builds a WP_Query meta_query clause or nested group.
+	 *
+	 * @param array $entry Clause or group from block attributes.
+	 * @return array|null WP_Query meta_query entry, or null if invalid.
+	 */
+	function designsetgo_build_meta_query_entry( array $entry ) {
+		if ( isset( $entry['clauses'] ) ) {
+			// Nested group.
+			$sub = array(
+				'relation' => ( 'OR' === ( $entry['relation'] ?? 'AND' ) ) ? 'OR' : 'AND',
+			);
+			foreach ( (array) $entry['clauses'] as $child ) {
+				$built = designsetgo_build_meta_query_entry( $child );
+				if ( null !== $built ) {
+					$sub[] = $built;
+				}
+			}
+			return count( $sub ) > 1 ? $sub : null;
+		}
+		// Leaf clause.
+		if ( empty( $entry['key'] ) ) {
+			return null;
+		}
+		$valid_compare = array( '=', '!=', '>', '>=', '<', '<=', 'LIKE', 'NOT LIKE', 'IN', 'NOT IN', 'EXISTS', 'NOT EXISTS' );
+		$valid_type    = array( 'CHAR', 'NUMERIC', 'DATE' );
+		return array(
+			'key'     => sanitize_text_field( (string) $entry['key'] ),
+			'value'   => sanitize_text_field( (string) ( $entry['value'] ?? '' ) ),
+			'compare' => in_array( ( $entry['compare'] ?? '=' ), $valid_compare, true ) ? $entry['compare'] : '=',
+			'type'    => in_array( ( $entry['type'] ?? 'CHAR' ), $valid_type, true ) ? $entry['type'] : 'CHAR',
+		);
+	}
+endif;
+
 if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 
 	/**
@@ -307,24 +343,17 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 			}
 		}
 
-		// Meta query.
+		// Meta query (supports nested AND/OR groups).
 		$meta_clauses = isset( $atts['metaQuery']['clauses'] ) ? (array) $atts['metaQuery']['clauses'] : array();
 		if ( ! empty( $meta_clauses ) ) {
-			$meta_query    = array(
+			$meta_query = array(
 				'relation' => ( 'OR' === ( $atts['metaQuery']['relation'] ?? 'AND' ) ) ? 'OR' : 'AND',
 			);
-			$valid_compare = array( '=', '!=', '>', '>=', '<', '<=', 'LIKE', 'NOT LIKE', 'IN', 'NOT IN', 'EXISTS', 'NOT EXISTS' );
-			$valid_type    = array( 'CHAR', 'NUMERIC', 'DATE' );
-			foreach ( $meta_clauses as $clause ) {
-				if ( empty( $clause['key'] ) ) {
-					continue;
+			foreach ( $meta_clauses as $entry ) {
+				$built = designsetgo_build_meta_query_entry( $entry );
+				if ( null !== $built ) {
+					$meta_query[] = $built;
 				}
-				$meta_query[] = array(
-					'key'     => sanitize_text_field( (string) $clause['key'] ),
-					'value'   => sanitize_text_field( (string) ( $clause['value'] ?? '' ) ),
-					'compare' => in_array( ( $clause['compare'] ?? '=' ), $valid_compare, true ) ? $clause['compare'] : '=',
-					'type'    => in_array( ( $clause['type'] ?? 'CHAR' ), $valid_type, true ) ? $clause['type'] : 'CHAR',
-				);
 			}
 			if ( count( $meta_query ) > 1 ) {
 				$args['meta_query'] = $meta_query; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query

--- a/src/blocks/query/render-posts.php
+++ b/src/blocks/query/render-posts.php
@@ -302,6 +302,46 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 			}
 		}
 
+		// Date query.
+		$date_clauses = isset( $atts['dateQuery']['clauses'] ) ? (array) $atts['dateQuery']['clauses'] : array();
+		if ( ! empty( $date_clauses ) ) {
+			$valid_columns = array( 'post_date', 'post_modified', 'post_date_gmt', 'post_modified_gmt' );
+			$date_query    = array(
+				'relation' => ( 'OR' === ( $atts['dateQuery']['relation'] ?? 'AND' ) ) ? 'OR' : 'AND',
+			);
+			foreach ( $date_clauses as $clause ) {
+				$mode   = $clause['mode'] ?? 'after';
+				$after  = sanitize_text_field( (string) ( $clause['after'] ?? '' ) );
+				$before = sanitize_text_field( (string) ( $clause['before'] ?? '' ) );
+
+				// Skip clauses with no date value.
+				if ( 'between' === $mode && ( '' === $after || '' === $before ) ) {
+					continue;
+				}
+				if ( 'after' === $mode && '' === $after ) {
+					continue;
+				}
+				if ( 'before' === $mode && '' === $before ) {
+					continue;
+				}
+
+				$entry = array(
+					'column'    => in_array( ( $clause['column'] ?? 'post_date' ), $valid_columns, true ) ? $clause['column'] : 'post_date',
+					'inclusive' => ! empty( $clause['inclusive'] ),
+				);
+				if ( 'after' === $mode || 'between' === $mode ) {
+					$entry['after'] = $after;
+				}
+				if ( 'before' === $mode || 'between' === $mode ) {
+					$entry['before'] = $before;
+				}
+				$date_query[] = $entry;
+			}
+			if ( count( $date_query ) > 1 ) {
+				$args['date_query'] = $date_query;
+			}
+		}
+
 		// Manual source: override with specific post IDs in user-defined order.
 		if ( 'manual' === $atts['source'] && ! empty( $atts['manualIds'] ) && is_array( $atts['manualIds'] ) ) {
 			$ids = array_values( array_filter( array_map( 'absint', $atts['manualIds'] ) ) );

--- a/src/extensions/style-binding/filters.js
+++ b/src/extensions/style-binding/filters.js
@@ -1,0 +1,131 @@
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+import { InspectorControls } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	Button,
+	SelectControl,
+	TextControl,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { Fragment } from '@wordpress/element';
+
+const SOURCE_OPTIONS = [
+	{ label: __( 'Post meta', 'designsetgo' ), value: 'designsetgo/post-meta' },
+	{ label: __( 'ACF', 'designsetgo' ), value: 'designsetgo/acf' },
+	{ label: __( 'Meta Box', 'designsetgo' ), value: 'designsetgo/metabox' },
+	{ label: __( 'Pods', 'designsetgo' ), value: 'designsetgo/pods' },
+	{ label: __( 'JetEngine', 'designsetgo' ), value: 'designsetgo/jetengine' },
+];
+
+addFilter(
+	'blocks.registerBlockType',
+	'designsetgo/style-binding-attribute',
+	( settings ) => {
+		if ( ! settings.attributes ) {
+			settings.attributes = {};
+		}
+		settings.attributes.dsgoStyleBinding = {
+			type: 'object',
+			default: {},
+		};
+		return settings;
+	}
+);
+
+const withStyleBindingInspector = createHigherOrderComponent( ( BlockEdit ) => {
+	return function WithStyleBindingInspector( props ) {
+		const { attributes, setAttributes } = props;
+		const binding = attributes.dsgoStyleBinding ?? {};
+		const entries = Object.entries( binding );
+
+		const updateEntry = ( oldProp, newProp, config ) => {
+			const next = { ...binding };
+			if ( oldProp !== newProp ) {
+				delete next[ oldProp ];
+			}
+			next[ newProp ] = config;
+			setAttributes( { dsgoStyleBinding: next } );
+		};
+
+		const removeEntry = ( prop ) => {
+			const next = { ...binding };
+			delete next[ prop ];
+			setAttributes( { dsgoStyleBinding: next } );
+		};
+
+		const addEntry = () => {
+			const key = `--dsgo-binding-${ Date.now() }`;
+			setAttributes( {
+				dsgoStyleBinding: {
+					...binding,
+					[ key ]: { source: 'designsetgo/post-meta', args: { key: '' } },
+				},
+			} );
+		};
+
+		return (
+			<Fragment>
+				<BlockEdit { ...props } />
+				<InspectorControls group="advanced">
+					<PanelBody
+						title={ __( 'Style Bindings', 'designsetgo' ) }
+						initialOpen={ entries.length > 0 }
+					>
+						{ entries.map( ( [ prop, config ] ) => (
+							<VStack key={ prop } spacing={ 1 } style={ { marginBottom: '12px' } }>
+								<HStack>
+									<TextControl
+										label={ __( 'CSS property', 'designsetgo' ) }
+										value={ prop }
+										placeholder="--brand-color"
+										onChange={ ( val ) => updateEntry( prop, val, config ) }
+										__nextHasNoMarginBottom
+									/>
+									<Button
+										variant="tertiary"
+										isDestructive
+										size="small"
+										onClick={ () => removeEntry( prop ) }
+										style={ { alignSelf: 'flex-end' } }
+									>
+										{ __( 'Remove', 'designsetgo' ) }
+									</Button>
+								</HStack>
+								<SelectControl
+									label={ __( 'Source', 'designsetgo' ) }
+									value={ config.source }
+									options={ SOURCE_OPTIONS }
+									onChange={ ( val ) => updateEntry( prop, prop, { ...config, source: val } ) }
+									__nextHasNoMarginBottom
+								/>
+								<TextControl
+									label={ __( 'Field key / name', 'designsetgo' ) }
+									value={ config.args?.key ?? config.args?.name ?? config.args?.id ?? config.args?.field ?? '' }
+									onChange={ ( val ) => {
+										const argKey = [ 'designsetgo/acf' ].includes( config.source ) ? 'name'
+											: [ 'designsetgo/pods' ].includes( config.source ) ? 'field'
+											: 'key';
+										updateEntry( prop, prop, { ...config, args: { [ argKey ]: val } } );
+									} }
+									__nextHasNoMarginBottom
+								/>
+							</VStack>
+						) ) }
+						<Button variant="secondary" size="small" onClick={ addEntry } __next40pxDefaultSize>
+							{ __( '+ Add style binding', 'designsetgo' ) }
+						</Button>
+					</PanelBody>
+				</InspectorControls>
+			</Fragment>
+		);
+	};
+}, 'withStyleBindingInspector' );
+
+addFilter(
+	'editor.BlockEdit',
+	'designsetgo/style-binding-inspector',
+	withStyleBindingInspector
+);

--- a/src/extensions/style-binding/filters.js
+++ b/src/extensions/style-binding/filters.js
@@ -111,13 +111,10 @@ const withStyleBindingInspector = createHigherOrderComponent( ( BlockEdit ) => {
 								/>
 								<TextControl
 									label={ __( 'Field key / name', 'designsetgo' ) }
-									value={ config.args?.key ?? config.args?.name ?? config.args?.id ?? config.args?.field ?? '' }
-									onChange={ ( val ) => {
-										const argKey = [ 'designsetgo/acf' ].includes( config.source ) ? 'name'
-											: [ 'designsetgo/pods' ].includes( config.source ) ? 'field'
-											: 'key';
-										updateEntry( prop, prop, { ...config, args: { [ argKey ]: val } } );
-									} }
+									value={ config.args?.key ?? '' }
+									onChange={ ( val ) =>
+										updateEntry( prop, prop, { ...config, args: { key: val } } )
+									}
 									__nextHasNoMarginBottom
 								/>
 							</VStack>

--- a/src/extensions/style-binding/filters.js
+++ b/src/extensions/style-binding/filters.js
@@ -25,8 +25,8 @@ const SOURCE_OPTIONS = [
 addFilter(
 	'blocks.registerBlockType',
 	'designsetgo/style-binding-attribute',
-	( settings ) => {
-		if ( BLOCKED.has( settings.name ) ) {
+	( settings, name ) => {
+		if ( BLOCKED.has( name ) ) {
 			return settings;
 		}
 		if ( ! settings.attributes ) {

--- a/src/extensions/style-binding/filters.js
+++ b/src/extensions/style-binding/filters.js
@@ -1,5 +1,5 @@
 import { addFilter } from '@wordpress/hooks';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -97,6 +97,11 @@ const withStyleBindingInspector = createHigherOrderComponent( ( BlockEdit ) => {
 										isDestructive
 										size="small"
 										onClick={ () => removeEntry( prop ) }
+										aria-label={ sprintf(
+											/* translators: %s: CSS property name being unbound. */
+											__( 'Remove style binding for "%s"', 'designsetgo' ),
+											prop
+										) }
 										style={ { alignSelf: 'flex-end' } }
 									>
 										{ __( 'Remove', 'designsetgo' ) }

--- a/src/extensions/style-binding/filters.js
+++ b/src/extensions/style-binding/filters.js
@@ -12,6 +12,8 @@ import {
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { Fragment } from '@wordpress/element';
 
+const BLOCKED = new Set( [ 'core/freeform', 'core/missing', 'core/template-part' ] );
+
 const SOURCE_OPTIONS = [
 	{ label: __( 'Post meta', 'designsetgo' ), value: 'designsetgo/post-meta' },
 	{ label: __( 'ACF', 'designsetgo' ), value: 'designsetgo/acf' },
@@ -24,6 +26,9 @@ addFilter(
 	'blocks.registerBlockType',
 	'designsetgo/style-binding-attribute',
 	( settings ) => {
+		if ( BLOCKED.has( settings.name ) ) {
+			return settings;
+		}
 		if ( ! settings.attributes ) {
 			settings.attributes = {};
 		}
@@ -37,6 +42,9 @@ addFilter(
 
 const withStyleBindingInspector = createHigherOrderComponent( ( BlockEdit ) => {
 	return function WithStyleBindingInspector( props ) {
+		if ( BLOCKED.has( props.name ) ) {
+			return <BlockEdit { ...props } />;
+		}
 		const { attributes, setAttributes } = props;
 		const binding = attributes.dsgoStyleBinding ?? {};
 		const entries = Object.entries( binding );

--- a/src/extensions/style-binding/index.js
+++ b/src/extensions/style-binding/index.js
@@ -1,0 +1,1 @@
+import './filters';

--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,9 @@ import './extensions/hover-effects';
 // Conditional Visibility - registers dsgoVisibility attribute for query-driven inner-block visibility
 import './extensions/visibility';
 
+// Style Binding - maps CSS properties to dynamic data sources (post-meta, ACF, MetaBox, Pods, JetEngine)
+import './extensions/style-binding';
+
 // ===== RICH TEXT FORMATS =====
 // Text Style - adds inline text styling (color, gradient, size) to selected text
 import './formats/text-style';

--- a/tests/phpunit/blocks/query/qm-collector-test.php
+++ b/tests/phpunit/blocks/query/qm-collector-test.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @group query-block
+ */
+class DSGo_QM_Collector_Test extends WP_UnitTestCase {
+
+	public function test_collector_ignores_data_when_qm_absent() {
+		if ( defined( 'QM_VERSION' ) ) {
+			$this->markTestSkipped( 'QM is active in this environment; test only applies when QM is absent.' );
+		}
+		$this->assertFalse( class_exists( 'DesignSetGo\QueryMonitor\Collector' ) );
+	}
+
+	public function test_data_structure_is_serialisable() {
+		$data = array(
+			'query_id'    => 'abc123',
+			'source'      => 'posts',
+			'wp_args'     => array( 'post_type' => 'post', 'posts_per_page' => 6 ),
+			'found_posts' => 12,
+			'sql'         => 'SELECT ...',
+			'filters'     => array(),
+			'duration_ms' => 14.5,
+		);
+		$this->assertIsString( wp_json_encode( $data ) );
+	}
+}

--- a/tests/phpunit/blocks/query/render-posts-test.php
+++ b/tests/phpunit/blocks/query/render-posts-test.php
@@ -397,6 +397,98 @@ class DesignSetGo_Query_Render_Posts_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'active', $args['meta_query'][1]['key'] );
 	}
 
+	/**
+	 * Date query supports `before`-only mode (upper bound, no after).
+	 * Regression: missing branch coverage in the inlined date builder.
+	 */
+	public function test_date_query_before_builds_correctly() {
+		$this->load_helpers();
+		$base_atts = [
+			'perPage' => 10, 'orderBy' => 'date', 'order' => 'DESC',
+			'postType' => 'post', 'offset' => 0, 'ignoreSticky' => false,
+			'search' => '', 'bindSearchTo' => '',
+		];
+		$atts = array_merge( $base_atts, [
+			'source'    => 'posts',
+			'dateQuery' => [
+				'relation' => 'AND',
+				'clauses'  => [ [
+					'column'    => 'post_modified',
+					'mode'      => 'before',
+					'after'     => '',
+					'before'    => '2025-01-01',
+					'inclusive' => true,
+				] ],
+			],
+		] );
+		$args = designsetgo_query_build_posts_args( $atts, [ 'page' => 1, 'query_id' => '' ] );
+		$this->assertArrayHasKey( 'date_query', $args );
+		$this->assertEquals( 'post_modified', $args['date_query'][0]['column'] );
+		$this->assertEquals( '2025-01-01', $args['date_query'][0]['before'] );
+		$this->assertArrayNotHasKey( 'after', $args['date_query'][0] );
+	}
+
+	/**
+	 * Single-child nested groups are unwrapped to the bare child to avoid
+	 * WP_Query's `_doing_it_wrong()` notice when a tax_query group has
+	 * `relation` set with only one sub-clause.
+	 */
+	public function test_single_child_tax_group_is_unwrapped() {
+		$this->load_helpers();
+		$base_atts = [
+			'perPage' => 10, 'orderBy' => 'date', 'order' => 'DESC',
+			'postType' => 'post', 'offset' => 0, 'ignoreSticky' => false,
+			'search' => '', 'bindSearchTo' => '',
+		];
+		$atts = array_merge( $base_atts, [
+			'source'   => 'posts',
+			'taxQuery' => [
+				'relation' => 'AND',
+				'clauses'  => [ [
+					'relation' => 'OR',
+					'clauses'  => [ [
+						'taxonomy' => 'category',
+						'terms'    => [ 1 ],
+						'operator' => 'IN',
+					] ],
+				] ],
+			],
+		] );
+		$args = designsetgo_query_build_posts_args( $atts, [ 'page' => 1, 'query_id' => '' ] );
+		// The single-child OR group should collapse to a bare leaf clause.
+		$this->assertArrayHasKey( 'tax_query', $args );
+		$this->assertSame( 'category', $args['tax_query'][0]['taxonomy'] );
+		$this->assertArrayNotHasKey( 'relation', $args['tax_query'][0] );
+	}
+
+	/**
+	 * Empty groups (all-invalid leaves) are pruned from the WP_Query args
+	 * entirely instead of emitting a `relation`-only stub.
+	 */
+	public function test_empty_meta_group_is_pruned() {
+		$this->load_helpers();
+		$base_atts = [
+			'perPage' => 10, 'orderBy' => 'date', 'order' => 'DESC',
+			'postType' => 'post', 'offset' => 0, 'ignoreSticky' => false,
+			'search' => '', 'bindSearchTo' => '',
+		];
+		$atts = array_merge( $base_atts, [
+			'source'    => 'posts',
+			'metaQuery' => [
+				'relation' => 'AND',
+				'clauses'  => [ [
+					'relation' => 'OR',
+					'clauses'  => [
+						[ 'key' => '', 'compare' => '=', 'value' => 'a', 'type' => 'CHAR' ],
+						[ 'key' => '', 'compare' => '=', 'value' => 'b', 'type' => 'CHAR' ],
+					],
+				] ],
+			],
+		] );
+		$args = designsetgo_query_build_posts_args( $atts, [ 'page' => 1, 'query_id' => '' ] );
+		$this->assertArrayNotHasKey( 'meta_query', $args );
+	}
+
 	public function test_child_blocks_resolve_per_item_context() {
 		$ids   = array();
 		$ids[] = self::factory()->post->create( array( 'post_title' => 'Alpha', 'post_status' => 'publish' ) );

--- a/tests/phpunit/blocks/query/render-posts-test.php
+++ b/tests/phpunit/blocks/query/render-posts-test.php
@@ -205,6 +205,57 @@ class DesignSetGo_Query_Render_Posts_Test extends WP_UnitTestCase {
 		$this->assertSame( 2, $result['totalItems'] );
 	}
 
+	public function test_tax_clause_defaults_include_children_true() {
+		$this->load_helpers();
+		$base_atts = [
+			'perPage'       => 10,
+			'orderBy'       => 'date',
+			'order'         => 'DESC',
+			'postType'      => 'post',
+			'offset'        => 0,
+			'ignoreSticky'  => false,
+			'search'        => '',
+			'bindSearchTo'  => '',
+		];
+		$atts = array_merge( $base_atts, [
+			'source'   => 'posts',
+			'taxQuery' => [
+				'relation' => 'AND',
+				'clauses'  => [ [ 'taxonomy' => 'category', 'terms' => [ 1 ], 'operator' => 'IN' ] ],
+			],
+		] );
+		$args = designsetgo_query_build_posts_args( $atts, [ 'page' => 1, 'query_id' => '' ] );
+		$this->assertTrue( $args['tax_query'][0]['include_children'] );
+	}
+
+	public function test_tax_clause_include_children_false() {
+		$this->load_helpers();
+		$base_atts = [
+			'perPage'       => 10,
+			'orderBy'       => 'date',
+			'order'         => 'DESC',
+			'postType'      => 'post',
+			'offset'        => 0,
+			'ignoreSticky'  => false,
+			'search'        => '',
+			'bindSearchTo'  => '',
+		];
+		$atts = array_merge( $base_atts, [
+			'source'   => 'posts',
+			'taxQuery' => [
+				'relation' => 'AND',
+				'clauses'  => [ [
+					'taxonomy'         => 'category',
+					'terms'            => [ 1 ],
+					'operator'         => 'IN',
+					'include_children' => false,
+				] ],
+			],
+		] );
+		$args = designsetgo_query_build_posts_args( $atts, [ 'page' => 1, 'query_id' => '' ] );
+		$this->assertFalse( $args['tax_query'][0]['include_children'] );
+	}
+
 	public function test_child_blocks_resolve_per_item_context() {
 		$ids   = array();
 		$ids[] = self::factory()->post->create( array( 'post_title' => 'Alpha', 'post_status' => 'publish' ) );

--- a/tests/phpunit/blocks/query/render-posts-test.php
+++ b/tests/phpunit/blocks/query/render-posts-test.php
@@ -327,6 +327,40 @@ class DesignSetGo_Query_Render_Posts_Test extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'date_query', $args );
 	}
 
+	public function test_nested_tax_group_builds_correctly() {
+		$this->load_helpers();
+		$base_atts = [
+			'perPage' => 10, 'orderBy' => 'date', 'order' => 'DESC',
+			'postType' => 'post', 'offset' => 0, 'ignoreSticky' => false,
+			'search' => '', 'bindSearchTo' => '',
+		];
+		$atts = array_merge( $base_atts, [
+			'source'   => 'posts',
+			'taxQuery' => [
+				'relation' => 'AND',
+				'clauses'  => [
+					[
+						'relation' => 'OR',
+						'clauses'  => [
+							[ 'taxonomy' => 'category', 'terms' => [ 1 ], 'operator' => 'IN', 'include_children' => true ],
+							[ 'taxonomy' => 'category', 'terms' => [ 2 ], 'operator' => 'IN', 'include_children' => true ],
+						],
+					],
+					[ 'taxonomy' => 'post_tag', 'terms' => [ 5 ], 'operator' => 'IN', 'include_children' => false ],
+				],
+			],
+		] );
+		$args = designsetgo_query_build_posts_args( $atts, [ 'page' => 1, 'query_id' => '' ] );
+		$this->assertEquals( 'AND', $args['tax_query']['relation'] );
+		$sub = $args['tax_query'][0];
+		$this->assertEquals( 'OR', $sub['relation'] );
+		$this->assertEquals( 'category', $sub[0]['taxonomy'] );
+		$this->assertEquals( 'category', $sub[1]['taxonomy'] );
+		$leaf = $args['tax_query'][1];
+		$this->assertEquals( 'post_tag', $leaf['taxonomy'] );
+		$this->assertFalse( $leaf['include_children'] );
+	}
+
 	public function test_child_blocks_resolve_per_item_context() {
 		$ids   = array();
 		$ids[] = self::factory()->post->create( array( 'post_title' => 'Alpha', 'post_status' => 'publish' ) );

--- a/tests/phpunit/blocks/query/render-posts-test.php
+++ b/tests/phpunit/blocks/query/render-posts-test.php
@@ -37,7 +37,7 @@ class DesignSetGo_Query_Render_Posts_Test extends WP_UnitTestCase {
 		self::factory()->post->create_many( 7, array( 'post_status' => 'publish' ) );
 		$this->load_helpers();
 
-		$atts = array( 'source' => 'posts', 'postType' => 'post', 'perPage' => 3 );
+		$atts = array( 'source' => 'posts', 'postType' => 'post', 'perPage' => 3, 'itemTagName' => 'li' );
 		$page1 = designsetgo_query_render( $atts, array( 'query_id' => 't', 'page' => 1, 'inner_html' => '' ) );
 		$page2 = designsetgo_query_render( $atts, array( 'query_id' => 't', 'page' => 2, 'inner_html' => '' ) );
 		$page3 = designsetgo_query_render( $atts, array( 'query_id' => 't', 'page' => 3, 'inner_html' => '' ) );
@@ -114,7 +114,7 @@ class DesignSetGo_Query_Render_Posts_Test extends WP_UnitTestCase {
 		add_filter( 'designsetgo_query_args', $filter_cb, 10, 3 );
 
 		$result = designsetgo_query_render(
-			array( 'source' => 'posts', 'postType' => 'post', 'perPage' => 10 ),
+			array( 'source' => 'posts', 'postType' => 'post', 'perPage' => 10, 'itemTagName' => 'li' ),
 			array( 'query_id' => 'hook', 'page' => 1, 'inner_html' => '' )
 		);
 
@@ -359,6 +359,42 @@ class DesignSetGo_Query_Render_Posts_Test extends WP_UnitTestCase {
 		$leaf = $args['tax_query'][1];
 		$this->assertEquals( 'post_tag', $leaf['taxonomy'] );
 		$this->assertFalse( $leaf['include_children'] );
+	}
+
+	public function test_nested_meta_group_builds_correctly() {
+		$this->load_helpers();
+		$base_atts = [
+			'perPage'      => 10,
+			'orderBy'      => 'date',
+			'order'        => 'DESC',
+			'postType'     => 'post',
+			'offset'       => 0,
+			'ignoreSticky' => false,
+			'search'       => '',
+			'bindSearchTo' => '',
+		];
+		$atts = array_merge( $base_atts, [
+			'source'    => 'posts',
+			'metaQuery' => [
+				'relation' => 'AND',
+				'clauses'  => [
+					[
+						'relation' => 'OR',
+						'clauses'  => [
+							[ 'key' => 'status', 'compare' => '=', 'value' => 'featured', 'type' => 'CHAR' ],
+							[ 'key' => 'featured', 'compare' => '=', 'value' => '1', 'type' => 'NUMERIC' ],
+						],
+					],
+					[ 'key' => 'active', 'compare' => '=', 'value' => '1', 'type' => 'CHAR' ],
+				],
+			],
+		] );
+		$args = designsetgo_query_build_posts_args( $atts, [ 'page' => 1, 'query_id' => '' ] );
+		$this->assertEquals( 'AND', $args['meta_query']['relation'] );
+		$sub = $args['meta_query'][0];
+		$this->assertEquals( 'OR', $sub['relation'] );
+		$this->assertEquals( 'status', $sub[0]['key'] );
+		$this->assertEquals( 'active', $args['meta_query'][1]['key'] );
 	}
 
 	public function test_child_blocks_resolve_per_item_context() {

--- a/tests/phpunit/blocks/query/render-posts-test.php
+++ b/tests/phpunit/blocks/query/render-posts-test.php
@@ -256,6 +256,77 @@ class DesignSetGo_Query_Render_Posts_Test extends WP_UnitTestCase {
 		$this->assertFalse( $args['tax_query'][0]['include_children'] );
 	}
 
+	public function test_date_query_after_builds_correctly() {
+		$this->load_helpers();
+		$base_atts = [
+			'perPage' => 10, 'orderBy' => 'date', 'order' => 'DESC',
+			'postType' => 'post', 'offset' => 0, 'ignoreSticky' => false,
+			'search' => '', 'bindSearchTo' => '',
+		];
+		$atts = array_merge( $base_atts, [
+			'source'    => 'posts',
+			'dateQuery' => [
+				'relation' => 'AND',
+				'clauses'  => [ [
+					'column'    => 'post_date',
+					'mode'      => 'after',
+					'after'     => '-30 days',
+					'before'    => '',
+					'inclusive' => false,
+				] ],
+			],
+		] );
+		$args = designsetgo_query_build_posts_args( $atts, [ 'page' => 1, 'query_id' => '' ] );
+		$this->assertArrayHasKey( 'date_query', $args );
+		$this->assertEquals( 'post_date', $args['date_query'][0]['column'] );
+		$this->assertEquals( '-30 days', $args['date_query'][0]['after'] );
+		$this->assertArrayNotHasKey( 'before', $args['date_query'][0] );
+	}
+
+	public function test_date_query_between_includes_both_bounds() {
+		$this->load_helpers();
+		$base_atts = [
+			'perPage' => 10, 'orderBy' => 'date', 'order' => 'DESC',
+			'postType' => 'post', 'offset' => 0, 'ignoreSticky' => false,
+			'search' => '', 'bindSearchTo' => '',
+		];
+		$atts = array_merge( $base_atts, [
+			'source'    => 'posts',
+			'dateQuery' => [
+				'relation' => 'AND',
+				'clauses'  => [ [
+					'column'    => 'post_date',
+					'mode'      => 'between',
+					'after'     => '2024-01-01',
+					'before'    => '2024-12-31',
+					'inclusive' => true,
+				] ],
+			],
+		] );
+		$args = designsetgo_query_build_posts_args( $atts, [ 'page' => 1, 'query_id' => '' ] );
+		$this->assertEquals( '2024-01-01', $args['date_query'][0]['after'] );
+		$this->assertEquals( '2024-12-31', $args['date_query'][0]['before'] );
+		$this->assertTrue( $args['date_query'][0]['inclusive'] );
+	}
+
+	public function test_date_query_skips_empty_clauses() {
+		$this->load_helpers();
+		$base_atts = [
+			'perPage' => 10, 'orderBy' => 'date', 'order' => 'DESC',
+			'postType' => 'post', 'offset' => 0, 'ignoreSticky' => false,
+			'search' => '', 'bindSearchTo' => '',
+		];
+		$atts = array_merge( $base_atts, [
+			'source'    => 'posts',
+			'dateQuery' => [
+				'relation' => 'AND',
+				'clauses'  => [ [ 'column' => 'post_date', 'mode' => 'after', 'after' => '', 'before' => '' ] ],
+			],
+		] );
+		$args = designsetgo_query_build_posts_args( $atts, [ 'page' => 1, 'query_id' => '' ] );
+		$this->assertArrayNotHasKey( 'date_query', $args );
+	}
+
 	public function test_child_blocks_resolve_per_item_context() {
 		$ids   = array();
 		$ids[] = self::factory()->post->create( array( 'post_title' => 'Alpha', 'post_status' => 'publish' ) );

--- a/tests/phpunit/extensions/style-binding-test.php
+++ b/tests/phpunit/extensions/style-binding-test.php
@@ -128,6 +128,53 @@ class StyleBindingTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Resolver passes the iterated post id and the `key` arg to source plugins.
+	 *
+	 * Locks in the contract that every built-in source reads `args['key']` (not
+	 * a per-source synonym like `id`/`name`/`field`) and resolves against the
+	 * current post id from `$GLOBALS['designsetgo_parent_stack']`. Regression
+	 * for editor → resolver mismatch and JetEngine dropping the post id.
+	 */
+	public function test_resolver_uses_key_arg_and_iterated_post_id() {
+		$post_id              = self::factory()->post->create();
+		$captured             = array();
+		$GLOBALS['designsetgo_parent_stack'] = array(
+			array( 'id' => $post_id, 'type' => 'post' ),
+		);
+
+		add_filter(
+			'designsetgo_style_binding_resolve',
+			function ( $val, $source, $args ) use ( &$captured ) {
+				$captured[ $source ] = $args;
+				return $val ?? 'sentinel';
+			},
+			10,
+			3
+		);
+
+		foreach ( array( 'designsetgo/metabox', 'designsetgo/pods', 'designsetgo/jetengine' ) as $source ) {
+			$block = $this->make_block(
+				array(
+					'dsgoStyleBinding' => array(
+						'--brand' => array(
+							'source' => $source,
+							'args'   => array( 'key' => 'brand_color' ),
+						),
+					),
+				)
+			);
+			$this->sb->apply_style_bindings( '<p>X</p>', $block );
+		}
+
+		unset( $GLOBALS['designsetgo_parent_stack'] );
+		remove_all_filters( 'designsetgo_style_binding_resolve' );
+
+		foreach ( array( 'designsetgo/metabox', 'designsetgo/pods', 'designsetgo/jetengine' ) as $source ) {
+			$this->assertSame( 'brand_color', $captured[ $source ]['key'] ?? null, "Source $source must receive args.key" );
+		}
+	}
+
+	/**
 	 * Existing style attribute is preserved when new styles are injected.
 	 */
 	public function test_existing_style_attribute_is_preserved() {

--- a/tests/phpunit/extensions/style-binding-test.php
+++ b/tests/phpunit/extensions/style-binding-test.php
@@ -175,6 +175,122 @@ class StyleBindingTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Password-protected posts must not leak meta values via style bindings.
+	 * Mirrors the gate the v2.4 block-bindings adapter applies.
+	 */
+	public function test_password_protected_post_blocks_resolution() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+			)
+		);
+		update_post_meta( $post_id, 'brand_color', '#ff0000' );
+
+		$GLOBALS['designsetgo_parent_stack'] = array(
+			array( 'id' => $post_id, 'type' => 'post' ),
+		);
+
+		$block = $this->make_block(
+			array(
+				'dsgoStyleBinding' => array(
+					'--brand' => array(
+						'source' => 'designsetgo/post-meta',
+						'args'   => array( 'key' => 'brand_color' ),
+					),
+				),
+			)
+		);
+		$result = $this->sb->apply_style_bindings( '<div>X</div>', $block );
+
+		unset( $GLOBALS['designsetgo_parent_stack'] );
+
+		$this->assertStringNotContainsString( '#ff0000', $result );
+		$this->assertStringNotContainsString( '--brand', $result );
+	}
+
+	/**
+	 * Protected meta keys (prefixed with `_`) must be rejected.
+	 */
+	public function test_protected_meta_key_blocks_resolution() {
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		update_post_meta( $post_id, '_internal_color', '#ff0000' );
+
+		$GLOBALS['designsetgo_parent_stack'] = array(
+			array( 'id' => $post_id, 'type' => 'post' ),
+		);
+
+		$block = $this->make_block(
+			array(
+				'dsgoStyleBinding' => array(
+					'--brand' => array(
+						'source' => 'designsetgo/post-meta',
+						'args'   => array( 'key' => '_internal_color' ),
+					),
+				),
+			)
+		);
+		$result = $this->sb->apply_style_bindings( '<div>X</div>', $block );
+
+		unset( $GLOBALS['designsetgo_parent_stack'] );
+
+		$this->assertStringNotContainsString( '#ff0000', $result );
+	}
+
+	/**
+	 * CSS values containing `{`, `}`, or `data:` are rejected as injection
+	 * vectors, in addition to `url(`, `expression(`, `javascript:`, and `;`.
+	 */
+	public function test_blocklist_rejects_braces_and_data_uri() {
+		$dangerous = array(
+			'red} body { display:none',
+			'expression(alert(1))',
+			'javascript:alert(1)',
+			'data:image/svg+xml;base64,PHN2Zy8+',
+			'red; display:none',
+			'{color:red}',
+		);
+		foreach ( $dangerous as $value ) {
+			add_filter( 'designsetgo_style_binding_resolve', fn() => $value, 10, 3 );
+			$block = $this->make_block(
+				array(
+					'dsgoStyleBinding' => array(
+						'--brand' => array(
+							'source' => 'designsetgo/post-meta',
+							'args'   => array( 'key' => 'c' ),
+						),
+					),
+				)
+			);
+			$result = $this->sb->apply_style_bindings( '<div>X</div>', $block );
+			remove_all_filters( 'designsetgo_style_binding_resolve' );
+			$this->assertStringNotContainsString( $value, $result, "Should reject: $value" );
+		}
+	}
+
+	/**
+	 * Vendor-prefixed and digit-bearing CSS property names are accepted.
+	 * Regression: previous regex excluded `-webkit-text-fill-color` and
+	 * any property with a digit.
+	 */
+	public function test_vendor_prefixed_and_digit_props_accepted() {
+		add_filter( 'designsetgo_style_binding_resolve', fn() => 'red', 10, 3 );
+		$block = $this->make_block(
+			array(
+				'dsgoStyleBinding' => array(
+					'-webkit-text-fill-color' => array(
+						'source' => 'designsetgo/post-meta',
+						'args'   => array( 'key' => 'c' ),
+					),
+				),
+			)
+		);
+		$result = $this->sb->apply_style_bindings( '<div>X</div>', $block );
+		remove_all_filters( 'designsetgo_style_binding_resolve' );
+		$this->assertStringContainsString( '-webkit-text-fill-color:red', $result );
+	}
+
+	/**
 	 * Existing style attribute is preserved when new styles are injected.
 	 */
 	public function test_existing_style_attribute_is_preserved() {

--- a/tests/phpunit/extensions/style-binding-test.php
+++ b/tests/phpunit/extensions/style-binding-test.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Tests for StyleBinding class.
+ *
+ * @package DesignSetGo
+ */
+
+namespace DesignSetGo\Tests;
+
+use WP_UnitTestCase;
+use DesignSetGo\StyleBinding;
+
+/**
+ * Style Binding Test Case
+ */
+class StyleBindingTest extends WP_UnitTestCase {
+
+	/**
+	 * StyleBinding instance.
+	 *
+	 * @var StyleBinding
+	 */
+	private StyleBinding $sb;
+
+	/**
+	 * Set up test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->sb = new StyleBinding();
+	}
+
+	/**
+	 * Build a minimal block array for testing.
+	 *
+	 * @param array $attrs Block attributes.
+	 * @return array
+	 */
+	private function make_block( array $attrs ): array {
+		return array(
+			'blockName'   => 'core/paragraph',
+			'attrs'       => $attrs,
+			'innerBlocks' => array(),
+			'innerHTML'   => '',
+		);
+	}
+
+	/**
+	 * No binding returns HTML unchanged.
+	 */
+	public function test_no_binding_returns_html_unchanged() {
+		$html = '<p class="wp-block">Hello</p>';
+		$this->assertSame( $html, $this->sb->apply_style_bindings( $html, $this->make_block( array() ) ) );
+	}
+
+	/**
+	 * Invalid CSS property name is skipped.
+	 */
+	public function test_invalid_css_prop_is_skipped() {
+		$html  = '<p>Hello</p>';
+		$block = $this->make_block(
+			array(
+				'dsgoStyleBinding' => array(
+					'bad prop!' => array(
+						'source' => 'designsetgo/post-meta',
+						'args'   => array( 'key' => 'x' ),
+					),
+				),
+			)
+		);
+		$this->assertStringNotContainsString( 'bad prop!', $this->sb->apply_style_bindings( $html, $block ) );
+	}
+
+	/**
+	 * Value containing dangerous URL is rejected.
+	 */
+	public function test_dangerous_value_is_rejected() {
+		add_filter(
+			'designsetgo_style_binding_resolve',
+			function ( $val, $source, $args ) {
+				return 'url(javascript:alert(1))';
+			},
+			10,
+			3
+		);
+		$html  = '<div class="wp-block">X</div>';
+		$block = $this->make_block(
+			array(
+				'dsgoStyleBinding' => array(
+					'--color' => array(
+						'source' => 'designsetgo/post-meta',
+						'args'   => array( 'key' => 'c' ),
+					),
+				),
+			)
+		);
+		$result = $this->sb->apply_style_bindings( $html, $block );
+		$this->assertStringNotContainsString( 'javascript', $result );
+		remove_all_filters( 'designsetgo_style_binding_resolve' );
+	}
+
+	/**
+	 * Valid binding injects style attribute.
+	 */
+	public function test_valid_binding_injects_style_attribute() {
+		add_filter(
+			'designsetgo_style_binding_resolve',
+			function ( $val, $source, $args ) {
+				return '#ff0000';
+			},
+			10,
+			3
+		);
+		$html  = '<div class="wp-block">X</div>';
+		$block = $this->make_block(
+			array(
+				'dsgoStyleBinding' => array(
+					'--brand' => array(
+						'source' => 'designsetgo/post-meta',
+						'args'   => array( 'key' => 'color' ),
+					),
+				),
+			)
+		);
+		$result = $this->sb->apply_style_bindings( $html, $block );
+		$this->assertStringContainsString( '--brand:#ff0000', $result );
+		remove_all_filters( 'designsetgo_style_binding_resolve' );
+	}
+
+	/**
+	 * Existing style attribute is preserved when new styles are injected.
+	 */
+	public function test_existing_style_attribute_is_preserved() {
+		add_filter( 'designsetgo_style_binding_resolve', fn() => 'blue', 10, 3 );
+		$html  = '<div style="color:red">X</div>';
+		$block = $this->make_block(
+			array(
+				'dsgoStyleBinding' => array(
+					'background-color' => array(
+						'source' => 'designsetgo/post-meta',
+						'args'   => array( 'key' => 'bg' ),
+					),
+				),
+			)
+		);
+		$result = $this->sb->apply_style_bindings( $html, $block );
+		$this->assertStringContainsString( 'color:red', $result );
+		$this->assertStringContainsString( 'background-color:blue', $result );
+		remove_all_filters( 'designsetgo_style_binding_resolve' );
+	}
+}

--- a/tests/unit/blocks/query/date-query-builder.test.js
+++ b/tests/unit/blocks/query/date-query-builder.test.js
@@ -1,0 +1,162 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// ─── WordPress module mocks ───────────────────────────────────────────────────
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text ) => text,
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: () => undefined,
+	useDispatch: () => ( {} ),
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( { store: 'core' } ) );
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: () => ( {} ),
+	useInnerBlocksProps: ( p = {} ) => ( { ...p, children: null } ),
+	InspectorControls: ( { children } ) => <div>{ children }</div>,
+	store: 'core/block-editor',
+} ) );
+
+jest.mock( '@wordpress/blocks', () => ( {
+	createBlocksFromInnerBlocksTemplate: jest.fn( ( t ) => t ),
+} ) );
+
+jest.mock( '@wordpress/components', () => {
+	const SelectControl = ( { label, value, options, onChange } ) => (
+		<label>
+			{ label }
+			<select
+				value={ value }
+				onChange={ ( e ) => onChange( e.target.value ) }
+				aria-label={ label }
+			>
+				{ ( options || [] ).map( ( opt ) => (
+					<option key={ opt.value } value={ opt.value }>
+						{ opt.label }
+					</option>
+				) ) }
+			</select>
+		</label>
+	);
+
+	const TextControl = ( { label, value, onChange } ) => (
+		<label>
+			{ label }
+			<input
+				type="text"
+				value={ value }
+				onChange={ ( e ) => onChange( e.target.value ) }
+				aria-label={ label }
+			/>
+		</label>
+	);
+
+	const Button = ( {
+		children,
+		onClick,
+		disabled,
+		'aria-label': ariaLabel,
+		isDestructive,
+		variant,
+	} ) => (
+		<button
+			type="button"
+			onClick={ onClick }
+			disabled={ disabled }
+			aria-label={ ariaLabel }
+			data-destructive={ isDestructive ? 'true' : undefined }
+			data-variant={ variant }
+		>
+			{ children }
+		</button>
+	);
+
+	const ToggleControl = ( { label, checked, onChange } ) => (
+		<label>
+			{ label }
+			<input
+				type="checkbox"
+				aria-label={ label }
+				checked={ checked }
+				onChange={ ( e ) => onChange( e.target.checked ) }
+			/>
+		</label>
+	);
+
+	// ToolsPanelItem: isShownByDefault=false items are hidden.
+	const ToolsPanelItem = ( { children, isShownByDefault } ) =>
+		isShownByDefault !== false ? <>{ children }</> : null;
+
+	const ToolsPanel = ( { children, label } ) => (
+		<fieldset aria-label={ label }>{ children }</fieldset>
+	);
+
+	const VStack = ( { children } ) => <div>{ children }</div>;
+	const HStack = ( { children } ) => <div>{ children }</div>;
+
+	return {
+		SelectControl,
+		TextControl,
+		Button,
+		ToggleControl,
+		__experimentalToolsPanel: ToolsPanel,
+		__experimentalToolsPanelItem: ToolsPanelItem,
+		__experimentalHStack: HStack,
+		__experimentalVStack: VStack,
+	};
+} );
+
+jest.mock( '@wordpress/element', () => jest.requireActual( '@wordpress/element' ) );
+
+// ─── Component under test ─────────────────────────────────────────────────────
+import DateQueryBuilder from '../../../../src/blocks/query/components/DateQueryBuilder';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const defaultAttrs = {
+	dateQuery: { relation: 'AND', clauses: [] },
+};
+
+describe( 'DateQueryBuilder', () => {
+	it( 'renders empty state with an Add button', () => {
+		render(
+			<DateQueryBuilder
+				attributes={ defaultAttrs }
+				setAttributes={ jest.fn() }
+				clientId="test"
+			/>
+		);
+		expect(
+			screen.getByRole( 'button', { name: /add date clause/i } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'seeds new clause with post_date / after / inclusive:true defaults', () => {
+		const setAttributes = jest.fn();
+		render(
+			<DateQueryBuilder
+				attributes={ defaultAttrs }
+				setAttributes={ setAttributes }
+				clientId="test"
+			/>
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: /add date clause/i } ) );
+		expect( setAttributes ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				dateQuery: expect.objectContaining( {
+					clauses: [
+						expect.objectContaining( {
+							column: 'post_date',
+							mode: 'after',
+							inclusive: true,
+						} ),
+					],
+				} ),
+			} )
+		);
+	} );
+} );

--- a/tests/unit/blocks/query/date-query-builder.test.js
+++ b/tests/unit/blocks/query/date-query-builder.test.js
@@ -5,6 +5,10 @@ import '@testing-library/jest-dom';
 
 jest.mock( '@wordpress/i18n', () => ( {
 	__: ( text ) => text,
+	sprintf: ( fmt, ...args ) => {
+		let i = 0;
+		return fmt.replace( /%[sd]/g, () => String( args[ i++ ] ?? '' ) );
+	},
 } ) );
 
 jest.mock( '@wordpress/data', () => ( {

--- a/tests/unit/blocks/query/meta-query-builder.test.js
+++ b/tests/unit/blocks/query/meta-query-builder.test.js
@@ -5,6 +5,10 @@ import '@testing-library/jest-dom';
 
 jest.mock('@wordpress/i18n', () => ({
 	__: (text) => text,
+	sprintf: (fmt, ...args) => {
+		let i = 0;
+		return fmt.replace(/%[sd]/g, () => String(args[i++] ?? ''));
+	},
 }));
 
 // MetaQueryBuilder has no coreStore lookups — useSelect is not used.
@@ -128,7 +132,7 @@ describe('MetaQueryBuilder', () => {
 	it('renders + Clause button when no clauses', () => {
 		renderWith();
 		expect(
-			screen.getByRole('button', { name: /\+ clause/i })
+			screen.getByRole('button', { name: /add clause/i })
 		).toBeInTheDocument();
 	});
 
@@ -201,8 +205,10 @@ describe('MetaQueryBuilder', () => {
 				],
 			},
 		});
+		// Each Remove button now carries a per-clause aria-label like
+		// `Remove meta filter for "field_a"`.
 		const removeButtons = screen.getAllByRole('button', {
-			name: /^remove$/i,
+			name: /remove meta filter for/i,
 		});
 		expect(removeButtons).toHaveLength(2);
 	});
@@ -272,7 +278,7 @@ describe('MetaQueryBuilder', () => {
 				clientId="test"
 			/>
 		);
-		fireEvent.click(getByRole('button', { name: /\+ group/i }));
+		fireEvent.click(getByRole('button', { name: /add group/i }));
 		const call = setAttributes.mock.calls[0][0];
 		expect(call.metaQuery.clauses[0]).toHaveProperty('clauses');
 	});

--- a/tests/unit/blocks/query/meta-query-builder.test.js
+++ b/tests/unit/blocks/query/meta-query-builder.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 // ─── WordPress module mocks ───────────────────────────────────────────────────
@@ -125,10 +125,10 @@ function renderWith(attributeOverrides = {}) {
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('MetaQueryBuilder', () => {
-	it('renders Add meta condition button when no clauses', () => {
+	it('renders + Clause button when no clauses', () => {
 		renderWith();
 		expect(
-			screen.getByRole('button', { name: /add meta condition/i })
+			screen.getByRole('button', { name: /\+ clause/i })
 		).toBeInTheDocument();
 	});
 
@@ -186,7 +186,7 @@ describe('MetaQueryBuilder', () => {
 		expect(screen.queryByLabelText(/^value$/i)).not.toBeInTheDocument();
 	});
 
-	it('renders Remove button with aria-label for each clause', () => {
+	it('renders Remove button for each clause', () => {
 		renderWith({
 			metaQuery: {
 				relation: 'AND',
@@ -202,17 +202,17 @@ describe('MetaQueryBuilder', () => {
 			},
 		});
 		const removeButtons = screen.getAllByRole('button', {
-			name: /remove meta condition/i,
+			name: /^remove$/i,
 		});
 		expect(removeButtons).toHaveLength(2);
 	});
 
-	it('renders Relation selector only when more than 1 clause is present', () => {
-		// 0 clauses — no relation selector.
+	it('renders Match selector only when more than 1 clause is present', () => {
+		// 0 clauses — no match selector.
 		const { rerender } = renderWith();
-		expect(screen.queryByLabelText(/relation/i)).not.toBeInTheDocument();
+		expect(screen.queryByLabelText(/match/i)).not.toBeInTheDocument();
 
-		// 1 clause — no relation selector.
+		// 1 clause — no match selector.
 		rerender(
 			<MetaQueryBuilder
 				attributes={{
@@ -232,9 +232,9 @@ describe('MetaQueryBuilder', () => {
 				clientId="test-client"
 			/>
 		);
-		expect(screen.queryByLabelText(/relation/i)).not.toBeInTheDocument();
+		expect(screen.queryByLabelText(/match/i)).not.toBeInTheDocument();
 
-		// 2 clauses — relation selector appears.
+		// 2 clauses — match selector appears.
 		rerender(
 			<MetaQueryBuilder
 				attributes={{
@@ -260,6 +260,20 @@ describe('MetaQueryBuilder', () => {
 				clientId="test-client"
 			/>
 		);
-		expect(screen.getByLabelText(/relation/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/match/i)).toBeInTheDocument();
+	});
+
+	it('adds a nested group when clicking + Group', () => {
+		const setAttributes = jest.fn();
+		const { getByRole } = render(
+			<MetaQueryBuilder
+				attributes={{ metaQuery: { relation: 'AND', clauses: [] } }}
+				setAttributes={setAttributes}
+				clientId="test"
+			/>
+		);
+		fireEvent.click(getByRole('button', { name: /\+ group/i }));
+		const call = setAttributes.mock.calls[0][0];
+		expect(call.metaQuery.clauses[0]).toHaveProperty('clauses');
 	});
 });

--- a/tests/unit/blocks/query/tax-query-builder.test.js
+++ b/tests/unit/blocks/query/tax-query-builder.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 // ─── WordPress module mocks ───────────────────────────────────────────────────
@@ -119,10 +119,23 @@ jest.mock('@wordpress/components', () => {
 	const VStack = ({ children }) => <div>{children}</div>;
 	const HStack = ({ children }) => <div>{children}</div>;
 
+	const ToggleControl = ({ label, checked, onChange }) => (
+		<label>
+			{label}
+			<input
+				type="checkbox"
+				aria-label={label}
+				checked={checked}
+				onChange={(e) => onChange(e.target.checked)}
+			/>
+		</label>
+	);
+
 	return {
 		SelectControl,
 		FormTokenField,
 		Button,
+		ToggleControl,
 		__experimentalToolsPanel: ToolsPanel,
 		__experimentalToolsPanelItem: ToolsPanelItem,
 		__experimentalHStack: HStack,
@@ -245,5 +258,47 @@ describe('TaxQueryBuilder', () => {
 			/>
 		);
 		expect(screen.getByLabelText(/relation/i)).toBeInTheDocument();
+	});
+
+	it('addClause seeds include_children: true on the new clause', () => {
+		const { setAttributes } = renderWith();
+		const addBtn = screen.getByRole('button', {
+			name: /add taxonomy filter/i,
+		});
+		fireEvent.click( addBtn );
+		expect(setAttributes).toHaveBeenCalledTimes(1);
+		const call = setAttributes.mock.calls[0][0];
+		const newClause = call.taxQuery.clauses[0];
+		expect(newClause).toHaveProperty('include_children', true);
+	});
+
+	it('renders include_children toggle checked by default for existing clause', () => {
+		renderWith({
+			taxQuery: {
+				relation: 'AND',
+				clauses: [{ taxonomy: 'category', terms: [], operator: 'IN' }],
+			},
+		});
+		const toggle = screen.getByLabelText(/include child terms/i);
+		expect(toggle).toBeInTheDocument();
+		expect(toggle).toBeChecked();
+	});
+
+	it('renders include_children toggle unchecked when set to false', () => {
+		renderWith({
+			taxQuery: {
+				relation: 'AND',
+				clauses: [
+					{
+						taxonomy: 'category',
+						terms: [],
+						operator: 'IN',
+						include_children: false,
+					},
+				],
+			},
+		});
+		const toggle = screen.getByLabelText(/include child terms/i);
+		expect(toggle).not.toBeChecked();
 	});
 });

--- a/tests/unit/blocks/query/tax-query-builder.test.js
+++ b/tests/unit/blocks/query/tax-query-builder.test.js
@@ -170,28 +170,20 @@ function renderWith(attributeOverrides = {}) {
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('TaxQueryBuilder', () => {
-	it('renders with no clauses — shows Add button', () => {
+	it('renders with no clauses — shows + Clause and + Group buttons', () => {
 		renderWith();
 		expect(
-			screen.getByRole('button', { name: /add taxonomy filter/i })
+			screen.getByRole('button', { name: /\+ clause/i })
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('button', { name: /\+ group/i })
 		).toBeInTheDocument();
 	});
 
-	it('Add button is enabled when relevant taxonomies exist', () => {
+	it('+ Clause button is enabled when relevant taxonomies exist', () => {
 		renderWith();
-		const addBtn = screen.getByRole('button', {
-			name: /add taxonomy filter/i,
-		});
+		const addBtn = screen.getByRole('button', { name: /\+ clause/i });
 		expect(addBtn).not.toBeDisabled();
-	});
-
-	it('Add button is disabled when no relevant taxonomies for postType', () => {
-		// 'event' is not in any taxonomy's types list returned by our mock.
-		renderWith({ postType: 'event' });
-		const addBtn = screen.getByRole('button', {
-			name: /add taxonomy filter/i,
-		});
-		expect(addBtn).toBeDisabled();
 	});
 
 	it('renders clause row with taxonomy selector and Remove button when clauses > 0', () => {
@@ -217,12 +209,12 @@ describe('TaxQueryBuilder', () => {
 		expect(screen.getByLabelText(/^terms$/i)).toBeInTheDocument();
 	});
 
-	it('renders Relation selector only when more than 1 clause is present', () => {
-		// 0 clauses — no relation selector.
+	it('renders Match selector only when more than 1 clause is present', () => {
+		// 0 clauses — no match selector.
 		const { rerender } = renderWith();
-		expect(screen.queryByLabelText(/relation/i)).not.toBeInTheDocument();
+		expect(screen.queryByLabelText(/^match$/i)).not.toBeInTheDocument();
 
-		// 1 clause — still no relation selector.
+		// 1 clause — still no match selector.
 		rerender(
 			<TaxQueryBuilder
 				attributes={{
@@ -238,9 +230,9 @@ describe('TaxQueryBuilder', () => {
 				clientId="test-client"
 			/>
 		);
-		expect(screen.queryByLabelText(/relation/i)).not.toBeInTheDocument();
+		expect(screen.queryByLabelText(/^match$/i)).not.toBeInTheDocument();
 
-		// 2 clauses — relation selector appears.
+		// 2 clauses — match selector appears.
 		rerender(
 			<TaxQueryBuilder
 				attributes={{
@@ -257,15 +249,13 @@ describe('TaxQueryBuilder', () => {
 				clientId="test-client"
 			/>
 		);
-		expect(screen.getByLabelText(/relation/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/^match$/i)).toBeInTheDocument();
 	});
 
 	it('addClause seeds include_children: true on the new clause', () => {
 		const { setAttributes } = renderWith();
-		const addBtn = screen.getByRole('button', {
-			name: /add taxonomy filter/i,
-		});
-		fireEvent.click( addBtn );
+		const addBtn = screen.getByRole('button', { name: /\+ clause/i });
+		fireEvent.click(addBtn);
 		expect(setAttributes).toHaveBeenCalledTimes(1);
 		const call = setAttributes.mock.calls[0][0];
 		const newClause = call.taxQuery.clauses[0];
@@ -301,4 +291,19 @@ describe('TaxQueryBuilder', () => {
 		const toggle = screen.getByLabelText(/include child terms/i);
 		expect(toggle).not.toBeChecked();
 	});
+
+	it('adds a nested group when clicking + Group', () => {
+		const setAttributes = jest.fn();
+		const { getByRole } = render(
+			<TaxQueryBuilder
+				attributes={ { taxQuery: { relation: 'AND', clauses: [] }, postType: 'post' } }
+				setAttributes={ setAttributes }
+				clientId="test"
+			/>
+		);
+		fireEvent.click( getByRole( 'button', { name: /\+ group/i } ) );
+		const call = setAttributes.mock.calls[0][0];
+		expect( call.taxQuery.clauses[0] ).toHaveProperty( 'clauses' );
+		expect( call.taxQuery.clauses[0].relation ).toBe( 'AND' );
+	} );
 });

--- a/tests/unit/blocks/query/tax-query-builder.test.js
+++ b/tests/unit/blocks/query/tax-query-builder.test.js
@@ -5,6 +5,10 @@ import '@testing-library/jest-dom';
 
 jest.mock('@wordpress/i18n', () => ({
 	__: (text) => text,
+	sprintf: (fmt, ...args) => {
+		let i = 0;
+		return fmt.replace(/%[sd]/g, () => String(args[i++] ?? ''));
+	},
 }));
 
 // useSelect is called twice per render: once in TaxQueryBuilder (getTaxonomies)
@@ -173,16 +177,16 @@ describe('TaxQueryBuilder', () => {
 	it('renders with no clauses — shows + Clause and + Group buttons', () => {
 		renderWith();
 		expect(
-			screen.getByRole('button', { name: /\+ clause/i })
+			screen.getByRole('button', { name: /add clause/i })
 		).toBeInTheDocument();
 		expect(
-			screen.getByRole('button', { name: /\+ group/i })
+			screen.getByRole('button', { name: /add group/i })
 		).toBeInTheDocument();
 	});
 
 	it('+ Clause button is enabled when relevant taxonomies exist', () => {
 		renderWith();
-		const addBtn = screen.getByRole('button', { name: /\+ clause/i });
+		const addBtn = screen.getByRole('button', { name: /add clause/i });
 		expect(addBtn).not.toBeDisabled();
 	});
 
@@ -254,7 +258,7 @@ describe('TaxQueryBuilder', () => {
 
 	it('addClause seeds include_children: true on the new clause', () => {
 		const { setAttributes } = renderWith();
-		const addBtn = screen.getByRole('button', { name: /\+ clause/i });
+		const addBtn = screen.getByRole('button', { name: /add clause/i });
 		fireEvent.click(addBtn);
 		expect(setAttributes).toHaveBeenCalledTimes(1);
 		const call = setAttributes.mock.calls[0][0];
@@ -301,7 +305,7 @@ describe('TaxQueryBuilder', () => {
 				clientId="test"
 			/>
 		);
-		fireEvent.click( getByRole( 'button', { name: /\+ group/i } ) );
+		fireEvent.click( getByRole( 'button', { name: /add group/i } ) );
 		const call = setAttributes.mock.calls[0][0];
 		expect( call.taxQuery.clauses[0] ).toHaveProperty( 'clauses' );
 		expect( call.taxQuery.clauses[0].relation ).toBe( 'AND' );

--- a/tests/unit/extensions/style-binding/style-binding.test.js
+++ b/tests/unit/extensions/style-binding/style-binding.test.js
@@ -1,0 +1,33 @@
+import { applyFilters } from '@wordpress/hooks';
+import '../../../../src/extensions/style-binding/filters';
+
+describe( 'style-binding extension', () => {
+	it( 'registers dsgoStyleBinding attribute on block registration', () => {
+		const result = applyFilters(
+			'blocks.registerBlockType',
+			{ attributes: {} },
+			'core/paragraph'
+		);
+		expect( result.attributes ).toHaveProperty( 'dsgoStyleBinding' );
+		expect( result.attributes.dsgoStyleBinding.type ).toBe( 'object' );
+	} );
+
+	it( 'sets dsgoStyleBinding default to empty object', () => {
+		const result = applyFilters(
+			'blocks.registerBlockType',
+			{ attributes: {} },
+			'core/group'
+		);
+		expect( result.attributes.dsgoStyleBinding.default ).toEqual( {} );
+	} );
+
+	it( 'creates attributes object when settings.attributes is missing', () => {
+		const result = applyFilters(
+			'blocks.registerBlockType',
+			{},
+			'core/paragraph'
+		);
+		expect( result.attributes ).toBeDefined();
+		expect( result.attributes.dsgoStyleBinding ).toBeDefined();
+	} );
+} );

--- a/tests/unit/extensions/style-binding/style-binding.test.js
+++ b/tests/unit/extensions/style-binding/style-binding.test.js
@@ -30,4 +30,15 @@ describe( 'style-binding extension', () => {
 		expect( result.attributes ).toBeDefined();
 		expect( result.attributes.dsgoStyleBinding ).toBeDefined();
 	} );
+
+	it( 'does not add dsgoStyleBinding to BLOCKED block types', () => {
+		for ( const name of [ 'core/freeform', 'core/missing', 'core/template-part' ] ) {
+			const result = applyFilters(
+				'blocks.registerBlockType',
+				{ attributes: {} },
+				name
+			);
+			expect( result.attributes.dsgoStyleBinding ).toBeUndefined();
+		}
+	} );
 } );


### PR DESCRIPTION
## Summary

Dynamic Query v2.5 adds advanced filtering, debugging, and dynamic-styling capabilities to the DSGo query family.

- **Date-query UI** — new `DateQueryBuilder` with `after` / `before` / `between` modes across 4 date columns
- **Multi-level AND/OR trees** — recursive `ClauseGroupShell` powers both tax and meta clause builders with nested group support
- **Hierarchical taxonomy drilldown** — `include_children` toggle on taxonomy clauses
- **Query Monitor panel** — new QM collector + HTML output showing per-query args, SQL, found_posts, and duration (gated by `QM_VERSION`)
- **Dynamic CSS from meta** — new `dsgoStyleBinding` attribute on every block; server-side injection via `WP_HTML_Tag_Processor` with strict prop-name regex and value validation (blocks `url(`, `expression(`, `javascript:`, and `;`)

## Test plan

- [ ] Editor: add a Query block, enable multiple tax/meta clauses with nested AND/OR groups — preview reflects changes
- [ ] Editor: set date-query across `after` / `before` / `between` modes — preview updates correctly
- [ ] Frontend: verify SQL `tax_query` / `meta_query` / `date_query` trees built correctly for nested groups
- [ ] Frontend: enable style bindings on a block, populate meta, confirm CSS vars/props render — confirm `red;display:none` style injections are rejected
- [ ] Enable Query Monitor plugin — confirm "DSGo Queries" panel shows render captures
- [ ] PHPUnit: `composer test` all green
- [ ] Jest: `npm test` all green
- [ ] Build + lint: `npm run build && npm run lint:js && npm run lint:css && npm run lint:php` clean

## Follow-ups (flagged, not in scope)

- Populate QM capture `filters` field with active URL-param filters
- Add depth guard to recursive PHP builders (hard stop at 4–5 levels)
- Support comma-separated values for `IN` / `NOT IN` in MetaQueryBuilder UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)