### PR TITLE
feat(form-builder): persist confirmation message across page reloads

### DIFF
--- a/src/blocks/form-builder/view.js
+++ b/src/blocks/form-builder/view.js
@@ -182,7 +182,18 @@ function initFormBuilder() {
 		}
 
 		const formId = formContainer.getAttribute('data-form-id');
-		const storageKey = `dsgo_confirmed_${formId || 'default'}`;
+		const storageKey = (() => {
+			if (formId) {
+				return `dsgo_confirmed_${formId}`;
+			}
+			if (formContainer.id) {
+				return `dsgo_confirmed_instance_${formContainer.id.replace(/[^a-zA-Z0-9_-]/g, '_')}`;
+			}
+			const idx = Array.from(
+				document.querySelectorAll('[data-form-id]')
+			).indexOf(formContainer);
+			return `dsgo_confirmed_instance_${idx >= 0 ? idx : 0}`;
+		})();
 		const successMessage = formContainer.getAttribute(
 			'data-success-message'
 		);
@@ -231,6 +242,14 @@ function initFormBuilder() {
 			}
 		}
 
+		function clearConfirmation() {
+			try {
+				sessionStorage.removeItem(storageKey);
+			} catch {
+				// sessionStorage unavailable
+			}
+		}
+
 		function showRedirectStatus() {
 			const params = new URLSearchParams(window.location.search);
 			const status = params.get('dsgo_form_status');
@@ -253,6 +272,7 @@ function initFormBuilder() {
 				matchesCurrentForm &&
 				(params.has('dsgo_form_error') || status === 'error')
 			) {
+				clearConfirmation();
 				showMessage(
 					messageContainer,
 					errorMessage ||
@@ -323,11 +343,12 @@ function initFormBuilder() {
 
 		const shownFromRedirect = showRedirectStatus();
 
-		// Restore confirmation message persisted from a previous submission
+		// Restore confirmation message persisted from a previous submission (one-time)
 		if (!shownFromRedirect) {
 			const storedConfirmation = getStoredConfirmation();
 			if (storedConfirmation) {
 				showMessage(messageContainer, storedConfirmation, 'success');
+				clearConfirmation();
 			}
 		}
 
@@ -348,8 +369,9 @@ function initFormBuilder() {
 		formElement.addEventListener('submit', async function (e) {
 			e.preventDefault();
 
-			// Clear previous messages
+			// Clear previous messages and any persisted confirmation state
 			hideMessage(messageContainer);
+			clearConfirmation();
 
 			// Validate form using HTML5 validation
 			if (!formElement.checkValidity()) {

--- a/src/blocks/form-builder/view.js
+++ b/src/blocks/form-builder/view.js
@@ -182,6 +182,7 @@ function initFormBuilder() {
 		}
 
 		const formId = formContainer.getAttribute('data-form-id');
+		const storageKey = `dsgo_confirmed_${formId || 'default'}`;
 		const successMessage = formContainer.getAttribute(
 			'data-success-message'
 		);
@@ -214,6 +215,22 @@ function initFormBuilder() {
 			nonceField.defaultValue = nonceField.value;
 		}
 
+		function getStoredConfirmation() {
+			try {
+				return sessionStorage.getItem(storageKey);
+			} catch {
+				return null;
+			}
+		}
+
+		function storeConfirmation(message) {
+			try {
+				sessionStorage.setItem(storageKey, message);
+			} catch {
+				// sessionStorage unavailable
+			}
+		}
+
 		function showRedirectStatus() {
 			const params = new URLSearchParams(window.location.search);
 			const status = params.get('dsgo_form_status');
@@ -225,12 +242,11 @@ function initFormBuilder() {
 				matchesCurrentForm &&
 				(params.has('dsgo_form_success') || status === 'success')
 			) {
-				showMessage(
-					messageContainer,
+				const msg =
 					successMessage ||
-						__('Form submitted successfully!', 'designsetgo'),
-					'success'
-				);
+					__('Form submitted successfully!', 'designsetgo');
+				showMessage(messageContainer, msg, 'success');
+				storeConfirmation(msg);
 				formElement.reset();
 				shown = true;
 			} else if (
@@ -305,7 +321,15 @@ function initFormBuilder() {
 			window.HTMLFormElement.prototype.submit.call(formElement);
 		}
 
-		showRedirectStatus();
+		const shownFromRedirect = showRedirectStatus();
+
+		// Restore confirmation message persisted from a previous submission
+		if (!shownFromRedirect) {
+			const storedConfirmation = getStoredConfirmation();
+			if (storedConfirmation) {
+				showMessage(messageContainer, storedConfirmation, 'success');
+			}
+		}
 
 		// Check if AJAX is enabled
 		const ajaxEnabled =
@@ -507,12 +531,10 @@ function initFormBuilder() {
 						return;
 					}
 
-					// Show success message
-					showMessage(
-						messageContainer,
-						successMessage || result.message,
-						'success'
-					);
+					// Show success message and persist for reload
+					const successMsg = successMessage || result.message;
+					showMessage(messageContainer, successMsg, 'success');
+					storeConfirmation(successMsg);
 
 					// Reset form
 					formElement.reset();


### PR DESCRIPTION
## Summary

- Stores the success message in `sessionStorage` after both AJAX and non-AJAX (redirect) form submission
- On page load, restores the confirmation message from `sessionStorage` if no URL-param redirect is present
- Scoped per form ID (`dsgo_confirmed_<formId>`) so multiple forms on the same page are handled independently

## Test Plan

- [ ] Submit a form via AJAX — confirm message appears, then reload the page and verify message still shows
- [ ] Submit a form via non-AJAX POST — confirm message appears on redirect, then reload and verify it persists
- [ ] Open the same page in a new tab — verify the confirmation does NOT carry over (sessionStorage is tab-scoped)
- [ ] Submit a form with a redirect URL configured — verify no message is stored (redirect takes over)

🤖 Generated with [Claude Code](https://claude.com/claude-code)