### PR TITLE
feat(llms-txt): per-URL Markdown content negotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Per-URL Markdown content negotiation** — any published page/post URL now returns Markdown when the request sends `Accept: text/markdown` (or any Accept header where `text/markdown` outranks `text/html` via q-values). Responds with `Content-Type: text/markdown; charset=utf-8` and `Vary: Accept`. Returns `406 Not Acceptable` when the client rejects both `text/html` and `text/markdown`. Reuses the existing per-post Markdown files (falls back to live conversion). Respects the llms.txt enablement flag, post-type allowlist, exclusion meta, and password-protected posts. Passes the [acceptmarkdown.com](https://acceptmarkdown.com/) readiness contract.
+
 ### Removed
 - **Visual Revision Comparison** - Deprecated and removed in favor of WordPress 7.0's native visual diff for revisions. Removed the visual comparison admin page, block differ, revision renderer, REST API endpoints (`/designsetgo/v1/revisions/*`), and associated settings (`revisions.enable_visual_comparison`, `revisions.default_to_visual`)
 

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -573,6 +573,7 @@ class Plugin {
 		require_once DESIGNSETGO_PATH . 'includes/llms-txt/class-generator.php';
 		require_once DESIGNSETGO_PATH . 'includes/llms-txt/class-conflict-detector.php';
 		require_once DESIGNSETGO_PATH . 'includes/llms-txt/class-rest-controller.php';
+		require_once DESIGNSETGO_PATH . 'includes/llms-txt/class-negotiation-handler.php';
 		require_once DESIGNSETGO_PATH . 'includes/llms-txt/class-controller.php';
 
 		// Markdown converter classes.

--- a/includes/llms-txt/class-controller.php
+++ b/includes/llms-txt/class-controller.php
@@ -86,18 +86,27 @@ class Controller {
 	private $conflict_detector;
 
 	/**
+	 * Per-URL content-negotiation handler.
+	 *
+	 * @var Negotiation_Handler
+	 */
+	private $negotiation_handler;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		// Initialize components.
-		$this->file_manager      = new File_Manager();
-		$this->generator         = new Generator( $this->file_manager );
-		$this->conflict_detector = new Conflict_Detector();
-		$this->rest_controller   = new REST_Controller(
+		$this->file_manager        = new File_Manager();
+		$this->generator           = new Generator( $this->file_manager );
+		$this->conflict_detector   = new Conflict_Detector();
+		$this->rest_controller     = new REST_Controller(
 			$this->file_manager,
 			$this->generator,
 			$this->conflict_detector
 		);
+		$this->negotiation_handler = new Negotiation_Handler( $this->file_manager, $this->generator );
+		$this->negotiation_handler->register();
 
 		// Register hooks.
 		add_action( 'init', array( $this, 'add_rewrite_rule' ) );

--- a/includes/llms-txt/class-negotiation-handler.php
+++ b/includes/llms-txt/class-negotiation-handler.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * Content-Negotiation Handler
+ *
+ * Serves per-URL Markdown when the request advertises
+ * `Accept: text/markdown` with higher preference than `text/html`.
+ *
+ * Mirrors the acceptmarkdown.com readiness contract: honor q-values,
+ * set `Vary: Accept`, reject fully-unsupported Accept headers with 406.
+ *
+ * @package DesignSetGo
+ * @since   1.5.0
+ */
+
+namespace DesignSetGo\LLMS_Txt;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Negotiation_Handler
+ *
+ * Hooks `template_redirect` and, when the Accept header prefers Markdown,
+ * serves the post's pre-generated `.md` file (or converts on the fly) and
+ * short-circuits normal template loading.
+ */
+class Negotiation_Handler {
+
+	/**
+	 * File manager.
+	 *
+	 * @var File_Manager
+	 */
+	private $file_manager;
+
+	/**
+	 * Markdown generator (fallback source).
+	 *
+	 * @var Generator
+	 */
+	private $generator;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param File_Manager $file_manager File manager.
+	 * @param Generator    $generator    Generator.
+	 */
+	public function __construct( File_Manager $file_manager, Generator $generator ) {
+		$this->file_manager = $file_manager;
+		$this->generator    = $generator;
+	}
+
+	/**
+	 * Register WordPress hooks.
+	 *
+	 * Priority 11 so `redirect_canonical` (priority 10) settles first —
+	 * we only want to negotiate on the final canonical URL.
+	 */
+	public function register(): void {
+		add_action( 'template_redirect', array( $this, 'handle_request' ), 11 );
+	}
+
+	/**
+	 * Template_redirect callback.
+	 */
+	public function handle_request(): void {
+		if ( is_admin() || is_feed() || is_robots() || is_trackback() ) {
+			return;
+		}
+
+		if ( ! isset( $_SERVER['HTTP_ACCEPT'] ) ) {
+			return;
+		}
+
+		$accept = sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT'] ) );
+		if ( '' === $accept ) {
+			return;
+		}
+
+		$preferred = self::preferred_type( $accept );
+
+		if ( 'none' === $preferred ) {
+			$this->send_406();
+			return;
+		}
+
+		if ( 'markdown' !== $preferred ) {
+			return; // HTML wins; let WordPress render normally.
+		}
+
+		// Feature must be enabled to serve per-URL Markdown.
+		$settings = \DesignSetGo\Admin\Settings::get_settings();
+		if ( empty( $settings['llms_txt']['enable'] ) ) {
+			return;
+		}
+
+		// Front page or blog posts index: serve the llms.txt listing as Markdown.
+		if ( is_front_page() || is_home() ) {
+			$markdown = $this->generator->generate_content();
+			if ( '' !== $markdown ) {
+				$this->send_markdown( $markdown );
+				exit;
+			}
+			return;
+		}
+
+		$post = self::resolve_post();
+		if ( ! $post ) {
+			return;
+		}
+
+		$enabled_types = $settings['llms_txt']['post_types'] ?? array( 'page', 'post' );
+		if ( ! in_array( $post->post_type, $enabled_types, true ) ) {
+			return;
+		}
+
+		if ( 'publish' !== $post->post_status ) {
+			return;
+		}
+
+		if ( ! empty( $post->post_password ) ) {
+			return;
+		}
+
+		if ( get_post_meta( $post->ID, Controller::EXCLUDE_META_KEY, true ) ) {
+			return;
+		}
+
+		$markdown = $this->read_markdown( $post );
+		if ( '' === $markdown ) {
+			return; // Conversion failed; fall through to HTML.
+		}
+
+		$this->send_markdown( $markdown );
+		exit;
+	}
+
+	/**
+	 * Parse an Accept header and return the preferred representation.
+	 *
+	 * Returns one of:
+	 *  - `'markdown'` — `text/markdown` outranks `text/html` (strictly greater q).
+	 *  - `'html'`     — `text/html` is acceptable at q > 0 (ties go to html).
+	 *  - `'none'`     — Accept was present but rejects html AND markdown.
+	 *
+	 * Wildcards (`text/*`, `*\/*`) count for both html and markdown.
+	 *
+	 * @param string $accept Raw Accept header value.
+	 * @return string One of 'markdown' | 'html' | 'none'.
+	 */
+	public static function preferred_type( string $accept ): string {
+		$md_q   = 0.0;
+		$html_q = 0.0;
+		$saw    = false;
+
+		foreach ( explode( ',', $accept ) as $raw ) {
+			$raw = trim( $raw );
+			if ( '' === $raw ) {
+				continue;
+			}
+
+			$parts = array_map( 'trim', explode( ';', $raw ) );
+			$type  = strtolower( (string) array_shift( $parts ) );
+			$q     = 1.0;
+
+			foreach ( $parts as $param ) {
+				if ( 0 === stripos( $param, 'q=' ) ) {
+					$q = (float) substr( $param, 2 );
+					break;
+				}
+			}
+
+			if ( $q <= 0 ) {
+				continue; // Explicit rejection.
+			}
+
+			$saw = true;
+
+			switch ( $type ) {
+				case 'text/markdown':
+					$md_q = max( $md_q, $q );
+					break;
+				case 'text/html':
+					$html_q = max( $html_q, $q );
+					break;
+				case 'text/*':
+				case '*/*':
+					$md_q   = max( $md_q, $q );
+					$html_q = max( $html_q, $q );
+					break;
+			}
+		}
+
+		if ( ! $saw || ( 0.0 === $md_q && 0.0 === $html_q ) ) {
+			return 'none';
+		}
+
+		return ( $md_q > $html_q ) ? 'markdown' : 'html';
+	}
+
+	/**
+	 * Resolve the singular post for this request, if any.
+	 *
+	 * @return \WP_Post|null
+	 */
+	private static function resolve_post(): ?\WP_Post {
+		if ( ! is_singular() ) {
+			return null;
+		}
+		$obj = get_queried_object();
+		return ( $obj instanceof \WP_Post ) ? $obj : null;
+	}
+
+	/**
+	 * Read the post's Markdown — prefer the static file, fall back to conversion.
+	 *
+	 * @param \WP_Post $post Post.
+	 * @return string Markdown body (empty string on failure).
+	 */
+	private function read_markdown( \WP_Post $post ): string {
+		if ( $this->file_manager->file_exists( $post->ID ) ) {
+			$filename = $this->file_manager->get_filename( $post );
+			if ( '' !== $filename ) {
+				$path = $this->file_manager->get_directory() . '/' . $filename . '.md';
+				if ( is_readable( $path ) ) {
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local file, size-bounded.
+					$content = file_get_contents( $path );
+					if ( is_string( $content ) && '' !== $content ) {
+						return $content;
+					}
+				}
+			}
+		}
+
+		$converter = new \DesignSetGo\Markdown\Converter();
+		return (string) $converter->convert( $post );
+	}
+
+	/**
+	 * Emit a 200 Markdown response.
+	 *
+	 * @param string $markdown Body.
+	 */
+	private function send_markdown( string $markdown ): void {
+		nocache_headers();
+		status_header( 200 );
+		header( 'Content-Type: text/markdown; charset=utf-8' );
+		header( 'Vary: Accept' );
+		header( 'X-Robots-Tag: noindex' );
+		header( 'Content-Length: ' . strlen( $markdown ) );
+		echo $markdown; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Markdown body.
+	}
+
+	/**
+	 * Emit 406 Not Acceptable when the client rejects both html and markdown.
+	 */
+	private function send_406(): void {
+		nocache_headers();
+		status_header( 406 );
+		header( 'Content-Type: text/plain; charset=utf-8' );
+		header( 'Vary: Accept' );
+		echo "Not Acceptable. Supported media types: text/html, text/markdown.\n";
+		exit;
+	}
+}

--- a/includes/llms-txt/class-negotiation-handler.php
+++ b/includes/llms-txt/class-negotiation-handler.php
@@ -79,6 +79,14 @@ class Negotiation_Handler {
 			return;
 		}
 
+		// Feature must be enabled before we change any HTTP semantics.
+		// Without this guard, a disabled plugin would still answer 406
+		// to unrelated Accept headers on every page.
+		$settings = \DesignSetGo\Admin\Settings::get_settings();
+		if ( empty( $settings['llms_txt']['enable'] ) ) {
+			return;
+		}
+
 		$preferred = self::preferred_type( $accept );
 
 		if ( 'none' === $preferred ) {
@@ -88,12 +96,6 @@ class Negotiation_Handler {
 
 		if ( 'markdown' !== $preferred ) {
 			return; // HTML wins; let WordPress render normally.
-		}
-
-		// Feature must be enabled to serve per-URL Markdown.
-		$settings = \DesignSetGo\Admin\Settings::get_settings();
-		if ( empty( $settings['llms_txt']['enable'] ) ) {
-			return;
 		}
 
 		// Front page or blog posts index: serve the llms.txt listing as Markdown.
@@ -145,15 +147,23 @@ class Negotiation_Handler {
 	 *  - `'html'`     — `text/html` is acceptable at q > 0 (ties go to html).
 	 *  - `'none'`     — Accept was present but rejects html AND markdown.
 	 *
-	 * Wildcards (`text/*`, `*\/*`) count for both html and markdown.
+	 * Honors RFC 7231 §5.3.2 media-range specificity: an explicit
+	 * `text/html` or `text/markdown` q-value always overrides a wildcard
+	 * (`text/*`, `*\/*`). Without this, `Accept: *\/*;q=0.9, text/html;q=0.5`
+	 * would leak wildcard weight onto `text/markdown` and misresolve the tie.
+	 *
+	 * Invalid q-values (`q=abc`, `q=1.5`, `q=-1`) are treated as missing and
+	 * default to 1.0 rather than 0.0, so a malformed parameter cannot silently
+	 * turn a positive preference into a rejection.
 	 *
 	 * @param string $accept Raw Accept header value.
 	 * @return string One of 'markdown' | 'html' | 'none'.
 	 */
 	public static function preferred_type( string $accept ): string {
-		$md_q   = 0.0;
-		$html_q = 0.0;
-		$saw    = false;
+		$md_explicit   = null; // null = no explicit text/markdown entry seen.
+		$html_explicit = null;
+		$wild_q        = 0.0;  // best q from text/* or */*.
+		$saw           = false;
 
 		foreach ( explode( ',', $accept ) as $raw ) {
 			$raw = trim( $raw );
@@ -163,41 +173,68 @@ class Negotiation_Handler {
 
 			$parts = array_map( 'trim', explode( ';', $raw ) );
 			$type  = strtolower( (string) array_shift( $parts ) );
-			$q     = 1.0;
+			$q     = self::parse_q_value( $parts );
 
-			foreach ( $parts as $param ) {
-				if ( 0 === stripos( $param, 'q=' ) ) {
-					$q = (float) substr( $param, 2 );
-					break;
-				}
-			}
-
-			if ( $q <= 0 ) {
-				continue; // Explicit rejection.
+			if ( null === $q ) {
+				continue; // Explicit rejection (q=0) or nonsense we can't interpret as a preference.
 			}
 
 			$saw = true;
 
 			switch ( $type ) {
 				case 'text/markdown':
-					$md_q = max( $md_q, $q );
+					$md_explicit = ( null === $md_explicit ) ? $q : max( $md_explicit, $q );
 					break;
 				case 'text/html':
-					$html_q = max( $html_q, $q );
+					$html_explicit = ( null === $html_explicit ) ? $q : max( $html_explicit, $q );
 					break;
 				case 'text/*':
 				case '*/*':
-					$md_q   = max( $md_q, $q );
-					$html_q = max( $html_q, $q );
+					$wild_q = max( $wild_q, $q );
 					break;
 			}
 		}
+
+		// Specificity: explicit entries override wildcards (RFC 7231 §5.3.2).
+		$md_q   = ( null !== $md_explicit ) ? $md_explicit : $wild_q;
+		$html_q = ( null !== $html_explicit ) ? $html_explicit : $wild_q;
 
 		if ( ! $saw || ( 0.0 === $md_q && 0.0 === $html_q ) ) {
 			return 'none';
 		}
 
 		return ( $md_q > $html_q ) ? 'markdown' : 'html';
+	}
+
+	/**
+	 * Extract the q-value from a media-range parameter list.
+	 *
+	 * Returns `null` when the entry is an explicit rejection (`q=0`),
+	 * otherwise a float in (0, 1]. Malformed q-values (`q=abc`, `q=1.5`,
+	 * negative) default to 1.0 per "treat invalid as missing."
+	 *
+	 * @param array $params Semicolon-delimited parameter list (already trimmed).
+	 * @return float|null
+	 */
+	private static function parse_q_value( array $params ): ?float {
+		foreach ( $params as $param ) {
+			if ( 0 !== stripos( $param, 'q=' ) ) {
+				continue;
+			}
+			$raw = substr( $param, 2 );
+			if ( ! is_numeric( $raw ) ) {
+				return 1.0; // Malformed → treat as missing.
+			}
+			$q = (float) $raw;
+			if ( $q <= 0 ) {
+				return null; // Explicit rejection.
+			}
+			if ( $q > 1 ) {
+				return 1.0; // Out-of-range → clamp.
+			}
+			return $q;
+		}
+		return 1.0; // No q= param → default weight.
 	}
 
 	/**
@@ -223,12 +260,25 @@ class Negotiation_Handler {
 		if ( $this->file_manager->file_exists( $post->ID ) ) {
 			$filename = $this->file_manager->get_filename( $post );
 			if ( '' !== $filename ) {
-				$path = $this->file_manager->get_directory() . '/' . $filename . '.md';
-				if ( is_readable( $path ) ) {
-					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local file, size-bounded.
-					$content = file_get_contents( $path );
-					if ( is_string( $content ) && '' !== $content ) {
-						return $content;
+				$directory     = $this->file_manager->get_directory();
+				$path          = $directory . '/' . $filename . '.md';
+				$resolved_dir  = realpath( $directory );
+				$resolved_path = realpath( $path );
+
+				// Defense-in-depth: confirm the resolved file is actually under
+				// the markdown directory. `get_filename()` sanitizes each slug
+				// segment, but this mirrors the containment check used in
+				// `Generator::generate_full_content()`.
+				if ( false !== $resolved_dir && false !== $resolved_path ) {
+					$normalized_dir  = wp_normalize_path( trailingslashit( $resolved_dir ) );
+					$normalized_path = wp_normalize_path( $resolved_path );
+
+					if ( 0 === strpos( $normalized_path, $normalized_dir ) && is_readable( $resolved_path ) ) {
+						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local file, containment-checked.
+						$content = file_get_contents( $resolved_path );
+						if ( is_string( $content ) && '' !== $content ) {
+							return $content;
+						}
 					}
 				}
 			}
@@ -249,7 +299,8 @@ class Negotiation_Handler {
 		header( 'Content-Type: text/markdown; charset=utf-8' );
 		header( 'Vary: Accept' );
 		header( 'X-Robots-Tag: noindex' );
-		header( 'Content-Length: ' . strlen( $markdown ) );
+		// Intentionally no Content-Length: it becomes incorrect under
+		// mod_deflate / ob_gzhandler, causing truncated or hung responses.
 		echo $markdown; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Markdown body.
 	}
 

--- a/tests/phpunit/llms-txt-test.php
+++ b/tests/phpunit/llms-txt-test.php
@@ -16,6 +16,7 @@ use DesignSetGo\LLMS_Txt\Controller;
 use DesignSetGo\LLMS_Txt\REST_Controller;
 use DesignSetGo\LLMS_Txt\Generator;
 use DesignSetGo\LLMS_Txt\File_Manager;
+use DesignSetGo\LLMS_Txt\Negotiation_Handler;
 use DesignSetGo\Markdown\Converter;
 use DesignSetGo\Admin\Settings;
 
@@ -1022,5 +1023,90 @@ class Test_Markdown_Converter extends WP_UnitTestCase {
 		// Should escape special characters.
 		$this->assertStringContainsString( '\\*stars\\*', $markdown );
 		$this->assertStringContainsString( '\\[brackets\\]', $markdown );
+	}
+
+	/**
+	 * `Accept: text/markdown` alone selects markdown.
+	 */
+	public function test_negotiation_markdown_only_selects_markdown() {
+		$this->assertSame( 'markdown', Negotiation_Handler::preferred_type( 'text/markdown' ) );
+	}
+
+	/**
+	 * A browser-style Accept (html first) resolves to html.
+	 */
+	public function test_negotiation_browser_accept_selects_html() {
+		$browser = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8';
+		$this->assertSame( 'html', Negotiation_Handler::preferred_type( $browser ) );
+	}
+
+	/**
+	 * When markdown outranks html via q-value, markdown wins.
+	 */
+	public function test_negotiation_q_values_prefer_markdown() {
+		$accept = 'text/html;q=0.5, text/markdown;q=1.0';
+		$this->assertSame( 'markdown', Negotiation_Handler::preferred_type( $accept ) );
+	}
+
+	/**
+	 * When html outranks markdown via q-value, html wins.
+	 */
+	public function test_negotiation_q_values_prefer_html() {
+		$accept = 'text/markdown;q=0.5, text/html;q=0.9';
+		$this->assertSame( 'html', Negotiation_Handler::preferred_type( $accept ) );
+	}
+
+	/**
+	 * Tie between html and markdown goes to html (safe default for browsers).
+	 */
+	public function test_negotiation_tie_prefers_html() {
+		$this->assertSame( 'html', Negotiation_Handler::preferred_type( 'text/html, text/markdown' ) );
+	}
+
+	/**
+	 * `*\/*` accepts everything — html wins by default tiebreak.
+	 */
+	public function test_negotiation_wildcard_prefers_html() {
+		$this->assertSame( 'html', Negotiation_Handler::preferred_type( '*/*' ) );
+	}
+
+	/**
+	 * Curl default (`*\/*`) resolves to html, not markdown.
+	 */
+	public function test_negotiation_curl_default_is_html() {
+		$this->assertSame( 'html', Negotiation_Handler::preferred_type( '*/*' ) );
+	}
+
+	/**
+	 * An Accept that lists only unsupported types returns 'none' so the
+	 * handler can emit 406.
+	 */
+	public function test_negotiation_unsupported_only_is_none() {
+		$this->assertSame( 'none', Negotiation_Handler::preferred_type( 'application/pdf' ) );
+		$this->assertSame( 'none', Negotiation_Handler::preferred_type( 'image/png, application/json' ) );
+	}
+
+	/**
+	 * `q=0` is an explicit rejection — a markdown-only Accept with q=0
+	 * should not be treated as a markdown preference.
+	 */
+	public function test_negotiation_q_zero_is_rejection() {
+		$this->assertSame( 'none', Negotiation_Handler::preferred_type( 'text/markdown;q=0' ) );
+		$this->assertSame( 'html', Negotiation_Handler::preferred_type( 'text/html, text/markdown;q=0' ) );
+	}
+
+	/**
+	 * Parameter ordering and whitespace shouldn't break parsing.
+	 */
+	public function test_negotiation_parses_parameters_loosely() {
+		$accept = '  text/markdown ;  q=0.9 ,text/html;charset=utf-8;q=0.5';
+		$this->assertSame( 'markdown', Negotiation_Handler::preferred_type( $accept ) );
+	}
+
+	/**
+	 * Empty header resolves to 'none' — caller treats it as a no-op.
+	 */
+	public function test_negotiation_empty_accept_is_none() {
+		$this->assertSame( 'none', Negotiation_Handler::preferred_type( '' ) );
 	}
 }

--- a/tests/phpunit/llms-txt-test.php
+++ b/tests/phpunit/llms-txt-test.php
@@ -1071,10 +1071,23 @@ class Test_Markdown_Converter extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Curl default (`*\/*`) resolves to html, not markdown.
+	 * RFC 7231 §5.3.2: an explicit media-range overrides a wildcard's q-value.
+	 * `Accept: *\/*;q=0.9, text/html;q=0.5` should resolve to markdown
+	 * (markdown from wildcard = 0.9, html explicit = 0.5).
 	 */
-	public function test_negotiation_curl_default_is_html() {
-		$this->assertSame( 'html', Negotiation_Handler::preferred_type( '*/*' ) );
+	public function test_negotiation_explicit_overrides_wildcard() {
+		$accept = '*/*;q=0.9, text/html;q=0.5';
+		$this->assertSame( 'markdown', Negotiation_Handler::preferred_type( $accept ) );
+	}
+
+	/**
+	 * An explicit `text/markdown` q-value must not be bumped by a wildcard.
+	 * `text/markdown;q=0.3, *\/*;q=0.9` → markdown explicit at 0.3, html
+	 * via wildcard at 0.9 → html wins.
+	 */
+	public function test_negotiation_wildcard_does_not_raise_explicit() {
+		$accept = 'text/markdown;q=0.3, */*;q=0.9';
+		$this->assertSame( 'html', Negotiation_Handler::preferred_type( $accept ) );
 	}
 
 	/**
@@ -1108,5 +1121,21 @@ class Test_Markdown_Converter extends WP_UnitTestCase {
 	 */
 	public function test_negotiation_empty_accept_is_none() {
 		$this->assertSame( 'none', Negotiation_Handler::preferred_type( '' ) );
+	}
+
+	/**
+	 * Malformed q-values (non-numeric, out-of-range) should be treated as
+	 * "missing" and default to 1.0 — not as explicit rejections that would
+	 * silently flip a positive preference to 'none'.
+	 */
+	public function test_negotiation_malformed_q_defaults_to_one() {
+		// `q=abc` is invalid; markdown should still count at q=1.0.
+		$this->assertSame( 'markdown', Negotiation_Handler::preferred_type( 'text/markdown;q=abc, text/html;q=0.9' ) );
+
+		// `q=1.5` is out of range; treat as 1.0 (clamp).
+		$this->assertSame( 'markdown', Negotiation_Handler::preferred_type( 'text/markdown;q=1.5, text/html;q=0.9' ) );
+
+		// A solo markdown with malformed q must NOT become a 406.
+		$this->assertSame( 'markdown', Negotiation_Handler::preferred_type( 'text/markdown;q=abc' ) );
 	}
 }


### PR DESCRIPTION
## Summary

- Agents hitting a page URL directly had no way to discover a Markdown version existed. This adds standards-compliant per-URL content negotiation (per the [acceptmarkdown.com](https://acceptmarkdown.com/#readiness) contract): parse the `Accept` header with q-values, honor wildcards, set `Vary: Accept`, reject unsupported media types with `406`.
- Reuses the existing per-post `.md` files (falls back to live conversion). Respects all existing llms.txt gates: feature enable flag, post-type allowlist, exclusion meta, password protection, `publish`-only status.
- Blog posts index (`is_home()` / `is_front_page()`) serves the llms.txt listing as Markdown so the homepage scan passes the readiness checks.

## Files

- `includes/llms-txt/class-negotiation-handler.php` (new) — hooks `template_redirect` at priority 11 (after `redirect_canonical`).
- `includes/llms-txt/class-controller.php` — instantiates and registers the handler.
- `includes/class-plugin.php` — `require_once` for the new class.
- `tests/phpunit/llms-txt-test.php` — 11 new tests for the `Accept` parser.

## Test plan

- [x] `vendor/bin/phpunit --testsuite DesignSetGo --filter LLMS` — all 44 LLMS tests pass
- [x] `phpcs --standard=phpcs.xml includes/llms-txt/class-negotiation-handler.php` — clean
- [x] Live-site smoke test against https://designsetgoblocks.com/ (cache-busted URL): returns `200 text/markdown; charset=utf-8` with `Vary: Accept`, `X-Robots-Tag: noindex`
- [x] Local `wp eval` smoke test: `Accept: text/markdown` serves markdown; `Accept: application/pdf` returns 406
- [ ] Browser-style `Accept: text/html,…,*/*;q=0.8` falls through to HTML (covered by unit test `test_negotiation_browser_accept_selects_html`)

## Known edge-case (out of scope for this PR)

On hosts behind Cloudflare or an aggressive full-page cache that keys on URL only, `Vary: Accept` is ignored and cached HTML will be served regardless of Accept header. The plugin emits the correct headers — the edge must be configured to vary its cache key on `Accept` (or bypass cache when `Accept` contains `text/markdown`). Worth documenting in the admin settings panel in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)