### PR TITLE
feat(query): slider + scroll-slides as Dynamic Query item hosts

### DIFF
--- a/.claude/docs/QUERY-BLOCK-GUIDE.md
+++ b/.claude/docs/QUERY-BLOCK-GUIDE.md
@@ -676,6 +676,109 @@ The stack is pushed before each item is rendered and popped after. It is safe to
 
 ---
 
+## v2.6 Extension points — layout blocks as query item hosts
+
+The item host — the block whose innerBlocks are the per-iteration template — defaults to `designsetgo/query-results` (grid/list). Any "chrome + N items" block (slider, scroll-slides) can opt in as an alternative host so authors can compose `designsetgo/query > designsetgo/<layout> > designsetgo/<item>` and get a dynamic iteration of posts/users/terms in the layout's native presentation.
+
+Two hosts ship by default: `designsetgo/slider` and `designsetgo/scroll-slides`.
+
+### The contract
+
+A query-capable layout block must:
+
+1. **Declare the query context in `block.json`:**
+
+   ```json
+   "usesContext": [
+       "designsetgo/queryId",
+       "designsetgo/querySource",
+       "designsetgo/queryPostType",
+       "designsetgo/currentItemId",
+       "designsetgo/currentItemType"
+   ]
+   ```
+
+2. **Register a `render.php`** (via `"render": "file:./render.php"` in `block.json`) that:
+   - Echoes `$content` unchanged when `$block->context['designsetgo/queryId']` is empty (authored mode — save.js output passes through).
+   - When a queryId is present, reads the pre-rendered items from `$GLOBALS['designsetgo_query_items_html'][ $query_id ]` and emits its own chrome around them. Because block.json `render` wraps the file in `ob_start()` / `ob_get_clean()`, **echo, don't return**.
+
+3. **Join the host registry** via the `designsetgo_query_item_host_block_names` filter (or have DesignSetGo add it to the defaults). The container uses this list to resolve which child carries the per-item template.
+
+### How the container behaves
+
+When `designsetgo_query_render_container()` sees a registered layout host child, it:
+
+- **Template** — takes only `innerBlocks[0]` as the per-item template (vs. all innerBlocks for `query-results`). Extra authored siblings are ignored server-side, so the editor should enforce single-child via `templateLock: 'insert'`.
+- **Item wrapper** — sets `itemTagName = 'none'` on the render context, which tells `designsetgo_query_render_item()` to skip its default `<li class="dsgo-query__item">` wrapper. The host's template block (slide, scroll-slide) already wraps itself.
+- **Stash** — writes both `$GLOBALS['designsetgo_query_results_html'][ queryId ]` (fully wrapped) and `$GLOBALS['designsetgo_query_items_html'][ queryId ]` (bare items) before walking children, and unsets both after.
+
+### Recipe — register a new layout host
+
+```php
+// In your plugin's bootstrap.
+add_filter( 'designsetgo_query_item_host_block_names', function ( $hosts ) {
+    $hosts[] = 'acme/tabs';
+    return $hosts;
+} );
+```
+
+In `src/blocks/tabs/render.php`:
+
+```php
+defined( 'ABSPATH' ) || exit;
+
+$query_id = isset( $block->context['designsetgo/queryId'] )
+    ? sanitize_key( (string) $block->context['designsetgo/queryId'] )
+    : '';
+
+if ( '' === $query_id ) {
+    echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    return;
+}
+
+$items_html = $GLOBALS['designsetgo_query_items_html'][ $query_id ] ?? '';
+
+$wrapper_attrs = get_block_wrapper_attributes( array(
+    'class' => 'acme-tabs',
+    'role'  => 'tablist',
+) );
+
+printf(
+    '<div %s><div class="acme-tabs__panels">%s</div></div>',
+    $wrapper_attrs, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    $items_html     // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+);
+```
+
+In `src/blocks/tabs/edit.js`:
+
+```jsx
+export default function TabsEdit({ attributes, setAttributes, clientId, context }) {
+    const queryId = context?.['designsetgo/queryId'] || '';
+    const inQueryMode = !!queryId;
+
+    const innerBlocksProps = useInnerBlocksProps(
+        { className: 'acme-tabs__track' },
+        {
+            allowedBlocks: ['acme/tab'],
+            templateLock: inQueryMode ? 'insert' : false,
+        }
+    );
+    // ...render + inspector notice when inQueryMode...
+}
+```
+
+### Sibling composition
+
+The query container still accepts `designsetgo/query-filter`, `designsetgo/query-pagination`, and `designsetgo/query-no-results` as siblings of the item host — filters and pagination continue to work whether the host is `query-results`, `slider`, or `scroll-slides`. Filter actions rebuild the stash via the IAPI REST endpoint; the layout block then re-initializes on DOM mutation.
+
+Recommended pairings:
+- Slider + `paginationKind: 'infinite'` — IntersectionObserver triggers `loadMore` as the last visible slide becomes intersected.
+- Scroll-slides + `designsetgo/query-group-header` — group headers become pinned section headings.
+- Slider + grouping (`groupBy` attribute) — not recommended; interleaved group headers inside a carousel are noisy. Not blocked in the editor, but call it out in your variation docs if you ship one.
+
+---
+
 ## Known v1 limits
 
 | Limit | Notes |

--- a/includes/abilities/class-block-inserter.php
+++ b/includes/abilities/class-block-inserter.php
@@ -2245,7 +2245,7 @@ class Block_Inserter {
 	 * Block_Inserter would skip wrapper HTML generation because the render
 	 * callback is non-null, producing an empty innerHTML.
 	 *
-	 * v2.6: slider + scroll-slides became hybrid to support item-host
+	 * V2.6: slider + scroll-slides became hybrid to support item-host
 	 * rendering inside designsetgo/query.
 	 */
 	private const HYBRID_BLOCKS = array(

--- a/includes/abilities/class-block-inserter.php
+++ b/includes/abilities/class-block-inserter.php
@@ -2238,15 +2238,37 @@ class Block_Inserter {
 	}
 
 	/**
+	 * Blocks that carry BOTH a save.js (static HTML saved to post content)
+	 * AND a render.php (dynamic transform at display time). For insertion
+	 * purposes these should be treated as authored-mode blocks — their
+	 * save.js output is the canonical wrapper HTML. Without this allowlist,
+	 * Block_Inserter would skip wrapper HTML generation because the render
+	 * callback is non-null, producing an empty innerHTML.
+	 *
+	 * v2.6: slider + scroll-slides became hybrid to support item-host
+	 * rendering inside designsetgo/query.
+	 */
+	private const HYBRID_BLOCKS = array(
+		'designsetgo/slider',
+		'designsetgo/scroll-slides',
+	);
+
+	/**
 	 * Check if a block is dynamic (has a render callback).
 	 *
 	 * Dynamic blocks are rendered server-side via PHP and should not have
-	 * wrapper HTML generated during insertion.
+	 * wrapper HTML generated during insertion. Hybrid blocks (see
+	 * HYBRID_BLOCKS) return false here because their save.js output is still
+	 * authoritative at insertion time.
 	 *
 	 * @param string $block_name Block name (e.g., 'designsetgo/section').
 	 * @return bool True if block has a render callback, false otherwise.
 	 */
 	private static function is_dynamic_block( string $block_name ): bool {
+		if ( in_array( $block_name, self::HYBRID_BLOCKS, true ) ) {
+			return false;
+		}
+
 		$registry   = \WP_Block_Type_Registry::get_instance();
 		$block_type = $registry->get_registered( $block_name );
 

--- a/includes/blocks/class-query-filter-index-hooks.php
+++ b/includes/blocks/class-query-filter-index-hooks.php
@@ -47,6 +47,44 @@ class FilterIndexHooks {
 		add_action( 'added_post_meta', array( __CLASS__, 'on_post_meta_changed' ), 20, 3 );
 		add_action( 'updated_post_meta', array( __CLASS__, 'on_post_meta_changed' ), 20, 3 );
 		add_action( 'deleted_post_meta', array( __CLASS__, 'on_post_meta_changed' ), 20, 3 );
+
+		// Queue a background backfill the first time each filter key is seen.
+		// Runs out-of-band via WP-Cron so the post-save request that triggered
+		// registration isn't blocked iterating the posts table.
+		add_action( 'designsetgo_query_filter_registered', array( __CLASS__, 'on_filter_registered' ) );
+		add_action( 'designsetgo_query_filter_backfill', array( __CLASS__, 'on_filter_backfill' ) );
+	}
+
+	/**
+	 * Handles a first-time filter registration by scheduling a single-event
+	 * backfill. Deduplicates via `wp_next_scheduled` so rapid repeat saves of
+	 * a post containing the same filter don't pile up cron jobs.
+	 *
+	 * @param string $filter_key The freshly-registered filter key.
+	 * @return void
+	 */
+	public static function on_filter_registered( string $filter_key ): void {
+		$filter_key = sanitize_key( $filter_key );
+		if ( '' === $filter_key ) {
+			return;
+		}
+		$args = array( $filter_key );
+		if ( false !== wp_next_scheduled( 'designsetgo_query_filter_backfill', $args ) ) {
+			return;
+		}
+		wp_schedule_single_event( time() + 5, 'designsetgo_query_filter_backfill', $args );
+	}
+
+	/**
+	 * Cron handler — runs the actual index rebuild for the given filter key.
+	 *
+	 * @param string $filter_key The filter key to rebuild.
+	 * @return void
+	 */
+	public static function on_filter_backfill( string $filter_key ): void {
+		if ( class_exists( FilterIndexRebuilder::class ) ) {
+			FilterIndexRebuilder::rebuild_filter( sanitize_key( $filter_key ) );
+		}
 	}
 
 	/**

--- a/includes/blocks/class-query-filter-registry.php
+++ b/includes/blocks/class-query-filter-registry.php
@@ -72,6 +72,8 @@ class FilterRegistry {
 			return;
 		}
 
+		$is_new = ! isset( $filters[ $sanitized_key ] );
+
 		$filters[ $sanitized_key ] = array(
 			'type'   => sanitize_key( $config['type'] ?? '' ),
 			'source' => sanitize_text_field( $config['source'] ?? '' ),
@@ -80,6 +82,18 @@ class FilterRegistry {
 
 		update_option( self::OPTION, $filters, false );
 		self::$cache = null;
+
+		// First-time registration: backfill index rows for all existing posts.
+		// Without this, posts that predate the filter block (common when
+		// authors add the block to an already-populated site) show "(0)" next
+		// to terms they legitimately belong to because save_post-based hooks
+		// only cover posts updated AFTER the filter exists. `rebuild_filter`
+		// is mutex-locked + batched, so repeated calls during bulk saves are
+		// safe. Fires after update_option so FilterRegistry::get() inside
+		// rebuild_filter resolves the freshly-registered config.
+		if ( $is_new && class_exists( FilterIndexRebuilder::class ) ) {
+			FilterIndexRebuilder::rebuild_filter( $sanitized_key );
+		}
 	}
 
 	/**

--- a/includes/blocks/class-query-filter-registry.php
+++ b/includes/blocks/class-query-filter-registry.php
@@ -83,16 +83,25 @@ class FilterRegistry {
 		update_option( self::OPTION, $filters, false );
 		self::$cache = null;
 
-		// First-time registration: backfill index rows for all existing posts.
-		// Without this, posts that predate the filter block (common when
-		// authors add the block to an already-populated site) show "(0)" next
-		// to terms they legitimately belong to because save_post-based hooks
-		// only cover posts updated AFTER the filter exists. `rebuild_filter`
-		// is mutex-locked + batched, so repeated calls during bulk saves are
-		// safe. Fires after update_option so FilterRegistry::get() inside
-		// rebuild_filter resolves the freshly-registered config.
-		if ( $is_new && class_exists( FilterIndexRebuilder::class ) ) {
-			FilterIndexRebuilder::rebuild_filter( $sanitized_key );
+		// First-time registration: queue a background backfill of index rows
+		// for all existing posts. Without this, posts that predate the filter
+		// block (common when authors add the block to an already-populated
+		// site) show "(0)" next to terms they legitimately belong to because
+		// the save_post hooks only cover posts updated AFTER the filter was
+		// registered.
+		//
+		// Queued (not inline) because `rebuild_filter` iterates the entire
+		// posts table — on a large site that would stall the post-save
+		// request that triggered registration and could time out. WP-Cron
+		// runs the backfill on the next request instead. The hook is handled
+		// by FilterIndexHooks::on_filter_registered below.
+		if ( $is_new ) {
+			/**
+			 * Fires when a new filter key is added to the registry.
+			 *
+			 * @param string $filter_key The sanitized filter key that was just registered.
+			 */
+			do_action( 'designsetgo_query_filter_registered', $sanitized_key );
 		}
 	}
 

--- a/src/blocks/query-filter/block.json
+++ b/src/blocks/query-filter/block.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "title": "Query Filter",
   "category": "designsetgo",
-  "parent": ["designsetgo/query"],
+  "ancestor": ["designsetgo/query"],
   "description": "Filter, search, sort, or reset a Dynamic Query via URL parameters with no page reload.",
   "keywords": ["filter", "facet", "search", "sort", "query"],
   "textdomain": "designsetgo",
@@ -44,7 +44,8 @@
       ]
     },
     "showCounts": { "type": "boolean", "default": true },
-    "orientation": { "type": "string", "default": "vertical", "enum": ["vertical", "horizontal"] }
+    "orientation": { "type": "string", "default": "vertical", "enum": ["vertical", "horizontal"] },
+    "filterStyle": { "type": "string", "default": "underline", "enum": ["default", "pill", "underline"] }
   },
   "example": { "attributes": { "filterKind": "checkbox" } },
   "editorScript": "file:./index.js",

--- a/src/blocks/query-filter/block.json
+++ b/src/blocks/query-filter/block.json
@@ -45,7 +45,7 @@
     },
     "showCounts": { "type": "boolean", "default": true },
     "orientation": { "type": "string", "default": "vertical", "enum": ["vertical", "horizontal"] },
-    "filterStyle": { "type": "string", "default": "underline", "enum": ["default", "pill", "underline"] }
+    "filterStyle": { "type": "string", "default": "default", "enum": ["default", "pill", "underline"] }
   },
   "example": { "attributes": { "filterKind": "checkbox" } },
   "editorScript": "file:./index.js",

--- a/src/blocks/query-filter/components/FilterPreview.js
+++ b/src/blocks/query-filter/components/FilterPreview.js
@@ -19,7 +19,7 @@ export default function FilterPreview({
 	label,
 	placeholder,
 	orientation = 'vertical',
-	filterStyle = 'underline',
+	filterStyle = 'default',
 	terms = null,
 	termsLoading = false,
 }) {

--- a/src/blocks/query-filter/components/FilterPreview.js
+++ b/src/blocks/query-filter/components/FilterPreview.js
@@ -5,13 +5,29 @@
  */
 import { __ } from '@wordpress/i18n';
 
+// Placeholder term list shown when terms haven't resolved yet or no taxonomy
+// terms exist on the site. Keeps the preview visually stable (prevents the
+// block from collapsing to zero height) while the REST request is in flight.
+const PLACEHOLDER_TERMS = [
+	{ id: 0, slug: 'a', name: __('Category A', 'designsetgo') },
+	{ id: 1, slug: 'b', name: __('Category B', 'designsetgo') },
+	{ id: 2, slug: 'c', name: __('Category C', 'designsetgo') },
+];
+
 export default function FilterPreview({
 	filterKind,
 	label,
 	placeholder,
 	orientation = 'vertical',
+	filterStyle = 'underline',
+	terms = null,
+	termsLoading = false,
 }) {
 	const displayLabel = label || null;
+	// Use real terms when available, otherwise fall back to placeholders so
+	// the block always renders something recognisable in the editor.
+	const effectiveTerms =
+		Array.isArray(terms) && terms.length > 0 ? terms : PLACEHOLDER_TERMS;
 
 	switch (filterKind) {
 		case 'search':
@@ -69,8 +85,9 @@ export default function FilterPreview({
 					)}
 					<select className="dsgo-query-filter__select" disabled>
 						<option>{__('All', 'designsetgo')}</option>
-						<option>{__('Category A', 'designsetgo')}</option>
-						<option>{__('Category B', 'designsetgo')}</option>
+						{effectiveTerms.map((term) => (
+							<option key={term.id}>{term.name}</option>
+						))}
 					</select>
 				</div>
 			);
@@ -108,7 +125,19 @@ export default function FilterPreview({
 			);
 
 		case 'checkbox':
-		default:
+		default: {
+			const isPill = filterStyle === 'pill';
+			const isUnderline = filterStyle === 'underline';
+			const isHorizontal =
+				orientation === 'horizontal' || isPill || isUnderline;
+			const listClass = [
+				'dsgo-query-filter__checkbox-list',
+				isHorizontal ? 'is-horizontal' : '',
+				isPill ? 'is-style-pill' : '',
+				isUnderline ? 'is-style-underline' : '',
+			]
+				.filter(Boolean)
+				.join(' ');
 			return (
 				<div className="dsgo-query-filter dsgo-query-filter--checkbox dsgo-query-filter--preview">
 					{displayLabel && (
@@ -117,28 +146,22 @@ export default function FilterPreview({
 						</span>
 					)}
 					<div
-						className={
-							orientation === 'horizontal'
-								? 'dsgo-query-filter__checkbox-list is-horizontal'
-								: 'dsgo-query-filter__checkbox-list'
-						}
+						className={listClass}
+						aria-busy={termsLoading || undefined}
 					>
-						{[
-							__('Category A', 'designsetgo'),
-							__('Category B', 'designsetgo'),
-							__('Category C', 'designsetgo'),
-						].map((item) => (
+						{effectiveTerms.map((term) => (
 							// eslint-disable-next-line jsx-a11y/label-has-associated-control -- static preview; input is nested inside label (valid HTML), readOnly attr confuses the linter
 							<label
-								key={item}
+								key={term.id}
 								className="dsgo-query-filter__checkbox-item"
 							>
 								<input type="checkbox" readOnly />
-								<span>{item}</span>
+								<span>{term.name}</span>
 							</label>
 						))}
 					</div>
 				</div>
 			);
+		}
 	}
 }

--- a/src/blocks/query-filter/edit.js
+++ b/src/blocks/query-filter/edit.js
@@ -40,7 +40,7 @@ const DEFAULTS = {
 	placeholder: '',
 	showCounts: true,
 	orientation: 'vertical',
-	filterStyle: 'underline',
+	filterStyle: 'default',
 };
 
 const ORIENTATION_OPTIONS = [
@@ -102,10 +102,7 @@ export default function QueryFilterEdit({
 	// we call it unconditionally with an empty taxonomy slug when disabled —
 	// core-data returns null records and never issues a request.
 	const isTaxonomyKind = filterKind === 'checkbox' || filterKind === 'select';
-	const termQuery = useMemo(
-		() => ({ per_page: 20, hide_empty: false }),
-		[]
-	);
+	const termQuery = useMemo(() => ({ per_page: 20, hide_empty: false }), []);
 	const termsResult = useEntityRecords(
 		'taxonomy',
 		isTaxonomyKind ? taxonomy || 'category' : '',
@@ -317,29 +314,29 @@ export default function QueryFilterEdit({
 							<DsgoInspectorPanel.Item
 								label={__('Style', 'designsetgo')}
 								hasValue={() =>
-									(filterStyle || 'underline') !== 'underline'
+									(filterStyle || 'default') !== 'default'
 								}
 								onDeselect={() =>
-									setAttributes({ filterStyle: 'underline' })
+									setAttributes({ filterStyle: 'default' })
 								}
 								isShownByDefault
 							>
 								<SelectControl
 									label={__('Style', 'designsetgo')}
-									value={filterStyle || 'underline'}
+									value={filterStyle || 'default'}
 									options={FILTER_STYLE_OPTIONS}
 									onChange={(v) =>
 										setAttributes({ filterStyle: v })
 									}
 									help={__(
-										'Underlined tabs (default) and pills render the filter as a modern horizontal selector. Switch to Checkboxes for a classic multi-select list. The underlying input stays accessible to keyboard + screen-reader users.',
+										'Pills and underlined tabs render the filter as a modern horizontal selector. The underlying input stays accessible to keyboard + screen-reader users.',
 										'designsetgo'
 									)}
 									__next40pxDefaultSize
 									__nextHasNoMarginBottom
 								/>
 							</DsgoInspectorPanel.Item>
-							{(filterStyle || 'underline') === 'default' && (
+							{(filterStyle || 'default') === 'default' && (
 								<DsgoInspectorPanel.Item
 									label={__('Orientation', 'designsetgo')}
 									hasValue={() => orientation !== 'vertical'}
@@ -373,11 +370,9 @@ export default function QueryFilterEdit({
 					label={label}
 					placeholder={placeholder}
 					orientation={orientation || 'vertical'}
-					filterStyle={filterStyle || 'underline'}
+					filterStyle={filterStyle || 'default'}
 					terms={previewTerms}
-					termsLoading={
-						isTaxonomyKind && !termsResult.hasResolved
-					}
+					termsLoading={isTaxonomyKind && !termsResult.hasResolved}
 				/>
 			</div>
 		</>

--- a/src/blocks/query-filter/edit.js
+++ b/src/blocks/query-filter/edit.js
@@ -15,7 +15,7 @@ import {
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
-import { store as coreStore } from '@wordpress/core-data';
+import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
 import { DsgoInspectorPanel } from '../../components/shared';
 import FilterPreview from './components/FilterPreview';
 
@@ -24,8 +24,8 @@ import FilterPreview from './components/FilterPreview';
 const EMPTY_TAXONOMIES = Object.freeze([]);
 
 const FILTER_KIND_OPTIONS = [
-	{ value: 'checkbox', label: __('Taxonomy checkboxes', 'designsetgo') },
-	{ value: 'select', label: __('Taxonomy dropdown', 'designsetgo') },
+	{ value: 'checkbox', label: __('Taxonomy (multi-select)', 'designsetgo') },
+	{ value: 'select', label: __('Taxonomy (dropdown)', 'designsetgo') },
 	{ value: 'search', label: __('Search input', 'designsetgo') },
 	{ value: 'sort', label: __('Sort dropdown', 'designsetgo') },
 	{ value: 'active', label: __('Active filters', 'designsetgo') },
@@ -40,11 +40,18 @@ const DEFAULTS = {
 	placeholder: '',
 	showCounts: true,
 	orientation: 'vertical',
+	filterStyle: 'underline',
 };
 
 const ORIENTATION_OPTIONS = [
 	{ value: 'vertical', label: __('Vertical', 'designsetgo') },
 	{ value: 'horizontal', label: __('Horizontal', 'designsetgo') },
+];
+
+const FILTER_STYLE_OPTIONS = [
+	{ value: 'default', label: __('Checkboxes', 'designsetgo') },
+	{ value: 'pill', label: __('Pills', 'designsetgo') },
+	{ value: 'underline', label: __('Underlined tabs', 'designsetgo') },
 ];
 
 export default function QueryFilterEdit({
@@ -60,6 +67,7 @@ export default function QueryFilterEdit({
 		placeholder,
 		showCounts,
 		orientation,
+		filterStyle,
 	} = attributes;
 
 	const blockProps = useBlockProps({
@@ -86,6 +94,33 @@ export default function QueryFilterEdit({
 			.filter((t) => t.show_in_rest !== false)
 			.map((t) => ({ value: t.slug, label: t.name }));
 	}, [filterKind, rawTaxonomies]);
+
+	// Pull the real taxonomy terms so the editor preview shows the same
+	// options visitors will see, not placeholder strings. Gated on taxonomy
+	// filter kinds so we don't fire the REST request for search/sort/etc.
+	// `useEntityRecords` must still run every render (rules of hooks), so
+	// we call it unconditionally with an empty taxonomy slug when disabled —
+	// core-data returns null records and never issues a request.
+	const isTaxonomyKind = filterKind === 'checkbox' || filterKind === 'select';
+	const termQuery = useMemo(
+		() => ({ per_page: 20, hide_empty: false }),
+		[]
+	);
+	const termsResult = useEntityRecords(
+		'taxonomy',
+		isTaxonomyKind ? taxonomy || 'category' : '',
+		termQuery
+	);
+	const previewTerms = useMemo(() => {
+		if (!isTaxonomyKind || !termsResult.records) {
+			return null;
+		}
+		return termsResult.records.map((term) => ({
+			id: term.id,
+			slug: term.slug,
+			name: term.name,
+		}));
+	}, [isTaxonomyKind, termsResult.records]);
 
 	const showTaxonomyControl =
 		filterKind === 'checkbox' || filterKind === 'select';
@@ -121,10 +156,18 @@ export default function QueryFilterEdit({
 	}
 
 	function handleFilterKindChange(nextKind) {
-		setAttributes({
+		const next = {
 			filterKind: nextKind,
 			paramName: defaultParamNameForKind(nextKind, taxonomy),
-		});
+		};
+		// Seed a sensible default button label when switching to Reset so
+		// newly-inserted reset filters don't render as a bare "Reset filters"
+		// fallback. Skip when the author has already typed their own label so
+		// we never overwrite intentional copy.
+		if (nextKind === 'reset' && !label) {
+			next.label = __('Reset', 'designsetgo');
+		}
+		setAttributes(next);
 	}
 
 	return (
@@ -270,25 +313,56 @@ export default function QueryFilterEdit({
 					)}
 
 					{filterKind === 'checkbox' && (
-						<DsgoInspectorPanel.Item
-							label={__('Orientation', 'designsetgo')}
-							hasValue={() => orientation !== 'vertical'}
-							onDeselect={() =>
-								setAttributes({ orientation: 'vertical' })
-							}
-							isShownByDefault
-						>
-							<SelectControl
-								label={__('Orientation', 'designsetgo')}
-								value={orientation || 'vertical'}
-								options={ORIENTATION_OPTIONS}
-								onChange={(v) =>
-									setAttributes({ orientation: v })
+						<>
+							<DsgoInspectorPanel.Item
+								label={__('Style', 'designsetgo')}
+								hasValue={() =>
+									(filterStyle || 'underline') !== 'underline'
 								}
-								__next40pxDefaultSize
-								__nextHasNoMarginBottom
-							/>
-						</DsgoInspectorPanel.Item>
+								onDeselect={() =>
+									setAttributes({ filterStyle: 'underline' })
+								}
+								isShownByDefault
+							>
+								<SelectControl
+									label={__('Style', 'designsetgo')}
+									value={filterStyle || 'underline'}
+									options={FILTER_STYLE_OPTIONS}
+									onChange={(v) =>
+										setAttributes({ filterStyle: v })
+									}
+									help={__(
+										'Underlined tabs (default) and pills render the filter as a modern horizontal selector. Switch to Checkboxes for a classic multi-select list. The underlying input stays accessible to keyboard + screen-reader users.',
+										'designsetgo'
+									)}
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
+								/>
+							</DsgoInspectorPanel.Item>
+							{(filterStyle || 'underline') === 'default' && (
+								<DsgoInspectorPanel.Item
+									label={__('Orientation', 'designsetgo')}
+									hasValue={() => orientation !== 'vertical'}
+									onDeselect={() =>
+										setAttributes({
+											orientation: 'vertical',
+										})
+									}
+									isShownByDefault
+								>
+									<SelectControl
+										label={__('Orientation', 'designsetgo')}
+										value={orientation || 'vertical'}
+										options={ORIENTATION_OPTIONS}
+										onChange={(v) =>
+											setAttributes({ orientation: v })
+										}
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+									/>
+								</DsgoInspectorPanel.Item>
+							)}
+						</>
 					)}
 				</DsgoInspectorPanel>
 			</InspectorControls>
@@ -299,6 +373,11 @@ export default function QueryFilterEdit({
 					label={label}
 					placeholder={placeholder}
 					orientation={orientation || 'vertical'}
+					filterStyle={filterStyle || 'underline'}
+					terms={previewTerms}
+					termsLoading={
+						isTaxonomyKind && !termsResult.hasResolved
+					}
 				/>
 			</div>
 		</>

--- a/src/blocks/query-filter/render.php
+++ b/src/blocks/query-filter/render.php
@@ -469,12 +469,13 @@ $dsgo_filter_label       = isset( $attributes['label'] ) ? (string) $attributes[
 $dsgo_filter_placeholder = isset( $attributes['placeholder'] ) ? (string) $attributes['placeholder'] : '';
 $dsgo_filter_taxonomy    = isset( $attributes['taxonomy'] ) ? sanitize_key( (string) $attributes['taxonomy'] ) : 'category';
 $dsgo_filter_orientation = ( isset( $attributes['orientation'] ) && 'horizontal' === $attributes['orientation'] ) ? 'horizontal' : 'vertical';
-// Default `filterStyle` is `underline` (matches block.json). WordPress omits
-// attributes that equal the block default from the saved markup, so a missing
-// `filterStyle` key here means the author kept the default.
-$dsgo_filter_style       = isset( $attributes['filterStyle'] ) && in_array( $attributes['filterStyle'], array( 'default', 'pill', 'underline' ), true )
+// Default `filterStyle` is `default` (classic checkboxes) to preserve the
+// look of pre-existing saved blocks that have no `filterStyle` attribute.
+// New inserts through the inserter variation opt into `underline` explicitly
+// — see the variation attributes in src/blocks/query-filter/variations.js.
+$dsgo_filter_style       = isset( $attributes['filterStyle'] ) && in_array( $attributes['filterStyle'], array( 'pill', 'underline' ), true )
 	? $attributes['filterStyle']
-	: 'underline';
+	: 'default';
 
 // Post-type scope for counts: only non-empty when the parent query targets a
 // specific post type (source === 'posts'). Users/terms sources leave it empty
@@ -575,8 +576,8 @@ $dsgo_filter_wrapper = get_block_wrapper_attributes(
 		'data-dsgo-param'       => $dsgo_filter_param,
 	)
 );
-// Seed IAPI context so `getContext()` inside setFilter / setFilterDebounced /
-// toggleFilter / removeActiveFilter / resetAll resolves ctx.queryId. Appended
+// Seed IAPI context so `getContext()` inside setFilter / toggleFilter /
+// removeActiveFilter / resetAll resolves ctx.queryId. Appended
 // outside get_block_wrapper_attributes() because that helper runs esc_attr()
 // on values, which would mangle JSON quotes.
 // JSON_HEX_APOS defends the single-quoted attribute boundary against a

--- a/src/blocks/query-filter/render.php
+++ b/src/blocks/query-filter/render.php
@@ -44,7 +44,7 @@ if ( ! function_exists( 'designsetgo_query_filter_render_search' ) ) :
 		$aria_label = $label ? '' : ' aria-label="' . esc_attr__( 'Search', 'designsetgo' ) . '"';
 
 		printf(
-			'<form %1$s method="get" action="" role="search">%2$s<div class="dsgo-query-filter__search-row"><input type="search" id="%7$s" name="%3$s" value="%4$s" placeholder="%5$s" class="dsgo-query-filter__search-input" data-wp-on--change="actions.setFilter" data-wp-on--input="actions.setFilterDebounced"%8$s /><button type="submit" class="dsgo-query-filter__submit">%6$s</button></div></form>',
+			'<form %1$s method="get" action="" role="search" data-wp-on--submit="actions.setFilter">%2$s<div class="dsgo-query-filter__search-row"><input type="search" id="%7$s" name="%3$s" value="%4$s" placeholder="%5$s" class="dsgo-query-filter__search-input"%8$s /><button type="submit" class="dsgo-query-filter__submit">%6$s</button></div></form>',
 			$wrapper, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() output + appended data-wp-context JSON (sanitized values + wp_json_encode with JSON_HEX_APOS).
 			$label ? '<label for="' . esc_attr( $input_id ) . '" class="dsgo-query-filter__label">' . esc_html( $label ) . '</label>' : '',
 			esc_attr( $param_name ),
@@ -202,7 +202,7 @@ if ( ! function_exists( 'designsetgo_query_filter_render_checkbox' ) ) :
 	 * @param array  $active_filters  Current active filter state for intersection counts.
 	 * @param string $post_type       Optional post-type scope for counts.
 	 */
-	function designsetgo_query_filter_render_checkbox( $wrapper, $param_name, $label, $filter_taxonomy, $show_counts = false, $active_filters = array(), $post_type = '', $orientation = 'vertical' ) {
+	function designsetgo_query_filter_render_checkbox( $wrapper, $param_name, $label, $filter_taxonomy, $show_counts = false, $active_filters = array(), $post_type = '', $orientation = 'vertical', $style = 'default' ) {
 		if ( ! taxonomy_exists( $filter_taxonomy ) ) {
 			return;
 		}
@@ -259,10 +259,23 @@ if ( ! function_exists( 'designsetgo_query_filter_render_checkbox' ) ) :
 		}
 
 		// Fix 4: noscript submit so no-JS users can apply checkbox filters.
-		$dsgo_nojs_btn = '<noscript><button type="submit" class="dsgo-query-filter__nojs-submit">' . esc_html__( 'Apply filter', 'designsetgo' ) . '</button></noscript>';
-		$list_class    = 'horizontal' === $orientation
-			? 'dsgo-query-filter__checkbox-list is-horizontal'
-			: 'dsgo-query-filter__checkbox-list';
+		$dsgo_nojs_btn      = '<noscript><button type="submit" class="dsgo-query-filter__nojs-submit">' . esc_html__( 'Apply filter', 'designsetgo' ) . '</button></noscript>';
+		$list_class_parts   = array( 'dsgo-query-filter__checkbox-list' );
+		if ( 'horizontal' === $orientation ) {
+			$list_class_parts[] = 'is-horizontal';
+		}
+		if ( in_array( $style, array( 'pill', 'underline' ), true ) ) {
+			// `is-style-pill` / `is-style-underline` → SCSS hides the native
+			// checkbox and styles the label as a pill or underlined tab. The
+			// input stays in the DOM so keyboard/screen-reader users still
+			// toggle filters the same way.
+			$list_class_parts[] = 'is-style-' . $style;
+			// Pill + underline variants always read better as a horizontal row.
+			if ( 'horizontal' !== $orientation ) {
+				$list_class_parts[] = 'is-horizontal';
+			}
+		}
+		$list_class = implode( ' ', $list_class_parts );
 		if ( $label ) {
 			printf(
 				'<form %1$s method="get" action=""><fieldset class="dsgo-query-filter__fieldset"><legend class="dsgo-query-filter__label">%2$s</legend><div class="%5$s">%3$s</div></fieldset>%4$s</form>',
@@ -456,6 +469,12 @@ $dsgo_filter_label       = isset( $attributes['label'] ) ? (string) $attributes[
 $dsgo_filter_placeholder = isset( $attributes['placeholder'] ) ? (string) $attributes['placeholder'] : '';
 $dsgo_filter_taxonomy    = isset( $attributes['taxonomy'] ) ? sanitize_key( (string) $attributes['taxonomy'] ) : 'category';
 $dsgo_filter_orientation = ( isset( $attributes['orientation'] ) && 'horizontal' === $attributes['orientation'] ) ? 'horizontal' : 'vertical';
+// Default `filterStyle` is `underline` (matches block.json). WordPress omits
+// attributes that equal the block default from the saved markup, so a missing
+// `filterStyle` key here means the author kept the default.
+$dsgo_filter_style       = isset( $attributes['filterStyle'] ) && in_array( $attributes['filterStyle'], array( 'default', 'pill', 'underline' ), true )
+	? $attributes['filterStyle']
+	: 'underline';
 
 // Post-type scope for counts: only non-empty when the parent query targets a
 // specific post type (source === 'posts'). Users/terms sources leave it empty
@@ -595,6 +614,6 @@ switch ( $dsgo_filter_kind ) {
 		break;
 	case 'checkbox':
 	default:
-		designsetgo_query_filter_render_checkbox( $dsgo_filter_wrapper, $dsgo_filter_param, $dsgo_filter_label, $dsgo_filter_taxonomy, $dsgo_counts_enabled, $dsgo_active_filters_by_key, $dsgo_query_post_type, $dsgo_filter_orientation );
+		designsetgo_query_filter_render_checkbox( $dsgo_filter_wrapper, $dsgo_filter_param, $dsgo_filter_label, $dsgo_filter_taxonomy, $dsgo_counts_enabled, $dsgo_active_filters_by_key, $dsgo_query_post_type, $dsgo_filter_orientation, $dsgo_filter_style );
 		break;
 }

--- a/src/blocks/query-filter/style.scss
+++ b/src/blocks/query-filter/style.scss
@@ -94,6 +94,109 @@
 				column-gap: 1.25em;
 				row-gap: 0.5em;
 			}
+
+			// Pill and underlined-tab styles hide the native checkbox and
+			// style the label as an interactive chip. The input stays in the
+			// DOM (visually hidden, not `display:none`) so keyboard users can
+			// still Tab to it and Space toggles. `:has(:checked)` swaps the
+			// label to its active visual on modern browsers; the fallback is
+			// a subtle hover on unchecked items.
+			&.is-style-pill,
+			&.is-style-underline {
+				align-items: center;
+				column-gap: 0.5em;
+				row-gap: 0.5em;
+
+				.dsgo-query-filter__checkbox-item {
+					padding: 0;
+					gap: 0;
+				}
+
+				.dsgo-query-filter__checkbox-item input[type="checkbox"] {
+					// Keep accessible — tab-focusable, space toggles — but
+					// collapse the visual box entirely. clip-path hides it
+					// without impacting layout or screen-reader discovery.
+					position: absolute;
+					width: 1px;
+					height: 1px;
+					padding: 0;
+					margin: -1px;
+					overflow: hidden;
+					clip: rect(0, 0, 0, 0);
+					border: 0;
+					appearance: none;
+				}
+
+				.dsgo-query-filter__checkbox-item > span {
+					display: inline-flex;
+					align-items: center;
+					gap: 0.35em;
+					cursor: pointer;
+					user-select: none;
+					transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+				}
+
+				// Keyboard focus ring — lands on the label's span since the
+				// input is visually hidden.
+				.dsgo-query-filter__checkbox-item input[type="checkbox"]:focus-visible + span {
+					box-shadow: var(--dsgo-filter-shadow-focus);
+					outline: none;
+				}
+
+				.dsgo-query-filter__count {
+					margin-inline-start: 0;
+					color: inherit;
+					opacity: 0.7;
+				}
+			}
+
+			// Pill variant — rounded chip with filled active state.
+			&.is-style-pill {
+
+				.dsgo-query-filter__checkbox-item > span {
+					padding: 0.4em 0.95em;
+					border: 1px solid var(--dsgo-filter-border);
+					border-radius: 999px;
+					font-size: 0.95em;
+					line-height: 1.3;
+					background: transparent;
+				}
+
+				.dsgo-query-filter__checkbox-item > span:hover {
+					border-color: var(--dsgo-filter-border-hover);
+				}
+
+				.dsgo-query-filter__checkbox-item:has(:checked) > span {
+					background: var(--wp--preset--color--contrast, currentcolor);
+					color: var(--wp--preset--color--base, #fff);
+					border-color: var(--wp--preset--color--contrast, currentcolor);
+				}
+			}
+
+			// Underlined-tab variant — flat row with a growing underline on
+			// the active item.
+			&.is-style-underline {
+				column-gap: 1.5em;
+				border-bottom: 1px solid var(--dsgo-filter-border);
+
+				.dsgo-query-filter__checkbox-item > span {
+					padding: 0.5em 0.1em;
+					margin-block-end: -1px;
+					border-block-end: 2px solid transparent;
+					font-size: 0.95em;
+					font-weight: 500;
+					opacity: 0.7;
+				}
+
+				.dsgo-query-filter__checkbox-item > span:hover {
+					opacity: 1;
+				}
+
+				.dsgo-query-filter__checkbox-item:has(:checked) > span {
+					opacity: 1;
+					border-block-end-color: currentcolor;
+				}
+			}
 		}
 
 		.dsgo-query-filter__checkbox-item {

--- a/src/blocks/query-filter/variations.js
+++ b/src/blocks/query-filter/variations.js
@@ -3,10 +3,10 @@ import { __ } from '@wordpress/i18n';
 export default [
 	{
 		name: 'checkbox',
-		title: __('Taxonomy checkboxes', 'designsetgo'),
+		title: __('Taxonomy (multi-select)', 'designsetgo'),
 		icon: 'list-view',
 		description: __(
-			'Filter by taxonomy term via checkboxes.',
+			'Multi-select taxonomy filter — render as checkboxes, pills, or underlined tabs.',
 			'designsetgo'
 		),
 		attributes: { filterKind: 'checkbox', paramName: 'filter_category' },
@@ -15,10 +15,10 @@ export default [
 	},
 	{
 		name: 'select',
-		title: __('Taxonomy dropdown', 'designsetgo'),
+		title: __('Taxonomy (dropdown)', 'designsetgo'),
 		icon: 'menu',
 		description: __(
-			'Filter by taxonomy term via single-select dropdown.',
+			'Single-select taxonomy dropdown.',
 			'designsetgo'
 		),
 		attributes: { filterKind: 'select', paramName: 'filter_category' },
@@ -56,7 +56,11 @@ export default [
 		title: __('Reset button', 'designsetgo'),
 		icon: 'undo',
 		description: __('Clear all filter params.', 'designsetgo'),
-		attributes: { filterKind: 'reset', paramName: '' },
+		attributes: {
+			filterKind: 'reset',
+			paramName: '',
+			label: __('Reset', 'designsetgo'),
+		},
 		scope: ['inserter', 'transform'],
 	},
 ];

--- a/src/blocks/query-filter/variations.js
+++ b/src/blocks/query-filter/variations.js
@@ -9,7 +9,14 @@ export default [
 			'Multi-select taxonomy filter — render as checkboxes, pills, or underlined tabs.',
 			'designsetgo'
 		),
-		attributes: { filterKind: 'checkbox', paramName: 'filter_category' },
+		// New inserts opt into the modern underlined-tabs look. The block
+		// default stays `default` (classic checkboxes) so legacy saved blocks
+		// don't silently change appearance on upgrade.
+		attributes: {
+			filterKind: 'checkbox',
+			paramName: 'filter_category',
+			filterStyle: 'underline',
+		},
 		isDefault: true,
 		scope: ['inserter', 'transform'],
 	},
@@ -17,10 +24,7 @@ export default [
 		name: 'select',
 		title: __('Taxonomy (dropdown)', 'designsetgo'),
 		icon: 'menu',
-		description: __(
-			'Single-select taxonomy dropdown.',
-			'designsetgo'
-		),
+		description: __('Single-select taxonomy dropdown.', 'designsetgo'),
 		attributes: { filterKind: 'select', paramName: 'filter_category' },
 		scope: ['inserter', 'transform'],
 	},

--- a/src/blocks/query-group-header/edit.js
+++ b/src/blocks/query-group-header/edit.js
@@ -2,14 +2,17 @@ import { __ } from '@wordpress/i18n';
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
 const TEMPLATE = [
-	[ 'core/heading', { level: 3, placeholder: __( 'Group header', 'designsetgo' ) } ],
+	[
+		'core/heading',
+		{ level: 3, placeholder: __('Group header', 'designsetgo') },
+	],
 ];
 
 export default function Edit() {
-	const blockProps = useBlockProps( { className: 'dsgo-query-group-header' } );
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+	const blockProps = useBlockProps({ className: 'dsgo-query-group-header' });
+	const innerBlocksProps = useInnerBlocksProps(blockProps, {
 		template: TEMPLATE,
 		templateLock: false,
-	} );
-	return <div { ...innerBlocksProps } />;
+	});
+	return <div {...innerBlocksProps} />;
 }

--- a/src/blocks/query-group-header/index.js
+++ b/src/blocks/query-group-header/index.js
@@ -4,7 +4,7 @@ import save from './save';
 import metadata from './block.json';
 import { ICON_COLOR } from '../shared/constants';
 
-registerBlockType( metadata.name, {
+registerBlockType(metadata.name, {
 	...metadata,
 	icon: {
 		src: (
@@ -26,4 +26,4 @@ registerBlockType( metadata.name, {
 	},
 	edit,
 	save,
-} );
+});

--- a/src/blocks/query-no-results/block.json
+++ b/src/blocks/query-no-results/block.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "title": "No Results",
   "category": "designsetgo",
-  "parent": ["designsetgo/query"],
+  "ancestor": ["designsetgo/query"],
   "description": "Content shown when the Dynamic Query returns no items.",
   "textdomain": "designsetgo",
   "icon": "no",

--- a/src/blocks/query-pagination/block.json
+++ b/src/blocks/query-pagination/block.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "title": "Query Pagination",
   "category": "designsetgo",
-  "parent": ["designsetgo/query"],
+  "ancestor": ["designsetgo/query"],
   "description": "Pagination controls for the Dynamic Query block. Supports numbered links and Interactivity-API load-more.",
   "keywords": ["pagination", "load more"],
   "textdomain": "designsetgo",
@@ -38,7 +38,8 @@
     "showPrevNext": { "type": "boolean", "default": true },
     "autoPauseAfter": { "type": "number", "default": 3 },
     "sentinelOffsetPx": { "type": "number", "default": 200 },
-    "buttonLabelWhenPaused": { "type": "string", "default": "Load more" }
+    "buttonLabelWhenPaused": { "type": "string", "default": "Load more" },
+    "alignment": { "type": "string", "default": "left", "enum": ["left", "center", "right"] }
   },
   "example": { "attributes": { "mode": "numbered" } },
   "editorScript": "file:./index.js",

--- a/src/blocks/query-pagination/edit.js
+++ b/src/blocks/query-pagination/edit.js
@@ -68,7 +68,14 @@ const DEFAULTS = {
 	autoPauseAfter: 3,
 	sentinelOffsetPx: 200,
 	buttonLabelWhenPaused: 'Load more',
+	alignment: 'left',
 };
+
+const ALIGNMENT_OPTIONS = [
+	{ value: 'left', label: __('Left', 'designsetgo') },
+	{ value: 'center', label: __('Center', 'designsetgo') },
+	{ value: 'right', label: __('Right', 'designsetgo') },
+];
 
 export default function QueryPaginationEdit({
 	attributes,
@@ -82,6 +89,7 @@ export default function QueryPaginationEdit({
 		labelLoading,
 		showPrevNext,
 		buttonLabelWhenPaused,
+		alignment,
 	} = attributes;
 
 	// Determine the effective kind: paginationKind takes precedence when set
@@ -89,7 +97,9 @@ export default function QueryPaginationEdit({
 	const effectiveKind = paginationKind !== 'numbered' ? paginationKind : mode;
 
 	const blockProps = useBlockProps({
-		className: 'dsgo-query-pagination is-editor',
+		className: `dsgo-query-pagination is-editor is-align-${
+			alignment || 'left'
+		}`,
 	});
 
 	return (
@@ -210,6 +220,22 @@ export default function QueryPaginationEdit({
 							panelId={clientId}
 						/>
 					)}
+
+					<DsgoInspectorPanel.Item
+						label={__('Alignment', 'designsetgo')}
+						hasValue={() => (alignment || 'left') !== 'left'}
+						onDeselect={() => setAttributes({ alignment: 'left' })}
+						isShownByDefault
+					>
+						<SelectControl
+							label={__('Alignment', 'designsetgo')}
+							value={alignment || 'left'}
+							options={ALIGNMENT_OPTIONS}
+							onChange={(v) => setAttributes({ alignment: v })}
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+					</DsgoInspectorPanel.Item>
 				</DsgoInspectorPanel>
 			</InspectorControls>
 

--- a/src/blocks/query-pagination/render.php
+++ b/src/blocks/query-pagination/render.php
@@ -40,6 +40,14 @@ $pagination_kind = isset( $attributes['paginationKind'] ) && 'numbered' !== $att
 	? $attributes['paginationKind']
 	: ( isset( $attributes['mode'] ) ? $attributes['mode'] : 'numbered' );
 
+// Horizontal alignment of the pagination control. Drives the SCSS
+// `is-align-{left|center|right}` modifier so the numbered flex list / load-more
+// button / infinite sentinel all honour the setting with a single class.
+$alignment = isset( $attributes['alignment'] ) && in_array( $attributes['alignment'], array( 'center', 'right' ), true )
+	? $attributes['alignment']
+	: 'left';
+$align_class = 'is-align-' . $alignment;
+
 // Single-page guard applies to ALL pagination kinds, including infinite.
 // Emit nothing for single-page results so no sentinel or button is injected.
 if ( ! $state || (int) $state['totalPages'] < 2 ) {
@@ -68,7 +76,7 @@ if ( 'infinite' === $pagination_kind ) {
 
 	$wrapper = get_block_wrapper_attributes(
 		array(
-			'class'                    => 'dsgo-query-pagination dsgo-query-pagination--infinite',
+			'class'                    => 'dsgo-query-pagination dsgo-query-pagination--infinite ' . $align_class,
 			'data-wp-interactive'      => 'designsetgo/query',
 			'data-dsgo-query-id'       => $query_id,
 			'data-dsgo-pagination'     => 'infinite',
@@ -122,7 +130,7 @@ if ( 'loadmore' === $pagination_mode ) {
 	);
 	$wrapper = get_block_wrapper_attributes(
 		array(
-			'class'                => 'dsgo-query-pagination dsgo-query-pagination--loadmore',
+			'class'                => 'dsgo-query-pagination dsgo-query-pagination--loadmore ' . $align_class,
 			'data-wp-interactive'  => 'designsetgo/query',
 			'data-dsgo-query-id'   => $query_id,
 			'data-dsgo-pagination' => 'loadmore',
@@ -161,7 +169,7 @@ if ( empty( $links ) || ! is_array( $links ) ) {
 
 $wrapper = get_block_wrapper_attributes(
 	array(
-		'class'              => 'dsgo-query-pagination dsgo-query-pagination--numbered',
+		'class'              => 'dsgo-query-pagination dsgo-query-pagination--numbered ' . $align_class,
 		'role'               => 'navigation',
 		'aria-label'         => __( 'Query pagination', 'designsetgo' ),
 		'data-dsgo-query-id' => $query_id,

--- a/src/blocks/query-pagination/style.scss
+++ b/src/blocks/query-pagination/style.scss
@@ -1,4 +1,30 @@
-.wp-block-designsetgo-query-pagination {
+// BEM root uses the `.dsgo-query-pagination` class emitted by render.php, NOT
+// `.wp-block-designsetgo-query-pagination`. The WP-generated block class is
+// present too but the `--numbered` / `--loadmore` / `--infinite` modifiers are
+// on the dsgo- prefix only (see get_block_wrapper_attributes call in
+// render.php). Keeping selectors rooted on the BEM class means layout still
+// applies after a filter/pagination REST refresh re-serialises the wrapper.
+.dsgo-query-pagination {
+
+	// Horizontal alignment modifier. Numbered pagination centres/right-aligns
+	// via flex justify-content on the list; load-more + infinite are a single
+	// inline-block element so text-align on the wrapper is enough. Left is the
+	// natural flow default, no rule needed.
+	&.is-align-center {
+		text-align: center;
+
+		.dsgo-query-pagination__list {
+			justify-content: center;
+		}
+	}
+
+	&.is-align-right {
+		text-align: right;
+
+		.dsgo-query-pagination__list {
+			justify-content: flex-end;
+		}
+	}
 
 	&--numbered {
 

--- a/src/blocks/query-results/_layout-variants.scss
+++ b/src/blocks/query-results/_layout-variants.scss
@@ -1,0 +1,301 @@
+// Per-variation layout styles for designsetgo/query-results. Each variation
+// in src/blocks/query/variations.js sets `layoutVariant: '<slug>'` on the
+// query-results child; the editor/frontend renderers emit `is-layout-<slug>`
+// on the results wrapper. Rules below target both the frontend grid
+// (`[data-dsgo-query-results-role="container"]`) and the editor preview list
+// (`.dsgo-query__editor-preview-list`) so authors see the same thing in the
+// inserter preview as on the published page.
+
+// Magazine ────────────────────────────────────────────────────────────────
+// Default-ish card. Date as faint meta above the title; excerpt tight.
+.dsgo-query-results.is-layout-magazine {
+
+	&[data-dsgo-query-results-role="container"],
+	.dsgo-query__editor-preview-list {
+
+		.wp-block-post-date {
+			font-size: 0.8em;
+			text-transform: uppercase;
+			letter-spacing: 0.06em;
+			opacity: 0.65;
+			margin: 0 0 0.25em;
+		}
+
+		.wp-block-post-title {
+			margin: 0 0 0.5em;
+			line-height: 1.2;
+		}
+
+		.wp-block-post-featured-image {
+			margin-bottom: 0.75em;
+		}
+	}
+}
+
+// ── Avatar grid ───────────────────────────────────────────────────────────
+// Centered square-cropped avatars; compact text column underneath.
+.dsgo-query-results.is-layout-avatar-grid {
+
+	&[data-dsgo-query-results-role="container"],
+	.dsgo-query__editor-preview-list {
+
+		.wp-block-designsetgo-section {
+			text-align: center;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			gap: 0.5rem;
+		}
+
+		// The variation sets `align: 'center'` on the featured-image block so
+		// core's .aligncenter does the inline-centering natively; we only add
+		// the circular crop treatment here.
+		.wp-block-post-featured-image {
+			max-width: 140px;
+
+			img {
+				aspect-ratio: 1 / 1;
+				object-fit: cover;
+				border-radius: 50%;
+				width: 100%;
+				height: auto;
+				display: block;
+			}
+		}
+
+		.wp-block-post-title {
+			margin: 0;
+			font-size: 1em;
+			line-height: 1.3;
+		}
+
+		.wp-block-post-excerpt {
+			margin: 0;
+			font-size: 0.9em;
+			opacity: 0.75;
+		}
+	}
+}
+
+// ── Quote card ────────────────────────────────────────────────────────────
+// Oversized excerpt (the quote) with a decorative leading mark; title is the
+// small attribution, prefixed with an em-dash.
+.dsgo-query-results.is-layout-quote-card {
+
+	&[data-dsgo-query-results-role="container"],
+	.dsgo-query__editor-preview-list {
+
+		.dsgo-query__item .wp-block-designsetgo-section {
+			padding: 1.5rem;
+			background: var(--wp--preset--color--base-2, rgba(0, 0, 0, 0.04));
+			border-radius: 8px;
+			display: flex;
+			flex-direction: column;
+			gap: 1rem;
+		}
+
+		.wp-block-post-excerpt {
+			font-size: 1.15em;
+			line-height: 1.5;
+			font-style: italic;
+			position: relative;
+			padding-inline-start: 1.75rem;
+			margin: 0;
+
+			&::before {
+				content: "\201C";
+				position: absolute;
+				inset-inline-start: -0.1em;
+				top: -0.4em;
+				font-size: 3.5em;
+				line-height: 1;
+				opacity: 0.25;
+				font-style: normal;
+			}
+		}
+
+		.wp-block-post-title {
+			margin: 0;
+			font-size: 0.95em;
+			font-weight: 600;
+			opacity: 0.8;
+
+			&::before {
+				content: "— ";
+			}
+		}
+	}
+}
+
+// ── Image tile ────────────────────────────────────────────────────────────
+// Featured image fills the tile; title lays over the bottom with a gradient
+// scrim so it stays legible regardless of the image.
+.dsgo-query-results.is-layout-image-tile {
+
+	&[data-dsgo-query-results-role="container"],
+	.dsgo-query__editor-preview-list {
+
+		.dsgo-query__item .wp-block-designsetgo-section {
+			position: relative;
+			overflow: hidden;
+			border-radius: 6px;
+			isolation: isolate;
+			padding: 0;
+		}
+
+		.wp-block-post-featured-image {
+			margin: 0;
+			position: relative;
+			transition: transform 0.4s ease;
+
+			img {
+				aspect-ratio: 4 / 3;
+				object-fit: cover;
+				width: 100%;
+				height: auto;
+				display: block;
+			}
+
+			// Core renders the overlay as an absolutely-positioned span covering
+			// the image. Re-stating inset:0 here defeats any theme CSS that
+			// might reposition it and keeps it glued to the image on scale.
+			.wp-block-post-featured-image__overlay {
+				position: absolute;
+				inset: 0;
+				pointer-events: none;
+			}
+
+			// Dark gradient lives on the image wrapper (not the title) so it
+			// scales with the image on hover and never leaves a transparent
+			// seam between gradient and photo.
+			&::after {
+				content: '';
+				position: absolute;
+				inset-inline: 0;
+				inset-block-end: 0;
+				height: 55%;
+				background: linear-gradient(to top, rgba(0, 0, 0, 0.75) 0%, rgba(0, 0, 0, 0) 100%);
+				pointer-events: none;
+			}
+		}
+
+		.dsgo-query__item .wp-block-designsetgo-section:hover .wp-block-post-featured-image {
+			transform: scale(1.05);
+		}
+
+		.wp-block-post-title {
+			position: absolute;
+			inset-inline: 0;
+			inset-block-end: 0;
+			margin: 0;
+			padding: 1rem;
+			color: #fff;
+			z-index: 1;
+
+			a {
+				color: inherit;
+				text-decoration: none;
+			}
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+
+		&[data-dsgo-query-results-role="container"],
+		.dsgo-query__editor-preview-list {
+
+			.wp-block-post-featured-image {
+				transition: none;
+			}
+		}
+	}
+}
+
+// ── Compact row ───────────────────────────────────────────────────────────
+// Horizontal row: small square thumbnail + stacked title/date column. Works
+// at any `columns` value — the grid still partitions items across columns,
+// each item is just laid out as a flex row internally.
+.dsgo-query-results.is-layout-compact-row {
+
+	&[data-dsgo-query-results-role="container"],
+	.dsgo-query__editor-preview-list {
+
+		.dsgo-query__item > .wp-block-designsetgo-section {
+			display: flex;
+			align-items: center;
+			gap: 1rem;
+			padding: 0.5rem 0;
+		}
+
+		.wp-block-post-featured-image {
+			flex: 0 0 auto;
+			margin: 0;
+
+			img {
+				width: 96px;
+				height: 96px;
+				aspect-ratio: 1 / 1;
+				object-fit: cover;
+				border-radius: 6px;
+			}
+		}
+
+		.dsgo-query__item .wp-block-designsetgo-section .wp-block-designsetgo-section {
+			flex: 1 1 auto;
+			display: flex;
+			flex-direction: column;
+			gap: 0.2rem;
+			padding: 0;
+			border: 0;
+		}
+
+		.wp-block-post-title {
+			margin: 0;
+			font-size: 1em;
+			line-height: 1.3;
+		}
+
+		.wp-block-post-date {
+			font-size: 0.8em;
+			opacity: 0.65;
+			margin: 0;
+		}
+	}
+}
+
+// ── Date-forward ──────────────────────────────────────────────────────────
+// Calendar-style accent rail on the inline-start edge of each card; date
+// reads as a tagline above the title.
+.dsgo-query-results.is-layout-date-forward {
+
+	&[data-dsgo-query-results-role="container"],
+	.dsgo-query__editor-preview-list {
+
+		.dsgo-query__item .wp-block-designsetgo-section {
+			border-inline-start: 3px solid currentcolor;
+			padding-inline-start: 1rem;
+			display: flex;
+			flex-direction: column;
+			gap: 0.35rem;
+		}
+
+		.wp-block-post-date {
+			font-size: 0.8em;
+			text-transform: uppercase;
+			letter-spacing: 0.08em;
+			font-weight: 600;
+			color: var(--wp--preset--color--primary, currentcolor);
+			margin: 0;
+		}
+
+		.wp-block-post-title {
+			margin: 0;
+			line-height: 1.25;
+		}
+
+		.wp-block-post-excerpt {
+			margin: 0;
+			opacity: 0.8;
+		}
+	}
+}

--- a/src/blocks/query-results/block.json
+++ b/src/blocks/query-results/block.json
@@ -14,7 +14,6 @@
     "anchor": true,
     "html": false,
     "inserter": false,
-    "multiple": false,
     "reusable": false,
     "color": {
       "background": true,
@@ -41,8 +40,10 @@
     "columns": { "type": "number", "default": 1 },
     "columnsTablet": { "type": "number", "default": 0 },
     "columnsMobile": { "type": "number", "default": 0 },
-    "columnGap": { "type": "string", "default": "" },
-    "groupBy": { "type": "object", "default": null }
+    "firstItemColumnSpan": { "type": "number", "default": 1 },
+    "firstItemRowSpan": { "type": "number", "default": 1 },
+    "groupBy": { "type": "object", "default": null },
+    "layoutVariant": { "type": "string", "default": "" }
   },
   "example": { "attributes": { "columns": 3 } },
   "editorScript": "file:./index.js",

--- a/src/blocks/query-results/edit.js
+++ b/src/blocks/query-results/edit.js
@@ -5,22 +5,13 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
-import {
-	PanelBody,
-	RangeControl,
-	SelectControl,
-	TextControl,
-	Placeholder,
-} from '@wordpress/components';
+import { Placeholder } from '@wordpress/components';
 
 import EditorPreviewList from '../query/components/EditorPreviewList';
 import { RESULT_TEMPLATE } from '../query/edit-template';
-import {
-	GROUP_BY_OPTIONS,
-	DATE_PRECISION_OPTIONS,
-} from '../query/components/QuerySourcePanel';
-import { store as coreStore } from '@wordpress/core-data';
+import ResultsLayoutControls from '../query/components/ResultsLayoutControls';
 
 const EMPTY_BLOCKS = Object.freeze([]);
 
@@ -29,6 +20,7 @@ const EMPTY_BLOCKS = Object.freeze([]);
  * return its attributes. The query-results block depends on the parent for
  * source / postType / perPage / taxQuery / etc. — everything needed by the
  * REST render endpoint that powers the editor preview.
+ * @param {string} clientId The block clientId to walk up from.
  */
 function useParentQueryAttributes(clientId) {
 	return useSelect(
@@ -55,8 +47,6 @@ export default function QueryResultsEdit({
 }) {
 	const parentAttrs = useParentQueryAttributes(clientId);
 
-	// Taxonomy list for the group-by-taxonomy key selector. Filtered to visible
-	// taxonomies (show_in_rest) since hidden ones can't be queried from here.
 	const taxonomyOptions = useSelect((select) => {
 		const taxes = select(coreStore).getTaxonomies({ per_page: -1 }) || [];
 		return taxes
@@ -66,17 +56,6 @@ export default function QueryResultsEdit({
 				label: t.labels?.singular_name || t.name || t.slug,
 			}));
 	}, []);
-
-	const groupBy = attributes.groupBy || null;
-	const groupByField = groupBy?.field || 'none';
-
-	const handleGroupByFieldChange = (value) => {
-		if (value === 'none') {
-			setAttributes({ groupBy: null });
-		} else {
-			setAttributes({ groupBy: { field: value, key: '' } });
-		}
-	};
 
 	const hasInnerBlocks = useSelect(
 		(select) =>
@@ -91,14 +70,18 @@ export default function QueryResultsEdit({
 		[clientId]
 	);
 
+	const variantClass = attributes.layoutVariant
+		? `is-layout-${attributes.layoutVariant}`
+		: '';
 	const blockProps = useBlockProps({
-		className: 'dsgo-query-results',
+		className: `dsgo-query-results ${variantClass}`.trim(),
 		style: {
 			'--dsgo-query-columns': attributes.columns || 1,
 			'--dsgo-query-columns-tablet':
 				attributes.columnsTablet || attributes.columns || 1,
 			'--dsgo-query-columns-mobile': attributes.columnsMobile || 1,
-			'--dsgo-query-gap': attributes.columnGap || undefined,
+			'--dsgo-query-first-col-span': attributes.firstItemColumnSpan || 1,
+			'--dsgo-query-first-row-span': attributes.firstItemRowSpan || 1,
 		},
 	});
 
@@ -134,7 +117,8 @@ export default function QueryResultsEdit({
 		columns: attributes.columns,
 		columnsTablet: attributes.columnsTablet,
 		columnsMobile: attributes.columnsMobile,
-		columnGap: attributes.columnGap,
+		firstItemColumnSpan: attributes.firstItemColumnSpan,
+		firstItemRowSpan: attributes.firstItemRowSpan,
 		groupBy: attributes.groupBy,
 	};
 
@@ -147,142 +131,27 @@ export default function QueryResultsEdit({
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={__('Layout', 'designsetgo')} initialOpen>
-					<RangeControl
-						label={__('Columns', 'designsetgo')}
-						value={attributes.columns || 1}
-						min={1}
-						max={6}
-						onChange={(v) => setAttributes({ columns: v })}
-						__nextHasNoMarginBottom
-						__next40pxDefaultSize
-					/>
-					<RangeControl
-						label={__('Columns (tablet)', 'designsetgo')}
-						help={__(
-							'0 inherits the desktop column count.',
-							'designsetgo'
-						)}
-						value={attributes.columnsTablet || 0}
-						min={0}
-						max={6}
-						onChange={(v) => setAttributes({ columnsTablet: v })}
-						__nextHasNoMarginBottom
-						__next40pxDefaultSize
-					/>
-					<RangeControl
-						label={__('Columns (mobile)', 'designsetgo')}
-						value={attributes.columnsMobile || 1}
-						min={1}
-						max={3}
-						onChange={(v) => setAttributes({ columnsMobile: v })}
-						__nextHasNoMarginBottom
-						__next40pxDefaultSize
-					/>
-					<TextControl
-						label={__('Column gap', 'designsetgo')}
-						help={__(
-							'e.g. 1.5rem, 24px. Leave blank for theme default.',
-							'designsetgo'
-						)}
-						value={attributes.columnGap || ''}
-						onChange={(v) => setAttributes({ columnGap: v })}
-						__nextHasNoMarginBottom
-						__next40pxDefaultSize
-					/>
-					<SelectControl
-						label={__('List tag', 'designsetgo')}
-						value={attributes.tagName || 'ul'}
-						options={[
-							{ label: 'ul', value: 'ul' },
-							{ label: 'ol', value: 'ol' },
-							{ label: 'div', value: 'div' },
-						]}
-						onChange={(v) => setAttributes({ tagName: v })}
-						__nextHasNoMarginBottom
-						__next40pxDefaultSize
-					/>
-					<SelectControl
-						label={__('Item tag', 'designsetgo')}
-						value={attributes.itemTagName || 'li'}
-						options={[
-							{ label: 'li', value: 'li' },
-							{ label: 'div', value: 'div' },
-							{ label: 'article', value: 'article' },
-						]}
-						onChange={(v) => setAttributes({ itemTagName: v })}
-						__nextHasNoMarginBottom
-						__next40pxDefaultSize
-					/>
-				</PanelBody>
-
-				<PanelBody title={__('Group by', 'designsetgo')} initialOpen={false}>
-					<SelectControl
-						label={__('Group by', 'designsetgo')}
-						value={groupByField}
-						options={GROUP_BY_OPTIONS}
-						onChange={handleGroupByFieldChange}
-						help={__(
-							'Grouped output requires a Query group header block inside this results template.',
-							'designsetgo'
-						)}
-						__nextHasNoMarginBottom
-						__next40pxDefaultSize
-					/>
-
-					{groupByField === 'taxonomy' && (
-						<SelectControl
-							label={__('Group taxonomy', 'designsetgo')}
-							value={groupBy?.key || ''}
-							options={[
-								{
-									value: '',
-									label: __('— Select —', 'designsetgo'),
-								},
-								...taxonomyOptions,
-							]}
-							onChange={(v) =>
-								setAttributes({
-									groupBy: { ...groupBy, key: v },
-								})
-							}
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-						/>
-					)}
-
-					{groupByField === 'meta' && (
-						<TextControl
-							label={__('Group meta key', 'designsetgo')}
-							value={groupBy?.key || ''}
-							onChange={(v) =>
-								setAttributes({
-									groupBy: { ...groupBy, key: v },
-								})
-							}
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-						/>
-					)}
-
-					{groupByField === 'date' && (
-						<SelectControl
-							label={__('Date precision', 'designsetgo')}
-							value={groupBy?.key || 'Y'}
-							options={DATE_PRECISION_OPTIONS}
-							onChange={(v) =>
-								setAttributes({
-									groupBy: { ...groupBy, key: v },
-								})
-							}
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-						/>
-					)}
-				</PanelBody>
+				<ResultsLayoutControls
+					attributes={attributes}
+					set={setAttributes}
+					panelId={clientId}
+					taxonomyOptions={taxonomyOptions}
+				/>
 			</InspectorControls>
-
-			<div {...blockProps}>
+			<div
+				{...blockProps}
+				onClickCapture={(event) => {
+					// Prevent navigation when authors click post-title, featured-image,
+					// or any bound link inside the editor preview. Real anchors land
+					// here from server-rendered readonly items and from core blocks
+					// like core/post-title{isLink:true}. Scope to real hrefs so we
+					// don't interfere with in-editor anchor tooling.
+					const anchor = event.target.closest?.('a[href]');
+					if (anchor) {
+						event.preventDefault();
+					}
+				}}
+			>
 				<div className="dsgo-query-results__editor-grid">
 					{showLivePreview && hasInnerBlocks ? (
 						<EditorPreviewList

--- a/src/blocks/query-results/editor.scss
+++ b/src/blocks/query-results/editor.scss
@@ -1,3 +1,5 @@
+@use 'layout-variants';
+
 // Editor styles for designsetgo/query-results.
 
 .wp-block-designsetgo-query-results {
@@ -10,7 +12,19 @@
 	.dsgo-query-results__editor-grid {
 		display: grid;
 		grid-template-columns: repeat(var(--dsgo-query-columns, 1), minmax(0, 1fr));
-		gap: var(--dsgo-query-gap, 1.5rem);
+		gap: var(--wp--style--block-gap, 1.5rem);
+
+		// Mirror the frontend's featured-first-item span so authors see the
+		// callout as they design it. First-child is the real editable
+		// template. Excluded: the live-preview <ul> wrapper, which spans
+		// the full row itself (see the `grid-column: 1 / -1` rule below) —
+		// a higher-specificity first-child span would otherwise clamp it
+		// to one column and collapse the grid.
+		> .dsgo-query-results__inner:first-child,
+		> :first-child:not(.dsgo-query__editor-preview-list) {
+			grid-column: span min(var(--dsgo-query-first-col-span, 1), var(--dsgo-query-columns, 1));
+			grid-row: span var(--dsgo-query-first-row-span, 1);
+		}
 	}
 
 	// The useInnerBlocksProps wrapper — the live editable prototype.
@@ -60,6 +74,14 @@
 		.dsgo-query__editor-preview-list {
 			grid-template-columns: repeat(var(--dsgo-query-columns-tablet, var(--dsgo-query-columns, 1)), minmax(0, 1fr));
 		}
+
+		.dsgo-query__editor-preview-list {
+
+			> .dsgo-query__item:first-child,
+			> .dsgo-query__editor-preview-item:first-child {
+				grid-column: span min(var(--dsgo-query-first-col-span, 1), var(--dsgo-query-columns-tablet, var(--dsgo-query-columns, 1)));
+			}
+		}
 	}
 
 	@media (max-width: 600px) {
@@ -67,6 +89,15 @@
 		.dsgo-query-results__editor-grid,
 		.dsgo-query__editor-preview-list {
 			grid-template-columns: repeat(var(--dsgo-query-columns-mobile, 1), minmax(0, 1fr));
+		}
+
+		.dsgo-query__editor-preview-list {
+
+			> .dsgo-query__item:first-child,
+			> .dsgo-query__editor-preview-item:first-child {
+				grid-column: span min(var(--dsgo-query-first-col-span, 1), var(--dsgo-query-columns-mobile, 1));
+				grid-row: auto;
+			}
 		}
 
 		// Hide ghost cards on mobile preview — a single-column layout
@@ -83,10 +114,20 @@
 		grid-column: 1 / -1;
 		display: grid;
 		grid-template-columns: repeat(var(--dsgo-query-columns, 1), minmax(0, 1fr));
-		gap: var(--dsgo-query-gap, 1.5rem);
+		gap: var(--wp--style--block-gap, 1.5rem);
 		list-style: none;
 		margin: 0;
 		padding: 0;
+
+		// Mirror the frontend's featured-first-item span. The live preview
+		// wraps each record in `.dsgo-query__editor-preview-item` (not
+		// `.dsgo-query__item`, which is the published-HTML class), so target
+		// both to keep editor and frontend visual parity.
+		> .dsgo-query__item:first-child,
+		> .dsgo-query__editor-preview-item:first-child {
+			grid-column: span min(var(--dsgo-query-first-col-span, 1), var(--dsgo-query-columns, 1));
+			grid-row: span var(--dsgo-query-first-row-span, 1);
+		}
 
 		&.is-grouped {
 			display: flex;

--- a/src/blocks/query-results/style.scss
+++ b/src/blocks/query-results/style.scss
@@ -1,3 +1,5 @@
+@use 'layout-variants';
+
 // Frontend grid layout. Scoped to `[data-dsgo-query-results-role="container"]`
 // so the grid attaches only to the rendered <ul>/<ol>/<div> list and doesn't
 // apply to the editor wrapper (which would turn template blocks into columns
@@ -5,10 +7,19 @@
 .dsgo-query-results[data-dsgo-query-results-role="container"] {
 	display: grid;
 	grid-template-columns: repeat(var(--dsgo-query-columns, 1), minmax(0, 1fr));
-	gap: var(--dsgo-query-gap, 1.5rem);
+	gap: var(--wp--style--block-gap, 1.5rem);
 	list-style: none;
 	margin: 0;
 	padding: 0;
+
+	// Featured first item — optional callout that spans extra columns/rows.
+	// The span is already clamped server-side to the desktop column count;
+	// responsive rules below clamp again for tablet/mobile so the callout
+	// doesn't overflow a narrower grid.
+	> .dsgo-query__item:first-child {
+		grid-column: span min(var(--dsgo-query-first-col-span, 1), var(--dsgo-query-columns, 1));
+		grid-row: span var(--dsgo-query-first-row-span, 1);
+	}
 }
 
 .dsgo-query__item {
@@ -20,6 +31,10 @@
 
 	.dsgo-query-results[data-dsgo-query-results-role="container"] {
 		grid-template-columns: repeat(var(--dsgo-query-columns-tablet, var(--dsgo-query-columns, 1)), minmax(0, 1fr));
+
+		> .dsgo-query__item:first-child {
+			grid-column: span min(var(--dsgo-query-first-col-span, 1), var(--dsgo-query-columns-tablet, var(--dsgo-query-columns, 1)));
+		}
 	}
 }
 
@@ -27,6 +42,11 @@
 
 	.dsgo-query-results[data-dsgo-query-results-role="container"] {
 		grid-template-columns: repeat(var(--dsgo-query-columns-mobile, 1), minmax(0, 1fr));
+
+		> .dsgo-query__item:first-child {
+			grid-column: span min(var(--dsgo-query-first-col-span, 1), var(--dsgo-query-columns-mobile, 1));
+			grid-row: auto;
+		}
 	}
 }
 

--- a/src/blocks/query/components/AdvancedPanel.js
+++ b/src/blocks/query/components/AdvancedPanel.js
@@ -1,23 +1,10 @@
 import { __ } from '@wordpress/i18n';
 import {
 	ToggleControl,
-	SelectControl,
 	TextControl,
 	TextareaControl,
 } from '@wordpress/components';
 import { DsgoInspectorPanel } from '../../../components/shared';
-
-const TAG_OPTIONS = [
-	{ value: 'ul', label: __('Unordered list (ul)', 'designsetgo') },
-	{ value: 'ol', label: __('Ordered list (ol)', 'designsetgo') },
-	{ value: 'div', label: __('Container (div)', 'designsetgo') },
-];
-
-const ITEM_TAG_OPTIONS = [
-	{ value: 'li', label: 'li' },
-	{ value: 'div', label: 'div' },
-	{ value: 'article', label: 'article' },
-];
 
 const ATTR_DEFAULTS = {
 	search: '',
@@ -25,8 +12,6 @@ const ATTR_DEFAULTS = {
 	excludeCurrent: false,
 	ignoreSticky: true,
 	manualIds: [],
-	tagName: 'ul',
-	itemTagName: 'li',
 };
 
 export default function AdvancedPanel({ attributes, setAttributes, clientId }) {
@@ -37,8 +22,6 @@ export default function AdvancedPanel({ attributes, setAttributes, clientId }) {
 		excludeCurrent,
 		ignoreSticky,
 		manualIds,
-		tagName,
-		itemTagName,
 	} = attributes;
 
 	const manualIdsAsText = Array.isArray(manualIds)
@@ -56,6 +39,7 @@ export default function AdvancedPanel({ attributes, setAttributes, clientId }) {
 				label={__('Search', 'designsetgo')}
 				hasValue={() => search !== ''}
 				onDeselect={() => setAttributes({ search: '' })}
+				isShownByDefault
 			>
 				<TextControl
 					label={__('Search text', 'designsetgo')}
@@ -74,6 +58,7 @@ export default function AdvancedPanel({ attributes, setAttributes, clientId }) {
 				label={__('Bind search to URL param', 'designsetgo')}
 				hasValue={() => bindSearchTo !== ''}
 				onDeselect={() => setAttributes({ bindSearchTo: '' })}
+				isShownByDefault
 			>
 				<TextControl
 					label={__('URL parameter name', 'designsetgo')}
@@ -92,6 +77,7 @@ export default function AdvancedPanel({ attributes, setAttributes, clientId }) {
 				label={__('Exclude current post', 'designsetgo')}
 				hasValue={() => excludeCurrent !== false}
 				onDeselect={() => setAttributes({ excludeCurrent: false })}
+				isShownByDefault
 			>
 				<ToggleControl
 					label={__('Exclude current post', 'designsetgo')}
@@ -105,6 +91,7 @@ export default function AdvancedPanel({ attributes, setAttributes, clientId }) {
 				label={__('Ignore sticky', 'designsetgo')}
 				hasValue={() => ignoreSticky !== true}
 				onDeselect={() => setAttributes({ ignoreSticky: true })}
+				isShownByDefault
 			>
 				<ToggleControl
 					label={__('Ignore sticky posts', 'designsetgo')}
@@ -141,35 +128,6 @@ export default function AdvancedPanel({ attributes, setAttributes, clientId }) {
 				</DsgoInspectorPanel.Item>
 			)}
 
-			<DsgoInspectorPanel.Item
-				label={__('Wrapper tag', 'designsetgo')}
-				hasValue={() => tagName !== 'ul'}
-				onDeselect={() => setAttributes({ tagName: 'ul' })}
-			>
-				<SelectControl
-					label={__('Wrapper tag', 'designsetgo')}
-					value={tagName}
-					options={TAG_OPTIONS}
-					onChange={(v) => setAttributes({ tagName: v })}
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-				/>
-			</DsgoInspectorPanel.Item>
-
-			<DsgoInspectorPanel.Item
-				label={__('Item tag', 'designsetgo')}
-				hasValue={() => itemTagName !== 'li'}
-				onDeselect={() => setAttributes({ itemTagName: 'li' })}
-			>
-				<SelectControl
-					label={__('Item tag', 'designsetgo')}
-					value={itemTagName}
-					options={ITEM_TAG_OPTIONS}
-					onChange={(v) => setAttributes({ itemTagName: v })}
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-				/>
-			</DsgoInspectorPanel.Item>
 		</DsgoInspectorPanel>
 	);
 }

--- a/src/blocks/query/components/ClauseGroupShell.js
+++ b/src/blocks/query/components/ClauseGroupShell.js
@@ -1,5 +1,9 @@
 import { __, sprintf } from '@wordpress/i18n';
-import { Button, SelectControl, __experimentalVStack as VStack } from '@wordpress/components';
+import {
+	Button,
+	SelectControl,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 
 /**
  * Reusable recursive group shell for tax/meta clause builders.
@@ -11,8 +15,16 @@ import { Button, SelectControl, __experimentalVStack as VStack } from '@wordpres
  *   depth        - number (0 = root)
  *   renderClause - (clause, idx, updateEntry, removeEntry) => JSX — renders one leaf clause
  *   newClause    - object — default shape for a new leaf clause
+ * @param root0
+ * @param root0.group
+ * @param root0.onChange
+ * @param root0.onRemove
+ * @param root0.depth
+ * @param root0.renderClause
+ * @param root0.newClause
+ * @param root0.isAddDisabled
  */
-export default function ClauseGroupShell( {
+export default function ClauseGroupShell({
 	group,
 	onChange,
 	onRemove,
@@ -20,126 +32,141 @@ export default function ClauseGroupShell( {
 	renderClause,
 	newClause,
 	isAddDisabled,
-} ) {
+}) {
 	const { relation = 'AND', clauses = [] } = group;
 
-	const updateEntry = ( idx, patch ) => {
-		const next = clauses.map( ( c, i ) => ( i === idx ? { ...c, ...patch } : c ) );
-		onChange( { clauses: next } );
+	const updateEntry = (idx, patch) => {
+		const next = clauses.map((c, i) =>
+			i === idx ? { ...c, ...patch } : c
+		);
+		onChange({ clauses: next });
 	};
 
-	const replaceEntry = ( idx, entry ) => {
-		const next = clauses.map( ( c, i ) => ( i === idx ? entry : c ) );
-		onChange( { clauses: next } );
+	const replaceEntry = (idx, entry) => {
+		const next = clauses.map((c, i) => (i === idx ? entry : c));
+		onChange({ clauses: next });
 	};
 
-	const removeEntry = ( idx ) =>
-		onChange( { clauses: clauses.filter( ( _, i ) => i !== idx ) } );
+	const removeEntry = (idx) =>
+		onChange({ clauses: clauses.filter((_, i) => i !== idx) });
 
 	const addClause = () =>
-		onChange( { clauses: [ ...clauses, { ...newClause } ] } );
+		onChange({ clauses: [...clauses, { ...newClause }] });
 
 	const addGroup = () =>
-		onChange( {
-			clauses: [ ...clauses, { relation: 'AND', clauses: [ { ...newClause } ] } ],
-		} );
+		onChange({
+			clauses: [
+				...clauses,
+				{ relation: 'AND', clauses: [{ ...newClause }] },
+			],
+		});
 
 	const groupLabel =
 		depth === 0
-			? __( 'top level', 'designsetgo' )
+			? __('top level', 'designsetgo')
 			: sprintf(
-				/* translators: %d: nesting depth, where 1 is the first nested group. */
-				__( 'nested group level %d', 'designsetgo' ),
-				depth
-			);
+					/* translators: %d: nesting depth, where 1 is the first nested group. */
+					__('nested group level %d', 'designsetgo'),
+					depth
+				);
 
 	return (
 		<VStack
-			spacing={ 2 }
-			className={ `dsgo-clause-group dsgo-clause-group--depth-${ depth }` }
+			spacing={2}
+			className={`dsgo-clause-group dsgo-clause-group--depth-${depth}`}
 			role="group"
-			aria-label={ sprintf(
+			aria-label={sprintf(
 				/* translators: %s: human label for the group's nesting depth. */
-				__( 'Filter clauses, %s', 'designsetgo' ),
+				__('Filter clauses, %s', 'designsetgo'),
 				groupLabel
-			) }
-			style={ depth > 0 ? { paddingLeft: '12px', borderLeft: '2px solid var(--wp-admin-theme-color-darker-10, #ccc)' } : undefined }
+			)}
+			style={
+				depth > 0
+					? {
+							paddingLeft: '12px',
+							borderLeft:
+								'2px solid var(--wp-admin-theme-color-darker-10, #ccc)',
+						}
+					: undefined
+			}
 		>
-			{ ( clauses.length > 1 || depth > 0 ) && (
+			{(clauses.length > 1 || depth > 0) && (
 				<SelectControl
-					label={ __( 'Match', 'designsetgo' ) }
-					value={ relation }
-					options={ [
-						{ label: __( 'All (AND)', 'designsetgo' ), value: 'AND' },
-						{ label: __( 'Any (OR)', 'designsetgo' ), value: 'OR' },
-					] }
-					onChange={ ( val ) => onChange( { relation: val } ) }
+					label={__('Match', 'designsetgo')}
+					value={relation}
+					options={[
+						{ label: __('All (AND)', 'designsetgo'), value: 'AND' },
+						{ label: __('Any (OR)', 'designsetgo'), value: 'OR' },
+					]}
+					onChange={(val) => onChange({ relation: val })}
 					__nextHasNoMarginBottom
 				/>
-			) }
+			)}
 
-			{ clauses.map( ( entry, idx ) =>
-				Array.isArray( entry.clauses ) ? (
+			{clauses.map((entry, idx) =>
+				Array.isArray(entry.clauses) ? (
 					<ClauseGroupShell
-						key={ idx }
-						group={ entry }
-						onChange={ ( patch ) => replaceEntry( idx, { ...entry, ...patch } ) }
-						onRemove={ () => removeEntry( idx ) }
-						depth={ depth + 1 }
-						renderClause={ renderClause }
-						newClause={ newClause }
-						isAddDisabled={ isAddDisabled }
+						key={idx}
+						group={entry}
+						onChange={(patch) =>
+							replaceEntry(idx, { ...entry, ...patch })
+						}
+						onRemove={() => removeEntry(idx)}
+						depth={depth + 1}
+						renderClause={renderClause}
+						newClause={newClause}
+						isAddDisabled={isAddDisabled}
 					/>
 				) : (
-					renderClause( entry, idx, updateEntry, removeEntry )
+					renderClause(entry, idx, updateEntry, removeEntry)
 				)
-			) }
+			)}
 
 			<div className="dsgo-clause-group__actions">
 				<Button
 					variant="secondary"
 					size="small"
-					onClick={ addClause }
-					disabled={ isAddDisabled }
-					aria-label={ sprintf(
+					onClick={addClause}
+					disabled={isAddDisabled}
+					aria-label={sprintf(
 						/* translators: %s: human label for the group's nesting depth. */
-						__( 'Add clause to %s', 'designsetgo' ),
+						__('Add clause to %s', 'designsetgo'),
 						groupLabel
-					) }
+					)}
 					__next40pxDefaultSize
 				>
-					{ __( '+ Clause', 'designsetgo' ) }
+					{__('+ Clause', 'designsetgo')}
 				</Button>
 				<Button
 					variant="secondary"
 					size="small"
-					onClick={ addGroup }
-					disabled={ isAddDisabled }
-					aria-label={ sprintf(
+					onClick={addGroup}
+					disabled={isAddDisabled}
+					aria-label={sprintf(
 						/* translators: %s: human label for the group's nesting depth. */
-						__( 'Add group inside %s', 'designsetgo' ),
+						__('Add group inside %s', 'designsetgo'),
 						groupLabel
-					) }
+					)}
 					__next40pxDefaultSize
 				>
-					{ __( '+ Group', 'designsetgo' ) }
+					{__('+ Group', 'designsetgo')}
 				</Button>
-				{ onRemove && (
+				{onRemove && (
 					<Button
 						variant="tertiary"
 						isDestructive
 						size="small"
-						onClick={ onRemove }
-						aria-label={ sprintf(
+						onClick={onRemove}
+						aria-label={sprintf(
 							/* translators: %s: human label for the group's nesting depth. */
-							__( 'Remove %s', 'designsetgo' ),
+							__('Remove %s', 'designsetgo'),
 							groupLabel
-						) }
+						)}
 						__next40pxDefaultSize
 					>
-						{ __( 'Remove group', 'designsetgo' ) }
+						{__('Remove group', 'designsetgo')}
 					</Button>
-				) }
+				)}
 			</div>
 		</VStack>
 	);

--- a/src/blocks/query/components/DateQueryBuilder.js
+++ b/src/blocks/query/components/DateQueryBuilder.js
@@ -44,9 +44,11 @@ export default function DateQueryBuilder({
 	// Normalise both `dateQuery` and `dateQuery.clauses` so a malformed import
 	// (e.g. `{ relation: 'AND' }` with no clauses) doesn't crash the builder.
 	const rawDateQuery = attributes.dateQuery ?? EMPTY_DEFAULT;
-	const dateQuery    = {
+	const dateQuery = {
 		relation: rawDateQuery.relation ?? 'AND',
-		clauses: Array.isArray(rawDateQuery.clauses) ? rawDateQuery.clauses : [],
+		clauses: Array.isArray(rawDateQuery.clauses)
+			? rawDateQuery.clauses
+			: [],
 	};
 
 	const updateClause = (i, patch) => {
@@ -184,7 +186,11 @@ export default function DateQueryBuilder({
 						);
 					})}
 
-					<Button variant="secondary" onClick={addClause} __next40pxDefaultSize>
+					<Button
+						variant="secondary"
+						onClick={addClause}
+						__next40pxDefaultSize
+					>
 						{__('Add date clause', 'designsetgo')}
 					</Button>
 				</VStack>

--- a/src/blocks/query/components/EditorPreviewList.js
+++ b/src/blocks/query/components/EditorPreviewList.js
@@ -77,8 +77,8 @@ export default function EditorPreviewList({
 	const { records, hasResolved } = isPostsLike
 		? postsData
 		: isRelationship
-		? relationshipData
-		: remoteData;
+			? relationshipData
+			: remoteData;
 
 	if (!hasResolved) {
 		return (
@@ -243,6 +243,13 @@ function buildGroupLabel(item, groupBy) {
  * heading for each group.
  *
  * @param {Object} props
+ * @param          props.records
+ * @param          props.attributes
+ * @param          props.innerBlocks
+ * @param          props.innerBlocksProps
+ * @param          props.context
+ * @param          props.groupBy
+ * @param          props.renderedItems
  */
 function GroupedPreviewList({
 	records,
@@ -326,7 +333,9 @@ function GroupedPreviewList({
 												: 'dsgo-query__editor-preview-item is-read-only'
 										}
 									>
-										<BlockContextProvider value={itemContext}>
+										<BlockContextProvider
+											value={itemContext}
+										>
 											{idx === 0 ? (
 												<EditableTemplate
 													innerBlocksProps={
@@ -337,8 +346,9 @@ function GroupedPreviewList({
 												<ReadOnlyItem
 													innerBlocks={innerBlocks}
 													serverHtml={
-														renderedItems
-															.items?.[idx] ?? null
+														renderedItems.items?.[
+															idx
+														] ?? null
 													}
 													loading={
 														renderedItems.loading
@@ -611,11 +621,11 @@ function buildTermsMap(item) {
  *   or a self-referencing fallback for root-level Queries so inner Query
  *   blocks always receive a defined value.
  *
- * @param {Object} item           Preview item: { id, type, ... }.
- * @param {string} source         The query block source attribute value.
- * @param {number} index          Zero-based item index in the current result set (flat/cross-group).
- * @param {Object} outerCtx       The block's `context` prop from edit.js. May carry
- *                                `designsetgo/parentItem` when this Query is nested.
+ * @param {Object} item             Preview item: { id, type, ... }.
+ * @param {string} source           The query block source attribute value.
+ * @param {number} index            Zero-based item index in the current result set (flat/cross-group).
+ * @param {Object} outerCtx         The block's `context` prop from edit.js. May carry
+ *                                  `designsetgo/parentItem` when this Query is nested.
  * @param {number} [groupItemIndex] Zero-based position within the current group (grouped queries only).
  * @return {Object} Context object for BlockContextProvider.
  */
@@ -673,6 +683,25 @@ function buildContext(item, source, index, outerCtx, groupItemIndex) {
 	};
 }
 
+// The WP REST /wp/v2/posts endpoint accepts a fixed enum for `orderby` and
+// 400s on anything outside it — notably `menu_order`, `rand`, `meta_value`,
+// `meta_value_num`, and `comment_count`, all of which WP_Query accepts on the
+// frontend. For the editor preview we fall back to `date` so authors see
+// representative posts instead of an empty "No results" placeholder; the
+// frontend still uses the real orderBy value via PHP render.
+const REST_ALLOWED_POSTS_ORDERBY = new Set([
+	'author',
+	'date',
+	'id',
+	'include',
+	'modified',
+	'parent',
+	'relevance',
+	'slug',
+	'include_slugs',
+	'title',
+]);
+
 /**
  * Translate block attributes into @wordpress/core-data useEntityRecords args.
  *
@@ -684,10 +713,14 @@ function buildContext(item, source, index, outerCtx, groupItemIndex) {
  * @return {Object} Query args for useEntityRecords.
  */
 function buildCoreDataQuery(attributes) {
+	const rawOrderBy = (attributes.orderBy || 'date').toLowerCase();
+	const orderBy = REST_ALLOWED_POSTS_ORDERBY.has(rawOrderBy)
+		? rawOrderBy
+		: 'date';
 	const args = {
 		per_page: attributes.perPage || 6,
 		offset: attributes.offset || 0,
-		orderby: (attributes.orderBy || 'date').toLowerCase(),
+		orderby: orderBy,
 		order: (attributes.order || 'DESC').toLowerCase(),
 		status: 'publish',
 		_embed: true,

--- a/src/blocks/query/components/EditorPreviewList.js
+++ b/src/blocks/query/components/EditorPreviewList.js
@@ -41,14 +41,18 @@ export default function EditorPreviewList({
 	context,
 }) {
 	const source = attributes.source || 'posts';
-	const isPosts = source === 'posts';
+	const isPostsLike =
+		source === 'posts' || source === 'manual' || source === 'current';
 	const isRelationship = source === 'relationship';
 
 	// All three hooks must be called unconditionally (Rules of Hooks).
 	// Each hook no-ops cheaply when its source doesn't match via its `enabled`
 	// guard or its internal isRelationship branch.
-	const postsData = usePosts(attributes, isPosts);
-	const remoteData = useRemotePreview(attributes, !isPosts && !isRelationship);
+	const postsData = usePosts(attributes, isPostsLike);
+	const remoteData = useRemotePreview(
+		attributes,
+		!isPostsLike && !isRelationship
+	);
 	const relationshipData = useQueryPreview({
 		source,
 		relationshipField: attributes.relationshipField || '',
@@ -70,7 +74,7 @@ export default function EditorPreviewList({
 	});
 
 	// Select the active data path.
-	const { records, hasResolved } = isPosts
+	const { records, hasResolved } = isPostsLike
 		? postsData
 		: isRelationship
 		? relationshipData

--- a/src/blocks/query/components/MetaQueryBuilder.js
+++ b/src/blocks/query/components/MetaQueryBuilder.js
@@ -26,76 +26,78 @@ const COMPARE_OPTIONS = [
 ];
 
 const TYPE_OPTIONS = [
-	{ value: 'CHAR', label: __( 'Text', 'designsetgo' ) },
-	{ value: 'NUMERIC', label: __( 'Numeric', 'designsetgo' ) },
-	{ value: 'DATE', label: __( 'Date', 'designsetgo' ) },
+	{ value: 'CHAR', label: __('Text', 'designsetgo') },
+	{ value: 'NUMERIC', label: __('Numeric', 'designsetgo') },
+	{ value: 'DATE', label: __('Date', 'designsetgo') },
 ];
 
 const EMPTY_DEFAULT = { relation: 'AND', clauses: [] };
 const NEW_CLAUSE = { key: '', compare: '=', value: '', type: 'CHAR' };
 
-export default function MetaQueryBuilder( {
+export default function MetaQueryBuilder({
 	attributes,
 	setAttributes,
 	clientId,
-} ) {
+}) {
 	const rawMetaQuery = attributes.metaQuery ?? EMPTY_DEFAULT;
 	const metaQuery = {
 		relation: rawMetaQuery.relation ?? 'AND',
-		clauses: Array.isArray( rawMetaQuery.clauses ) ? rawMetaQuery.clauses : [],
+		clauses: Array.isArray(rawMetaQuery.clauses)
+			? rawMetaQuery.clauses
+			: [],
 	};
 
-	const renderClause = ( clause, idx, updateEntry, removeEntry ) => {
+	const renderClause = (clause, idx, updateEntry, removeEntry) => {
 		const hideValue =
 			clause.compare === 'EXISTS' || clause.compare === 'NOT EXISTS';
 		return (
-			<VStack key={ idx } spacing={ 2 }>
+			<VStack key={idx} spacing={2}>
 				<TextControl
-					label={ __( 'Key', 'designsetgo' ) }
-					value={ clause.key }
-					onChange={ ( v ) => updateEntry( idx, { key: v } ) }
+					label={__('Key', 'designsetgo')}
+					value={clause.key}
+					onChange={(v) => updateEntry(idx, { key: v })}
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
 				/>
 				<HStack>
 					<SelectControl
-						label={ __( 'Compare', 'designsetgo' ) }
-						value={ clause.compare }
-						options={ COMPARE_OPTIONS }
-						onChange={ ( v ) => updateEntry( idx, { compare: v } ) }
+						label={__('Compare', 'designsetgo')}
+						value={clause.compare}
+						options={COMPARE_OPTIONS}
+						onChange={(v) => updateEntry(idx, { compare: v })}
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
 					/>
 					<SelectControl
-						label={ __( 'Type', 'designsetgo' ) }
-						value={ clause.type }
-						options={ TYPE_OPTIONS }
-						onChange={ ( v ) => updateEntry( idx, { type: v } ) }
+						label={__('Type', 'designsetgo')}
+						value={clause.type}
+						options={TYPE_OPTIONS}
+						onChange={(v) => updateEntry(idx, { type: v })}
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
 					/>
 				</HStack>
-				{ ! hideValue && (
+				{!hideValue && (
 					<TextControl
-						label={ __( 'Value', 'designsetgo' ) }
-						value={ clause.value }
-						onChange={ ( v ) => updateEntry( idx, { value: v } ) }
+						label={__('Value', 'designsetgo')}
+						value={clause.value}
+						onChange={(v) => updateEntry(idx, { value: v })}
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
 					/>
-				) }
+				)}
 				<Button
 					isDestructive
 					variant="tertiary"
-					onClick={ () => removeEntry( idx ) }
-					aria-label={ sprintf(
+					onClick={() => removeEntry(idx)}
+					aria-label={sprintf(
 						/* translators: %s: meta key being removed, or "(empty)" when blank. */
-						__( 'Remove meta filter for "%s"', 'designsetgo' ),
-						clause.key || __( '(empty)', 'designsetgo' )
-					) }
+						__('Remove meta filter for "%s"', 'designsetgo'),
+						clause.key || __('(empty)', 'designsetgo')
+					)}
 					__next40pxDefaultSize
 				>
-					{ __( 'Remove', 'designsetgo' ) }
+					{__('Remove', 'designsetgo')}
 				</Button>
 			</VStack>
 		);
@@ -103,25 +105,25 @@ export default function MetaQueryBuilder( {
 
 	return (
 		<DsgoInspectorPanel
-			title={ __( 'Meta filters', 'designsetgo' ) }
+			title={__('Meta filters', 'designsetgo')}
 			panelName="settings"
-			panelId={ clientId }
-			resetAll={ () => setAttributes( { metaQuery: EMPTY_DEFAULT } ) }
+			panelId={clientId}
+			resetAll={() => setAttributes({ metaQuery: EMPTY_DEFAULT })}
 		>
 			<DsgoInspectorPanel.Item
-				label={ __( 'Meta query', 'designsetgo' ) }
-				hasValue={ () => metaQuery.clauses.length > 0 }
-				onDeselect={ () => setAttributes( { metaQuery: EMPTY_DEFAULT } ) }
+				label={__('Meta query', 'designsetgo')}
+				hasValue={() => metaQuery.clauses.length > 0}
+				onDeselect={() => setAttributes({ metaQuery: EMPTY_DEFAULT })}
 				isShownByDefault
 			>
 				<ClauseGroupShell
-					group={ metaQuery }
-					onChange={ ( patch ) =>
-						setAttributes( { metaQuery: { ...metaQuery, ...patch } } )
+					group={metaQuery}
+					onChange={(patch) =>
+						setAttributes({ metaQuery: { ...metaQuery, ...patch } })
 					}
-					depth={ 0 }
-					newClause={ NEW_CLAUSE }
-					renderClause={ renderClause }
+					depth={0}
+					newClause={NEW_CLAUSE}
+					renderClause={renderClause}
 				/>
 			</DsgoInspectorPanel.Item>
 		</DsgoInspectorPanel>

--- a/src/blocks/query/components/QueryHostReadOnlyItem.js
+++ b/src/blocks/query/components/QueryHostReadOnlyItem.js
@@ -1,0 +1,65 @@
+/**
+ * QueryHostReadOnlyItem — injects a single pre-rendered item's HTML into a
+ * plain container so the slider / scroll-slides editor preview can show
+ * items 1..N as true-to-frontend markup.
+ *
+ * Item 0 is owned by the parent block's useInnerBlocksProps (the editable
+ * template). Items 1..N come from /designsetgo/v1/query/render and land here.
+ *
+ * Content is produced by the plugin's own render pipeline — the same markup
+ * served to frontend visitors, already passed through wp_kses_post / block
+ * rendering. The REST endpoint requires edit_posts capability, so only
+ * trusted editors can influence this output.
+ *
+ * @since 2.6.0
+ */
+import { useEffect, useRef } from '@wordpress/element';
+import { Spinner, Placeholder } from '@wordpress/components';
+
+/**
+ * @param {Object}      props
+ * @param {string|null} props.html    Rendered inner HTML for this item.
+ * @param {boolean}     props.loading True while the server render is in flight.
+ * @param {string}      [props.className] Optional wrapping className.
+ */
+export default function QueryHostReadOnlyItem({ html, loading, className }) {
+	const hostRef = useRef(null);
+
+	useEffect(() => {
+		const node = hostRef.current;
+		if (!node) {
+			return;
+		}
+		while (node.firstChild) {
+			node.removeChild(node.firstChild);
+		}
+		if (typeof html !== 'string') {
+			return;
+		}
+		const range = node.ownerDocument.createRange();
+		range.selectNodeContents(node);
+		const fragment = range.createContextualFragment(html);
+		node.appendChild(fragment);
+	}, [html]);
+
+	if (typeof html === 'string') {
+		return (
+			<div
+				ref={hostRef}
+				className={className}
+				aria-hidden="true"
+				contentEditable={false}
+			/>
+		);
+	}
+	if (loading) {
+		return (
+			<Placeholder
+				className={`${className || ''} dsgo-query__editor-placeholder`}
+			>
+				<Spinner />
+			</Placeholder>
+		);
+	}
+	return null;
+}

--- a/src/blocks/query/components/QueryHostReadOnlyItem.js
+++ b/src/blocks/query/components/QueryHostReadOnlyItem.js
@@ -18,8 +18,8 @@ import { Spinner, Placeholder } from '@wordpress/components';
 
 /**
  * @param {Object}      props
- * @param {string|null} props.html    Rendered inner HTML for this item.
- * @param {boolean}     props.loading True while the server render is in flight.
+ * @param {string|null} props.html        Rendered inner HTML for this item.
+ * @param {boolean}     props.loading     True while the server render is in flight.
  * @param {string}      [props.className] Optional wrapping className.
  */
 export default function QueryHostReadOnlyItem({ html, loading, className }) {

--- a/src/blocks/query/components/QuerySourcePanel.js
+++ b/src/blocks/query/components/QuerySourcePanel.js
@@ -30,7 +30,10 @@ const SOURCES = [
 	{ value: 'terms', label: __('Terms', 'designsetgo') },
 	{ value: 'manual', label: __('Manual picks', 'designsetgo') },
 	{ value: 'current', label: __('Current archive', 'designsetgo') },
-	{ value: 'relationship', label: __('Related items (field-driven)', 'designsetgo') },
+	{
+		value: 'relationship',
+		label: __('Related items (field-driven)', 'designsetgo'),
+	},
 ];
 
 const RELATIONSHIP_FALLBACK_OPTIONS = [
@@ -78,7 +81,6 @@ export default function QuerySourcePanel({
 		(select) => select(coreStore).getPostTypes({ per_page: -1 }) || [],
 		[]
 	);
-
 
 	const postTypeOptions = (postTypes || [])
 		.filter((pt) => pt && pt.viewable)
@@ -158,7 +160,9 @@ export default function QuerySourcePanel({
 							'designsetgo'
 						)}
 						value={relationshipField || ''}
-						onChange={(v) => setAttributes({ relationshipField: v })}
+						onChange={(v) =>
+							setAttributes({ relationshipField: v })
+						}
 					/>
 				</DsgoInspectorPanel.Item>
 			)}
@@ -166,8 +170,12 @@ export default function QuerySourcePanel({
 			{showRelationship && (
 				<DsgoInspectorPanel.Item
 					label={__('When no related items', 'designsetgo')}
-					hasValue={() => (relationshipFallback || 'empty') !== 'empty'}
-					onDeselect={() => setAttributes({ relationshipFallback: 'empty' })}
+					hasValue={() =>
+						(relationshipFallback || 'empty') !== 'empty'
+					}
+					onDeselect={() =>
+						setAttributes({ relationshipFallback: 'empty' })
+					}
 					isShownByDefault
 				>
 					<SelectControl
@@ -175,7 +183,9 @@ export default function QuerySourcePanel({
 						__nextHasNoMarginBottom
 						label={__('When no related items', 'designsetgo')}
 						value={relationshipFallback || 'empty'}
-						onChange={(v) => setAttributes({ relationshipFallback: v })}
+						onChange={(v) =>
+							setAttributes({ relationshipFallback: v })
+						}
 						options={RELATIONSHIP_FALLBACK_OPTIONS}
 					/>
 				</DsgoInspectorPanel.Item>
@@ -202,7 +212,7 @@ export default function QuerySourcePanel({
 				label={__('Offset', 'designsetgo')}
 				hasValue={() => offset !== 0}
 				onDeselect={() => setAttributes({ offset: 0 })}
-				isShownByDefault={false}
+				isShownByDefault
 			>
 				<NumberControl
 					label={__('Offset', 'designsetgo')}
@@ -220,7 +230,7 @@ export default function QuerySourcePanel({
 				label={__('Order by', 'designsetgo')}
 				hasValue={() => orderBy !== 'date'}
 				onDeselect={() => setAttributes({ orderBy: 'date' })}
-				isShownByDefault={false}
+				isShownByDefault
 			>
 				<SelectControl
 					label={__('Order by', 'designsetgo')}
@@ -257,7 +267,7 @@ export default function QuerySourcePanel({
 				label={__('Order direction', 'designsetgo')}
 				hasValue={() => order !== 'DESC'}
 				onDeselect={() => setAttributes({ order: 'DESC' })}
-				isShownByDefault={false}
+				isShownByDefault
 			>
 				<SelectControl
 					label={__('Order direction', 'designsetgo')}

--- a/src/blocks/query/components/ResultsLayoutControls.js
+++ b/src/blocks/query/components/ResultsLayoutControls.js
@@ -1,0 +1,308 @@
+import { __ } from '@wordpress/i18n';
+import {
+	RangeControl,
+	SelectControl,
+	TextControl,
+} from '@wordpress/components';
+
+import { DsgoInspectorPanel } from '../../../components/shared';
+import { GROUP_BY_OPTIONS, DATE_PRECISION_OPTIONS } from './QuerySourcePanel';
+
+export const RESULTS_DEFAULTS = {
+	tagName: 'ul',
+	itemTagName: 'li',
+	columns: 1,
+	columnsTablet: 0,
+	columnsMobile: 0,
+	firstItemColumnSpan: 1,
+	firstItemRowSpan: 1,
+	groupBy: null,
+};
+
+/**
+ * Shared "Results layout" inspector panel used by both the parent
+ * designsetgo/query proxy and the child designsetgo/query-results own inspector.
+ *
+ * Both callers read and write the same block attributes (the child's), so a
+ * change in either panel is immediately reflected in the other.
+ *
+ * @param {Object}   root0
+ * @param {Object}   root0.attributes      The query-results block's attributes.
+ * @param {Function} root0.set             Partial-attribute setter (maps to setAttributes or updateBlockAttributes).
+ * @param {string}   root0.panelId         clientId for ToolsPanel reset-state scoping.
+ * @param {Array}    root0.taxonomyOptions [{value, label}] list from core-data.
+ */
+export default function ResultsLayoutControls({
+	attributes,
+	set,
+	panelId,
+	taxonomyOptions,
+}) {
+	const a = { ...RESULTS_DEFAULTS, ...attributes };
+	const groupByField = a.groupBy?.field || 'none';
+
+	const handleGroupByFieldChange = (value) => {
+		if (value === 'none') {
+			set({ groupBy: null });
+		} else {
+			set({ groupBy: { field: value, key: '' } });
+		}
+	};
+
+	return (
+		<DsgoInspectorPanel
+			title={__('Results layout', 'designsetgo')}
+			panelName="settings"
+			panelId={panelId}
+			resetAll={() => set(RESULTS_DEFAULTS)}
+		>
+			<DsgoInspectorPanel.Item
+				label={__('Columns', 'designsetgo')}
+				hasValue={() => a.columns !== RESULTS_DEFAULTS.columns}
+				onDeselect={() => set({ columns: RESULTS_DEFAULTS.columns })}
+				isShownByDefault
+			>
+				<RangeControl
+					label={__('Columns', 'designsetgo')}
+					value={a.columns || 1}
+					min={1}
+					max={6}
+					onChange={(v) => set({ columns: v })}
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+				/>
+			</DsgoInspectorPanel.Item>
+
+			<DsgoInspectorPanel.Item
+				label={__('Columns (tablet)', 'designsetgo')}
+				hasValue={() =>
+					a.columnsTablet !== RESULTS_DEFAULTS.columnsTablet
+				}
+				onDeselect={() =>
+					set({ columnsTablet: RESULTS_DEFAULTS.columnsTablet })
+				}
+				isShownByDefault
+			>
+				<RangeControl
+					label={__('Columns (tablet)', 'designsetgo')}
+					help={__(
+						'0 inherits the desktop column count.',
+						'designsetgo'
+					)}
+					value={a.columnsTablet || 0}
+					min={0}
+					max={6}
+					onChange={(v) => set({ columnsTablet: v })}
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+				/>
+			</DsgoInspectorPanel.Item>
+
+			<DsgoInspectorPanel.Item
+				label={__('Columns (mobile)', 'designsetgo')}
+				hasValue={() =>
+					a.columnsMobile !== RESULTS_DEFAULTS.columnsMobile
+				}
+				onDeselect={() =>
+					set({ columnsMobile: RESULTS_DEFAULTS.columnsMobile })
+				}
+				isShownByDefault
+			>
+				<RangeControl
+					label={__('Columns (mobile)', 'designsetgo')}
+					value={a.columnsMobile || 1}
+					min={1}
+					max={3}
+					onChange={(v) => set({ columnsMobile: v })}
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+				/>
+			</DsgoInspectorPanel.Item>
+
+			<DsgoInspectorPanel.Item
+				label={__('First item column span', 'designsetgo')}
+				hasValue={() =>
+					a.firstItemColumnSpan !== RESULTS_DEFAULTS.firstItemColumnSpan
+				}
+				onDeselect={() =>
+					set({
+						firstItemColumnSpan: RESULTS_DEFAULTS.firstItemColumnSpan,
+					})
+				}
+				isShownByDefault
+			>
+				<RangeControl
+					label={__('First item column span', 'designsetgo')}
+					help={__(
+						'Make the first result a featured callout by spanning extra columns. 1 = no span. Capped at the current column count on smaller screens.',
+						'designsetgo'
+					)}
+					value={a.firstItemColumnSpan || 1}
+					min={1}
+					max={Math.max(1, a.columns || 1)}
+					onChange={(v) => set({ firstItemColumnSpan: v })}
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+				/>
+			</DsgoInspectorPanel.Item>
+
+			<DsgoInspectorPanel.Item
+				label={__('First item row span', 'designsetgo')}
+				hasValue={() =>
+					a.firstItemRowSpan !== RESULTS_DEFAULTS.firstItemRowSpan
+				}
+				onDeselect={() =>
+					set({ firstItemRowSpan: RESULTS_DEFAULTS.firstItemRowSpan })
+				}
+				isShownByDefault
+			>
+				<RangeControl
+					label={__('First item row span', 'designsetgo')}
+					help={__(
+						'Extra height for the featured first item (like a Pinterest hero). 1 = no span.',
+						'designsetgo'
+					)}
+					value={a.firstItemRowSpan || 1}
+					min={1}
+					max={4}
+					onChange={(v) => set({ firstItemRowSpan: v })}
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+				/>
+			</DsgoInspectorPanel.Item>
+
+			<DsgoInspectorPanel.Item
+				label={__('List tag', 'designsetgo')}
+				hasValue={() => a.tagName !== RESULTS_DEFAULTS.tagName}
+				onDeselect={() => set({ tagName: RESULTS_DEFAULTS.tagName })}
+				isShownByDefault
+			>
+				<SelectControl
+					label={__('List tag', 'designsetgo')}
+					value={a.tagName || 'ul'}
+					options={[
+						{ label: 'ul', value: 'ul' },
+						{ label: 'ol', value: 'ol' },
+						{ label: 'div', value: 'div' },
+					]}
+					onChange={(v) => set({ tagName: v })}
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+				/>
+			</DsgoInspectorPanel.Item>
+
+			<DsgoInspectorPanel.Item
+				label={__('Item tag', 'designsetgo')}
+				hasValue={() => a.itemTagName !== RESULTS_DEFAULTS.itemTagName}
+				onDeselect={() =>
+					set({ itemTagName: RESULTS_DEFAULTS.itemTagName })
+				}
+				isShownByDefault
+			>
+				<SelectControl
+					label={__('Item tag', 'designsetgo')}
+					value={a.itemTagName || 'li'}
+					options={[
+						{ label: 'li', value: 'li' },
+						{ label: 'div', value: 'div' },
+						{ label: 'article', value: 'article' },
+					]}
+					onChange={(v) => set({ itemTagName: v })}
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+				/>
+			</DsgoInspectorPanel.Item>
+
+			<DsgoInspectorPanel.Item
+				label={__('Group by', 'designsetgo')}
+				hasValue={() => groupByField !== 'none'}
+				onDeselect={() => set({ groupBy: null })}
+				isShownByDefault
+			>
+				<SelectControl
+					label={__('Group by', 'designsetgo')}
+					value={groupByField}
+					options={GROUP_BY_OPTIONS}
+					onChange={handleGroupByFieldChange}
+					help={__(
+						'Grouped output requires a Query group header block inside the results template.',
+						'designsetgo'
+					)}
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+				/>
+			</DsgoInspectorPanel.Item>
+
+			{groupByField === 'taxonomy' && (
+				<DsgoInspectorPanel.Item
+					label={__('Group taxonomy', 'designsetgo')}
+					hasValue={() => !!a.groupBy?.key}
+					onDeselect={() =>
+						set({ groupBy: { ...a.groupBy, key: '' } })
+					}
+					isShownByDefault
+				>
+					<SelectControl
+						label={__('Group taxonomy', 'designsetgo')}
+						value={a.groupBy?.key || ''}
+						options={[
+							{
+								value: '',
+								label: __('— Select —', 'designsetgo'),
+							},
+							...(taxonomyOptions || []),
+						]}
+						onChange={(v) =>
+							set({ groupBy: { ...a.groupBy, key: v } })
+						}
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+				</DsgoInspectorPanel.Item>
+			)}
+
+			{groupByField === 'meta' && (
+				<DsgoInspectorPanel.Item
+					label={__('Group meta key', 'designsetgo')}
+					hasValue={() => !!a.groupBy?.key}
+					onDeselect={() =>
+						set({ groupBy: { ...a.groupBy, key: '' } })
+					}
+					isShownByDefault
+				>
+					<TextControl
+						label={__('Group meta key', 'designsetgo')}
+						value={a.groupBy?.key || ''}
+						onChange={(v) =>
+							set({ groupBy: { ...a.groupBy, key: v } })
+						}
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+				</DsgoInspectorPanel.Item>
+			)}
+
+			{groupByField === 'date' && (
+				<DsgoInspectorPanel.Item
+					label={__('Date precision', 'designsetgo')}
+					hasValue={() => (a.groupBy?.key || 'Y') !== 'Y'}
+					onDeselect={() =>
+						set({ groupBy: { ...a.groupBy, key: 'Y' } })
+					}
+					isShownByDefault
+				>
+					<SelectControl
+						label={__('Date precision', 'designsetgo')}
+						value={a.groupBy?.key || 'Y'}
+						options={DATE_PRECISION_OPTIONS}
+						onChange={(v) =>
+							set({ groupBy: { ...a.groupBy, key: v } })
+						}
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+				</DsgoInspectorPanel.Item>
+			)}
+		</DsgoInspectorPanel>
+	);
+}

--- a/src/blocks/query/components/ResultsLayoutPanel.js
+++ b/src/blocks/query/components/ResultsLayoutPanel.js
@@ -1,0 +1,52 @@
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+
+import ResultsLayoutControls from './ResultsLayoutControls';
+
+/**
+ * Proxy panel: surfaces the child designsetgo/query-results block's layout
+ * controls on the parent designsetgo/query inspector. Writes via
+ * updateBlockAttributes so changes are reflected in the child's own inspector.
+ *
+ * @param {Object} root0
+ * @param {string} root0.clientId Parent query block's clientId.
+ */
+export default function ResultsLayoutPanel({ clientId }) {
+	const { updateBlockAttributes } = useDispatch(blockEditorStore);
+
+	const child = useSelect(
+		(select) => {
+			const block = select(blockEditorStore).getBlock(clientId);
+			const inner = block?.innerBlocks || [];
+			return (
+				inner.find((b) => b?.name === 'designsetgo/query-results') ||
+				null
+			);
+		},
+		[clientId]
+	);
+
+	const taxonomyOptions = useSelect((select) => {
+		const taxes = select(coreStore).getTaxonomies({ per_page: -1 }) || [];
+		return taxes
+			.filter((t) => t.show_in_rest !== false)
+			.map((t) => ({
+				value: t.slug,
+				label: t.labels?.singular_name || t.name || t.slug,
+			}));
+	}, []);
+
+	if (!child) {
+		return null;
+	}
+
+	return (
+		<ResultsLayoutControls
+			attributes={child.attributes || {}}
+			set={(next) => updateBlockAttributes(child.clientId, next)}
+			panelId={clientId}
+			taxonomyOptions={taxonomyOptions}
+		/>
+	);
+}

--- a/src/blocks/query/components/TaxQueryBuilder.js
+++ b/src/blocks/query/components/TaxQueryBuilder.js
@@ -14,88 +14,99 @@ import { DsgoInspectorPanel } from '../../../components/shared';
 import ClauseGroupShell from './ClauseGroupShell';
 
 const OPERATORS = [
-	{ value: 'IN', label: __( 'In', 'designsetgo' ) },
-	{ value: 'NOT IN', label: __( 'Not in', 'designsetgo' ) },
-	{ value: 'AND', label: __( 'All of', 'designsetgo' ) },
+	{ value: 'IN', label: __('In', 'designsetgo') },
+	{ value: 'NOT IN', label: __('Not in', 'designsetgo') },
+	{ value: 'AND', label: __('All of', 'designsetgo') },
 ];
 
-export default function TaxQueryBuilder( {
+export default function TaxQueryBuilder({
 	attributes,
 	setAttributes,
 	clientId,
-} ) {
+}) {
 	const { postType } = attributes;
 	const rawTaxQuery = attributes.taxQuery ?? { relation: 'AND', clauses: [] };
 	const taxQuery = {
 		relation: rawTaxQuery.relation ?? 'AND',
-		clauses: Array.isArray( rawTaxQuery.clauses ) ? rawTaxQuery.clauses : [],
+		clauses: Array.isArray(rawTaxQuery.clauses) ? rawTaxQuery.clauses : [],
 	};
 
 	const taxonomies = useSelect(
-		( select ) => select( coreStore ).getTaxonomies( { per_page: -1 } ) || [],
+		(select) => select(coreStore).getTaxonomies({ per_page: -1 }) || [],
 		[]
 	);
-	const relevant = ( taxonomies || [] ).filter(
-		( t ) => t && t.types && t.types.includes( postType )
+	const relevant = (taxonomies || []).filter(
+		(t) => t && t.types && t.types.includes(postType)
 	);
 
 	return (
 		<DsgoInspectorPanel
-			title={ __( 'Taxonomy filters', 'designsetgo' ) }
+			title={__('Taxonomy filters', 'designsetgo')}
 			panelName="settings"
-			panelId={ clientId }
-			resetAll={ () =>
-				setAttributes( { taxQuery: { relation: 'AND', clauses: [] } } )
+			panelId={clientId}
+			resetAll={() =>
+				setAttributes({ taxQuery: { relation: 'AND', clauses: [] } })
 			}
 		>
 			<DsgoInspectorPanel.Item
-				label={ __( 'Taxonomy filters', 'designsetgo' ) }
-				hasValue={ () => taxQuery.clauses.length > 0 }
-				onDeselect={ () =>
-					setAttributes( { taxQuery: { relation: 'AND', clauses: [] } } )
+				label={__('Taxonomy filters', 'designsetgo')}
+				hasValue={() => taxQuery.clauses.length > 0}
+				onDeselect={() =>
+					setAttributes({
+						taxQuery: { relation: 'AND', clauses: [] },
+					})
 				}
 				isShownByDefault
 			>
 				<ClauseGroupShell
-					group={ taxQuery }
-					onChange={ ( patch ) =>
-						setAttributes( { taxQuery: { ...taxQuery, ...patch } } )
+					group={taxQuery}
+					onChange={(patch) =>
+						setAttributes({ taxQuery: { ...taxQuery, ...patch } })
 					}
-					depth={ 0 }
-					isAddDisabled={ relevant.length === 0 }
-					newClause={ {
-						taxonomy: relevant[ 0 ]?.slug ?? 'category',
+					depth={0}
+					isAddDisabled={relevant.length === 0}
+					newClause={{
+						taxonomy: relevant[0]?.slug ?? 'category',
 						terms: [],
 						operator: 'IN',
 						include_children: true,
-					} }
-					renderClause={ ( clause, idx, updateEntry, removeEntry ) => (
-						<VStack key={ idx } spacing={ 2 } className="dsgo-query-tax-clause">
+					}}
+					renderClause={(clause, idx, updateEntry, removeEntry) => (
+						<VStack
+							key={idx}
+							spacing={2}
+							className="dsgo-query-tax-clause"
+						>
 							<SelectControl
-								label={ __( 'Taxonomy', 'designsetgo' ) }
-								value={ clause.taxonomy }
-								options={ relevant.map( ( t ) => ( {
+								label={__('Taxonomy', 'designsetgo')}
+								value={clause.taxonomy}
+								options={relevant.map((t) => ({
 									label: t.labels?.singular_name || t.slug,
 									value: t.slug,
-								} ) ) }
-								onChange={ ( val ) =>
-									updateEntry( idx, { taxonomy: val, terms: [] } )
+								}))}
+								onChange={(val) =>
+									updateEntry(idx, {
+										taxonomy: val,
+										terms: [],
+									})
 								}
 								__next40pxDefaultSize
 								__nextHasNoMarginBottom
 							/>
 							<TermPicker
-								taxonomy={ clause.taxonomy }
-								selected={ clause.terms }
-								onChange={ ( ids ) => updateEntry( idx, { terms: ids } ) }
+								taxonomy={clause.taxonomy}
+								selected={clause.terms}
+								onChange={(ids) =>
+									updateEntry(idx, { terms: ids })
+								}
 							/>
 							<HStack>
 								<SelectControl
-									label={ __( 'Operator', 'designsetgo' ) }
-									value={ clause.operator || 'IN' }
-									options={ OPERATORS }
-									onChange={ ( val ) =>
-										updateEntry( idx, { operator: val } )
+									label={__('Operator', 'designsetgo')}
+									value={clause.operator || 'IN'}
+									options={OPERATORS}
+									onChange={(val) =>
+										updateEntry(idx, { operator: val })
 									}
 									__next40pxDefaultSize
 									__nextHasNoMarginBottom
@@ -103,56 +114,56 @@ export default function TaxQueryBuilder( {
 								<Button
 									isDestructive
 									variant="tertiary"
-									onClick={ () => removeEntry( idx ) }
-									aria-label={ __(
+									onClick={() => removeEntry(idx)}
+									aria-label={__(
 										'Remove taxonomy filter',
 										'designsetgo'
-									) }
+									)}
 									__next40pxDefaultSize
 								>
-									{ __( 'Remove', 'designsetgo' ) }
+									{__('Remove', 'designsetgo')}
 								</Button>
 							</HStack>
 							<ToggleControl
-								label={ __( 'Include child terms', 'designsetgo' ) }
-								checked={ clause.include_children ?? true }
-								onChange={ ( val ) =>
-									updateEntry( idx, { include_children: val } )
+								label={__('Include child terms', 'designsetgo')}
+								checked={clause.include_children ?? true}
+								onChange={(val) =>
+									updateEntry(idx, { include_children: val })
 								}
 								__nextHasNoMarginBottom
 							/>
 						</VStack>
-					) }
+					)}
 				/>
 			</DsgoInspectorPanel.Item>
 		</DsgoInspectorPanel>
 	);
 }
 
-function TermPicker( { taxonomy, selected, onChange } ) {
+function TermPicker({ taxonomy, selected, onChange }) {
 	const terms = useSelect(
-		( select ) =>
-			select( coreStore ).getEntityRecords( 'taxonomy', taxonomy, {
+		(select) =>
+			select(coreStore).getEntityRecords('taxonomy', taxonomy, {
 				per_page: -1,
-			} ) || [],
-		[ taxonomy ]
+			}) || [],
+		[taxonomy]
 	);
-	const suggestions = ( terms || [] ).map( ( t ) => t.name );
-	const selectedNames = ( terms || [] )
-		.filter( ( t ) => selected.includes( t.id ) )
-		.map( ( t ) => t.name );
+	const suggestions = (terms || []).map((t) => t.name);
+	const selectedNames = (terms || [])
+		.filter((t) => selected.includes(t.id))
+		.map((t) => t.name);
 
 	return (
 		<FormTokenField
-			label={ __( 'Terms', 'designsetgo' ) }
-			value={ selectedNames }
-			suggestions={ suggestions }
-			onChange={ ( names ) => {
-				const ids = ( terms || [] )
-					.filter( ( t ) => names.includes( t.name ) )
-					.map( ( t ) => t.id );
-				onChange( ids );
-			} }
+			label={__('Terms', 'designsetgo')}
+			value={selectedNames}
+			suggestions={suggestions}
+			onChange={(names) => {
+				const ids = (terms || [])
+					.filter((t) => names.includes(t.name))
+					.map((t) => t.id);
+				onChange(ids);
+			}}
 			__experimentalExpandOnFocus
 			__nextHasNoMarginBottom
 		/>

--- a/src/blocks/query/components/TemplateIO.js
+++ b/src/blocks/query/components/TemplateIO.js
@@ -10,13 +10,14 @@ import { store as noticesStore } from '@wordpress/notices';
 export default function TemplateIO({ clientId, attributes }) {
 	const { queryId } = attributes;
 	const { replaceBlocks } = useDispatch(blockEditorStore);
-	const { createSuccessNotice, createErrorNotice } = useDispatch(noticesStore);
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch(noticesStore);
 	const currentBlock = useSelect(
 		(select) => select(blockEditorStore).getBlock(clientId),
 		[clientId]
 	);
 	const fileInputRef = useRef(null);
-	const [ isBusy, setIsBusy ] = useState( false );
+	const [isBusy, setIsBusy] = useState(false);
 
 	async function handleExport() {
 		try {
@@ -25,7 +26,7 @@ export default function TemplateIO({ clientId, attributes }) {
 					__('Unable to read the current Query block.', 'designsetgo')
 				);
 			}
-			setIsBusy( true );
+			setIsBusy(true);
 			const payload = {
 				schemaVersion: 1,
 				exportedAt: new Date().toISOString(),
@@ -33,10 +34,9 @@ export default function TemplateIO({ clientId, attributes }) {
 				attributes: currentBlock.attributes || attributes,
 				innerBlocks: serialize(currentBlock.innerBlocks || []),
 			};
-			const blob = new Blob(
-				[JSON.stringify(payload, null, 2)],
-				{ type: 'application/json' }
-			);
+			const blob = new Blob([JSON.stringify(payload, null, 2)], {
+				type: 'application/json',
+			});
 			const url = URL.createObjectURL(blob);
 			const a = document.createElement('a');
 			a.href = url;
@@ -45,17 +45,16 @@ export default function TemplateIO({ clientId, attributes }) {
 			a.click();
 			document.body.removeChild(a);
 			URL.revokeObjectURL(url);
-			createSuccessNotice(
-				__('Query template exported.', 'designsetgo'),
-				{ type: 'snackbar' }
-			);
+			createSuccessNotice(__('Query template exported.', 'designsetgo'), {
+				type: 'snackbar',
+			});
 		} catch (err) {
 			createErrorNotice(
 				err?.message || __('Export failed.', 'designsetgo'),
 				{ type: 'snackbar' }
 			);
 		} finally {
-			setIsBusy( false );
+			setIsBusy(false);
 		}
 	}
 
@@ -71,7 +70,7 @@ export default function TemplateIO({ clientId, attributes }) {
 			return;
 		}
 		try {
-			setIsBusy( true );
+			setIsBusy(true);
 			const text = await file.text();
 			const payload = JSON.parse(text);
 			const response = await apiFetch({
@@ -82,21 +81,23 @@ export default function TemplateIO({ clientId, attributes }) {
 			const blocks = parse(response.blockMarkup);
 			if (!blocks.length) {
 				throw new Error(
-					__('Imported JSON did not yield a valid block.', 'designsetgo')
+					__(
+						'Imported JSON did not yield a valid block.',
+						'designsetgo'
+					)
 				);
 			}
 			replaceBlocks(clientId, blocks);
-			createSuccessNotice(
-				__('Query template imported.', 'designsetgo'),
-				{ type: 'snackbar' }
-			);
+			createSuccessNotice(__('Query template imported.', 'designsetgo'), {
+				type: 'snackbar',
+			});
 		} catch (err) {
 			createErrorNotice(
 				err?.message || __('Import failed.', 'designsetgo'),
 				{ type: 'snackbar' }
 			);
 		} finally {
-			setIsBusy( false );
+			setIsBusy(false);
 		}
 	}
 

--- a/src/blocks/query/edit-template.js
+++ b/src/blocks/query/edit-template.js
@@ -26,7 +26,7 @@ export const RESULT_TEMPLATE = [
 // most authors end up wanting, plus the required query-results wrapper.
 // Easy to remove a block; harder to discover one that wasn't scaffolded.
 export const DEFAULT_TEMPLATE = [
-	['designsetgo/query-results', {}, RESULT_TEMPLATE],
+	['designsetgo/query-results', { columns: 3 }, RESULT_TEMPLATE],
 	['designsetgo/query-no-results'],
 	['designsetgo/query-pagination', { paginationKind: 'numbered' }],
 ];

--- a/src/blocks/query/edit.js
+++ b/src/blocks/query/edit.js
@@ -14,6 +14,7 @@ import MetaQueryBuilder from './components/MetaQueryBuilder';
 import QueryPlaceholder from './components/QueryPlaceholder';
 import QuerySourcePanel from './components/QuerySourcePanel';
 import ResultCountBadge from './components/ResultCountBadge';
+import ResultsLayoutPanel from './components/ResultsLayoutPanel';
 import TaxQueryBuilder from './components/TaxQueryBuilder';
 
 /**
@@ -24,6 +25,10 @@ import TaxQueryBuilder from './components/TaxQueryBuilder';
  * context. Actual item rendering lives in the child designsetgo/query-results
  * block. Filters, pagination, and no-results render in-place as siblings of
  * query-results in whatever tree position the author chooses.
+ * @param {Object}   root0
+ * @param {Object}   root0.attributes
+ * @param {Function} root0.setAttributes
+ * @param {string}   root0.clientId
  */
 export default function QueryEdit({ attributes, setAttributes, clientId }) {
 	useQueryId({ clientId, queryId: attributes.queryId, setAttributes });
@@ -68,6 +73,7 @@ export default function QueryEdit({ attributes, setAttributes, clientId }) {
 					setAttributes={setAttributes}
 					clientId={clientId}
 				/>
+				<ResultsLayoutPanel clientId={clientId} />
 				{showPostsOnlyPanels && (
 					<>
 						<TaxQueryBuilder
@@ -95,7 +101,10 @@ export default function QueryEdit({ attributes, setAttributes, clientId }) {
 			</InspectorControls>
 
 			<div {...blockProps}>
-				<div className="dsgo-query__editor-header" contentEditable={false}>
+				<div
+					className="dsgo-query__editor-header"
+					contentEditable={false}
+				>
 					<ResultCountBadge
 						totalItems={preview.totalItems}
 						loading={preview.loading}

--- a/src/blocks/query/editor.scss
+++ b/src/blocks/query/editor.scss
@@ -32,6 +32,11 @@
 	}
 }
 
+.dsgo-clause-group__actions {
+	display: flex;
+	gap: 8px;
+}
+
 .dsgo-query-group-label {
 	font-size: 0.85em;
 	font-weight: 600;

--- a/src/blocks/query/hooks/useParentQueryAttrs.js
+++ b/src/blocks/query/hooks/useParentQueryAttrs.js
@@ -9,7 +9,7 @@
  *
  * @since 2.6.0
  *
- * @param {string}  clientId Current block clientId.
+ * @param {string}  clientId       Current block clientId.
  * @param {boolean} [enabled=true] Skip the lookup when false (lets callers
  *                                 pass a stable falsy value outside of
  *                                 query mode without wrapping the hook call).

--- a/src/blocks/query/hooks/useParentQueryAttrs.js
+++ b/src/blocks/query/hooks/useParentQueryAttrs.js
@@ -1,0 +1,39 @@
+/**
+ * useParentQueryAttrs — walk the block tree and return the nearest ancestor
+ * designsetgo/query block's attributes.
+ *
+ * Used by layout-host edit.js files (slider, scroll-slides) so the editor
+ * preview uses the same query config (postType, perPage, filters, orderBy)
+ * the frontend will. Returns null when no parent designsetgo/query is found
+ * or when `enabled` is false.
+ *
+ * @since 2.6.0
+ *
+ * @param {string}  clientId Current block clientId.
+ * @param {boolean} [enabled=true] Skip the lookup when false (lets callers
+ *                                 pass a stable falsy value outside of
+ *                                 query mode without wrapping the hook call).
+ * @return {Object|null} Parent query block attributes, or null.
+ */
+import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+export default function useParentQueryAttrs(clientId, enabled = true) {
+	return useSelect(
+		(select) => {
+			if (!enabled) {
+				return null;
+			}
+			const { getBlockParents, getBlock } = select(blockEditorStore);
+			const parents = getBlockParents(clientId);
+			for (const parentId of parents) {
+				const parent = getBlock(parentId);
+				if (parent?.name === 'designsetgo/query') {
+					return parent.attributes;
+				}
+			}
+			return null;
+		},
+		[clientId, enabled]
+	);
+}

--- a/src/blocks/query/hooks/useQueryHostPreview.js
+++ b/src/blocks/query/hooks/useQueryHostPreview.js
@@ -56,13 +56,14 @@ export default function useQueryHostPreview({
 	enabled = true,
 }) {
 	const source = attributes?.source || 'posts';
-	const isPosts = source === 'posts';
+	const isPostsLike =
+		source === 'posts' || source === 'manual' || source === 'current';
 	const isRelationship = source === 'relationship';
 
-	const postsData = usePosts(attributes, enabled && isPosts);
+	const postsData = usePosts(attributes, enabled && isPostsLike);
 	const remoteData = useRemotePreview(
 		attributes,
-		enabled && !isPosts && !isRelationship
+		enabled && !isPostsLike && !isRelationship
 	);
 	const relationshipData = useQueryPreview({
 		source,
@@ -81,7 +82,7 @@ export default function useQueryHostPreview({
 			!!queryId,
 	});
 
-	const { records, hasResolved } = isPosts
+	const { records, hasResolved } = isPostsLike
 		? postsData
 		: isRelationship
 		? relationshipData
@@ -143,13 +144,10 @@ function usePosts(attributes, enabled) {
 function useRemotePreview(attributes, enabled) {
 	const [state, setState] = useState({ records: null, hasResolved: false });
 
-	const cacheKey = enabled
-		? [
-				attributes?.source || 'posts',
-				attributes?.perPage || 6,
-				attributes?.taxonomy || '',
-		  ].join('|')
-		: null;
+	// Serialize the full attributes object so orderBy/order/offset/filters/etc.
+	// all invalidate the cache. `attributes` is always a plain serialisable
+	// object (block attribute storage), so JSON.stringify is deterministic.
+	const cacheKey = enabled ? JSON.stringify(attributes || {}) : null;
 
 	useEffect(() => {
 		if (!enabled || !cacheKey) {

--- a/src/blocks/query/hooks/useQueryHostPreview.js
+++ b/src/blocks/query/hooks/useQueryHostPreview.js
@@ -1,0 +1,285 @@
+/**
+ * useQueryHostPreview — editor preview data for layout blocks bound to a
+ * Dynamic Query (slider, scroll-slides, future hosts).
+ *
+ * Combines three paths into one hook:
+ *  - posts: useEntityRecords('postType', postType, args)
+ *  - users/terms: /designsetgo/v1/query/preview REST route via apiFetch
+ *  - relationship: useQueryPreview (reads parent post's field, resolves IDs)
+ *
+ * Also fetches server-rendered HTML for each item via useRenderedItems so
+ * items 1..N can be shown as true-to-frontend markup while item 0 stays
+ * editable via InnerBlocks.
+ *
+ * The goal is a single call site for layout blocks:
+ *
+ *     const { records, hasResolved, serverHtml, loading } =
+ *         useQueryHostPreview({ attributes, queryId, innerBlocks });
+ *
+ * where `innerBlocks` is the host's template block tree (e.g. the one
+ * designsetgo/slide child of designsetgo/slider) and `serverHtml[idx]` is the
+ * rendered inner HTML of item idx (see useRenderedItems for extraction
+ * details).
+ *
+ * NOTE: the data-fetching helpers here mirror usePosts/useRemotePreview in
+ * src/blocks/query/components/EditorPreviewList.js. If those get fixed, mirror
+ * the fix here too — or consolidate into a single module in a follow-up.
+ *
+ * @since 2.6.0
+ */
+import { useMemo, useState, useEffect } from '@wordpress/element';
+import { useEntityRecords } from '@wordpress/core-data';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import { __, sprintf } from '@wordpress/i18n';
+import useQueryPreview from './useQueryPreview';
+import useRenderedItems from './useRenderedItems';
+
+/**
+ * @param {Object} root0
+ * @param {Object} root0.attributes  Parent query block attributes (source,
+ *                                   postType, perPage, filters, etc.).
+ * @param {string} root0.queryId     Parent query's queryId attribute.
+ * @param {Array}  root0.innerBlocks Template block tree (rendered once per item).
+ * @param {boolean} [root0.enabled]  Skip all fetching when false.
+ * @return {{
+ *   records: Array|null,
+ *   hasResolved: boolean,
+ *   serverHtml: Array<string>|null,
+ *   loading: boolean,
+ * }}
+ */
+export default function useQueryHostPreview({
+	attributes,
+	queryId,
+	innerBlocks,
+	enabled = true,
+}) {
+	const source = attributes?.source || 'posts';
+	const isPosts = source === 'posts';
+	const isRelationship = source === 'relationship';
+
+	const postsData = usePosts(attributes, enabled && isPosts);
+	const remoteData = useRemotePreview(
+		attributes,
+		enabled && !isPosts && !isRelationship
+	);
+	const relationshipData = useQueryPreview({
+		source,
+		relationshipField: attributes?.relationshipField || '',
+		perPage: attributes?.perPage || 6,
+	});
+
+	const rendered = useRenderedItems({
+		queryId,
+		attributes,
+		innerBlocks,
+		enabled:
+			enabled &&
+			Array.isArray(innerBlocks) &&
+			innerBlocks.length > 0 &&
+			!!queryId,
+	});
+
+	const { records, hasResolved } = isPosts
+		? postsData
+		: isRelationship
+		? relationshipData
+		: remoteData;
+
+	return {
+		records,
+		hasResolved,
+		serverHtml: rendered.items,
+		loading: rendered.loading,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Data hooks (mirrored from EditorPreviewList — see NOTE in header above).
+// ---------------------------------------------------------------------------
+
+function usePosts(attributes, enabled) {
+	const authorKey = Array.isArray(attributes?.author)
+		? attributes.author.join(',')
+		: attributes?.author;
+	const queryArgs = useMemo(
+		() => buildCoreDataQuery(attributes || {}),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[
+			attributes?.perPage,
+			attributes?.offset,
+			attributes?.orderBy,
+			attributes?.order,
+			attributes?.search,
+			authorKey,
+		]
+	);
+
+	const postType = enabled ? attributes?.postType || 'post' : '';
+	const result = useEntityRecords('postType', postType, queryArgs);
+
+	if (!enabled) {
+		return { records: null, hasResolved: true };
+	}
+
+	const mapped = result.records
+		? result.records.map((post) => ({
+				...post,
+				id: post.id,
+				name:
+					post.title?.rendered ||
+					sprintf(
+						/* translators: %d: post ID */
+						__('Post %d', 'designsetgo'),
+						post.id
+					),
+		  }))
+		: null;
+
+	return { records: mapped, hasResolved: result.hasResolved };
+}
+
+function useRemotePreview(attributes, enabled) {
+	const [state, setState] = useState({ records: null, hasResolved: false });
+
+	const cacheKey = enabled
+		? [
+				attributes?.source || 'posts',
+				attributes?.perPage || 6,
+				attributes?.taxonomy || '',
+		  ].join('|')
+		: null;
+
+	useEffect(() => {
+		if (!enabled || !cacheKey) {
+			return undefined;
+		}
+
+		let cancelled = false;
+		setState({ records: null, hasResolved: false });
+
+		apiFetch({
+			path: addQueryArgs('/designsetgo/v1/query/preview', {
+				attributes,
+			}),
+		})
+			.then((items) => {
+				if (!cancelled) {
+					setState({ records: items, hasResolved: true });
+				}
+			})
+			.catch(() => {
+				if (!cancelled) {
+					setState({ records: [], hasResolved: true });
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [cacheKey, enabled]);
+
+	if (!enabled) {
+		return { records: null, hasResolved: true };
+	}
+
+	return state;
+}
+
+function buildCoreDataQuery(attributes) {
+	const args = {
+		per_page: attributes.perPage || 6,
+		offset: attributes.offset || 0,
+		orderby: (attributes.orderBy || 'date').toLowerCase(),
+		order: (attributes.order || 'DESC').toLowerCase(),
+		status: 'publish',
+		_embed: true,
+	};
+
+	if (attributes.search) {
+		args.search = attributes.search;
+	}
+
+	if (Array.isArray(attributes.author) && attributes.author.length) {
+		args.author = attributes.author.join(',');
+	}
+
+	return args;
+}
+
+// ---------------------------------------------------------------------------
+// Per-item context builder. Shared with EditorPreviewList (mirror if changed).
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the BlockContextProvider value for a single preview item so inner
+ * blocks (and Block Bindings) resolve against the iterated post/user/term
+ * just like they do on the frontend.
+ *
+ * @param {Object} item      Preview item.
+ * @param {string} source    Query source attribute.
+ * @param {number} index     Zero-based item index.
+ * @param {Object} [outerCtx] Outer block context (may contain parentItem).
+ * @return {Object} Context object.
+ */
+export function buildItemContext(item, source, index, outerCtx) {
+	const enrichment = {
+		'designsetgo/itemIndex': index,
+		'designsetgo/itemMeta': item.meta || {},
+		'designsetgo/itemTerms': buildTermsMap(item),
+		'designsetgo/isAuthenticated': true,
+	};
+
+	let base;
+	if (source === 'posts' || source === 'manual' || source === 'current') {
+		base = {
+			postId: item.id,
+			postType: item.type || 'post',
+		};
+	} else if (source === 'users') {
+		base = {
+			'designsetgo/currentItemId': item.id,
+			'designsetgo/currentItemType': 'user',
+		};
+	} else if (source === 'terms') {
+		base = {
+			'designsetgo/currentItemId': item.id,
+			'designsetgo/currentItemType': 'term',
+		};
+	} else {
+		base = {};
+	}
+
+	const parentItem =
+		outerCtx?.['designsetgo/parentItem'] ??
+		(base.postId !== undefined
+			? { postId: base.postId, postType: base.postType }
+			: { postId: item.id, postType: item.type || 'post' });
+
+	return {
+		...base,
+		...enrichment,
+		'designsetgo/parentItem': parentItem,
+	};
+}
+
+function buildTermsMap(item) {
+	const map = {};
+	const embedded = item?._embedded?.['wp:term'];
+	if (!Array.isArray(embedded)) {
+		return map;
+	}
+	embedded.forEach((taxTerms) => {
+		if (!Array.isArray(taxTerms) || taxTerms.length === 0) {
+			return;
+		}
+		const taxonomy = taxTerms[0]?.taxonomy;
+		if (!taxonomy) {
+			return;
+		}
+		map[taxonomy] = taxTerms.map((t) => t.slug).filter(Boolean);
+	});
+	return map;
+}

--- a/src/blocks/query/hooks/useQueryHostPreview.js
+++ b/src/blocks/query/hooks/useQueryHostPreview.js
@@ -36,12 +36,12 @@ import useQueryPreview from './useQueryPreview';
 import useRenderedItems from './useRenderedItems';
 
 /**
- * @param {Object} root0
- * @param {Object} root0.attributes  Parent query block attributes (source,
- *                                   postType, perPage, filters, etc.).
- * @param {string} root0.queryId     Parent query's queryId attribute.
- * @param {Array}  root0.innerBlocks Template block tree (rendered once per item).
- * @param {boolean} [root0.enabled]  Skip all fetching when false.
+ * @param {Object}  root0
+ * @param {Object}  root0.attributes  Parent query block attributes (source,
+ *                                    postType, perPage, filters, etc.).
+ * @param {string}  root0.queryId     Parent query's queryId attribute.
+ * @param {Array}   root0.innerBlocks Template block tree (rendered once per item).
+ * @param {boolean} [root0.enabled]   Skip all fetching when false.
  * @return {{
  *   records: Array|null,
  *   hasResolved: boolean,
@@ -85,8 +85,8 @@ export default function useQueryHostPreview({
 	const { records, hasResolved } = isPostsLike
 		? postsData
 		: isRelationship
-		? relationshipData
-		: remoteData;
+			? relationshipData
+			: remoteData;
 
 	return {
 		records,
@@ -135,7 +135,7 @@ function usePosts(attributes, enabled) {
 						__('Post %d', 'designsetgo'),
 						post.id
 					),
-		  }))
+			}))
 		: null;
 
 	return { records: mapped, hasResolved: result.hasResolved };
@@ -216,9 +216,9 @@ function buildCoreDataQuery(attributes) {
  * blocks (and Block Bindings) resolve against the iterated post/user/term
  * just like they do on the frontend.
  *
- * @param {Object} item      Preview item.
- * @param {string} source    Query source attribute.
- * @param {number} index     Zero-based item index.
+ * @param {Object} item       Preview item.
+ * @param {string} source     Query source attribute.
+ * @param {number} index      Zero-based item index.
  * @param {Object} [outerCtx] Outer block context (may contain parentItem).
  * @return {Object} Context object.
  */

--- a/src/blocks/query/hooks/useQueryPreview.js
+++ b/src/blocks/query/hooks/useQueryPreview.js
@@ -127,9 +127,7 @@ export default function useQueryPreview({
 	// render-relationship.php, covering all storage shapes ACF/postmeta can
 	// produce. PHP's maybe_unserialize() branch is omitted — the WP REST
 	// API always pre-deserializes meta values before exposing them.
-	const ids = isRelationship
-		? normalizeRelationshipIds(fieldValue)
-		: [];
+	const ids = isRelationship ? normalizeRelationshipIds(fieldValue) : [];
 
 	// useEntityRecords must always be called (rules of hooks). When not in
 	// relationship mode, or when ids is empty, we pass a sentinel [0] so

--- a/src/blocks/query/render-helpers.php
+++ b/src/blocks/query/render-helpers.php
@@ -53,7 +53,10 @@ if ( ! function_exists( 'designsetgo_query_item_host_block_names' ) ) :
 		 */
 		$hosts = apply_filters(
 			'designsetgo_query_item_host_block_names',
-			array( 'designsetgo/query-results' )
+			array(
+				'designsetgo/query-results',
+				'designsetgo/slider',
+			)
 		);
 		return array_values( array_filter( array_map( 'strval', (array) $hosts ) ) );
 	}
@@ -304,7 +307,11 @@ if ( ! function_exists( 'designsetgo_query_render' ) ) :
 	 *
 	 * @param string $inner_html   Serialized innerBlocks HTML from block content.
 	 * @param array  $item_context Context keys to override.
-	 * @param string $item_tag     li / div / article.
+	 * @param string $item_tag     li / div / article to wrap each item; pass
+	 *                             'none' to skip the wrapper entirely (used by
+	 *                             non-grid hosts like designsetgo/slider whose
+	 *                             template block — e.g. designsetgo/slide —
+	 *                             already provides its own outer element).
 	 * @return string
 	 */
 	function designsetgo_query_render_item( $inner_html, array $item_context, $item_tag ) {
@@ -314,7 +321,8 @@ if ( ! function_exists( 'designsetgo_query_render' ) ) :
 			require_once DESIGNSETGO_PATH . 'includes/class-block-visibility.php';
 		}
 
-		$tag = in_array( $item_tag, array( 'li', 'div', 'article' ), true ) ? $item_tag : 'li';
+		$skip_wrap = ( 'none' === $item_tag );
+		$tag       = in_array( $item_tag, array( 'li', 'div', 'article' ), true ) ? $item_tag : 'li';
 
 		$html   = '';
 		$parsed = parse_blocks( $inner_html );
@@ -355,6 +363,9 @@ if ( ! function_exists( 'designsetgo_query_render' ) ) :
 			}
 		}
 
+		if ( $skip_wrap ) {
+			return $html;
+		}
 		return sprintf( '<%1$s class="dsgo-query__item">%2$s</%1$s>', $tag, $html );
 	}
 
@@ -542,12 +553,19 @@ if ( ! function_exists( 'designsetgo_query_render_container' ) ) :
 		$template_blocks = array();
 
 		if ( $results_child ) {
+			$host_name       = (string) ( $results_child['blockName'] ?? '' );
+			$is_grid_host    = ( 'designsetgo/query-results' === $host_name );
 			$results_attrs   = is_array( $results_child['attrs'] ?? null ) ? $results_child['attrs'] : array();
 			$effective_attrs = array_merge(
 				$attributes,
 				array(
 					'tagName'       => $results_attrs['tagName'] ?? ( $attributes['tagName'] ?? 'ul' ),
-					'itemTagName'   => $results_attrs['itemTagName'] ?? ( $attributes['itemTagName'] ?? 'li' ),
+					// Non-grid hosts (slider, scroll-slides) wrap items with
+					// their own outer element (slide, scroll-slide). Suppress
+					// render_item()'s <li> wrapper so we don't double-wrap.
+					'itemTagName'   => $is_grid_host
+						? ( $results_attrs['itemTagName'] ?? ( $attributes['itemTagName'] ?? 'li' ) )
+						: 'none',
 					'columns'       => $results_attrs['columns'] ?? ( $attributes['columns'] ?? 1 ),
 					'columnsTablet' => $results_attrs['columnsTablet'] ?? ( $attributes['columnsTablet'] ?? 0 ),
 					'columnsMobile' => $results_attrs['columnsMobile'] ?? ( $attributes['columnsMobile'] ?? 0 ),
@@ -555,7 +573,16 @@ if ( ! function_exists( 'designsetgo_query_render_container' ) ) :
 					'groupBy'       => $results_attrs['groupBy'] ?? ( $attributes['groupBy'] ?? null ),
 				)
 			);
-			$template_blocks = (array) ( $results_child['innerBlocks'] ?? array() );
+			$inner_children  = (array) ( $results_child['innerBlocks'] ?? array() );
+			// Grid host: all innerBlocks collectively form the per-item
+			// template (post-title + featured-image + paragraph, etc.).
+			// Non-grid host: the host wraps exactly one template block
+			// (one slide, one scroll-slide). Ignore any extra authored
+			// siblings server-side — the editor enforces single-child via
+			// allowedBlocks + prune effect; this is a safety net.
+			$template_blocks = $is_grid_host
+				? $inner_children
+				: array_slice( $inner_children, 0, 1 );
 		} else {
 			// No query-results wrapper — fall through with parent-only attrs
 			// and treat every non-empty child as a template block.

--- a/src/blocks/query/render-helpers.php
+++ b/src/blocks/query/render-helpers.php
@@ -318,6 +318,33 @@ if ( ! function_exists( 'designsetgo_query_render' ) ) :
 			$grid_style .= sprintf( '--dsgo-query-first-row-span:%d;', $first_row_span );
 		}
 
+		// Honor the query-results child's `style.spacing.blockGap` setting on
+		// the frontend. The grid's CSS reads gap from
+		// `var(--wp--style--block-gap, 1.5rem)`, and the editor gets this
+		// variable for free via useBlockProps. On the server we bypass
+		// get_block_wrapper_attributes() (see comment below), so we translate
+		// the raw attr value to the same custom property ourselves. Accepts
+		// both direct CSS values ("1.5rem", "24px") and the `var:preset|…`
+		// reference syntax WordPress emits for preset spacing sizes.
+		$block_gap = $atts['style']['spacing']['blockGap'] ?? null;
+		if ( is_string( $block_gap ) && '' !== $block_gap ) {
+			if ( 0 === strpos( $block_gap, 'var:preset|' ) ) {
+				$parts = explode( '|', substr( $block_gap, 4 ) );
+				if ( 3 === count( $parts ) ) {
+					$block_gap = sprintf(
+						'var(--wp--%s--%s--%s)',
+						sanitize_key( $parts[0] ),
+						sanitize_key( $parts[1] ),
+						sanitize_key( $parts[2] )
+					);
+				}
+			}
+			$safe_gap = designsetgo_safe_css_value( $block_gap );
+			if ( '' !== $safe_gap ) {
+				$grid_style .= sprintf( '--wp--style--block-gap:%s;', $safe_gap );
+			}
+		}
+
 		// Post-restructure: this element IS the query-results grid. IAPI /
 		// context / blobs live on the outer dsgo-query-region container
 		// emitted by designsetgo_query_render_container(). The first-paint
@@ -628,6 +655,14 @@ if ( ! function_exists( 'designsetgo_query_render_container' ) ) :
 					'firstItemRowSpan'    => $results_attrs['firstItemRowSpan'] ?? ( $attributes['firstItemRowSpan'] ?? 1 ),
 					'groupBy'             => $results_attrs['groupBy'] ?? ( $attributes['groupBy'] ?? null ),
 					'layoutVariant' => $results_attrs['layoutVariant'] ?? ( $attributes['layoutVariant'] ?? '' ),
+					// Carry the child's `style` attribute forward so
+					// designsetgo_query_wrap() can translate
+					// `style.spacing.blockGap` into `--wp--style--block-gap`
+					// on the grid wrapper. Without this pass-through the
+					// editor respects block-gap (via useBlockProps) but the
+					// frontend falls back to the 1.5rem default because the
+					// grid is constructed without get_block_wrapper_attributes.
+					'style'         => $results_attrs['style'] ?? ( $attributes['style'] ?? null ),
 				)
 			);
 			$inner_children  = (array) ( $results_child['innerBlocks'] ?? array() );

--- a/src/blocks/query/render-helpers.php
+++ b/src/blocks/query/render-helpers.php
@@ -27,6 +27,39 @@
 
 defined( 'ABSPATH' ) || exit;
 
+if ( ! function_exists( 'designsetgo_query_item_host_block_names' ) ) :
+
+	/**
+	 * Block names that may act as the item host inside a designsetgo/query.
+	 *
+	 * An "item host" is the child block whose innerBlocks define the per-item
+	 * template and whose render.php emits the iterated items (or chrome that
+	 * wraps them). Today only designsetgo/query-results qualifies; slider and
+	 * scroll-slides join once their render paths opt in.
+	 *
+	 * Third parties can register their own layout blocks as item hosts via the
+	 * `designsetgo_query_item_host_block_names` filter, provided they pair the
+	 * registration with the matching render.php contract (read pre-rendered
+	 * items from $GLOBALS['designsetgo_query_items_html'][ queryId ], wrap in
+	 * their own chrome, echo).
+	 *
+	 * @return string[] Registered item host block names.
+	 */
+	function designsetgo_query_item_host_block_names() {
+		/**
+		 * Filter the list of blocks that may act as item hosts inside a Dynamic Query.
+		 *
+		 * @param string[] $hosts Default list: [ 'designsetgo/query-results' ].
+		 */
+		$hosts = apply_filters(
+			'designsetgo_query_item_host_block_names',
+			array( 'designsetgo/query-results' )
+		);
+		return array_values( array_filter( array_map( 'strval', (array) $hosts ) ) );
+	}
+
+endif;
+
 if ( ! function_exists( 'designsetgo_query_render' ) ) :
 
 	/**
@@ -80,6 +113,7 @@ if ( ! function_exists( 'designsetgo_query_render' ) ) :
 
 		return array(
 			'html'       => '',
+			'items_html' => '',
 			'totalPages' => 0,
 			'totalItems' => 0,
 		);
@@ -94,25 +128,25 @@ if ( ! function_exists( 'designsetgo_query_render' ) ) :
 	 */
 	function designsetgo_query_defaults( array $attributes ) {
 		$defaults = array(
-			'queryId'        => '',
-			'source'         => 'posts',
-			'postType'       => 'post',
-			'perPage'        => 6,
-			'offset'         => 0,
-			'orderBy'        => 'date',
-			'orderByMetaKey' => '',
-			'order'          => 'DESC',
-			'search'         => '',
-			'bindSearchTo'   => '',
-			'author'         => array(),
-			'excludeCurrent' => false,
-			'ignoreSticky'   => true,
-			'manualIds'      => array(),
-			'taxQuery'       => array(
+			'queryId'              => '',
+			'source'               => 'posts',
+			'postType'             => 'post',
+			'perPage'              => 6,
+			'offset'               => 0,
+			'orderBy'              => 'date',
+			'orderByMetaKey'       => '',
+			'order'                => 'DESC',
+			'search'               => '',
+			'bindSearchTo'         => '',
+			'author'               => array(),
+			'excludeCurrent'       => false,
+			'ignoreSticky'         => true,
+			'manualIds'            => array(),
+			'taxQuery'             => array(
 				'relation' => 'AND',
 				'clauses'  => array(),
 			),
-			'metaQuery'      => array(
+			'metaQuery'            => array(
 				'relation' => 'AND',
 				'clauses'  => array(),
 			),
@@ -135,13 +169,19 @@ if ( ! function_exists( 'designsetgo_query_render' ) ) :
 	 * Posts with multiple terms (taxonomy field) appear in ALL matching groups.
 	 * Posts with no matching term land in the '__none__' / Uncategorized bucket.
 	 *
-	 * @param int[]  $post_ids   Ordered list of post IDs to partition.
-	 * @param array  $group_spec { field: string, key: string }
+	 * @param int[] $post_ids   Ordered list of post IDs to partition.
+	 * @param array $group_spec { field: string, key: string }
 	 * @return array[] Array of groups: each { label: string, value: string, ids: int[] }
 	 */
 	function designsetgo_query_partition_items( array $post_ids, array $group_spec ) {
 		if ( empty( $group_spec['field'] ) || empty( $group_spec['key'] ) ) {
-			return array( array( 'label' => '', 'value' => '', 'ids' => $post_ids ) );
+			return array(
+				array(
+					'label' => '',
+					'value' => '',
+					'ids'   => $post_ids,
+				),
+			);
 		}
 		$field = (string) $group_spec['field'];
 		$key   = (string) $group_spec['key'];
@@ -175,7 +215,11 @@ if ( ! function_exists( 'designsetgo_query_render' ) ) :
 			}
 			foreach ( $values as $i => $v ) {
 				if ( ! isset( $groups[ $v ] ) ) {
-					$groups[ $v ] = array( 'label' => $labels[ $i ] ?? $v, 'value' => $v, 'ids' => array() );
+					$groups[ $v ] = array(
+						'label' => $labels[ $i ] ?? $v,
+						'value' => $v,
+						'ids'   => array(),
+					);
 				}
 				$groups[ $v ]['ids'][] = $pid;
 			}
@@ -204,11 +248,11 @@ if ( ! function_exists( 'designsetgo_query_render' ) ) :
 
 		// Column CSS variables drive the responsive grid layout in
 		// query-results/style.scss.
-		$columns         = isset( $atts['columns'] ) ? max( 1, (int) $atts['columns'] ) : 1;
-		$columns_tablet  = isset( $atts['columnsTablet'] ) ? (int) $atts['columnsTablet'] : 0;
-		$columns_mobile  = isset( $atts['columnsMobile'] ) ? (int) $atts['columnsMobile'] : 0;
-		$column_gap      = isset( $atts['columnGap'] ) ? sanitize_text_field( (string) $atts['columnGap'] ) : '';
-		$grid_style      = sprintf( '--dsgo-query-columns:%d;', $columns );
+		$columns        = isset( $atts['columns'] ) ? max( 1, (int) $atts['columns'] ) : 1;
+		$columns_tablet = isset( $atts['columnsTablet'] ) ? (int) $atts['columnsTablet'] : 0;
+		$columns_mobile = isset( $atts['columnsMobile'] ) ? (int) $atts['columnsMobile'] : 0;
+		$column_gap     = isset( $atts['columnGap'] ) ? sanitize_text_field( (string) $atts['columnGap'] ) : '';
+		$grid_style     = sprintf( '--dsgo-query-columns:%d;', $columns );
 		if ( $columns_tablet > 0 ) {
 			$grid_style .= sprintf( '--dsgo-query-columns-tablet:%d;', $columns_tablet );
 		}
@@ -472,12 +516,15 @@ if ( ! function_exists( 'designsetgo_query_render_container' ) ) :
 		$attributes = designsetgo_query_defaults( $attributes );
 		$source     = sanitize_key( (string) ( $attributes['source'] ?? 'posts' ) );
 
-		// Find the designsetgo/query-results child (only one allowed). Its attrs
-		// govern presentation (columns, tagName, groupBy...) and its innerBlocks
-		// are the per-item template.
-		$results_child = null;
+		// Find the item host child — any block registered as a query item host
+		// (designsetgo/query-results by default; slider/scroll-slides once they
+		// opt in). Only the first match is used; multiple hosts aren't supported.
+		// Its attrs govern presentation (columns, tagName, groupBy...) and its
+		// innerBlocks form the per-item template.
+		$host_block_names = designsetgo_query_item_host_block_names();
+		$results_child    = null;
 		foreach ( $parsed_children as $child ) {
-			if ( ( $child['blockName'] ?? '' ) === 'designsetgo/query-results' ) {
+			if ( in_array( ( $child['blockName'] ?? '' ), $host_block_names, true ) ) {
 				$results_child = $child;
 				break;
 			}
@@ -486,11 +533,11 @@ if ( ! function_exists( 'designsetgo_query_render_container' ) ) :
 		$total_items = 0;
 
 		// Two shapes are accepted:
-		//  1. First-paint path — children contain a <query-results> wrapper.
-		//     Use its attrs for presentation + its innerBlocks for the template.
-		//  2. Editor-preview / legacy path — children ARE the item template
-		//     directly (no query-results wrapper). Use parent attrs for
-		//     presentation and treat all children as template blocks.
+		// 1. First-paint path — children contain a <query-results> wrapper.
+		// Use its attrs for presentation + its innerBlocks for the template.
+		// 2. Editor-preview / legacy path — children ARE the item template
+		// directly (no query-results wrapper). Use parent attrs for
+		// presentation and treat all children as template blocks.
 		$effective_attrs = $attributes;
 		$template_blocks = array();
 
@@ -499,13 +546,13 @@ if ( ! function_exists( 'designsetgo_query_render_container' ) ) :
 			$effective_attrs = array_merge(
 				$attributes,
 				array(
-					'tagName'       => $results_attrs['tagName']       ?? ( $attributes['tagName']       ?? 'ul' ),
-					'itemTagName'   => $results_attrs['itemTagName']   ?? ( $attributes['itemTagName']   ?? 'li' ),
-					'columns'       => $results_attrs['columns']       ?? ( $attributes['columns']       ?? 1 ),
+					'tagName'       => $results_attrs['tagName'] ?? ( $attributes['tagName'] ?? 'ul' ),
+					'itemTagName'   => $results_attrs['itemTagName'] ?? ( $attributes['itemTagName'] ?? 'li' ),
+					'columns'       => $results_attrs['columns'] ?? ( $attributes['columns'] ?? 1 ),
 					'columnsTablet' => $results_attrs['columnsTablet'] ?? ( $attributes['columnsTablet'] ?? 0 ),
 					'columnsMobile' => $results_attrs['columnsMobile'] ?? ( $attributes['columnsMobile'] ?? 0 ),
-					'columnGap'     => $results_attrs['columnGap']     ?? ( $attributes['columnGap']     ?? '' ),
-					'groupBy'       => $results_attrs['groupBy']       ?? ( $attributes['groupBy']       ?? null ),
+					'columnGap'     => $results_attrs['columnGap'] ?? ( $attributes['columnGap'] ?? '' ),
+					'groupBy'       => $results_attrs['groupBy'] ?? ( $attributes['groupBy'] ?? null ),
 				)
 			);
 			$template_blocks = (array) ( $results_child['innerBlocks'] ?? array() );
@@ -541,11 +588,20 @@ if ( ! function_exists( 'designsetgo_query_render_container' ) ) :
 
 			// Stash the rendered items HTML so query-results/render.php can
 			// echo it when WordPress walks the tree below. Keyed by queryId so
-			// nested queries can't clash.
+			// nested queries can't clash. Two stashes:
+			// - designsetgo_query_results_html: the fully wrapped output
+			// (grid <ul> + schema). Consumed by query-results/render.php.
+			// - designsetgo_query_items_html: raw per-item HTML, no outer
+			// wrap. Consumed by non-grid item hosts (slider, scroll-slides)
+			// that supply their own chrome around the iterated items.
 			if ( ! isset( $GLOBALS['designsetgo_query_results_html'] ) || ! is_array( $GLOBALS['designsetgo_query_results_html'] ) ) {
 				$GLOBALS['designsetgo_query_results_html'] = array();
 			}
 			$GLOBALS['designsetgo_query_results_html'][ $query_id ] = (string) $result['html'];
+			if ( ! isset( $GLOBALS['designsetgo_query_items_html'] ) || ! is_array( $GLOBALS['designsetgo_query_items_html'] ) ) {
+				$GLOBALS['designsetgo_query_items_html'] = array();
+			}
+			$GLOBALS['designsetgo_query_items_html'][ $query_id ] = isset( $result['items_html'] ) ? (string) $result['items_html'] : '';
 
 			// Legacy path (no query-results wrapper): since no child block will
 			// emit the items, emit them directly here so the editor preview
@@ -558,7 +614,7 @@ if ( ! function_exists( 'designsetgo_query_render_container' ) ) :
 					esc_attr( $query_id ),
 					(int) $total_items
 				);
-				$wp_context_legacy = wp_json_encode(
+				$wp_context_legacy    = wp_json_encode(
 					array(
 						'queryId' => $query_id,
 						'source'  => $source,
@@ -569,13 +625,13 @@ if ( ! function_exists( 'designsetgo_query_render_container' ) ) :
 					),
 					JSON_HEX_APOS
 				);
-				$iapi_attrs_legacy = sprintf(
+				$iapi_attrs_legacy    = sprintf(
 					'data-dsgo-query-id="%1$s" data-dsgo-query-region="%1$s" data-wp-interactive="%2$s" data-wp-context=\'%3$s\' aria-live="polite"',
 					esc_attr( $query_id ),
 					esc_attr( 'designsetgo/query' ),
 					$wp_context_legacy // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON_HEX_APOS output is safe in single-quoted attr.
 				);
-				$merged_legacy = trim( (string) $wrapper_attrs . ' ' . $iapi_attrs_legacy );
+				$merged_legacy        = trim( (string) $wrapper_attrs . ' ' . $iapi_attrs_legacy );
 				return sprintf(
 					'<div %1$s>%2$s%3$s%4$s</div>',
 					$merged_legacy,         // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wrapper + esc_attr IAPI attrs.
@@ -614,6 +670,7 @@ if ( ! function_exists( 'designsetgo_query_render_container' ) ) :
 		// the request (e.g. multiple Dynamic Query blocks on one page).
 		if ( '' !== $query_id ) {
 			unset( $GLOBALS['designsetgo_query_results_html'][ $query_id ] );
+			unset( $GLOBALS['designsetgo_query_items_html'][ $query_id ] );
 		}
 
 		// IAPI + state-announcement markup. Appended to the block wrapper so

--- a/src/blocks/query/render-helpers.php
+++ b/src/blocks/query/render-helpers.php
@@ -56,6 +56,7 @@ if ( ! function_exists( 'designsetgo_query_item_host_block_names' ) ) :
 			array(
 				'designsetgo/query-results',
 				'designsetgo/slider',
+				'designsetgo/scroll-slides',
 			)
 		);
 		return array_values( array_filter( array_map( 'strval', (array) $hosts ) ) );

--- a/src/blocks/query/render-helpers.php
+++ b/src/blocks/query/render-helpers.php
@@ -298,20 +298,24 @@ if ( ! function_exists( 'designsetgo_query_render' ) ) :
 		// query-results/style.scss.
 		$columns        = isset( $atts['columns'] ) ? max( 1, (int) $atts['columns'] ) : 1;
 		$columns_tablet = isset( $atts['columnsTablet'] ) ? (int) $atts['columnsTablet'] : 0;
-		$columns_mobile = isset( $atts['columnsMobile'] ) ? (int) $atts['columnsMobile'] : 0;
-		$column_gap     = isset( $atts['columnGap'] ) ? sanitize_text_field( (string) $atts['columnGap'] ) : '';
-		$grid_style     = sprintf( '--dsgo-query-columns:%d;', $columns );
+		$columns_mobile   = isset( $atts['columnsMobile'] ) ? (int) $atts['columnsMobile'] : 0;
+		$first_col_span   = isset( $atts['firstItemColumnSpan'] ) ? max( 1, (int) $atts['firstItemColumnSpan'] ) : 1;
+		$first_row_span   = isset( $atts['firstItemRowSpan'] ) ? max( 1, (int) $atts['firstItemRowSpan'] ) : 1;
+		// Clamp the column span to the desktop column count so we never ask the
+		// grid to span more tracks than exist.
+		$first_col_span   = min( $first_col_span, $columns );
+		$grid_style       = sprintf( '--dsgo-query-columns:%d;', $columns );
 		if ( $columns_tablet > 0 ) {
 			$grid_style .= sprintf( '--dsgo-query-columns-tablet:%d;', $columns_tablet );
 		}
 		if ( $columns_mobile > 0 ) {
 			$grid_style .= sprintf( '--dsgo-query-columns-mobile:%d;', $columns_mobile );
 		}
-		if ( '' !== $column_gap ) {
-			// Whitelist a safe subset of CSS length values to defeat `;` / `}` injection.
-			if ( preg_match( '/^[0-9]+(?:\.[0-9]+)?(?:px|rem|em|%|vw|vh|ch|ex|pt)$/', $column_gap ) ) {
-				$grid_style .= '--dsgo-query-gap:' . $column_gap . ';';
-			}
+		if ( $first_col_span > 1 ) {
+			$grid_style .= sprintf( '--dsgo-query-first-col-span:%d;', $first_col_span );
+		}
+		if ( $first_row_span > 1 ) {
+			$grid_style .= sprintf( '--dsgo-query-first-row-span:%d;', $first_row_span );
 		}
 
 		// Post-restructure: this element IS the query-results grid. IAPI /
@@ -321,9 +325,13 @@ if ( ! function_exists( 'designsetgo_query_render' ) ) :
 		// always constructed by this helper since it belongs to query-results,
 		// not to the outer query block.
 		unset( $wrapper_attrs );
+		$layout_variant = isset( $atts['layoutVariant'] )
+			? sanitize_html_class( (string) $atts['layoutVariant'] )
+			: '';
+		$variant_class  = '' !== $layout_variant ? ' is-layout-' . $layout_variant : '';
 		$attrs_string = sprintf(
 			'class="%1$s" style="%3$s" data-dsgo-query-results-role="container" data-dsgo-query-id="%2$s"',
-			esc_attr( 'dsgo-query-results dsgo-query-results--source-' . $source ),
+			esc_attr( 'dsgo-query-results dsgo-query-results--source-' . $source . $variant_class ),
 			esc_attr( $query_id ),
 			esc_attr( $grid_style )
 		);
@@ -615,9 +623,11 @@ if ( ! function_exists( 'designsetgo_query_render_container' ) ) :
 						: 'none',
 					'columns'       => $results_attrs['columns'] ?? ( $attributes['columns'] ?? 1 ),
 					'columnsTablet' => $results_attrs['columnsTablet'] ?? ( $attributes['columnsTablet'] ?? 0 ),
-					'columnsMobile' => $results_attrs['columnsMobile'] ?? ( $attributes['columnsMobile'] ?? 0 ),
-					'columnGap'     => $results_attrs['columnGap'] ?? ( $attributes['columnGap'] ?? '' ),
-					'groupBy'       => $results_attrs['groupBy'] ?? ( $attributes['groupBy'] ?? null ),
+					'columnsMobile'       => $results_attrs['columnsMobile'] ?? ( $attributes['columnsMobile'] ?? 0 ),
+					'firstItemColumnSpan' => $results_attrs['firstItemColumnSpan'] ?? ( $attributes['firstItemColumnSpan'] ?? 1 ),
+					'firstItemRowSpan'    => $results_attrs['firstItemRowSpan'] ?? ( $attributes['firstItemRowSpan'] ?? 1 ),
+					'groupBy'             => $results_attrs['groupBy'] ?? ( $attributes['groupBy'] ?? null ),
+					'layoutVariant' => $results_attrs['layoutVariant'] ?? ( $attributes['layoutVariant'] ?? '' ),
 				)
 			);
 			$inner_children  = (array) ( $results_child['innerBlocks'] ?? array() );

--- a/src/blocks/query/render-helpers.php
+++ b/src/blocks/query/render-helpers.php
@@ -27,6 +27,46 @@
 
 defined( 'ABSPATH' ) || exit;
 
+if ( ! function_exists( 'designsetgo_safe_css_value' ) ) :
+
+	/**
+	 * Sanitize a CSS value destined for an inline `--prop: VALUE` declaration.
+	 *
+	 * Used by layout-host render.php files (slider, scroll-slides, …) which
+	 * emit block attributes as custom properties in a `style=""` attribute.
+	 * `get_block_wrapper_attributes()` HTML-encodes the outer quote, but that
+	 * alone does not prevent CSS-context injection — an editor-capability user
+	 * storing `20px; --dsgo-slider-slides-per-view:99` would otherwise inject
+	 * an extra custom property.
+	 *
+	 * The sanitizer strips characters that could close the current declaration
+	 * (`;`, `{`, `}`), escape sequences (`\`), control/newline characters, and
+	 * rejects CSS expression/javascript: patterns entirely. Legitimate CSS
+	 * values — `var(...)`, `calc(...)`, colors, lengths, aspect ratios — pass
+	 * through unchanged.
+	 *
+	 * @param mixed $value Raw attribute value.
+	 * @return string Safe-to-concatenate CSS value (empty string if rejected).
+	 */
+	function designsetgo_safe_css_value( $value ) {
+		if ( ! is_string( $value ) && ! is_numeric( $value ) ) {
+			return '';
+		}
+		$value = (string) $value;
+		if ( '' === $value ) {
+			return '';
+		}
+		$lower = strtolower( $value );
+		if ( false !== strpos( $lower, 'expression(' ) || false !== strpos( $lower, 'javascript:' ) ) {
+			return '';
+		}
+		// Strip chars that could break out of a `--prop: VALUE` declaration
+		// context: semicolon / braces / backslash (escape) / control + newline.
+		return preg_replace( '/[;{}\\\\\r\n\x00-\x1F]/', '', $value );
+	}
+
+endif;
+
 if ( ! function_exists( 'designsetgo_query_item_host_block_names' ) ) :
 
 	/**
@@ -34,8 +74,8 @@ if ( ! function_exists( 'designsetgo_query_item_host_block_names' ) ) :
 	 *
 	 * An "item host" is the child block whose innerBlocks define the per-item
 	 * template and whose render.php emits the iterated items (or chrome that
-	 * wraps them). Today only designsetgo/query-results qualifies; slider and
-	 * scroll-slides join once their render paths opt in.
+	 * wraps them). The built-in hosts are designsetgo/query-results (grid
+	 * layout), designsetgo/slider, and designsetgo/scroll-slides.
 	 *
 	 * Third parties can register their own layout blocks as item hosts via the
 	 * `designsetgo_query_item_host_block_names` filter, provided they pair the
@@ -49,7 +89,11 @@ if ( ! function_exists( 'designsetgo_query_item_host_block_names' ) ) :
 		/**
 		 * Filter the list of blocks that may act as item hosts inside a Dynamic Query.
 		 *
-		 * @param string[] $hosts Default list: [ 'designsetgo/query-results' ].
+		 * @param string[] $hosts Default list: [
+		 *     'designsetgo/query-results',
+		 *     'designsetgo/slider',
+		 *     'designsetgo/scroll-slides',
+		 * ].
 		 */
 		$hosts = apply_filters(
 			'designsetgo_query_item_host_block_names',
@@ -533,11 +577,13 @@ if ( ! function_exists( 'designsetgo_query_render_container' ) ) :
 		// opt in). Only the first match is used; multiple hosts aren't supported.
 		// Its attrs govern presentation (columns, tagName, groupBy...) and its
 		// innerBlocks form the per-item template.
-		$host_block_names = designsetgo_query_item_host_block_names();
-		$results_child    = null;
-		foreach ( $parsed_children as $child ) {
+		$host_block_names   = designsetgo_query_item_host_block_names();
+		$results_child      = null;
+		$results_child_index = null;
+		foreach ( $parsed_children as $child_index => $child ) {
 			if ( in_array( ( $child['blockName'] ?? '' ), $host_block_names, true ) ) {
-				$results_child = $child;
+				$results_child       = $child;
+				$results_child_index = (int) $child_index;
 				break;
 			}
 		}
@@ -685,12 +731,29 @@ if ( ! function_exists( 'designsetgo_query_render_container' ) ) :
 		// reads $GLOBALS['designsetgo_query_results_html'][queryId] and echoes
 		// the pre-rendered items HTML.
 		$children_html = '';
-		foreach ( $parsed_children as $child ) {
+		foreach ( $parsed_children as $child_index => $child ) {
 			if ( empty( $child['blockName'] ) ) {
+				continue;
+			}
+			$is_item_host_child = in_array( ( $child['blockName'] ?? '' ), $host_block_names, true );
+			if (
+				$is_item_host_child &&
+				null !== $results_child_index &&
+				(int) $child_index !== $results_child_index
+			) {
 				continue;
 			}
 			if ( class_exists( 'WP_Block' ) ) {
 				$children_html .= ( new WP_Block( $child, $shared_context ) )->render();
+				if (
+					$is_item_host_child &&
+					null !== $results_child_index &&
+					(int) $child_index === $results_child_index &&
+					'' !== $query_id
+				) {
+					unset( $GLOBALS['designsetgo_query_results_html'][ $query_id ] );
+					unset( $GLOBALS['designsetgo_query_items_html'][ $query_id ] );
+				}
 			}
 		}
 

--- a/src/blocks/query/render-posts.php
+++ b/src/blocks/query/render-posts.php
@@ -185,7 +185,7 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 		$group_header_blocks = array();
 		$item_template_html  = (string) $context['inner_html'];
 		if ( ! empty( $atts['groupBy'] ) && is_array( $atts['groupBy'] ) ) {
-			$parsed_inner = parse_blocks( $item_template_html );
+			$parsed_inner   = parse_blocks( $item_template_html );
 			$template_parts = array();
 			foreach ( $parsed_inner as $pb ) {
 				if ( empty( $pb['blockName'] ) ) {
@@ -213,7 +213,7 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 		try {
 			while ( $query->have_posts() ) {
 				$query->the_post();
-				$post_id   = get_the_ID();
+				$post_id     = get_the_ID();
 				$post_urls[] = get_permalink();
 				if ( $use_groups ) {
 					$collected_ids[] = $post_id;
@@ -232,7 +232,7 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 						$atts['itemTagName']
 					);
 				}
-				$flat_counter++;
+				++$flat_counter;
 			}
 		} finally {
 			wp_reset_postdata();
@@ -261,26 +261,26 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 				// Pass both the flat cross-group index (designsetgo/itemIndex) and a
 				// per-group zero-based index (designsetgo/groupItemIndex) so authors
 				// can target either in custom bindings or visibility rules.
-				$group_items_html  = '';
-				$group_item_index  = 0;
+				$group_items_html = '';
+				$group_item_index = 0;
 				foreach ( $group['ids'] as $gid ) {
 					$post_obj = get_post( $gid );
 					if ( ! $post_obj ) {
 						continue;
 					}
-					$item_index = isset( $collected_indexes[ $gid ] ) ? (int) $collected_indexes[ $gid ] : 0;
+					$item_index        = isset( $collected_indexes[ $gid ] ) ? (int) $collected_indexes[ $gid ] : 0;
 					$group_items_html .= designsetgo_query_render_item(
 						$item_template_html,
 						array(
-							'postId'                         => (int) $gid,
-							'postType'                       => $post_obj->post_type,
-							'index'                          => $item_index,
-							'designsetgo/itemIndex'          => $item_index,
-							'designsetgo/groupItemIndex'     => $group_item_index,
+							'postId'                     => (int) $gid,
+							'postType'                   => $post_obj->post_type,
+							'index'                      => $item_index,
+							'designsetgo/itemIndex'      => $item_index,
+							'designsetgo/groupItemIndex' => $group_item_index,
 						),
 						$atts['itemTagName']
 					);
-					$group_item_index++;
+					++$group_item_index;
 				}
 				$items_html .= sprintf(
 					'<section class="dsgo-query-group" data-dsgo-group-value="%s">%s%s</section>',
@@ -324,6 +324,7 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 
 		return array(
 			'html'       => designsetgo_query_wrap( $items_html, $atts, $context, $context['wrapper_attrs'] ?? null ) . $schema_html,
+			'items_html' => $items_html,
 			'totalPages' => $state['totalPages'],
 			'totalItems' => $state['totalItems'],
 		);
@@ -462,9 +463,9 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 		if ( 'manual' === $atts['source'] && ! empty( $atts['manualIds'] ) && is_array( $atts['manualIds'] ) ) {
 			$ids = array_values( array_filter( array_map( 'absint', $atts['manualIds'] ) ) );
 			if ( ! empty( $ids ) ) {
-				$args['post__in']       = $ids;
-				$args['orderby']        = 'post__in';
-				$args['post_type']      = 'any';
+				$args['post__in']  = $ids;
+				$args['orderby']   = 'post__in';
+				$args['post_type'] = 'any';
 				if ( empty( $atts['manualPaginated'] ) ) {
 					$args['posts_per_page'] = count( $ids );
 				}

--- a/src/blocks/query/render-relationship.php
+++ b/src/blocks/query/render-relationship.php
@@ -25,7 +25,12 @@ if ( ! function_exists( 'designsetgo_query_render_relationship' ) ) :
 	function designsetgo_query_render_relationship( array $atts, array $context ) {
 		$field = isset( $atts['relationshipField'] ) ? sanitize_text_field( (string) $atts['relationshipField'] ) : '';
 		if ( '' === $field ) {
-			return array( 'html' => '', 'totalPages' => 0, 'totalItems' => 0 );
+			return array(
+				'html'       => '',
+				'items_html' => '',
+				'totalPages' => 0,
+				'totalItems' => 0,
+			);
 		}
 
 		$parent_stack = array();
@@ -118,7 +123,12 @@ if ( ! function_exists( 'designsetgo_query_render_relationship' ) ) :
 		$mode = isset( $atts['relationshipFallback'] ) ? (string) $atts['relationshipFallback'] : 'empty';
 
 		if ( 'empty' === $mode ) {
-			return array( 'html' => designsetgo_query_wrap( '', $atts, $context, $context['wrapper_attrs'] ?? null ), 'totalPages' => 0, 'totalItems' => 0 );
+			return array(
+				'html'       => designsetgo_query_wrap( '', $atts, $context, $context['wrapper_attrs'] ?? null ),
+				'items_html' => '',
+				'totalPages' => 0,
+				'totalItems' => 0,
+			);
 		}
 
 		require_once __DIR__ . '/render-posts.php';
@@ -137,7 +147,12 @@ if ( ! function_exists( 'designsetgo_query_render_relationship' ) ) :
 		}
 		$parent = empty( $fallback_stack ) ? null : end( $fallback_stack );
 		if ( ! is_array( $parent ) || empty( $parent['postId'] ) ) {
-			return array( 'html' => '', 'totalPages' => 0, 'totalItems' => 0 );
+			return array(
+				'html'       => '',
+				'items_html' => '',
+				'totalPages' => 0,
+				'totalItems' => 0,
+			);
 		}
 		$atts['source']    = 'manual';
 		$atts['manualIds'] = array( (int) $parent['postId'] );

--- a/src/blocks/query/render-terms.php
+++ b/src/blocks/query/render-terms.php
@@ -87,7 +87,7 @@ if ( ! function_exists( 'designsetgo_query_render_terms' ) ) :
 				),
 				$atts['itemTagName']
 			);
-			$item_index++;
+			++$item_index;
 		}
 
 		$state = array(
@@ -99,6 +99,7 @@ if ( ! function_exists( 'designsetgo_query_render_terms' ) ) :
 
 		return array(
 			'html'       => designsetgo_query_wrap( $items_html, $atts, $context, $context['wrapper_attrs'] ?? null ),
+			'items_html' => $items_html,
 			'totalPages' => $state['totalPages'],
 			'totalItems' => $state['totalItems'],
 		);

--- a/src/blocks/query/render-users.php
+++ b/src/blocks/query/render-users.php
@@ -45,8 +45,8 @@ if ( ! function_exists( 'designsetgo_query_render_users' ) ) :
 		$users       = (array) $query->get_results();
 		$total_users = (int) $query->get_total();
 
-		$items_html  = '';
-		$item_index  = 0;
+		$items_html = '';
+		$item_index = 0;
 		foreach ( $users as $user ) {
 			$items_html .= designsetgo_query_render_item(
 				(string) $context['inner_html'],
@@ -58,7 +58,7 @@ if ( ! function_exists( 'designsetgo_query_render_users' ) ) :
 				),
 				$atts['itemTagName']
 			);
-			$item_index++;
+			++$item_index;
 		}
 
 		$state = array(
@@ -70,6 +70,7 @@ if ( ! function_exists( 'designsetgo_query_render_users' ) ) :
 
 		return array(
 			'html'       => designsetgo_query_wrap( $items_html, $atts, $context, $context['wrapper_attrs'] ?? null ),
+			'items_html' => $items_html,
 			'totalPages' => $state['totalPages'],
 			'totalItems' => $state['totalItems'],
 		);

--- a/src/blocks/query/style.scss
+++ b/src/blocks/query/style.scss
@@ -6,4 +6,11 @@
 // region can be targeted as one unit for AJAX refreshes.
 .wp-block-designsetgo-query {
 	box-sizing: border-box;
+
+	// Apply blockGap between all direct children (filters, results, pagination,
+	// no-results). WordPress sets --wp--style--block-gap on this wrapper when the
+	// author adjusts block spacing; this rule makes it visible on the frontend.
+	> * + * {
+		margin-block-start: var(--wp--style--block-gap, 0);
+	}
 }

--- a/src/blocks/query/variations.js
+++ b/src/blocks/query/variations.js
@@ -7,17 +7,19 @@ import { __ } from '@wordpress/i18n';
  * container; presentation attrs (columns, tagName, groupBy…) and the item
  * template live on the required designsetgo/query-results child.
  *
- * Each variation ships with a sensible default set of sibling blocks —
- * filter, no-results, pagination — so authors see the whole Dynamic Query
- * toolkit on first insert. Removing a block you don't need is trivial;
- * discovering blocks that weren't scaffolded for you is not.
+ * Each variation carries a `layoutVariant` on the query-results child so the
+ * scoped SCSS in query-results/style.scss can style each layout distinctly.
+ * Pair the layoutVariant with a per-variation template that plays to that
+ * layout's strengths (quote-card omits the image, compact-row uses a square
+ * thumb, etc.) so the inserter previews read as visually different at a
+ * glance rather than "same grid, different columns".
  */
 export default [
 	{
 		name: 'blog-index',
 		title: __('Blog index', 'designsetgo'),
 		description: __(
-			'Latest posts with search + sort, a responsive card grid, and numbered pagination.',
+			'Magazine-style cards with featured image, date, and excerpt. Search + sort + numbered pagination.',
 			'designsetgo'
 		),
 		icon: 'admin-post',
@@ -48,16 +50,24 @@ export default [
 			],
 			[
 				'designsetgo/query-results',
-				{ tagName: 'ul', itemTagName: 'li', columns: 3 },
+				{
+					tagName: 'ul',
+					itemTagName: 'li',
+					columns: 3,
+					layoutVariant: 'magazine',
+				},
 				[
 					[
 						'designsetgo/section',
 						{},
 						[
-							['core/post-featured-image', { isLink: true }],
-							['core/post-title', { level: 3, isLink: true }],
+							[
+								'core/post-featured-image',
+								{ isLink: true, aspectRatio: '3/2' },
+							],
 							['core/post-date'],
-							['core/post-excerpt', { excerptLength: 30 }],
+							['core/post-title', { level: 3, isLink: true }],
+							['core/post-excerpt', { excerptLength: 25 }],
 						],
 					],
 				],
@@ -70,7 +80,7 @@ export default [
 		name: 'team',
 		title: __('Team directory', 'designsetgo'),
 		description: __(
-			'Searchable grid of team members. Switch Post type to your `team` CPT in the inspector.',
+			'Circular avatars in a centered grid. Switch Post type to your `team` CPT in the inspector.',
 			'designsetgo'
 		),
 		icon: 'groups',
@@ -93,15 +103,27 @@ export default [
 			],
 			[
 				'designsetgo/query-results',
-				{ tagName: 'ul', itemTagName: 'li', columns: 4 },
+				{
+					tagName: 'ul',
+					itemTagName: 'li',
+					columns: 4,
+					layoutVariant: 'avatar-grid',
+				},
 				[
 					[
 						'designsetgo/section',
 						{},
 						[
-							['core/post-featured-image'],
+							[
+								'core/post-featured-image',
+								{
+									align: 'center',
+									aspectRatio: '1',
+									width: '140px',
+								},
+							],
 							['core/post-title', { level: 3 }],
-							['core/post-excerpt', { excerptLength: 15 }],
+							['core/post-excerpt', { excerptLength: 12 }],
 						],
 					],
 				],
@@ -113,7 +135,7 @@ export default [
 		name: 'testimonials',
 		title: __('Testimonials', 'designsetgo'),
 		description: __(
-			'Customer quotes layout with load-more pagination. Pair with the ACF binding source to render quote meta.',
+			'Pull-quote cards with oversized excerpt and attribution. Load-more pagination.',
 			'designsetgo'
 		),
 		icon: 'format-quote',
@@ -127,13 +149,18 @@ export default [
 		innerBlocks: [
 			[
 				'designsetgo/query-results',
-				{ tagName: 'ul', itemTagName: 'li', columns: 2 },
+				{
+					tagName: 'ul',
+					itemTagName: 'li',
+					columns: 2,
+					layoutVariant: 'quote-card',
+				},
 				[
 					[
 						'designsetgo/section',
 						{},
 						[
-							['core/post-excerpt'],
+							['core/post-excerpt', { excerptLength: 40 }],
 							['core/post-title', { level: 4 }],
 						],
 					],
@@ -146,7 +173,7 @@ export default [
 		name: 'portfolio',
 		title: __('Portfolio', 'designsetgo'),
 		description: __(
-			'Project showcase with category filter and load-more pagination.',
+			'Image tiles with overlay title. Category filter and load-more pagination.',
 			'designsetgo'
 		),
 		icon: 'portfolio',
@@ -165,11 +192,17 @@ export default [
 					taxonomy: 'category',
 					paramName: 'filter_category',
 					label: __('Filter by category', 'designsetgo'),
+					filterStyle: 'pill',
 				},
 			],
 			[
 				'designsetgo/query-results',
-				{ tagName: 'ul', itemTagName: 'li', columns: 3 },
+				{
+					tagName: 'ul',
+					itemTagName: 'li',
+					columns: 3,
+					layoutVariant: 'image-tile',
+				},
 				[
 					[
 						'designsetgo/section',
@@ -192,14 +225,14 @@ export default [
 		name: 'related-posts',
 		title: __('Related posts', 'designsetgo'),
 		description: __(
-			'Posts excluding the current one. Pair with the designsetgo/query/{queryId}/args filter to narrow by shared taxonomy.',
+			'Compact horizontal rows — small thumbnail + title. Excludes current post by default.',
 			'designsetgo'
 		),
 		icon: 'controls-repeat',
 		attributes: {
 			source: 'posts',
 			postType: 'post',
-			perPage: 3,
+			perPage: 6,
 			orderBy: 'rand',
 			order: 'DESC',
 			excludeCurrent: true,
@@ -207,14 +240,36 @@ export default [
 		innerBlocks: [
 			[
 				'designsetgo/query-results',
-				{ tagName: 'ul', itemTagName: 'li', columns: 3 },
+				{
+					tagName: 'ul',
+					itemTagName: 'li',
+					columns: 3,
+					layoutVariant: 'compact-row',
+				},
 				[
 					[
 						'designsetgo/section',
 						{},
 						[
-							['core/post-featured-image', { isLink: true }],
-							['core/post-title', { level: 4, isLink: true }],
+							[
+								'core/post-featured-image',
+								{
+									isLink: true,
+									aspectRatio: '1',
+									width: '96px',
+								},
+							],
+							[
+								'designsetgo/section',
+								{},
+								[
+									[
+										'core/post-title',
+										{ level: 4, isLink: true },
+									],
+									['core/post-date'],
+								],
+							],
 						],
 					],
 				],
@@ -225,7 +280,7 @@ export default [
 		name: 'featured-carousel',
 		title: __('Featured carousel', 'designsetgo'),
 		description: __(
-			'Slider that iterates posts — featured image, title, excerpt per slide. Edits to slide 1 apply to all.',
+			'Cinematic slider — one post per slide, oversized image, centered title. Dots + arrows.',
 			'designsetgo'
 		),
 		icon: 'images-alt2',
@@ -240,9 +295,13 @@ export default [
 			[
 				'designsetgo/slider',
 				{
-					slidesPerView: 1,
+					slidesPerView: 3,
+					slidesPerViewTablet: 2,
+					slidesPerViewMobile: 1,
 					showArrows: true,
 					showDots: true,
+					arrowPosition: 'outside',
+					dotPosition: 'outside',
 					effect: 'slide',
 					loop: true,
 					autoplay: false,
@@ -255,7 +314,10 @@ export default [
 							contentHorizontalAlign: 'center',
 						},
 						[
-							['core/post-featured-image', { aspectRatio: '16/9' }],
+							[
+								'core/post-featured-image',
+								{ aspectRatio: '21/9' },
+							],
 							['core/post-title', { level: 3, isLink: true }],
 							['core/post-excerpt', { excerptLength: 20 }],
 						],
@@ -269,7 +331,7 @@ export default [
 		name: 'post-spotlight',
 		title: __('Post spotlight (scroll-slides)', 'designsetgo'),
 		description: __(
-			'Scroll-driven panels that iterate posts. Each panel shows title + excerpt; one template applies to every post.',
+			'Scroll-driven story panels. One post per panel, big title, no image. Ideal for narrative lists.',
 			'designsetgo'
 		),
 		icon: 'format-gallery',
@@ -279,18 +341,37 @@ export default [
 			perPage: 4,
 			orderBy: 'date',
 			order: 'DESC',
+			// Scroll-slides is a pinned, viewport-height experience; a
+			// constrained outer query container would letterbox it.
+			align: 'full',
 		},
 		innerBlocks: [
 			[
 				'designsetgo/scroll-slides',
-				{ minHeight: '70vh' },
+				{
+					align: 'full',
+					minHeight: '100vh',
+					// Default maxHeight on the block is 900px, which caps the
+					// pinned section below the 100vh the variation asks for on
+					// tall viewports. Clear it so 100vh lands at viewport
+					// height.
+					maxHeight: '',
+					overlayColor: '#000000',
+					style: { color: { text: '#ffffff' } },
+				},
 				[
 					[
 						'designsetgo/scroll-slide',
-						{ navHeading: __('Story', 'designsetgo') },
+						{},
 						[
-							['core/post-title', { level: 2, isLink: true }],
-							['core/post-excerpt', { excerptLength: 30 }],
+							[
+								'core/post-excerpt',
+								{
+									excerptLength: 30,
+									moreText: __('Read more', 'designsetgo'),
+									showMoreOnNewLine: true,
+								},
+							],
 						],
 					],
 				],
@@ -302,7 +383,7 @@ export default [
 		name: 'events',
 		title: __('Events', 'designsetgo'),
 		description: __(
-			'Upcoming event listings with sort controls and pagination. Switch Post type to your `events` CPT in the inspector.',
+			'Date-forward cards with accent rail. Sort controls and numbered pagination. Switch Post type to your `events` CPT.',
 			'designsetgo'
 		),
 		icon: 'calendar-alt',
@@ -324,13 +405,17 @@ export default [
 			],
 			[
 				'designsetgo/query-results',
-				{ tagName: 'ul', itemTagName: 'li', columns: 2 },
+				{
+					tagName: 'ul',
+					itemTagName: 'li',
+					columns: 2,
+					layoutVariant: 'date-forward',
+				},
 				[
 					[
 						'designsetgo/section',
 						{},
 						[
-							['core/post-featured-image'],
 							['core/post-date'],
 							['core/post-title', { level: 3, isLink: true }],
 							['core/post-excerpt', { excerptLength: 20 }],

--- a/src/blocks/query/variations.js
+++ b/src/blocks/query/variations.js
@@ -222,6 +222,83 @@ export default [
 		],
 	},
 	{
+		name: 'featured-carousel',
+		title: __('Featured carousel', 'designsetgo'),
+		description: __(
+			'Slider that iterates posts — featured image, title, excerpt per slide. Edits to slide 1 apply to all.',
+			'designsetgo'
+		),
+		icon: 'images-alt2',
+		attributes: {
+			source: 'posts',
+			postType: 'post',
+			perPage: 5,
+			orderBy: 'date',
+			order: 'DESC',
+		},
+		innerBlocks: [
+			[
+				'designsetgo/slider',
+				{
+					slidesPerView: 1,
+					showArrows: true,
+					showDots: true,
+					effect: 'slide',
+					loop: true,
+					autoplay: false,
+				},
+				[
+					[
+						'designsetgo/slide',
+						{
+							contentVerticalAlign: 'center',
+							contentHorizontalAlign: 'center',
+						},
+						[
+							['core/post-featured-image', { aspectRatio: '16/9' }],
+							['core/post-title', { level: 3, isLink: true }],
+							['core/post-excerpt', { excerptLength: 20 }],
+						],
+					],
+				],
+			],
+			['designsetgo/query-no-results'],
+		],
+	},
+	{
+		name: 'post-spotlight',
+		title: __('Post spotlight (scroll-slides)', 'designsetgo'),
+		description: __(
+			'Scroll-driven panels that iterate posts. Each panel shows title + excerpt; one template applies to every post.',
+			'designsetgo'
+		),
+		icon: 'format-gallery',
+		attributes: {
+			source: 'posts',
+			postType: 'post',
+			perPage: 4,
+			orderBy: 'date',
+			order: 'DESC',
+		},
+		innerBlocks: [
+			[
+				'designsetgo/scroll-slides',
+				{ minHeight: '70vh' },
+				[
+					[
+						'designsetgo/scroll-slide',
+						{ navHeading: __('Story', 'designsetgo') },
+						[
+							['core/post-title', { level: 2, isLink: true }],
+							['core/post-excerpt', { excerptLength: 30 }],
+						],
+					],
+				],
+			],
+			['designsetgo/query-no-results'],
+		],
+	},
+	{
 		name: 'events',
 		title: __('Events', 'designsetgo'),
 		description: __(

--- a/src/blocks/query/view.js
+++ b/src/blocks/query/view.js
@@ -21,9 +21,6 @@ import {
 	collectParams as dsgoCollectParamsShared,
 } from './view-helpers.js';
 
-// Per-element debounce timer map (module-level, not reactive state).
-const dsgoDebounceTimers = {};
-
 // Events already processed by the IAPI store (first render). Used by the
 // delegated fallback listener so we never double-fire. The WeakSet lets the
 // browser GC events when they're done.
@@ -88,47 +85,6 @@ store('designsetgo/query', {
 			url.searchParams.delete('paged');
 			url.searchParams.delete('page');
 			yield* dsgoQueryRefresh(ctx, url);
-		},
-
-		/**
-		 * Debounced input handler for the search field.
-		 * Fires 250 ms after typing stops. Declared as a regular function
-		 * (not a generator) so IAPI treats it as synchronous — which is
-		 * what we need for the setTimeout pattern.
-		 *
-		 * @param {Event} event
-		 */
-		setFilterDebounced(event) {
-			dsgoHandledEvents.add(event);
-			const el = event.target;
-			const paramName = el.getAttribute('name')?.replace(/\[\]$/, '');
-			if (!paramName) {
-				return;
-			}
-
-			const ctx = getContext(); // capture while IAPI frame is live
-
-			clearTimeout(dsgoDebounceTimers[paramName]);
-			dsgoDebounceTimers[paramName] = setTimeout(() => {
-				// Bail out if the input was removed mid-debounce by a concurrent
-				// setFilter / toggleFilter refresh — the captured ctx is bound to
-				// an orphaned state object in that case, and the fresh HTML has
-				// its own data-wp-context to drive subsequent interactions.
-				if (!el.isConnected) {
-					return;
-				}
-				const url = new URL(window.location.href);
-				if (el.value) {
-					url.searchParams.set(paramName, el.value);
-				} else {
-					url.searchParams.delete(paramName);
-				}
-				// Fix 3: strip both pagination params.
-				url.searchParams.delete('paged');
-				url.searchParams.delete('page');
-				// Use the Promise-based helper — no yield needed here.
-				dsgoQueryRefreshPlain(ctx, url);
-			}, 250);
 		},
 
 		/**

--- a/src/blocks/query/view.js
+++ b/src/blocks/query/view.js
@@ -63,17 +63,22 @@ store('designsetgo/query', {
 			event.preventDefault?.();
 			dsgoHandledEvents.add(event);
 			const { ref } = getElement();
-			const form = ref.closest('form');
+			// ref may be the form (submit event) or the input/select (change event).
+			const form =
+				ref.closest('form') ?? (ref.tagName === 'FORM' ? ref : null);
 			const input = form?.querySelector('[name]');
 			const paramName = input?.getAttribute('name')?.replace(/\[\]$/, '');
 			if (!paramName) {
 				return;
 			}
 
+			// Read the value from the named input, not from ref — ref may be the
+			// <form> element when the directive is bound to the form's submit event.
+			const value = input?.value ?? ref.value ?? '';
 			const ctx = getContext();
 			const url = new URL(window.location.href);
-			if (ref.value) {
-				url.searchParams.set(paramName, ref.value);
+			if (value) {
+				url.searchParams.set(paramName, value);
 			} else {
 				url.searchParams.delete(paramName);
 			}
@@ -305,10 +310,23 @@ function dsgoGetContextFromDom(el) {
 }
 
 function dsgoGetQueryContainer(queryId, el) {
+	// The grid <ul> / <ol> / <div> is the actual item container — it carries
+	// `data-dsgo-query-results-role="container"` + the matching query id.
+	// The outer .dsgo-query-region wrapper ALSO carries data-dsgo-query-id
+	// (so view.js can target the whole region for full swaps), so targeting
+	// [data-dsgo-query-id] alone would match the region and cause load-more
+	// to append new items after the pagination button instead of into the
+	// grid. Scope by role to always land inside the grid.
+	const doc = el?.ownerDocument || document;
+	// Prefer scoping via the enclosing region so nested queries on the same
+	// page can't collide even when another query shares the same queryId.
+	const region = el?.closest(`[data-dsgo-query-region="${queryId}"]`);
 	return (
-		el?.closest('[data-dsgo-query-id]:not([data-dsgo-pagination])') ||
-		document.querySelector(
-			`[data-dsgo-query-id="${queryId}"]:not([data-dsgo-pagination])`
+		region?.querySelector(
+			`[data-dsgo-query-results-role="container"][data-dsgo-query-id="${queryId}"]`
+		) ||
+		doc.querySelector(
+			`[data-dsgo-query-results-role="container"][data-dsgo-query-id="${queryId}"]`
 		)
 	);
 }
@@ -419,7 +437,12 @@ async function dsgoLoadMorePlain(ctx, button) {
 						{ once: true }
 					);
 				}
-				focusable.focus();
+				// preventScroll keeps the viewport anchored on the Load more
+				// button the user just clicked. Without this the browser jumps
+				// to wherever the first new item lands (often well below the
+				// fold on long grids), which reads as a lost scroll position
+				// even though focus is moving for a screen-reader handoff.
+				focusable.focus({ preventScroll: true });
 			}
 		}
 
@@ -609,23 +632,28 @@ function dsgoDelegatedChange(event) {
 }
 
 /**
- * Delegated input handler for the debounced search field.
+ * Delegated submit handler for search filter forms.
  *
- * @param {Event} event Native input event.
+ * Covers the post-swap DOM where IAPI directives are no longer live.
+ * Mirrors the IAPI setFilter logic but reads the form's named input directly.
+ *
+ * @param {Event} event Native submit event.
  */
-function dsgoDelegatedInput(event) {
+function dsgoDelegatedSubmit(event) {
 	if (dsgoHandledEvents.has(event)) {
 		return;
 	}
 	const target = event.target;
-	if (!(target instanceof HTMLInputElement)) {
+	if (!(target instanceof HTMLElement)) {
 		return;
 	}
 	const filterRoot = target.closest('.dsgo-query-filter--search');
 	if (!filterRoot) {
 		return;
 	}
-	const paramName = (target.getAttribute('name') || '').replace(/\[\]$/, '');
+	event.preventDefault();
+	const input = target.querySelector('[name]');
+	const paramName = (input?.getAttribute('name') || '').replace(/\[\]$/, '');
 	if (!paramName) {
 		return;
 	}
@@ -633,22 +661,15 @@ function dsgoDelegatedInput(event) {
 	if (!ctx) {
 		return;
 	}
-
-	clearTimeout(dsgoDebounceTimers[paramName]);
-	dsgoDebounceTimers[paramName] = setTimeout(() => {
-		if (!target.isConnected) {
-			return;
-		}
-		const url = new URL(window.location.href);
-		if (target.value) {
-			url.searchParams.set(paramName, target.value);
-		} else {
-			url.searchParams.delete(paramName);
-		}
-		url.searchParams.delete('paged');
-		url.searchParams.delete('page');
-		dsgoDelegatedRefresh(ctx, url);
-	}, 250);
+	const url = new URL(window.location.href);
+	if (input?.value) {
+		url.searchParams.set(paramName, input.value);
+	} else {
+		url.searchParams.delete(paramName);
+	}
+	url.searchParams.delete('paged');
+	url.searchParams.delete('page');
+	dsgoDelegatedRefresh(ctx, url);
 }
 
 /**
@@ -701,7 +722,10 @@ function dsgoDelegatedClick(event) {
 }
 
 document.addEventListener('change', dsgoDelegatedChange);
-document.addEventListener('input', dsgoDelegatedInput);
+// No delegated `input` listener: the search filter is submit-only to avoid
+// yanking focus out of the input mid-typing when the debounced refresh swaps
+// the form's DOM. Submit (Enter / button) is handled by dsgoDelegatedSubmit.
+document.addEventListener('submit', dsgoDelegatedSubmit);
 document.addEventListener('click', dsgoDelegatedClick);
 if (document.readyState === 'loading') {
 	document.addEventListener('DOMContentLoaded', () =>

--- a/src/blocks/scroll-slide/block.json
+++ b/src/blocks/scroll-slide/block.json
@@ -17,6 +17,9 @@
 	"parent": [
 		"designsetgo/scroll-slides"
 	],
+	"usesContext": [
+		"designsetgo/queryId"
+	],
 	"attributes": {
 		"navHeading": {
 			"type": "string",
@@ -63,5 +66,6 @@
 	},
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
-	"style": "file:./style-index.css"
+	"style": "file:./style-index.css",
+	"render": "file:./render.php"
 }

--- a/src/blocks/scroll-slide/edit.js
+++ b/src/blocks/scroll-slide/edit.js
@@ -22,8 +22,12 @@ import './editor.scss';
  */
 const DEFAULT_OVERLAY_COLOR = '#111111';
 
-export default function Edit({ attributes, setAttributes, clientId }) {
+export default function Edit({ attributes, setAttributes, clientId, context }) {
 	const { navHeading } = attributes;
+	// When bound to a dynamic query the heading is driven by the iterated
+	// post's title (see src/blocks/scroll-slide/render.php), so showing an
+	// editable control that has no effect would be misleading.
+	const inQueryMode = !!context?.['designsetgo/queryId'];
 
 	const hasBackgroundImage =
 		!!attributes?.style?.background?.backgroundImage?.url;
@@ -111,35 +115,37 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 
 	return (
 		<>
-			<InspectorControls>
-				<DsgoInspectorPanel
-					title={__('Settings', 'designsetgo')}
-					panelName="settings"
-					panelId={clientId}
-					resetAll={() => setAttributes({ navHeading: '' })}
-				>
-					<DsgoInspectorPanel.Item
-						label={__('Navigation Heading', 'designsetgo')}
-						hasValue={() => navHeading !== ''}
-						onDeselect={() => setAttributes({ navHeading: '' })}
-						isShownByDefault
+			{!inQueryMode && (
+				<InspectorControls>
+					<DsgoInspectorPanel
+						title={__('Settings', 'designsetgo')}
+						panelName="settings"
+						panelId={clientId}
+						resetAll={() => setAttributes({ navHeading: '' })}
 					>
-						<TextControl
+						<DsgoInspectorPanel.Item
 							label={__('Navigation Heading', 'designsetgo')}
-							value={navHeading}
-							onChange={(value) =>
-								setAttributes({ navHeading: value })
-							}
-							help={__(
-								'Displayed in the slide navigation on the frontend',
-								'designsetgo'
-							)}
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-						/>
-					</DsgoInspectorPanel.Item>
-				</DsgoInspectorPanel>
-			</InspectorControls>
+							hasValue={() => navHeading !== ''}
+							onDeselect={() => setAttributes({ navHeading: '' })}
+							isShownByDefault
+						>
+							<TextControl
+								label={__('Navigation Heading', 'designsetgo')}
+								value={navHeading}
+								onChange={(value) =>
+									setAttributes({ navHeading: value })
+								}
+								help={__(
+									'Displayed in the slide navigation on the frontend',
+									'designsetgo'
+								)}
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+							/>
+						</DsgoInspectorPanel.Item>
+					</DsgoInspectorPanel>
+				</InspectorControls>
+			)}
 
 			<div {...innerBlocksProps} />
 		</>

--- a/src/blocks/scroll-slide/render.php
+++ b/src/blocks/scroll-slide/render.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Scroll Slide — server render.
+ *
+ * Standalone (authored) scroll-slides pass through unchanged. When iterated
+ * inside a designsetgo/query (the post-spotlight variation), each per-post
+ * render gets two enrichments so the template reads as a real story panel
+ * instead of N identical copies:
+ *
+ *  - `data-dsgo-nav-heading` is set to the iterated post's title so the
+ *    frontend nav column shows post titles instead of the template's
+ *    static heading.
+ *  - When the author has not set a custom background, the post's featured
+ *    image is injected as `background-image` in the wrapper's inline style.
+ *    The outer scroll-slides/view.js already lifts per-slide backgrounds
+ *    into its crossfading layer, so the image becomes the panel background
+ *    at scroll time.
+ *
+ * Detection: designsetgo_query_render_item() pushes an item context onto
+ * $GLOBALS['designsetgo_parent_stack'] before rendering each iterated
+ * block, so the presence of a postId on the top of that stack means we
+ * are inside a query iteration.
+ *
+ * @package DesignSetGo
+ * @since   2.6.0
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Pre-rendered save.js output.
+ * @param WP_Block $block      Block instance.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( empty( $GLOBALS['designsetgo_parent_stack'] ) || ! is_array( $GLOBALS['designsetgo_parent_stack'] ) ) {
+	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
+	return;
+}
+
+$top           = end( $GLOBALS['designsetgo_parent_stack'] );
+$iterated_post = is_array( $top ) && isset( $top['postId'] ) ? (int) $top['postId'] : 0;
+
+if ( ! $iterated_post || ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
+	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
+	return;
+}
+
+$iterated_title = get_the_title( $iterated_post );
+$thumb          = get_the_post_thumbnail_url( $iterated_post, 'full' );
+
+$processor = new WP_HTML_Tag_Processor( $content );
+if ( ! $processor->next_tag( array( 'class_name' => 'dsgo-scroll-slide' ) ) ) {
+	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
+	return;
+}
+
+if ( '' !== $iterated_title ) {
+	$processor->set_attribute( 'data-dsgo-nav-heading', $iterated_title );
+}
+
+if ( $thumb ) {
+	$existing_style = (string) $processor->get_attribute( 'style' );
+	// Only inject if the author hasn't already set a background image via
+	// block supports. Case-insensitive check on the property name catches
+	// `background-image` and the `background:` shorthand alike.
+	if ( false === stripos( $existing_style, 'background-image' ) && false === stripos( $existing_style, 'background:' ) ) {
+		$injected = sprintf( "background-image:url('%s');background-size:cover;background-position:center;", esc_url( $thumb ) );
+		$merged   = '' === trim( $existing_style )
+			? $injected
+			: rtrim( $existing_style, "; \t\n\r\0\x0B" ) . ';' . $injected;
+		$processor->set_attribute( 'style', $merged );
+	}
+}
+
+echo $processor->get_updated_html(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Tag_Processor output.

--- a/src/blocks/scroll-slide/style.scss
+++ b/src/blocks/scroll-slide/style.scss
@@ -11,6 +11,17 @@
 	padding: 2rem;
 
 	/**
+	 * Flex gap doesn't collapse with element margins — theme headings and
+	 * paragraphs would add their own margin-block on top of the gap,
+	 * producing uneven spacing. Zero out direct children so the gap alone
+	 * controls rhythm (matches the editor, which WP normalises the same
+	 * way via .editor-styles-wrapper).
+	 */
+	> :where(h1, h2, h3, h4, h5, h6, p, figure, ul, ol) {
+		margin-block: 0;
+	}
+
+	/**
 	 * Transition styles apply in both pinned (desktop scroll) and
 	 * tap mode (mobile click). Without this scope, opacity:0 would
 	 * hide slides in the editor too.

--- a/src/blocks/scroll-slides/block.json
+++ b/src/blocks/scroll-slides/block.json
@@ -49,6 +49,13 @@
 			"default": ""
 		}
 	},
+	"usesContext": [
+		"designsetgo/queryId",
+		"designsetgo/querySource",
+		"designsetgo/queryPostType",
+		"designsetgo/currentItemId",
+		"designsetgo/currentItemType"
+	],
 	"supports": {
 		"anchor": true,
 		"align": [
@@ -110,5 +117,6 @@
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
 	"style": "file:./style-index.css",
-	"viewScript": "file:./view.js"
+	"viewScript": "file:./view.js",
+	"render": "file:./render.php"
 }

--- a/src/blocks/scroll-slides/edit.js
+++ b/src/blocks/scroll-slides/edit.js
@@ -7,7 +7,9 @@ import {
 	useInnerBlocksProps,
 	store as blockEditorStore,
 	useSettings,
+	InspectorControls,
 } from '@wordpress/block-editor';
+import { PanelBody, Notice } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 
@@ -22,7 +24,12 @@ import ScrollSlidesInspector from './components/ScrollSlidesInspector';
 const ALLOWED_BLOCKS = ['designsetgo/scroll-slide'];
 const MAX_SLIDES = 10;
 
-export default function Edit({ attributes, setAttributes, clientId }) {
+export default function Edit({
+	attributes,
+	setAttributes,
+	clientId,
+	context,
+}) {
 	const {
 		minHeight,
 		maxHeight,
@@ -33,6 +40,16 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 		navActiveColor,
 	} = attributes;
 	const [activeSlide, setActiveSlide] = useState(0);
+
+	// Dynamic mode: a parent designsetgo/query sets queryId in context. In
+	// that mode only the first scroll-slide is used as the per-item template;
+	// extras are ignored server-side. Lock add/remove at this level so the
+	// editor reflects the server contract.
+	const queryId =
+		typeof context === 'object' && context
+			? context['designsetgo/queryId'] || ''
+			: '';
+	const inQueryMode = !!queryId;
 
 	const [themeContentSize] = useSettings('layout.contentSize');
 
@@ -142,8 +159,11 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 		{
 			allowedBlocks: ALLOWED_BLOCKS,
 			orientation: 'vertical',
+			templateLock: inQueryMode ? 'insert' : false,
 			renderAppender:
-				innerBlocks.length >= MAX_SLIDES ? false : undefined,
+				inQueryMode || innerBlocks.length >= MAX_SLIDES
+					? false
+					: undefined,
 		}
 	);
 
@@ -187,6 +207,33 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 
 	return (
 		<>
+			{inQueryMode && (
+				<InspectorControls>
+					<PanelBody
+						title={__('Dynamic mode', 'designsetgo')}
+						initialOpen={true}
+					>
+						<Notice status="info" isDismissible={false}>
+							{__(
+								'This block is bound to a parent Dynamic Query. The first scroll slide is the per-item template — extra slides are ignored at render. Add/Remove is disabled while bound.',
+								'designsetgo'
+							)}
+						</Notice>
+						{innerBlocks.length > 1 && (
+							<Notice status="warning" isDismissible={false}>
+								{sprintf(
+									/* translators: %d: number of slides that will not render */
+									__(
+										'%d extra slide(s) will be ignored at render. Only the first slide is used as the template.',
+										'designsetgo'
+									),
+									innerBlocks.length - 1
+								)}
+							</Notice>
+						)}
+					</PanelBody>
+				</InspectorControls>
+			)}
 			<ScrollSlidesInspector
 				attributes={attributes}
 				setAttributes={setAttributes}

--- a/src/blocks/scroll-slides/edit.js
+++ b/src/blocks/scroll-slides/edit.js
@@ -8,6 +8,7 @@ import {
 	store as blockEditorStore,
 	useSettings,
 	InspectorControls,
+	BlockContextProvider,
 } from '@wordpress/block-editor';
 import { PanelBody, Notice } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -20,6 +21,10 @@ import './editor.scss';
 import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
 import ScrollSlidesPlaceholder from './components/ScrollSlidesPlaceholder';
 import ScrollSlidesInspector from './components/ScrollSlidesInspector';
+import useQueryHostPreview, {
+	buildItemContext,
+} from '../query/hooks/useQueryHostPreview';
+import QueryHostReadOnlyItem from '../query/components/QueryHostReadOnlyItem';
 
 const ALLOWED_BLOCKS = ['designsetgo/scroll-slide'];
 const MAX_SLIDES = 10;
@@ -68,6 +73,35 @@ export default function Edit({
 
 	const { updateBlockAttributes, selectBlock } =
 		useDispatch(blockEditorStore);
+
+	// Parent query's attributes (only resolved when bound via context).
+	const parentQueryAttrs = useSelect(
+		(select) => {
+			if (!inQueryMode) {
+				return null;
+			}
+			const { getBlockParents, getBlock } = select(blockEditorStore);
+			const parents = getBlockParents(clientId);
+			for (const parentId of parents) {
+				const parent = getBlock(parentId);
+				if (parent?.name === 'designsetgo/query') {
+					return parent.attributes;
+				}
+			}
+			return null;
+		},
+		[clientId, inQueryMode]
+	);
+
+	// Only the first scroll-slide is used as the template at render time.
+	const templateSlideBlocks = innerBlocks.slice(0, 1);
+
+	const preview = useQueryHostPreview({
+		attributes: parentQueryAttrs,
+		queryId,
+		innerBlocks: templateSlideBlocks,
+		enabled: inQueryMode && !!parentQueryAttrs,
+	});
 
 	// Clamp active slide to valid range when slides are removed
 	const clampedActive =
@@ -154,7 +188,9 @@ export default function Edit({
 
 	const innerBlocksProps = useInnerBlocksProps(
 		{
-			className: 'dsgo-scroll-slides__editor-panels',
+			className: inQueryMode
+				? 'dsgo-scroll-slides__editor-template-slot'
+				: 'dsgo-scroll-slides__editor-panels',
 		},
 		{
 			allowedBlocks: ALLOWED_BLOCKS,
@@ -287,9 +323,91 @@ export default function Edit({
 					)}
 
 					{/* Slide panels — all rendered, CSS shows only active */}
-					<div {...innerBlocksProps} />
+					{inQueryMode ? (
+						<QueryModePanels
+							innerBlocksProps={innerBlocksProps}
+							preview={preview}
+							parentQueryAttrs={parentQueryAttrs}
+							outerContext={context}
+						/>
+					) : (
+						<div {...innerBlocksProps} />
+					)}
 				</div>
 			</div>
 		</>
+	);
+}
+
+/**
+ * Render the scroll-slides panels in query-bound mode: panel 0 wraps the
+ * editable InnerBlocks slot (the template scroll-slide); panels 1..N are
+ * read-only server-rendered panels. Each panel is wrapped in a
+ * BlockContextProvider so bindings resolve against the iterated post.
+ */
+function QueryModePanels({
+	innerBlocksProps,
+	preview,
+	parentQueryAttrs,
+	outerContext,
+}) {
+	const source = parentQueryAttrs?.source || 'posts';
+	const { records, hasResolved, serverHtml, loading } = preview;
+
+	if (!hasResolved) {
+		return (
+			<div className="dsgo-scroll-slides__editor-panels dsgo-scroll-slides__editor-panels--query-loading">
+				<div {...innerBlocksProps} />
+			</div>
+		);
+	}
+
+	const items = Array.isArray(records) ? records : [];
+
+	if (items.length === 0) {
+		return (
+			<div className="dsgo-scroll-slides__editor-panels dsgo-scroll-slides__editor-panels--query-empty">
+				<div {...innerBlocksProps} />
+				<div
+					className="dsgo-scroll-slides__editor-empty-hint"
+					contentEditable={false}
+					aria-hidden="true"
+				>
+					{__(
+						'No posts match the parent query. Design the template panel above \u2014 it will render once per result at publish time.',
+						'designsetgo'
+					)}
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="dsgo-scroll-slides__editor-panels">
+			{items.map((item, idx) => {
+				const itemContext = buildItemContext(
+					item,
+					source,
+					idx,
+					outerContext
+				);
+				return (
+					<BlockContextProvider
+						key={item.id ?? idx}
+						value={itemContext}
+					>
+						{idx === 0 ? (
+							<div {...innerBlocksProps} />
+						) : (
+							<QueryHostReadOnlyItem
+								className="dsgo-scroll-slides__editor-readonly-item"
+								html={serverHtml?.[idx] ?? null}
+								loading={loading}
+							/>
+						)}
+					</BlockContextProvider>
+				);
+			})}
+		</div>
 	);
 }

--- a/src/blocks/scroll-slides/edit.js
+++ b/src/blocks/scroll-slides/edit.js
@@ -10,9 +10,9 @@ import {
 	InspectorControls,
 	BlockContextProvider,
 } from '@wordpress/block-editor';
-import { PanelBody, Notice } from '@wordpress/components';
+import { Notice } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -24,6 +24,7 @@ import ScrollSlidesInspector from './components/ScrollSlidesInspector';
 import useQueryHostPreview, {
 	buildItemContext,
 } from '../query/hooks/useQueryHostPreview';
+import useParentQueryAttrs from '../query/hooks/useParentQueryAttrs';
 import QueryHostReadOnlyItem from '../query/components/QueryHostReadOnlyItem';
 
 const ALLOWED_BLOCKS = ['designsetgo/scroll-slide'];
@@ -75,26 +76,15 @@ export default function Edit({
 		useDispatch(blockEditorStore);
 
 	// Parent query's attributes (only resolved when bound via context).
-	const parentQueryAttrs = useSelect(
-		(select) => {
-			if (!inQueryMode) {
-				return null;
-			}
-			const { getBlockParents, getBlock } = select(blockEditorStore);
-			const parents = getBlockParents(clientId);
-			for (const parentId of parents) {
-				const parent = getBlock(parentId);
-				if (parent?.name === 'designsetgo/query') {
-					return parent.attributes;
-				}
-			}
-			return null;
-		},
-		[clientId, inQueryMode]
-	);
+	const parentQueryAttrs = useParentQueryAttrs(clientId, inQueryMode);
 
 	// Only the first scroll-slide is used as the template at render time.
-	const templateSlideBlocks = innerBlocks.slice(0, 1);
+	// Memoize to preserve the array reference across renders — useRenderedItems
+	// re-serializes the template tree on every identity change.
+	const templateSlideBlocks = useMemo(
+		() => (innerBlocks.length > 0 ? [innerBlocks[0]] : []),
+		[innerBlocks]
+	);
 
 	const preview = useQueryHostPreview({
 		attributes: parentQueryAttrs,
@@ -245,29 +235,24 @@ export default function Edit({
 		<>
 			{inQueryMode && (
 				<InspectorControls>
-					<PanelBody
-						title={__('Dynamic mode', 'designsetgo')}
-						initialOpen={true}
-					>
-						<Notice status="info" isDismissible={false}>
-							{__(
-								'This block is bound to a parent Dynamic Query. The first scroll slide is the per-item template — extra slides are ignored at render. Add/Remove is disabled while bound.',
-								'designsetgo'
+					<Notice status="info" isDismissible={false}>
+						{__(
+							'This block is bound to a parent Dynamic Query. Only the first scroll slide is rendered for each iterated item; extras are ignored.',
+							'designsetgo'
+						)}
+					</Notice>
+					{innerBlocks.length > 1 && (
+						<Notice status="warning" isDismissible={false}>
+							{sprintf(
+								/* translators: %d: number of slides that will not render */
+								__(
+									'%d extra slide(s) will be ignored at render. Only the first slide is used as the template.',
+									'designsetgo'
+								),
+								innerBlocks.length - 1
 							)}
 						</Notice>
-						{innerBlocks.length > 1 && (
-							<Notice status="warning" isDismissible={false}>
-								{sprintf(
-									/* translators: %d: number of slides that will not render */
-									__(
-										'%d extra slide(s) will be ignored at render. Only the first slide is used as the template.',
-										'designsetgo'
-									),
-									innerBlocks.length - 1
-								)}
-							</Notice>
-						)}
-					</PanelBody>
+					)}
 				</InspectorControls>
 			)}
 			<ScrollSlidesInspector

--- a/src/blocks/scroll-slides/edit.js
+++ b/src/blocks/scroll-slides/edit.js
@@ -30,12 +30,7 @@ import QueryHostReadOnlyItem from '../query/components/QueryHostReadOnlyItem';
 const ALLOWED_BLOCKS = ['designsetgo/scroll-slide'];
 const MAX_SLIDES = 10;
 
-export default function Edit({
-	attributes,
-	setAttributes,
-	clientId,
-	context,
-}) {
+export default function Edit({ attributes, setAttributes, clientId, context }) {
 	const {
 		minHeight,
 		maxHeight,
@@ -93,11 +88,15 @@ export default function Edit({
 		enabled: inQueryMode && !!parentQueryAttrs,
 	});
 
-	// Clamp active slide to valid range when slides are removed
+	// Clamp active slide to valid range. In query mode the panel count is
+	// driven by the preview record count; outside of query mode by the
+	// authored inner blocks count.
+	const previewRecords = Array.isArray(preview?.records)
+		? preview.records
+		: [];
+	const slideCount = inQueryMode ? previewRecords.length : innerBlocks.length;
 	const clampedActive =
-		innerBlocks.length > 0
-			? Math.min(activeSlide, innerBlocks.length - 1)
-			: 0;
+		slideCount > 0 ? Math.min(activeSlide, slideCount - 1) : 0;
 
 	const blockClassName = [
 		'dsgo-scroll-slides',
@@ -146,6 +145,21 @@ export default function Edit({
 				slideStyle.background?.backgroundPosition || 'center';
 			editorBgStyle.backgroundRepeat =
 				slideStyle.background?.backgroundRepeat || 'no-repeat';
+		}
+	}
+
+	// In query mode, the active record's featured image becomes the panel
+	// background — mirroring what scroll-slide/render.php injects on the
+	// frontend when the template has no authored background.
+	if (inQueryMode && !editorBgStyle.backgroundImage) {
+		const activeRecord = previewRecords[clampedActive];
+		const featuredUrl =
+			activeRecord?._embedded?.['wp:featuredmedia']?.[0]?.source_url;
+		if (featuredUrl) {
+			editorBgStyle.backgroundImage = `url(${featuredUrl})`;
+			editorBgStyle.backgroundSize = 'cover';
+			editorBgStyle.backgroundPosition = 'center';
+			editorBgStyle.backgroundRepeat = 'no-repeat';
 		}
 	}
 
@@ -200,7 +214,10 @@ export default function Edit({
 	 */
 	const handleNavClick = (index) => {
 		setActiveSlide(index);
-		if (innerBlocks[index]) {
+		// Only select the authored child when it exists (outside query mode
+		// there is one block per nav item; in query mode there is only a
+		// single template block regardless of the active preview record).
+		if (!inQueryMode && innerBlocks[index]) {
 			selectBlock(innerBlocks[index].clientId);
 		}
 	};
@@ -262,7 +279,18 @@ export default function Edit({
 				themeContentSize={themeContentSize}
 			/>
 
-			<div {...blockProps}>
+			<div
+				{...blockProps}
+				onClickCapture={(event) => {
+					// Kill link navigation inside the editor — real anchors come
+					// from authored post-title/featured-image blocks and from
+					// server-rendered readonly slides in query mode.
+					const anchor = event.target.closest?.('a[href]');
+					if (anchor) {
+						event.preventDefault();
+					}
+				}}
+			>
 				{hasEditorBg && (
 					<div
 						className="dsgo-scroll-slides__editor-bg"
@@ -271,41 +299,84 @@ export default function Edit({
 					/>
 				)}
 				<div className="dsgo-scroll-slides__inner" style={innerStyle}>
-					{/* Navigation — editable headings, click to switch slide */}
-					{innerBlocks.length > 0 && (
-						<div className="dsgo-scroll-slides__editor-nav">
-							{innerBlocks.map((block, index) => (
-								<div
-									key={block.clientId}
-									className={`dsgo-scroll-slides__editor-nav-item${
-										index === clampedActive
-											? ' is-active'
-											: ''
-									}`}
-								>
-									<input
-										type="text"
-										className="dsgo-scroll-slides__editor-nav-input"
-										value={
-											block.attributes.navHeading || ''
-										}
-										placeholder={sprintf(
-											/* translators: %d: slide number */
-											__('Slide %d', 'designsetgo'),
-											index + 1
-										)}
-										onChange={(e) =>
-											handleNavHeadingChange(
-												index,
-												e.target.value
-											)
-										}
-										onFocus={() => handleNavClick(index)}
-									/>
+					{/* Navigation — editable headings outside query mode; in
+					    query mode, one read-only heading per preview record
+					    (post title, user name, term name, etc.). */}
+					{inQueryMode
+						? slideCount > 0 && (
+								<div className="dsgo-scroll-slides__editor-nav">
+									{previewRecords.map((record, index) => {
+										const heading =
+											record?.title?.rendered ||
+											record?.name ||
+											sprintf(
+												/* translators: %d: slide number */
+												__('Slide %d', 'designsetgo'),
+												index + 1
+											);
+										return (
+											<div
+												key={record?.id ?? index}
+												className={`dsgo-scroll-slides__editor-nav-item${
+													index === clampedActive
+														? ' is-active'
+														: ''
+												}`}
+											>
+												<button
+													type="button"
+													className="dsgo-scroll-slides__editor-nav-input"
+													onClick={() =>
+														handleNavClick(index)
+													}
+												>
+													{heading}
+												</button>
+											</div>
+										);
+									})}
 								</div>
-							))}
-						</div>
-					)}
+							)
+						: innerBlocks.length > 0 && (
+								<div className="dsgo-scroll-slides__editor-nav">
+									{innerBlocks.map((block, index) => (
+										<div
+											key={block.clientId}
+											className={`dsgo-scroll-slides__editor-nav-item${
+												index === clampedActive
+													? ' is-active'
+													: ''
+											}`}
+										>
+											<input
+												type="text"
+												className="dsgo-scroll-slides__editor-nav-input"
+												value={
+													block.attributes
+														.navHeading || ''
+												}
+												placeholder={sprintf(
+													/* translators: %d: slide number */
+													__(
+														'Slide %d',
+														'designsetgo'
+													),
+													index + 1
+												)}
+												onChange={(e) =>
+													handleNavHeadingChange(
+														index,
+														e.target.value
+													)
+												}
+												onFocus={() =>
+													handleNavClick(index)
+												}
+											/>
+										</div>
+									))}
+								</div>
+							)}
 
 					{/* Slide panels — all rendered, CSS shows only active */}
 					{inQueryMode ? (
@@ -329,6 +400,11 @@ export default function Edit({
  * editable InnerBlocks slot (the template scroll-slide); panels 1..N are
  * read-only server-rendered panels. Each panel is wrapped in a
  * BlockContextProvider so bindings resolve against the iterated post.
+ * @param {Object} root0                  Props.
+ * @param {Object} root0.innerBlocksProps useInnerBlocksProps result.
+ * @param {Object} root0.preview          useQueryHostPreview result.
+ * @param {Object} root0.parentQueryAttrs Parent query's attributes.
+ * @param {Object} root0.outerContext     Outer block context.
  */
 function QueryModePanels({
 	innerBlocksProps,
@@ -368,7 +444,7 @@ function QueryModePanels({
 	}
 
 	return (
-		<div className="dsgo-scroll-slides__editor-panels">
+		<div className="dsgo-scroll-slides__editor-panels dsgo-scroll-slides__editor-panels--query-mode">
 			{items.map((item, idx) => {
 				const itemContext = buildItemContext(
 					item,

--- a/src/blocks/scroll-slides/editor.scss
+++ b/src/blocks/scroll-slides/editor.scss
@@ -92,22 +92,29 @@
 	}
 }
 
-.dsgo-scroll-slides__editor-nav input.dsgo-scroll-slides__editor-nav-input {
+.dsgo-scroll-slides__editor-nav input.dsgo-scroll-slides__editor-nav-input,
+.dsgo-scroll-slides__editor-nav button.dsgo-scroll-slides__editor-nav-input {
 	display: block;
 	width: 100%;
 	background: none;
 	border: none;
-	border-bottom: 1px solid transparent;
+	border-radius: 0;
 	box-shadow: none;
 	padding: 0.25rem 0;
-	font-size: clamp(1.25rem, 2.5vw, 2rem);
+	// Match the frontend nav-item sizing so the editor preview reads the
+	// same scale as the published output.
+	font-size: clamp(1.5rem, 3vw, 2.5rem);
 	font-weight: 700;
 	font-family: inherit;
+	line-height: 1.2;
 	color: inherit;
+	text-align: left;
+	text-decoration: none;
 	opacity: 0.3;
 	transition: opacity 0.2s ease, color 0.2s ease;
-	cursor: text;
 	outline: none;
+	min-height: 0;
+	min-width: 0;
 
 	// When custom nav colors are set, use explicit colors
 	.dsgo-scroll-slides--has-nav-color & {
@@ -119,18 +126,38 @@
 		color: var(--dsgo-nav-active-color, var(--dsgo-nav-color, inherit));
 	}
 
-	&:hover {
-		opacity: 0.6;
-	}
-
+	&:hover,
 	&:focus {
-		opacity: 1;
-		border-bottom-color: currentcolor;
+		opacity: 0.6;
+		text-decoration: none;
 	}
 
 	&::placeholder {
 		color: inherit;
 		opacity: 0.3;
+	}
+}
+
+// Input-only — the freeform editable nav heading is a typed field, so
+// give it a text cursor and a focus underline cue so authors notice it.
+.dsgo-scroll-slides__editor-nav input.dsgo-scroll-slides__editor-nav-input {
+	cursor: text;
+	border-bottom: 1px solid transparent;
+
+	&:focus {
+		opacity: 1;
+		border-bottom-color: currentcolor;
+	}
+}
+
+// Button variant — query-mode nav is a read-only clickable label, so
+// show a pointer and keep focus subtle (no underline to match the
+// frontend nav behavior).
+.dsgo-scroll-slides__editor-nav button.dsgo-scroll-slides__editor-nav-input {
+	cursor: pointer;
+
+	.dsgo-scroll-slides__editor-nav-item.is-active & {
+		opacity: 1;
 	}
 }
 
@@ -141,6 +168,18 @@
  * This is editor-only — the saved HTML retains the inline styles for view.js.
  */
 .dsgo-scroll-slides [data-type="designsetgo/scroll-slide"] {
+	background-image: none !important;
+	background-color: transparent !important;
+}
+
+/**
+ * Readonly preview items (panels 1..N in query mode) ship the same inline
+ * background-image that view.js lifts into the crossfading layer at
+ * runtime. In the editor that hoist never happens, so the featured image
+ * would render both on the outer __editor-bg AND inside the panel box.
+ * Unset the inline bg with !important to defeat the inline style.
+ */
+.dsgo-scroll-slides__editor-readonly-item .dsgo-scroll-slide {
 	background-image: none !important;
 	background-color: transparent !important;
 }
@@ -204,10 +243,15 @@
 
 // Query-bound editor preview — the block-editor-managed template slot
 // sits alongside read-only server-rendered panels inside the panels grid.
-// `display: contents` keeps the slot wrapper transparent to layout.
 .wp-block-designsetgo-scroll-slides {
+
 	.dsgo-scroll-slides__editor-template-slot {
-		display: contents;
+		// Outside query mode, panels rely on nth-child selectors walking
+		// the real block-editor tree, which means the wrapper needs to be
+		// transparent to layout. In query mode, nth-child is applied to
+		// direct panel children, so a block-level template slot is fine
+		// (and is required for the active-panel toggle below).
+		display: block;
 	}
 
 	.dsgo-scroll-slides__editor-readonly-item {
@@ -222,3 +266,29 @@
 		border-radius: 4px;
 	}
 }
+
+/**
+ * Query-mode panels — one template slot at index 0 plus N read-only items
+ * at indices 1..N. Hide all by default and show the active one via the
+ * container's data-dsgo-active-slide attribute. This mirrors the authored
+ * mode's nth-child logic but targets direct children so both the
+ * template-slot div and the read-only-item divs are toggled together.
+ */
+/* stylelint-disable no-descending-specificity */
+.dsgo-scroll-slides__editor-panels--query-mode > * {
+	display: none;
+}
+
+.dsgo-scroll-slides[data-dsgo-active-slide="0"] .dsgo-scroll-slides__editor-panels--query-mode > :nth-child(1),
+.dsgo-scroll-slides[data-dsgo-active-slide="1"] .dsgo-scroll-slides__editor-panels--query-mode > :nth-child(2),
+.dsgo-scroll-slides[data-dsgo-active-slide="2"] .dsgo-scroll-slides__editor-panels--query-mode > :nth-child(3),
+.dsgo-scroll-slides[data-dsgo-active-slide="3"] .dsgo-scroll-slides__editor-panels--query-mode > :nth-child(4),
+.dsgo-scroll-slides[data-dsgo-active-slide="4"] .dsgo-scroll-slides__editor-panels--query-mode > :nth-child(5),
+.dsgo-scroll-slides[data-dsgo-active-slide="5"] .dsgo-scroll-slides__editor-panels--query-mode > :nth-child(6),
+.dsgo-scroll-slides[data-dsgo-active-slide="6"] .dsgo-scroll-slides__editor-panels--query-mode > :nth-child(7),
+.dsgo-scroll-slides[data-dsgo-active-slide="7"] .dsgo-scroll-slides__editor-panels--query-mode > :nth-child(8),
+.dsgo-scroll-slides[data-dsgo-active-slide="8"] .dsgo-scroll-slides__editor-panels--query-mode > :nth-child(9),
+.dsgo-scroll-slides[data-dsgo-active-slide="9"] .dsgo-scroll-slides__editor-panels--query-mode > :nth-child(10) {
+	display: block;
+}
+/* stylelint-enable no-descending-specificity */

--- a/src/blocks/scroll-slides/editor.scss
+++ b/src/blocks/scroll-slides/editor.scss
@@ -201,3 +201,24 @@
 		grid-template-columns: 1fr;
 	}
 }
+
+// Query-bound editor preview — the block-editor-managed template slot
+// sits alongside read-only server-rendered panels inside the panels grid.
+// `display: contents` keeps the slot wrapper transparent to layout.
+.wp-block-designsetgo-scroll-slides {
+	.dsgo-scroll-slides__editor-template-slot {
+		display: contents;
+	}
+
+	.dsgo-scroll-slides__editor-readonly-item {
+		pointer-events: none;
+	}
+
+	.dsgo-scroll-slides__editor-empty-hint {
+		padding: 1.25rem;
+		font-size: 0.875rem;
+		color: #6c7180;
+		background: rgba(0, 0, 0, 0.03);
+		border-radius: 4px;
+	}
+}

--- a/src/blocks/scroll-slides/render.php
+++ b/src/blocks/scroll-slides/render.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Scroll Slides — server render.
+ *
+ * Two modes:
+ *
+ * 1. Authored (no query context): echoes $content unchanged so the static
+ *    save.js output passes through untouched.
+ *
+ * 2. Query-bound (parent designsetgo/query provides `designsetgo/queryId`):
+ *    rebuilds the scroll-slides chrome in PHP (mirroring save.js) and
+ *    injects the pre-rendered items from the parent container's stash.
+ *    Each item is a full designsetgo/scroll-slide render with per-post
+ *    context; this file just wraps them in the panels/inner/outer divs.
+ *
+ * NOTE: the chrome below MUST stay in sync with src/blocks/scroll-slides/save.js.
+ * If save.js gains a new wrapper or attribute, mirror it here too.
+ *
+ * @package DesignSetGo
+ * @since   2.2.0
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Pre-rendered save.js output.
+ * @param WP_Block $block      Block instance (carries context).
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$query_id = '';
+if ( isset( $block->context['designsetgo/queryId'] ) ) {
+	$query_id = sanitize_key( (string) $block->context['designsetgo/queryId'] );
+}
+
+// Authored mode — pass through unchanged. block.json `render` captures the
+// output buffer so we ECHO rather than return.
+if ( '' === $query_id ) {
+	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
+	return;
+}
+
+// Query mode — pull pre-rendered items from the parent container's stash.
+$items_html = '';
+if ( isset( $GLOBALS['designsetgo_query_items_html'][ $query_id ] ) ) {
+	$items_html = (string) $GLOBALS['designsetgo_query_items_html'][ $query_id ];
+}
+
+$atts = wp_parse_args(
+	$attributes,
+	array(
+		'minHeight'      => '100vh',
+		'maxHeight'      => '900px',
+		'constrainWidth' => true,
+		'contentWidth'   => '',
+		'overlayColor'   => '',
+		'navColor'       => '',
+		'navActiveColor' => '',
+	)
+);
+
+// Minimal parity with save.js's convertColorToCSSVar(): convert the WP preset
+// shorthand (`var:preset|color|slug`) to a real `var(...)`, otherwise pass
+// through as-is (hex/rgb/CSS keywords already work inline).
+$color_to_css = static function ( $value ) {
+	$value = (string) $value;
+	if ( '' === $value ) {
+		return '';
+	}
+	if ( 0 === strpos( $value, 'var:preset|' ) ) {
+		$parts = explode( '|', substr( $value, strlen( 'var:preset|' ) ) );
+		return 'var(--wp--preset--' . implode( '--', $parts ) . ')';
+	}
+	return $value;
+};
+
+$classes = array( 'dsgo-scroll-slides' );
+if ( '' !== $atts['overlayColor'] ) {
+	$classes[] = 'dsgo-scroll-slides--has-overlay';
+}
+if ( empty( $atts['constrainWidth'] ) ) {
+	$classes[] = 'dsgo-scroll-slides--no-width-constraint';
+}
+if ( '' !== $atts['navColor'] || '' !== $atts['navActiveColor'] ) {
+	$classes[] = 'dsgo-scroll-slides--has-nav-color';
+}
+
+$style_parts = array();
+if ( '' !== $atts['overlayColor'] ) {
+	$style_parts[] = '--dsgo-overlay-color:' . $color_to_css( $atts['overlayColor'] );
+	$style_parts[] = '--dsgo-overlay-opacity:0.8';
+}
+if ( '' !== $atts['navColor'] ) {
+	$style_parts[] = '--dsgo-nav-color:' . $color_to_css( $atts['navColor'] );
+}
+if ( '' !== $atts['navActiveColor'] ) {
+	$style_parts[] = '--dsgo-nav-active-color:' . $color_to_css( $atts['navActiveColor'] );
+}
+$style_inline = implode( ';', $style_parts );
+if ( '' !== $style_inline ) {
+	$style_inline .= ';';
+}
+
+$wrapper_attrs_list = array(
+	'class'                => implode( ' ', $classes ),
+	'data-dsgo-min-height' => $atts['minHeight'] !== '' ? $atts['minHeight'] : '100vh',
+);
+if ( '' !== $atts['maxHeight'] ) {
+	$wrapper_attrs_list['data-dsgo-max-height'] = $atts['maxHeight'];
+}
+if ( '' !== $style_inline ) {
+	$wrapper_attrs_list['style'] = $style_inline;
+}
+
+$wrapper_attrs = get_block_wrapper_attributes( $wrapper_attrs_list );
+
+$inner_style = '';
+if ( ! empty( $atts['constrainWidth'] ) ) {
+	$max_width   = $atts['contentWidth'] !== ''
+		? $atts['contentWidth']
+		: 'var(--wp--style--global--content-size, 1140px)';
+	$inner_style = ' style="max-width:' . esc_attr( $max_width ) . ';margin-left:auto;margin-right:auto"';
+}
+
+printf(
+	'<div %1$s><div class="dsgo-scroll-slides__inner"%2$s><div class="dsgo-scroll-slides__panels">%3$s</div></div></div>',
+	$wrapper_attrs, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped via get_block_wrapper_attributes().
+	$inner_style,   // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- assembled from esc_attr().
+	$items_html     // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- items rendered via WP_Block (WP escapes server-side).
+);

--- a/src/blocks/scroll-slides/render.php
+++ b/src/blocks/scroll-slides/render.php
@@ -39,6 +39,15 @@ if ( '' === $query_id ) {
 }
 
 // Query mode — pull pre-rendered items from the parent container's stash.
+// Inner blocks render before their parent's render_callback fires, so we
+// can't rely on the query container having loaded the shared helpers yet.
+$helpers = DESIGNSETGO_PATH . 'build/blocks/query/render-helpers.php';
+if ( ! file_exists( $helpers ) ) {
+	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
+	return;
+}
+require_once $helpers;
+
 $items_html = '';
 if ( isset( $GLOBALS['designsetgo_query_items_html'][ $query_id ] ) ) {
 	$items_html = (string) $GLOBALS['designsetgo_query_items_html'][ $query_id ];

--- a/src/blocks/scroll-slides/render.php
+++ b/src/blocks/scroll-slides/render.php
@@ -17,7 +17,7 @@
  * If save.js gains a new wrapper or attribute, mirror it here too.
  *
  * @package DesignSetGo
- * @since   2.2.0
+ * @since   2.6.0
  *
  * @param array    $attributes Block attributes.
  * @param string   $content    Pre-rendered save.js output.
@@ -60,16 +60,23 @@ $atts = wp_parse_args(
 // Minimal parity with save.js's convertColorToCSSVar(): convert the WP preset
 // shorthand (`var:preset|color|slug`) to a real `var(...)`, otherwise pass
 // through as-is (hex/rgb/CSS keywords already work inline).
+//
+// Both branches run the final value through designsetgo_safe_css_value() so a
+// stored color like `red; content:'x'` or a crafted slug like `slug);}` can't
+// escape the `--prop: VALUE` declaration. Preset slug segments are also
+// constrained via sanitize_html_class() so only identifier characters survive.
 $color_to_css = static function ( $value ) {
 	$value = (string) $value;
 	if ( '' === $value ) {
 		return '';
 	}
 	if ( 0 === strpos( $value, 'var:preset|' ) ) {
-		$parts = explode( '|', substr( $value, strlen( 'var:preset|' ) ) );
-		return 'var(--wp--preset--' . implode( '--', $parts ) . ')';
+		$parts  = explode( '|', substr( $value, strlen( 'var:preset|' ) ) );
+		$parts  = array_filter( array_map( 'sanitize_html_class', $parts ) );
+		$result = 'var(--wp--preset--' . implode( '--', $parts ) . ')';
+		return designsetgo_safe_css_value( $result );
 	}
-	return $value;
+	return designsetgo_safe_css_value( $value );
 };
 
 $classes = array( 'dsgo-scroll-slides' );
@@ -99,12 +106,19 @@ if ( '' !== $style_inline ) {
 	$style_inline .= ';';
 }
 
+$min_height = designsetgo_safe_css_value( $atts['minHeight'] );
+if ( '' === $min_height ) {
+	$min_height = '100vh';
+}
 $wrapper_attrs_list = array(
 	'class'                => implode( ' ', $classes ),
-	'data-dsgo-min-height' => $atts['minHeight'] !== '' ? $atts['minHeight'] : '100vh',
+	'data-dsgo-min-height' => $min_height,
 );
 if ( '' !== $atts['maxHeight'] ) {
-	$wrapper_attrs_list['data-dsgo-max-height'] = $atts['maxHeight'];
+	$max_h = designsetgo_safe_css_value( $atts['maxHeight'] );
+	if ( '' !== $max_h ) {
+		$wrapper_attrs_list['data-dsgo-max-height'] = $max_h;
+	}
 }
 if ( '' !== $style_inline ) {
 	$wrapper_attrs_list['style'] = $style_inline;
@@ -114,9 +128,12 @@ $wrapper_attrs = get_block_wrapper_attributes( $wrapper_attrs_list );
 
 $inner_style = '';
 if ( ! empty( $atts['constrainWidth'] ) ) {
-	$max_width   = $atts['contentWidth'] !== ''
-		? $atts['contentWidth']
+	$max_width = $atts['contentWidth'] !== ''
+		? designsetgo_safe_css_value( $atts['contentWidth'] )
 		: 'var(--wp--style--global--content-size, 1140px)';
+	if ( '' === $max_width ) {
+		$max_width = 'var(--wp--style--global--content-size, 1140px)';
+	}
 	$inner_style = ' style="max-width:' . esc_attr( $max_width ) . ';margin-left:auto;margin-right:auto"';
 }
 

--- a/src/blocks/scroll-slides/style.scss
+++ b/src/blocks/scroll-slides/style.scss
@@ -84,9 +84,11 @@
 	position: relative;
 }
 
-.dsgo-scroll-slides__nav-item {
+.dsgo-scroll-slides .dsgo-scroll-slides__nav-item {
 	background: none;
 	border: none;
+	border-radius: 0;
+	box-shadow: none;
 	cursor: pointer;
 	text-align: left;
 	font-size: clamp(1.5rem, 3vw, 2.5rem);
@@ -97,6 +99,8 @@
 	padding: 0.25rem 0;
 	line-height: 1.2;
 	font-family: inherit;
+	min-height: 0;
+	min-width: 0;
 
 	&:hover {
 		opacity: 0.6;

--- a/src/blocks/slider/block.json
+++ b/src/blocks/slider/block.json
@@ -174,6 +174,13 @@
 		"designsetgo/slider/activeSlide": "activeSlide",
 		"designsetgo/slider/styleVariation": "styleVariation"
 	},
+	"usesContext": [
+		"designsetgo/queryId",
+		"designsetgo/querySource",
+		"designsetgo/queryPostType",
+		"designsetgo/currentItemId",
+		"designsetgo/currentItemType"
+	],
 	"supports": {
 		"anchor": true,
 		"align": [
@@ -236,5 +243,6 @@
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
 	"style": "file:./style-index.css",
-	"viewScript": "file:./view.js"
+	"viewScript": "file:./view.js",
+	"render": "file:./render.php"
 }

--- a/src/blocks/slider/edit.js
+++ b/src/blocks/slider/edit.js
@@ -1,12 +1,11 @@
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useMemo, useRef } from '@wordpress/element';
 import {
 	useBlockProps,
 	useInnerBlocksProps,
 	BlockControls,
 	InspectorControls,
 	BlockContextProvider,
-	store as blockEditorStore,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
 } from '@wordpress/block-editor';
@@ -37,6 +36,7 @@ import DsgoChildToolbar from '../../components/shared/DsgoChildToolbar';
 import useQueryHostPreview, {
 	buildItemContext,
 } from '../query/hooks/useQueryHostPreview';
+import useParentQueryAttrs from '../query/hooks/useParentQueryAttrs';
 import QueryHostReadOnlyItem from '../query/components/QueryHostReadOnlyItem';
 
 const SINGLE_SLIDE_EFFECTS = ['fade', 'zoom'];
@@ -154,27 +154,15 @@ export default function SliderEdit({
 	// When bound to a parent Dynamic Query, walk up to the parent's attributes
 	// so the editor preview uses the same query config (postType, perPage,
 	// filters, orderBy) the frontend will. Runs only when inQueryMode.
-	const parentQueryAttrs = useSelect(
-		(select) => {
-			if (!inQueryMode) {
-				return null;
-			}
-			const { getBlockParents, getBlock } = select(blockEditorStore);
-			const parents = getBlockParents(clientId);
-			for (const parentId of parents) {
-				const parent = getBlock(parentId);
-				if (parent?.name === 'designsetgo/query') {
-					return parent.attributes;
-				}
-			}
-			return null;
-		},
-		[clientId, inQueryMode]
-	);
+	const parentQueryAttrs = useParentQueryAttrs(clientId, inQueryMode);
 
-	// The per-item template is the first slide block. Extras are ignored at
-	// render; the editor shows a warning when slideCount > 1.
-	const templateSlideBlocks = slides.slice(0, 1);
+	// The per-item template is the first slide block. Memoize to avoid
+	// allocating a new array on every render — useQueryHostPreview /
+	// useRenderedItems depend on stable references to avoid re-serializing.
+	const templateSlideBlocks = useMemo(
+		() => (slides.length > 0 ? [slides[0]] : []),
+		[slides]
+	);
 
 	const preview = useQueryHostPreview({
 		attributes: parentQueryAttrs,
@@ -439,6 +427,10 @@ export default function SliderEdit({
 					removeLabel={__('Remove slide', 'designsetgo')}
 					movePrevLabel={__('Move slide left', 'designsetgo')}
 					moveNextLabel={__('Move slide right', 'designsetgo')}
+					disableAdd={inQueryMode}
+					disableDuplicate={inQueryMode}
+					disableRemove={inQueryMode}
+					disableMove={inQueryMode}
 				/>
 			</BlockControls>
 
@@ -450,7 +442,7 @@ export default function SliderEdit({
 					>
 						<Notice status="info" isDismissible={false}>
 							{__(
-								'This slider is bound to a parent Dynamic Query. The first slide is the per-item template — extra slides are ignored at render. Add or Remove in the toolbar is disabled while bound.',
+								'This slider is bound to a parent Dynamic Query. The first slide is the per-item template — extra slides are ignored at render. Slide management controls are disabled while bound.',
 								'designsetgo'
 							)}
 						</Notice>
@@ -1209,6 +1201,7 @@ export default function SliderEdit({
 												'Duplicate slide',
 												'designsetgo'
 											)}
+											disabled={inQueryMode}
 											onClick={() =>
 												handleDuplicateSlide(
 													slide,
@@ -1228,6 +1221,7 @@ export default function SliderEdit({
 												'Remove slide',
 												'designsetgo'
 											)}
+											disabled={inQueryMode}
 											onClick={() =>
 												handleRemoveSlide(slide)
 											}
@@ -1240,6 +1234,7 @@ export default function SliderEdit({
 							size="small"
 							icon={plus}
 							className="dsgo-slider__nav-add"
+							disabled={inQueryMode}
 							onClick={handleAddSlide}
 						>
 							{__('Add slide', 'designsetgo')}

--- a/src/blocks/slider/edit.js
+++ b/src/blocks/slider/edit.js
@@ -35,7 +35,21 @@ import DsgoChildToolbar from '../../components/shared/DsgoChildToolbar';
 
 const SINGLE_SLIDE_EFFECTS = ['fade', 'zoom'];
 
-export default function SliderEdit({ attributes, setAttributes, clientId }) {
+export default function SliderEdit({
+	attributes,
+	setAttributes,
+	clientId,
+	context,
+}) {
+	// When the slider sits inside a Dynamic Query, the parent provides a
+	// queryId via context. In that mode the slider becomes an item host: the
+	// first slide acts as the per-item template, extras are ignored
+	// server-side, and the toolbar's Add/Remove controls are locked out.
+	const queryId =
+		typeof context === 'object' && context
+			? context['designsetgo/queryId'] || ''
+			: '';
+	const inQueryMode = !!queryId;
 	const {
 		slidesPerView,
 		slidesPerViewTablet,
@@ -330,7 +344,9 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 
 	// Inner blocks configuration - ONLY allow slide children. Initial seeding
 	// is handled by SliderPlaceholder so authors pick a starter layout instead
-	// of landing on a generic three-slide template.
+	// of landing on a generic three-slide template. In query mode we also lock
+	// add/remove at the slider level — slides beyond the first are ignored at
+	// render, so allowing authors to add more would be misleading.
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'dsgo-slider__track',
@@ -338,6 +354,7 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 		{
 			allowedBlocks: ['designsetgo/slide'],
 			orientation: 'horizontal',
+			templateLock: inQueryMode ? 'insert' : false,
 		}
 	);
 
@@ -383,6 +400,31 @@ export default function SliderEdit({ attributes, setAttributes, clientId }) {
 			</BlockControls>
 
 			<InspectorControls>
+				{inQueryMode && (
+					<PanelBody
+						title={__('Dynamic mode', 'designsetgo')}
+						initialOpen={true}
+					>
+						<Notice status="info" isDismissible={false}>
+							{__(
+								'This slider is bound to a parent Dynamic Query. The first slide is the per-item template — extra slides are ignored at render. Add or Remove in the toolbar is disabled while bound.',
+								'designsetgo'
+							)}
+						</Notice>
+						{slideCount > 1 && (
+							<Notice status="warning" isDismissible={false}>
+								{sprintf(
+									/* translators: %d: number of slides that will not render */
+									__(
+										'%d extra slide(s) will be ignored at render. Only the first slide is used as the template.',
+										'designsetgo'
+									),
+									slideCount - 1
+								)}
+							</Notice>
+						)}
+					</PanelBody>
+				)}
 				<PanelBody
 					title={__('Layout Settings', 'designsetgo')}
 					initialOpen={true}

--- a/src/blocks/slider/edit.js
+++ b/src/blocks/slider/edit.js
@@ -5,6 +5,8 @@ import {
 	useInnerBlocksProps,
 	BlockControls,
 	InspectorControls,
+	BlockContextProvider,
+	store as blockEditorStore,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
 } from '@wordpress/block-editor';
@@ -32,6 +34,10 @@ import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
 import { useBlockColors } from '../../hooks';
 import SliderPlaceholder from './components/SliderPlaceholder';
 import DsgoChildToolbar from '../../components/shared/DsgoChildToolbar';
+import useQueryHostPreview, {
+	buildItemContext,
+} from '../query/hooks/useQueryHostPreview';
+import QueryHostReadOnlyItem from '../query/components/QueryHostReadOnlyItem';
 
 const SINGLE_SLIDE_EFFECTS = ['fade', 'zoom'];
 
@@ -144,6 +150,38 @@ export default function SliderEdit({
 		: -1;
 	const activeSlideIndex =
 		selectedSlideIndex >= 0 ? selectedSlideIndex : undefined;
+
+	// When bound to a parent Dynamic Query, walk up to the parent's attributes
+	// so the editor preview uses the same query config (postType, perPage,
+	// filters, orderBy) the frontend will. Runs only when inQueryMode.
+	const parentQueryAttrs = useSelect(
+		(select) => {
+			if (!inQueryMode) {
+				return null;
+			}
+			const { getBlockParents, getBlock } = select(blockEditorStore);
+			const parents = getBlockParents(clientId);
+			for (const parentId of parents) {
+				const parent = getBlock(parentId);
+				if (parent?.name === 'designsetgo/query') {
+					return parent.attributes;
+				}
+			}
+			return null;
+		},
+		[clientId, inQueryMode]
+	);
+
+	// The per-item template is the first slide block. Extras are ignored at
+	// render; the editor shows a warning when slideCount > 1.
+	const templateSlideBlocks = slides.slice(0, 1);
+
+	const preview = useQueryHostPreview({
+		attributes: parentQueryAttrs,
+		queryId,
+		innerBlocks: templateSlideBlocks,
+		enabled: inQueryMode && !!parentQueryAttrs,
+	});
 
 	const { insertBlock, removeBlock, selectBlock } =
 		useDispatch('core/block-editor');
@@ -346,10 +384,15 @@ export default function SliderEdit({
 	// is handled by SliderPlaceholder so authors pick a starter layout instead
 	// of landing on a generic three-slide template. In query mode we also lock
 	// add/remove at the slider level — slides beyond the first are ignored at
-	// render, so allowing authors to add more would be misleading.
+	// render, so allowing authors to add more would be misleading. The class
+	// name also switches: in authored mode this IS the track; in query mode
+	// it becomes a "display: contents" slot that sits inside a manually-built
+	// track alongside read-only preview items.
 	const innerBlocksProps = useInnerBlocksProps(
 		{
-			className: 'dsgo-slider__track',
+			className: inQueryMode
+				? 'dsgo-slider__editor-template-slot'
+				: 'dsgo-slider__track',
 		},
 		{
 			allowedBlocks: ['designsetgo/slide'],
@@ -1113,7 +1156,16 @@ export default function SliderEdit({
 
 			<div {...blockProps}>
 				<div className="dsgo-slider__viewport">
-					<div {...innerBlocksProps} />
+					{inQueryMode ? (
+						<QueryModeTrack
+							innerBlocksProps={innerBlocksProps}
+							preview={preview}
+							parentQueryAttrs={parentQueryAttrs}
+							outerContext={context}
+						/>
+					) : (
+						<div {...innerBlocksProps} />
+					)}
 				</div>
 
 				{/* Editor-only slide navigator */}
@@ -1239,5 +1291,78 @@ export default function SliderEdit({
 				)}
 			</div>
 		</>
+	);
+}
+
+/**
+ * Render the slider track in query-bound mode: item 0 wraps the editable
+ * InnerBlocks slot (the template slide), items 1..N are read-only server-
+ * rendered slides. Each item is wrapped in a BlockContextProvider so any
+ * Block Bindings inside the template resolve against the iterated post.
+ */
+function QueryModeTrack({
+	innerBlocksProps,
+	preview,
+	parentQueryAttrs,
+	outerContext,
+}) {
+	const source = parentQueryAttrs?.source || 'posts';
+	const { records, hasResolved, serverHtml, loading } = preview;
+
+	if (!hasResolved) {
+		return (
+			<div className="dsgo-slider__track dsgo-slider__track--query-loading">
+				<div {...innerBlocksProps} />
+			</div>
+		);
+	}
+
+	const items = Array.isArray(records) ? records : [];
+
+	if (items.length === 0) {
+		return (
+			<div className="dsgo-slider__track dsgo-slider__track--query-empty">
+				<div {...innerBlocksProps} />
+				<div
+					className="dsgo-slider__editor-empty-hint"
+					contentEditable={false}
+					aria-hidden="true"
+				>
+					{__(
+						'No posts match the parent query. Design the template slide above \u2014 it will render once per result at publish time.',
+						'designsetgo'
+					)}
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="dsgo-slider__track">
+			{items.map((item, idx) => {
+				const itemContext = buildItemContext(
+					item,
+					source,
+					idx,
+					outerContext
+				);
+				return (
+					<BlockContextProvider
+						key={item.id ?? idx}
+						value={itemContext}
+					>
+						{idx === 0 ? (
+							<div {...innerBlocksProps} />
+						) : (
+							<QueryHostReadOnlyItem
+								className="dsgo-slider__editor-readonly-item"
+								html={serverHtml?.[idx] ?? null}
+								loading={loading}
+							/>
+						)}
+					</BlockContextProvider>
+				);
+			})}
+		</div>
 	);
 }

--- a/src/blocks/slider/edit.js
+++ b/src/blocks/slider/edit.js
@@ -1146,7 +1146,18 @@ export default function SliderEdit({
 				</InspectorControls>
 			)}
 
-			<div {...blockProps}>
+			<div
+				{...blockProps}
+				onClickCapture={(event) => {
+					// Kill link navigation inside the editor — real anchors come
+					// from authored post-title/featured-image blocks and from
+					// server-rendered readonly slides in query mode.
+					const anchor = event.target.closest?.('a[href]');
+					if (anchor) {
+						event.preventDefault();
+					}
+				}}
+			>
 				<div className="dsgo-slider__viewport">
 					{inQueryMode ? (
 						<QueryModeTrack
@@ -1294,6 +1305,11 @@ export default function SliderEdit({
  * InnerBlocks slot (the template slide), items 1..N are read-only server-
  * rendered slides. Each item is wrapped in a BlockContextProvider so any
  * Block Bindings inside the template resolve against the iterated post.
+ * @param root0
+ * @param root0.innerBlocksProps
+ * @param root0.preview
+ * @param root0.parentQueryAttrs
+ * @param root0.outerContext
  */
 function QueryModeTrack({
 	innerBlocksProps,

--- a/src/blocks/slider/editor.scss
+++ b/src/blocks/slider/editor.scss
@@ -264,17 +264,24 @@
 // ---------------------------------------------------------------------------
 // Query-bound editor preview. The block-editor-managed template slot sits
 // inside a manually-built track alongside read-only server-rendered slides.
-// `display: contents` makes the slot wrapper transparent so the single
-// authored slide participates in the track's flex layout directly.
+// Give the slot the same flex-basis that .dsgo-slider__track > .dsgo-slide
+// would receive on the frontend — we can't use `display: contents` here
+// because the slider's `> .dsgo-slide` rule matches the DOM tree, and the
+// block-editor always wraps the slide in this intermediate div, so the
+// slide never becomes a DOM direct child of the track and the rule misses.
+// Without the explicit flex-basis below the slot collapses to width 0 and
+// the slide's text content wraps to absurd heights.
 // ---------------------------------------------------------------------------
 .wp-block-designsetgo-slider {
+
 	.dsgo-slider__editor-template-slot {
-		display: contents;
+		flex: 0 0 calc((100% - (var(--dsgo-slider-gap) * (var(--dsgo-slider-slides-per-view) - 1))) / var(--dsgo-slider-slides-per-view));
+		min-width: 0;
+		display: flex;
 	}
 
 	.dsgo-slider__editor-readonly-item {
-		flex: 0 0 auto;
-		width: 100%;
+		flex: 0 0 calc((100% - (var(--dsgo-slider-gap) * (var(--dsgo-slider-slides-per-view) - 1))) / var(--dsgo-slider-slides-per-view));
 		min-width: 0;
 		pointer-events: none;
 	}

--- a/src/blocks/slider/editor.scss
+++ b/src/blocks/slider/editor.scss
@@ -260,3 +260,36 @@
 		margin-left: auto;
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Query-bound editor preview. The block-editor-managed template slot sits
+// inside a manually-built track alongside read-only server-rendered slides.
+// `display: contents` makes the slot wrapper transparent so the single
+// authored slide participates in the track's flex layout directly.
+// ---------------------------------------------------------------------------
+.wp-block-designsetgo-slider {
+	.dsgo-slider__editor-template-slot {
+		display: contents;
+	}
+
+	.dsgo-slider__editor-readonly-item {
+		flex: 0 0 auto;
+		width: 100%;
+		min-width: 0;
+		pointer-events: none;
+	}
+
+	.dsgo-slider__editor-empty-hint {
+		flex: 1 1 auto;
+		padding: 1.25rem;
+		font-size: 0.875rem;
+		color: #6c7180;
+		background: rgba(0, 0, 0, 0.03);
+		border-radius: 4px;
+	}
+
+	.dsgo-slider__track--query-loading,
+	.dsgo-slider__track--query-empty {
+		min-height: 120px;
+	}
+}

--- a/src/blocks/slider/render.php
+++ b/src/blocks/slider/render.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * Slider — server render.
+ *
+ * Two modes:
+ *
+ * 1. Authored (no query context): returns $content unchanged so the static
+ *    save.js output passes through untouched.
+ *
+ * 2. Query-bound (parent designsetgo/query provides `designsetgo/queryId`):
+ *    rebuilds the slider chrome in PHP (mirroring save.js) and injects the
+ *    pre-rendered items from $GLOBALS['designsetgo_query_items_html']. The
+ *    parent query container iterates once and stashes raw item HTML (each
+ *    item is a full designsetgo/slide render with per-post context), so the
+ *    slider here just wraps that HTML in the track/viewport/outer divs.
+ *
+ * NOTE: the chrome below MUST stay in sync with src/blocks/slider/save.js.
+ * If save.js gains a new wrapper or attribute, mirror it here too — otherwise
+ * query-mode output diverges visually from authored-mode output.
+ *
+ * @package DesignSetGo
+ * @since   2.2.0
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Pre-rendered save.js output.
+ * @param WP_Block $block      Block instance (carries context).
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$query_id = '';
+if ( isset( $block->context['designsetgo/queryId'] ) ) {
+	$query_id = sanitize_key( (string) $block->context['designsetgo/queryId'] );
+}
+
+// Authored mode — slider behaves exactly as it did before the query integration.
+// block.json `render` wires this file as a render_callback that captures its
+// output buffer (require + ob_get_clean). So we ECHO rather than return.
+if ( '' === $query_id ) {
+	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
+	return;
+}
+
+// Query mode — pull pre-rendered items from the parent container's stash.
+$items_html = '';
+if ( isset( $GLOBALS['designsetgo_query_items_html'][ $query_id ] ) ) {
+	$items_html = (string) $GLOBALS['designsetgo_query_items_html'][ $query_id ];
+}
+
+$atts = wp_parse_args(
+	$attributes,
+	array(
+		'slidesPerView'         => 1,
+		'slidesPerViewTablet'   => 1,
+		'slidesPerViewMobile'   => 1,
+		'height'                => '',
+		'aspectRatio'           => '16/9',
+		'useAspectRatio'        => false,
+		'gap'                   => '20px',
+		'showArrows'            => true,
+		'showDots'              => true,
+		'arrowStyle'            => 'default',
+		'arrowPosition'         => 'sides',
+		'arrowVerticalPosition' => 'center',
+		'arrowColor'            => '',
+		'arrowBackgroundColor'  => '',
+		'arrowSize'             => '24px',
+		'arrowPadding'          => '',
+		'dotStyle'              => 'default',
+		'dotPosition'           => 'inside',
+		'dotColor'              => '',
+		'effect'                => 'slide',
+		'transitionDuration'    => '0.5s',
+		'transitionEasing'      => 'ease-in-out',
+		'autoplay'              => false,
+		'autoplayInterval'      => 3000,
+		'pauseOnHover'          => true,
+		'pauseOnInteraction'    => true,
+		'loop'                  => true,
+		'draggable'             => true,
+		'swipeable'             => true,
+		'freeMode'              => false,
+		'centeredSlides'        => false,
+		'mobileBreakpoint'      => 768,
+		'tabletBreakpoint'      => 1024,
+		'activeSlide'           => 0,
+		'styleVariation'        => 'classic',
+		'ariaLabel'             => '',
+		'scrollDriven'          => false,
+		'scrollDrivenSpeed'     => 1,
+	)
+);
+
+// Effects that force a single slide per view (mirrors SINGLE_SLIDE_EFFECTS in save.js).
+$single_effects = array( 'fade', 'zoom' );
+$forces_single  = in_array( $atts['effect'], $single_effects, true );
+
+$spv        = $forces_single ? 1 : (int) $atts['slidesPerView'];
+$spv_tablet = $forces_single ? 1 : (int) $atts['slidesPerViewTablet'];
+$spv_mobile = $forces_single ? 1 : (int) $atts['slidesPerViewMobile'];
+
+// Build class list. Order matches save.js for snapshot-friendly diffs.
+$classes = array( 'dsgo-slider' );
+if ( ! empty( $atts['styleVariation'] ) ) {
+	$classes[] = 'dsgo-slider--' . sanitize_html_class( (string) $atts['styleVariation'] );
+}
+if ( ! empty( $atts['effect'] ) ) {
+	$classes[] = 'dsgo-slider--effect-' . sanitize_html_class( (string) $atts['effect'] );
+}
+if ( $atts['showArrows'] ) {
+	$classes[] = 'dsgo-slider--has-arrows';
+}
+if ( $atts['showDots'] ) {
+	$classes[] = 'dsgo-slider--has-dots';
+}
+if ( $atts['centeredSlides'] ) {
+	$classes[] = 'dsgo-slider--centered';
+}
+if ( $atts['freeMode'] ) {
+	$classes[] = 'dsgo-slider--free-mode';
+}
+if ( $atts['scrollDriven'] ) {
+	$classes[] = 'dsgo-slider--scroll-driven';
+}
+
+// CSS custom properties. Only emit keys save.js would emit to keep diffs tight.
+$style_parts = array();
+if ( '' !== $atts['height'] ) {
+	$style_parts[] = '--dsgo-slider-height:' . $atts['height'];
+}
+$style_parts[] = '--dsgo-slider-aspect-ratio:' . $atts['aspectRatio'];
+$style_parts[] = '--dsgo-slider-gap:' . $atts['gap'];
+$style_parts[] = '--dsgo-slider-transition:' . $atts['transitionDuration'];
+$style_parts[] = '--dsgo-slider-slides-per-view:' . $spv;
+$style_parts[] = '--dsgo-slider-slides-per-view-tablet:' . $spv_tablet;
+$style_parts[] = '--dsgo-slider-slides-per-view-mobile:' . $spv_mobile;
+if ( '' !== $atts['arrowColor'] ) {
+	$style_parts[] = '--dsgo-slider-arrow-color:' . $atts['arrowColor'];
+}
+if ( '' !== $atts['arrowBackgroundColor'] ) {
+	$style_parts[] = '--dsgo-slider-arrow-bg-color:' . $atts['arrowBackgroundColor'];
+}
+if ( '' !== $atts['dotColor'] ) {
+	$style_parts[] = '--dsgo-slider-dot-color:' . $atts['dotColor'];
+}
+if ( '' !== $atts['arrowSize'] ) {
+	$style_parts[] = '--dsgo-slider-arrow-size:' . $atts['arrowSize'];
+}
+if ( '' !== $atts['arrowPadding'] ) {
+	$style_parts[] = '--dsgo-slider-arrow-padding:' . $atts['arrowPadding'];
+}
+$style_inline = implode( ';', $style_parts ) . ';';
+
+// Merge with get_block_wrapper_attributes() so native supports (padding, margin,
+// color, border, etc.) flow through to query-mode output identically.
+$wrapper_attrs = get_block_wrapper_attributes(
+	array(
+		'class'                => implode( ' ', $classes ),
+		'style'                => $style_inline,
+		'role'                 => 'region',
+		'aria-label'           => $atts['ariaLabel'] !== '' ? $atts['ariaLabel'] : __( 'Image slider', 'designsetgo' ),
+		'aria-roledescription' => 'slider',
+	)
+);
+
+// Data attributes read by view.js. Booleans serialize as the literal "true"/"false"
+// strings — matching how React's save.js emits them via JSX attribute props.
+$bool = static function ( $value ) {
+	return $value ? 'true' : 'false';
+};
+
+$data_attrs = array(
+	'data-slides-per-view'         => (string) $spv,
+	'data-slides-per-view-tablet'  => (string) $spv_tablet,
+	'data-slides-per-view-mobile'  => (string) $spv_mobile,
+	'data-use-aspect-ratio'        => $bool( $atts['useAspectRatio'] ),
+	'data-show-arrows'             => $bool( $atts['showArrows'] ),
+	'data-show-dots'               => $bool( $atts['showDots'] ),
+	'data-arrow-style'             => (string) $atts['arrowStyle'],
+	'data-arrow-position'          => (string) $atts['arrowPosition'],
+	'data-arrow-vertical-position' => (string) $atts['arrowVerticalPosition'],
+	'data-dot-style'               => (string) $atts['dotStyle'],
+	'data-dot-position'            => (string) $atts['dotPosition'],
+	'data-effect'                  => (string) $atts['effect'],
+	'data-transition-duration'     => (string) $atts['transitionDuration'],
+	'data-transition-easing'       => (string) $atts['transitionEasing'],
+	'data-autoplay'                => $bool( $atts['autoplay'] ),
+	'data-autoplay-interval'       => (string) (int) $atts['autoplayInterval'],
+	'data-pause-on-hover'          => $bool( $atts['pauseOnHover'] ),
+	'data-pause-on-interaction'    => $bool( $atts['pauseOnInteraction'] ),
+	'data-loop'                    => $bool( $atts['loop'] ),
+	'data-draggable'               => $bool( $atts['draggable'] ),
+	'data-swipeable'               => $bool( $atts['swipeable'] ),
+	'data-free-mode'               => $bool( $atts['freeMode'] ),
+	'data-centered-slides'         => $bool( $atts['centeredSlides'] ),
+	'data-mobile-breakpoint'       => (string) (int) $atts['mobileBreakpoint'],
+	'data-tablet-breakpoint'       => (string) (int) $atts['tabletBreakpoint'],
+	'data-active-slide'            => (string) (int) $atts['activeSlide'],
+);
+
+if ( $atts['scrollDriven'] ) {
+	$data_attrs['data-scroll-driven']       = 'true';
+	$data_attrs['data-scroll-driven-speed'] = (string) $atts['scrollDrivenSpeed'];
+}
+
+$data_string = '';
+foreach ( $data_attrs as $k => $v ) {
+	$data_string .= ' ' . esc_attr( $k ) . '="' . esc_attr( $v ) . '"';
+}
+
+printf(
+	'<div %1$s%2$s><div class="dsgo-slider__viewport"><div class="dsgo-slider__track">%3$s</div></div></div>',
+	$wrapper_attrs, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped via get_block_wrapper_attributes().
+	$data_string,   // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- assembled from esc_attr() escaped parts.
+	$items_html     // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- items rendered via WP_Block (WP escapes server-side).
+);

--- a/src/blocks/slider/render.php
+++ b/src/blocks/slider/render.php
@@ -19,7 +19,7 @@
  * query-mode output diverges visually from authored-mode output.
  *
  * @package DesignSetGo
- * @since   2.2.0
+ * @since   2.6.0
  *
  * @param array    $attributes Block attributes.
  * @param string   $content    Pre-rendered save.js output.
@@ -123,31 +123,33 @@ if ( $atts['scrollDriven'] ) {
 	$classes[] = 'dsgo-slider--scroll-driven';
 }
 
-// CSS custom properties. Only emit keys save.js would emit to keep diffs tight.
+// CSS custom properties. Each attribute passes through designsetgo_safe_css_value()
+// so a stored value like `20px; --dsgo-slider-slides-per-view:99` can't escape
+// the declaration context — see render-helpers.php for the rules.
 $style_parts = array();
 if ( '' !== $atts['height'] ) {
-	$style_parts[] = '--dsgo-slider-height:' . $atts['height'];
+	$style_parts[] = '--dsgo-slider-height:' . designsetgo_safe_css_value( $atts['height'] );
 }
-$style_parts[] = '--dsgo-slider-aspect-ratio:' . $atts['aspectRatio'];
-$style_parts[] = '--dsgo-slider-gap:' . $atts['gap'];
-$style_parts[] = '--dsgo-slider-transition:' . $atts['transitionDuration'];
-$style_parts[] = '--dsgo-slider-slides-per-view:' . $spv;
-$style_parts[] = '--dsgo-slider-slides-per-view-tablet:' . $spv_tablet;
-$style_parts[] = '--dsgo-slider-slides-per-view-mobile:' . $spv_mobile;
+$style_parts[] = '--dsgo-slider-aspect-ratio:' . designsetgo_safe_css_value( $atts['aspectRatio'] );
+$style_parts[] = '--dsgo-slider-gap:' . designsetgo_safe_css_value( $atts['gap'] );
+$style_parts[] = '--dsgo-slider-transition:' . designsetgo_safe_css_value( $atts['transitionDuration'] );
+$style_parts[] = '--dsgo-slider-slides-per-view:' . (int) $spv;
+$style_parts[] = '--dsgo-slider-slides-per-view-tablet:' . (int) $spv_tablet;
+$style_parts[] = '--dsgo-slider-slides-per-view-mobile:' . (int) $spv_mobile;
 if ( '' !== $atts['arrowColor'] ) {
-	$style_parts[] = '--dsgo-slider-arrow-color:' . $atts['arrowColor'];
+	$style_parts[] = '--dsgo-slider-arrow-color:' . designsetgo_safe_css_value( $atts['arrowColor'] );
 }
 if ( '' !== $atts['arrowBackgroundColor'] ) {
-	$style_parts[] = '--dsgo-slider-arrow-bg-color:' . $atts['arrowBackgroundColor'];
+	$style_parts[] = '--dsgo-slider-arrow-bg-color:' . designsetgo_safe_css_value( $atts['arrowBackgroundColor'] );
 }
 if ( '' !== $atts['dotColor'] ) {
-	$style_parts[] = '--dsgo-slider-dot-color:' . $atts['dotColor'];
+	$style_parts[] = '--dsgo-slider-dot-color:' . designsetgo_safe_css_value( $atts['dotColor'] );
 }
 if ( '' !== $atts['arrowSize'] ) {
-	$style_parts[] = '--dsgo-slider-arrow-size:' . $atts['arrowSize'];
+	$style_parts[] = '--dsgo-slider-arrow-size:' . designsetgo_safe_css_value( $atts['arrowSize'] );
 }
 if ( '' !== $atts['arrowPadding'] ) {
-	$style_parts[] = '--dsgo-slider-arrow-padding:' . $atts['arrowPadding'];
+	$style_parts[] = '--dsgo-slider-arrow-padding:' . designsetgo_safe_css_value( $atts['arrowPadding'] );
 }
 $style_inline = implode( ';', $style_parts ) . ';';
 
@@ -158,7 +160,9 @@ $wrapper_attrs = get_block_wrapper_attributes(
 		'class'                => implode( ' ', $classes ),
 		'style'                => $style_inline,
 		'role'                 => 'region',
-		'aria-label'           => $atts['ariaLabel'] !== '' ? $atts['ariaLabel'] : __( 'Image slider', 'designsetgo' ),
+		// Literal fallback mirrors save.js (which does not translate it).
+		// If save.js ever translates the default, match that change here too.
+		'aria-label'           => $atts['ariaLabel'] !== '' ? $atts['ariaLabel'] : 'Image slider',
 		'aria-roledescription' => 'slider',
 	)
 );

--- a/src/blocks/slider/render.php
+++ b/src/blocks/slider/render.php
@@ -42,6 +42,15 @@ if ( '' === $query_id ) {
 }
 
 // Query mode — pull pre-rendered items from the parent container's stash.
+// Inner blocks render before their parent's render_callback fires, so we
+// can't rely on the query container having loaded the shared helpers yet.
+$helpers = DESIGNSETGO_PATH . 'build/blocks/query/render-helpers.php';
+if ( ! file_exists( $helpers ) ) {
+	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
+	return;
+}
+require_once $helpers;
+
 $items_html = '';
 if ( isset( $GLOBALS['designsetgo_query_items_html'][ $query_id ] ) ) {
 	$items_html = (string) $GLOBALS['designsetgo_query_items_html'][ $query_id ];

--- a/src/components/shared/DsgoChildToolbar/index.js
+++ b/src/components/shared/DsgoChildToolbar/index.js
@@ -65,6 +65,10 @@ import {
  * @property {string}   [removeLabel]              Localized label for Remove.
  * @property {string}   [movePrevLabel]            Localized label for Move Previous.
  * @property {string}   [moveNextLabel]            Localized label for Move Next.
+ * @property {boolean}  [disableAdd=false]         Disables the Add button.
+ * @property {boolean}  [disableDuplicate=false]   Disables the Duplicate button.
+ * @property {boolean}  [disableRemove=false]      Disables the Remove button.
+ * @property {boolean}  [disableMove=false]        Disables both Move buttons.
  * @property {boolean}  [showMove=true]            Whether to render Move Prev/Next buttons.
  * @property {string}   [orientation='horizontal'] 'horizontal' renders chevronLeft/Right;
  *                                                 'vertical' renders chevronUp/Down so the
@@ -87,6 +91,10 @@ export default function DsgoChildToolbar({
 	removeLabel,
 	movePrevLabel,
 	moveNextLabel,
+	disableAdd = false,
+	disableDuplicate = false,
+	disableRemove = false,
+	disableMove = false,
 	showMove = true,
 	orientation = 'horizontal',
 }) {
@@ -203,6 +211,7 @@ export default function DsgoChildToolbar({
 				icon={plus}
 				label={resolvedAddLabel}
 				onClick={handleAdd}
+				disabled={disableAdd}
 				showTooltip
 			/>
 			{hasTarget && (
@@ -210,6 +219,7 @@ export default function DsgoChildToolbar({
 					icon={copy}
 					label={resolvedDuplicateLabel}
 					onClick={handleDuplicate}
+					disabled={disableDuplicate}
 					showTooltip
 				/>
 			)}
@@ -219,14 +229,14 @@ export default function DsgoChildToolbar({
 						icon={movePrevIcon}
 						label={resolvedMovePrevLabel}
 						onClick={handleMovePrev}
-						disabled={isFirst}
+						disabled={disableMove || isFirst}
 						showTooltip
 					/>
 					<ToolbarButton
 						icon={moveNextIcon}
 						label={resolvedMoveNextLabel}
 						onClick={handleMoveNext}
-						disabled={isLast}
+						disabled={disableMove || isLast}
 						showTooltip
 					/>
 				</>
@@ -236,7 +246,7 @@ export default function DsgoChildToolbar({
 					icon={trash}
 					label={resolvedRemoveLabel}
 					onClick={handleRemove}
-					disabled={isOnly}
+					disabled={disableRemove || isOnly}
 					isDestructive
 					showTooltip
 				/>

--- a/src/extensions/grid-span/index.js
+++ b/src/extensions/grid-span/index.js
@@ -170,8 +170,7 @@ const withGridSpanStyles = createHigherOrderComponent((BlockListBlock) => {
 			[clientId]
 		);
 
-		const hasColumnSpan =
-			isInGrid && dsgoColumnSpan && dsgoColumnSpan > 1;
+		const hasColumnSpan = isInGrid && dsgoColumnSpan && dsgoColumnSpan > 1;
 		const hasRowSpan = isInGrid && dsgoRowSpan && dsgoRowSpan > 1;
 
 		if (hasColumnSpan || hasRowSpan) {

--- a/src/extensions/style-binding/filters.js
+++ b/src/extensions/style-binding/filters.js
@@ -12,24 +12,28 @@ import {
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { Fragment } from '@wordpress/element';
 
-const BLOCKED = new Set( [ 'core/freeform', 'core/missing', 'core/template-part' ] );
+const BLOCKED = new Set([
+	'core/freeform',
+	'core/missing',
+	'core/template-part',
+]);
 
 const SOURCE_OPTIONS = [
-	{ label: __( 'Post meta', 'designsetgo' ), value: 'designsetgo/post-meta' },
-	{ label: __( 'ACF', 'designsetgo' ), value: 'designsetgo/acf' },
-	{ label: __( 'Meta Box', 'designsetgo' ), value: 'designsetgo/metabox' },
-	{ label: __( 'Pods', 'designsetgo' ), value: 'designsetgo/pods' },
-	{ label: __( 'JetEngine', 'designsetgo' ), value: 'designsetgo/jetengine' },
+	{ label: __('Post meta', 'designsetgo'), value: 'designsetgo/post-meta' },
+	{ label: __('ACF', 'designsetgo'), value: 'designsetgo/acf' },
+	{ label: __('Meta Box', 'designsetgo'), value: 'designsetgo/metabox' },
+	{ label: __('Pods', 'designsetgo'), value: 'designsetgo/pods' },
+	{ label: __('JetEngine', 'designsetgo'), value: 'designsetgo/jetengine' },
 ];
 
 addFilter(
 	'blocks.registerBlockType',
 	'designsetgo/style-binding-attribute',
-	( settings, name ) => {
-		if ( BLOCKED.has( name ) ) {
+	(settings, name) => {
+		if (BLOCKED.has(name)) {
 			return settings;
 		}
-		if ( ! settings.attributes ) {
+		if (!settings.attributes) {
 			settings.attributes = {};
 		}
 		settings.attributes.dsgoStyleBinding = {
@@ -40,99 +44,130 @@ addFilter(
 	}
 );
 
-const withStyleBindingInspector = createHigherOrderComponent( ( BlockEdit ) => {
-	return function WithStyleBindingInspector( props ) {
-		if ( BLOCKED.has( props.name ) ) {
-			return <BlockEdit { ...props } />;
+const withStyleBindingInspector = createHigherOrderComponent((BlockEdit) => {
+	return function WithStyleBindingInspector(props) {
+		if (BLOCKED.has(props.name)) {
+			return <BlockEdit {...props} />;
 		}
 		const { attributes, setAttributes } = props;
 		const binding = attributes.dsgoStyleBinding ?? {};
-		const entries = Object.entries( binding );
+		const entries = Object.entries(binding);
 
-		const updateEntry = ( oldProp, newProp, config ) => {
+		const updateEntry = (oldProp, newProp, config) => {
 			const next = { ...binding };
-			if ( oldProp !== newProp ) {
-				delete next[ oldProp ];
+			if (oldProp !== newProp) {
+				delete next[oldProp];
 			}
-			next[ newProp ] = config;
-			setAttributes( { dsgoStyleBinding: next } );
+			next[newProp] = config;
+			setAttributes({ dsgoStyleBinding: next });
 		};
 
-		const removeEntry = ( prop ) => {
+		const removeEntry = (prop) => {
 			const next = { ...binding };
-			delete next[ prop ];
-			setAttributes( { dsgoStyleBinding: next } );
+			delete next[prop];
+			setAttributes({ dsgoStyleBinding: next });
 		};
 
 		const addEntry = () => {
-			const key = `--dsgo-binding-${ Date.now() }`;
-			setAttributes( {
+			const key = `--dsgo-binding-${Date.now()}`;
+			setAttributes({
 				dsgoStyleBinding: {
 					...binding,
-					[ key ]: { source: 'designsetgo/post-meta', args: { key: '' } },
+					[key]: {
+						source: 'designsetgo/post-meta',
+						args: { key: '' },
+					},
 				},
-			} );
+			});
 		};
 
 		return (
 			<Fragment>
-				<BlockEdit { ...props } />
+				<BlockEdit {...props} />
 				<InspectorControls group="advanced">
 					<PanelBody
-						title={ __( 'Style Bindings', 'designsetgo' ) }
-						initialOpen={ entries.length > 0 }
+						title={__('Style Bindings', 'designsetgo')}
+						initialOpen={entries.length > 0}
 					>
-						{ entries.map( ( [ prop, config ] ) => (
-							<VStack key={ prop } spacing={ 1 } style={ { marginBottom: '12px' } }>
+						{entries.map(([prop, config]) => (
+							<VStack
+								key={prop}
+								spacing={1}
+								style={{ marginBottom: '12px' }}
+							>
 								<HStack>
 									<TextControl
-										label={ __( 'CSS property', 'designsetgo' ) }
-										value={ prop }
+										label={__(
+											'CSS property',
+											'designsetgo'
+										)}
+										value={prop}
 										placeholder="--brand-color"
-										onChange={ ( val ) => updateEntry( prop, val, config ) }
+										onChange={(val) =>
+											updateEntry(prop, val, config)
+										}
 										__nextHasNoMarginBottom
 									/>
 									<Button
 										variant="tertiary"
 										isDestructive
 										size="small"
-										onClick={ () => removeEntry( prop ) }
-										aria-label={ sprintf(
+										onClick={() => removeEntry(prop)}
+										aria-label={sprintf(
 											/* translators: %s: CSS property name being unbound. */
-											__( 'Remove style binding for "%s"', 'designsetgo' ),
+											__(
+												'Remove style binding for "%s"',
+												'designsetgo'
+											),
 											prop
-										) }
-										style={ { alignSelf: 'flex-end' } }
+										)}
+										style={{ alignSelf: 'flex-end' }}
 									>
-										{ __( 'Remove', 'designsetgo' ) }
+										{__('Remove', 'designsetgo')}
 									</Button>
 								</HStack>
 								<SelectControl
-									label={ __( 'Source', 'designsetgo' ) }
-									value={ config.source }
-									options={ SOURCE_OPTIONS }
-									onChange={ ( val ) => updateEntry( prop, prop, { ...config, source: val } ) }
+									label={__('Source', 'designsetgo')}
+									value={config.source}
+									options={SOURCE_OPTIONS}
+									onChange={(val) =>
+										updateEntry(prop, prop, {
+											...config,
+											source: val,
+										})
+									}
 									__nextHasNoMarginBottom
 								/>
 								<TextControl
-									label={ __( 'Field key / name', 'designsetgo' ) }
-									value={ config.args?.key ?? '' }
-									onChange={ ( val ) =>
-										updateEntry( prop, prop, { ...config, args: { key: val } } )
+									label={__(
+										'Field key / name',
+										'designsetgo'
+									)}
+									value={config.args?.key ?? ''}
+									onChange={(val) =>
+										updateEntry(prop, prop, {
+											...config,
+											args: { key: val },
+										})
 									}
 									__nextHasNoMarginBottom
 								/>
 							</VStack>
-						) ) }
-						<Button variant="secondary" size="small" onClick={ addEntry } __next40pxDefaultSize>
-							{ __( '+ Add style binding', 'designsetgo' ) }
+						))}
+						<Button
+							variant="secondary"
+							size="small"
+							onClick={addEntry}
+							__next40pxDefaultSize
+						>
+							{__('+ Add style binding', 'designsetgo')}
 						</Button>
 					</PanelBody>
 				</InspectorControls>
 			</Fragment>
 		);
 	};
-}, 'withStyleBindingInspector' );
+}, 'withStyleBindingInspector');
 
 addFilter(
 	'editor.BlockEdit',

--- a/src/extensions/visibility/RuleRow.js
+++ b/src/extensions/visibility/RuleRow.js
@@ -7,66 +7,66 @@ import {
 } from '@wordpress/components';
 
 const TYPE_OPTIONS = [
-	{ value: 'meta', label: __( 'Post Meta', 'designsetgo' ) },
-	{ value: 'taxonomy', label: __( 'Taxonomy', 'designsetgo' ) },
-	{ value: 'index', label: __( 'Item Index', 'designsetgo' ) },
-	{ value: 'auth', label: __( 'Auth State', 'designsetgo' ) },
+	{ value: 'meta', label: __('Post Meta', 'designsetgo') },
+	{ value: 'taxonomy', label: __('Taxonomy', 'designsetgo') },
+	{ value: 'index', label: __('Item Index', 'designsetgo') },
+	{ value: 'auth', label: __('Auth State', 'designsetgo') },
 ];
 
 const META_OP_OPTIONS = [
-	{ value: 'equals', label: __( 'equals', 'designsetgo' ) },
-	{ value: 'not_equals', label: __( 'does not equal', 'designsetgo' ) },
-	{ value: 'contains', label: __( 'contains', 'designsetgo' ) },
-	{ value: 'not_empty', label: __( 'is set', 'designsetgo' ) },
-	{ value: 'empty', label: __( 'is not set', 'designsetgo' ) },
+	{ value: 'equals', label: __('equals', 'designsetgo') },
+	{ value: 'not_equals', label: __('does not equal', 'designsetgo') },
+	{ value: 'contains', label: __('contains', 'designsetgo') },
+	{ value: 'not_empty', label: __('is set', 'designsetgo') },
+	{ value: 'empty', label: __('is not set', 'designsetgo') },
 ];
 
 const TAXONOMY_OP_OPTIONS = [
-	{ value: 'has', label: __( 'has term', 'designsetgo' ) },
-	{ value: 'not_has', label: __( 'does not have term', 'designsetgo' ) },
+	{ value: 'has', label: __('has term', 'designsetgo') },
+	{ value: 'not_has', label: __('does not have term', 'designsetgo') },
 ];
 
 const INDEX_OP_OPTIONS = [
-	{ value: 'equals', label: __( 'is', 'designsetgo' ) },
-	{ value: 'not_equals', label: __( 'is not', 'designsetgo' ) },
-	{ value: 'lt', label: __( 'less than', 'designsetgo' ) },
-	{ value: 'gt', label: __( 'greater than', 'designsetgo' ) },
+	{ value: 'equals', label: __('is', 'designsetgo') },
+	{ value: 'not_equals', label: __('is not', 'designsetgo') },
+	{ value: 'lt', label: __('less than', 'designsetgo') },
+	{ value: 'gt', label: __('greater than', 'designsetgo') },
 ];
 
 /**
  * Renders the extra controls for a meta-type rule.
  *
- * @param {Object} props
- * @param {Object} props.rule
+ * @param {Object}   props
+ * @param {Object}   props.rule
  * @param {Function} props.onChange
  */
-function MetaControls( { rule, onChange } ) {
+function MetaControls({ rule, onChange }) {
 	return (
 		<>
 			<TextControl
-				label={ __( 'Meta Key', 'designsetgo' ) }
-				value={ rule.key ?? '' }
-				onChange={ ( key ) => onChange( { ...rule, key } ) }
+				label={__('Meta Key', 'designsetgo')}
+				value={rule.key ?? ''}
+				onChange={(key) => onChange({ ...rule, key })}
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
 			<SelectControl
-				label={ __( 'Condition', 'designsetgo' ) }
-				value={ rule.op ?? 'equals' }
-				options={ META_OP_OPTIONS }
-				onChange={ ( op ) => onChange( { ...rule, op } ) }
+				label={__('Condition', 'designsetgo')}
+				value={rule.op ?? 'equals'}
+				options={META_OP_OPTIONS}
+				onChange={(op) => onChange({ ...rule, op })}
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
-			{ ! [ 'empty', 'not_empty' ].includes( rule.op ) && (
+			{!['empty', 'not_empty'].includes(rule.op) && (
 				<TextControl
-					label={ __( 'Value', 'designsetgo' ) }
-					value={ rule.value ?? '' }
-					onChange={ ( value ) => onChange( { ...rule, value } ) }
+					label={__('Value', 'designsetgo')}
+					value={rule.value ?? ''}
+					onChange={(value) => onChange({ ...rule, value })}
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
 				/>
-			) }
+			)}
 		</>
 	);
 }
@@ -74,32 +74,32 @@ function MetaControls( { rule, onChange } ) {
 /**
  * Renders the extra controls for a taxonomy-type rule.
  *
- * @param {Object} props
- * @param {Object} props.rule
+ * @param {Object}   props
+ * @param {Object}   props.rule
  * @param {Function} props.onChange
  */
-function TaxonomyControls( { rule, onChange } ) {
+function TaxonomyControls({ rule, onChange }) {
 	return (
 		<>
 			<TextControl
-				label={ __( 'Taxonomy Slug', 'designsetgo' ) }
-				value={ rule.taxonomy ?? '' }
-				onChange={ ( taxonomy ) => onChange( { ...rule, taxonomy } ) }
+				label={__('Taxonomy Slug', 'designsetgo')}
+				value={rule.taxonomy ?? ''}
+				onChange={(taxonomy) => onChange({ ...rule, taxonomy })}
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
 			<SelectControl
-				label={ __( 'Condition', 'designsetgo' ) }
-				value={ rule.op ?? 'has' }
-				options={ TAXONOMY_OP_OPTIONS }
-				onChange={ ( op ) => onChange( { ...rule, op } ) }
+				label={__('Condition', 'designsetgo')}
+				value={rule.op ?? 'has'}
+				options={TAXONOMY_OP_OPTIONS}
+				onChange={(op) => onChange({ ...rule, op })}
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
 			<TextControl
-				label={ __( 'Term Slug', 'designsetgo' ) }
-				value={ rule.value ?? '' }
-				onChange={ ( value ) => onChange( { ...rule, value } ) }
+				label={__('Term Slug', 'designsetgo')}
+				value={rule.value ?? ''}
+				onChange={(value) => onChange({ ...rule, value })}
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
@@ -110,25 +110,25 @@ function TaxonomyControls( { rule, onChange } ) {
 /**
  * Renders the extra controls for an index-type rule.
  *
- * @param {Object} props
- * @param {Object} props.rule
+ * @param {Object}   props
+ * @param {Object}   props.rule
  * @param {Function} props.onChange
  */
-function IndexControls( { rule, onChange } ) {
+function IndexControls({ rule, onChange }) {
 	return (
 		<>
 			<SelectControl
-				label={ __( 'Condition', 'designsetgo' ) }
-				value={ rule.op ?? 'equals' }
-				options={ INDEX_OP_OPTIONS }
-				onChange={ ( op ) => onChange( { ...rule, op } ) }
+				label={__('Condition', 'designsetgo')}
+				value={rule.op ?? 'equals'}
+				options={INDEX_OP_OPTIONS}
+				onChange={(op) => onChange({ ...rule, op })}
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
 			<TextControl
-				label={ __( 'Index Value', 'designsetgo' ) }
-				value={ String( rule.value ?? '' ) }
-				onChange={ ( value ) => onChange( { ...rule, value } ) }
+				label={__('Index Value', 'designsetgo')}
+				value={String(rule.value ?? '')}
+				onChange={(value) => onChange({ ...rule, value })}
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
@@ -139,20 +139,23 @@ function IndexControls( { rule, onChange } ) {
 /**
  * Renders the extra controls for an auth-type rule.
  *
- * @param {Object} props
- * @param {Object} props.rule
+ * @param {Object}   props
+ * @param {Object}   props.rule
  * @param {Function} props.onChange
  */
-function AuthControls( { rule, onChange } ) {
+function AuthControls({ rule, onChange }) {
 	return (
 		<SelectControl
-			label={ __( 'Visibility requires', 'designsetgo' ) }
-			value={ JSON.stringify( !! rule.value ) }
-			options={ [
-				{ value: 'true', label: __( 'Logged-in user', 'designsetgo' ) },
-				{ value: 'false', label: __( 'Logged-out visitor', 'designsetgo' ) },
-			] }
-			onChange={ ( v ) => onChange( { ...rule, value: JSON.parse( v ) } ) }
+			label={__('Visibility requires', 'designsetgo')}
+			value={JSON.stringify(!!rule.value)}
+			options={[
+				{ value: 'true', label: __('Logged-in user', 'designsetgo') },
+				{
+					value: 'false',
+					label: __('Logged-out visitor', 'designsetgo'),
+				},
+			]}
+			onChange={(v) => onChange({ ...rule, value: JSON.parse(v) })}
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom
 		/>
@@ -165,8 +168,8 @@ function AuthControls( { rule, onChange } ) {
  * @param {string} type Rule type.
  * @return {Object} Default rule object.
  */
-function getDefaultRule( type ) {
-	switch ( type ) {
+function getDefaultRule(type) {
+	switch (type) {
 		case 'meta':
 			return { type: 'meta', key: '', op: 'equals', value: '' };
 		case 'taxonomy':
@@ -184,43 +187,43 @@ function getDefaultRule( type ) {
  * A single visibility rule row.
  *
  * @param {Object}   props
- * @param {Object}   props.rule      Rule object.
- * @param {Function} props.onChange  Called with updated rule object.
- * @param {Function} props.onRemove  Called when the rule is removed.
+ * @param {Object}   props.rule     Rule object.
+ * @param {Function} props.onChange Called with updated rule object.
+ * @param {Function} props.onRemove Called when the rule is removed.
  */
-export default function RuleRow( { rule, onChange, onRemove } ) {
+export default function RuleRow({ rule, onChange, onRemove }) {
 	return (
 		<div className="dsgo-visibility-rule-row">
 			<HStack alignment="top">
 				<div className="dsgo-visibility-rule-row__controls">
 					<SelectControl
-						label={ __( 'Rule Type', 'designsetgo' ) }
-						value={ rule.type ?? 'meta' }
-						options={ TYPE_OPTIONS }
-						onChange={ ( type ) => onChange( getDefaultRule( type ) ) }
+						label={__('Rule Type', 'designsetgo')}
+						value={rule.type ?? 'meta'}
+						options={TYPE_OPTIONS}
+						onChange={(type) => onChange(getDefaultRule(type))}
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
 					/>
-					{ ( rule.type === 'meta' || ! rule.type ) && (
-						<MetaControls rule={ rule } onChange={ onChange } />
-					) }
-					{ rule.type === 'taxonomy' && (
-						<TaxonomyControls rule={ rule } onChange={ onChange } />
-					) }
-					{ rule.type === 'index' && (
-						<IndexControls rule={ rule } onChange={ onChange } />
-					) }
-					{ rule.type === 'auth' && (
-						<AuthControls rule={ rule } onChange={ onChange } />
-					) }
+					{(rule.type === 'meta' || !rule.type) && (
+						<MetaControls rule={rule} onChange={onChange} />
+					)}
+					{rule.type === 'taxonomy' && (
+						<TaxonomyControls rule={rule} onChange={onChange} />
+					)}
+					{rule.type === 'index' && (
+						<IndexControls rule={rule} onChange={onChange} />
+					)}
+					{rule.type === 'auth' && (
+						<AuthControls rule={rule} onChange={onChange} />
+					)}
 				</div>
 				<Button
 					variant="tertiary"
 					isDestructive
-					onClick={ onRemove }
-					aria-label={ __( 'Remove rule', 'designsetgo' ) }
+					onClick={onRemove}
+					aria-label={__('Remove rule', 'designsetgo')}
 				>
-					{ __( 'Remove', 'designsetgo' ) }
+					{__('Remove', 'designsetgo')}
 				</Button>
 			</HStack>
 		</div>

--- a/src/extensions/visibility/VisibilityPanel.js
+++ b/src/extensions/visibility/VisibilityPanel.js
@@ -9,80 +9,78 @@ import RuleRow from './RuleRow';
 const DEFAULT_RULE = { type: 'meta', key: '', op: 'equals', value: '' };
 
 const OPERATOR_OPTIONS = [
-	{ value: 'AND', label: __( 'All rules must match (AND)', 'designsetgo' ) },
-	{ value: 'OR', label: __( 'Any rule must match (OR)', 'designsetgo' ) },
+	{ value: 'AND', label: __('All rules must match (AND)', 'designsetgo') },
+	{ value: 'OR', label: __('Any rule must match (OR)', 'designsetgo') },
 ];
 
 /**
  * Inspector panel for configuring block visibility rules.
  *
- * @param {Object}        props
- * @param {Object|null}   props.value     Current visibility config ({ operator, rules }) or null.
- * @param {Function}      props.onChange  Called with the new visibility config.
+ * @param {Object}      props
+ * @param {Object|null} props.value    Current visibility config ({ operator, rules }) or null.
+ * @param {Function}    props.onChange Called with the new visibility config.
  */
-export default function VisibilityPanel( { value, onChange } ) {
+export default function VisibilityPanel({ value, onChange }) {
 	const rules = value?.rules ?? [];
 	const operator = value?.operator ?? 'AND';
 	const hasRules = rules.length > 0;
 
 	function handleAddRule() {
-		onChange( {
+		onChange({
 			operator,
-			rules: [ ...rules, { ...DEFAULT_RULE } ],
-		} );
+			rules: [...rules, { ...DEFAULT_RULE }],
+		});
 	}
 
-	function handleOperatorChange( newOperator ) {
-		onChange( { ...value, operator: newOperator } );
+	function handleOperatorChange(newOperator) {
+		onChange({ ...value, operator: newOperator });
 	}
 
-	function handleRuleChange( index, updatedRule ) {
-		const newRules = rules.map( ( r, i ) => ( i === index ? updatedRule : r ) );
-		onChange( { operator, rules: newRules } );
+	function handleRuleChange(index, updatedRule) {
+		const newRules = rules.map((r, i) => (i === index ? updatedRule : r));
+		onChange({ operator, rules: newRules });
 	}
 
-	function handleRuleRemove( index ) {
-		const newRules = rules.filter( ( _, i ) => i !== index );
-		if ( newRules.length === 0 ) {
-			onChange( null );
+	function handleRuleRemove(index) {
+		const newRules = rules.filter((_, i) => i !== index);
+		if (newRules.length === 0) {
+			onChange(null);
 		} else {
-			onChange( { operator, rules: newRules } );
+			onChange({ operator, rules: newRules });
 		}
 	}
 
 	return (
-		<VStack spacing={ 3 } className="dsgo-visibility-panel">
-			{ ! hasRules && (
+		<VStack spacing={3} className="dsgo-visibility-panel">
+			{!hasRules && (
 				<p className="dsgo-visibility-panel__empty-state">
-					{ __( 'Always visible', 'designsetgo' ) }
+					{__('Always visible', 'designsetgo')}
 				</p>
-			) }
+			)}
 
-			{ hasRules && rules.length > 1 && (
+			{hasRules && rules.length > 1 && (
 				<SelectControl
-					label={ __( 'Combine Rules', 'designsetgo' ) }
-					value={ operator }
-					options={ OPERATOR_OPTIONS }
-					onChange={ handleOperatorChange }
+					label={__('Combine Rules', 'designsetgo')}
+					value={operator}
+					options={OPERATOR_OPTIONS}
+					onChange={handleOperatorChange}
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
 				/>
-			) }
+			)}
 
-			{ hasRules && rules.map( ( rule, index ) => (
-				<RuleRow
-					key={ index }
-					rule={ rule }
-					onChange={ ( updated ) => handleRuleChange( index, updated ) }
-					onRemove={ () => handleRuleRemove( index ) }
-				/>
-			) ) }
+			{hasRules &&
+				rules.map((rule, index) => (
+					<RuleRow
+						key={index}
+						rule={rule}
+						onChange={(updated) => handleRuleChange(index, updated)}
+						onRemove={() => handleRuleRemove(index)}
+					/>
+				))}
 
-			<Button
-				variant="secondary"
-				onClick={ handleAddRule }
-			>
-				{ __( 'Add rule', 'designsetgo' ) }
+			<Button variant="secondary" onClick={handleAddRule}>
+				{__('Add rule', 'designsetgo')}
 			</Button>
 		</VStack>
 	);

--- a/src/extensions/visibility/evaluateRules.js
+++ b/src/extensions/visibility/evaluateRules.js
@@ -4,48 +4,63 @@
  * Pure function: no React imports, no WordPress imports.
  *
  * @param {object|null} rules   The dsgoVisibility attribute.
- * @param {object}      context Per-item context: { postId, postType, index, meta, terms, isAuthenticated }.
+ * @param {Object}      context Per-item context: { postId, postType, index, meta, terms, isAuthenticated }.
  * @return {boolean} Whether the block should be visible.
  */
-export default function evaluateRules( rules, context = {} ) {
-	if ( ! rules || ! rules.rules?.length ) return true;
-	const op = ( rules.operator || 'AND' ).toUpperCase();
-	for ( const rule of rules.rules ) {
-		const ok = evaluate( rule, context );
-		if ( op === 'OR' && ok ) return true;
-		if ( op === 'AND' && ! ok ) return false;
+export default function evaluateRules(rules, context = {}) {
+	if (!rules || !rules.rules?.length) {
+		return true;
+	}
+	const op = (rules.operator || 'AND').toUpperCase();
+	for (const rule of rules.rules) {
+		const ok = evaluate(rule, context);
+		if (op === 'OR' && ok) {
+			return true;
+		}
+		if (op === 'AND' && !ok) {
+			return false;
+		}
 	}
 	return op === 'AND';
 }
 
-function evaluate( rule, ctx ) {
+function evaluate(rule, ctx) {
 	const { type, op = 'equals', value } = rule;
-	switch ( type ) {
+	switch (type) {
 		case 'meta':
-			return compare( ctx.meta?.[ rule.key ], op, value );
+			return compare(ctx.meta?.[rule.key], op, value);
 		case 'taxonomy': {
-			const slugs = ctx.terms?.[ rule.taxonomy ] || [];
-			const has = slugs.includes( String( value ) );
-			return op === 'not_has' ? ! has : has;
+			const slugs = ctx.terms?.[rule.taxonomy] || [];
+			const has = slugs.includes(String(value));
+			return op === 'not_has' ? !has : has;
 		}
 		case 'index':
-			return compare( ctx.index, op, Number( value ) );
+			return compare(ctx.index, op, Number(value));
 		case 'auth':
-			return !! ctx.isAuthenticated === !! value;
+			return !!ctx.isAuthenticated === !!value;
 		default:
 			return false;
 	}
 }
 
-function compare( actual, op, expected ) {
-	switch ( op ) {
-		case 'not_equals': return String( actual ) !== String( expected );
-		case 'contains':   return String( actual ).toLowerCase().includes( String( expected ).toLowerCase() );
-		case 'gt':         return Number( actual ) > Number( expected );
-		case 'lt':         return Number( actual ) < Number( expected );
-		case 'empty':      return actual === '' || actual == null;
-		case 'not_empty':  return actual !== '' && actual != null;
+function compare(actual, op, expected) {
+	switch (op) {
+		case 'not_equals':
+			return String(actual) !== String(expected);
+		case 'contains':
+			return String(actual)
+				.toLowerCase()
+				.includes(String(expected).toLowerCase());
+		case 'gt':
+			return Number(actual) > Number(expected);
+		case 'lt':
+			return Number(actual) < Number(expected);
+		case 'empty':
+			return actual === '' || actual == null;
+		case 'not_empty':
+			return actual !== '' && actual != null;
 		case 'equals':
-		default:           return String( actual ) === String( expected );
+		default:
+			return String(actual) === String(expected);
 	}
 }

--- a/src/extensions/visibility/filters.js
+++ b/src/extensions/visibility/filters.js
@@ -5,18 +5,20 @@ import { Fragment } from '@wordpress/element';
 import VisibilityPanel from './VisibilityPanel';
 import evaluateRules from './evaluateRules';
 
-const BLOCKED = new Set( [
+const BLOCKED = new Set([
 	'core/freeform',
 	'core/missing',
 	'core/template-part',
-] );
+]);
 
-function addVisibilityAttribute( settings, name ) {
-	if ( BLOCKED.has( name ) ) return settings;
+function addVisibilityAttribute(settings, name) {
+	if (BLOCKED.has(name)) {
+		return settings;
+	}
 	return {
 		...settings,
 		attributes: {
-			...( settings.attributes ?? {} ),
+			...(settings.attributes ?? {}),
 			dsgoVisibility: { type: 'object', default: null },
 		},
 	};
@@ -28,20 +30,27 @@ addFilter(
 	addVisibilityAttribute
 );
 
-const withVisibilityPanel = createHigherOrderComponent( ( BlockEdit ) => ( props ) => {
-	if ( BLOCKED.has( props.name ) ) return <BlockEdit { ...props } />;
-	return (
-		<Fragment>
-			<BlockEdit { ...props } />
-			<InspectorControls group="advanced">
-				<VisibilityPanel
-					value={ props.attributes.dsgoVisibility }
-					onChange={ ( value ) => props.setAttributes( { dsgoVisibility: value } ) }
-				/>
-			</InspectorControls>
-		</Fragment>
-	);
-}, 'withDsgoVisibilityPanel' );
+const withVisibilityPanel = createHigherOrderComponent(
+	(BlockEdit) => (props) => {
+		if (BLOCKED.has(props.name)) {
+			return <BlockEdit {...props} />;
+		}
+		return (
+			<Fragment>
+				<BlockEdit {...props} />
+				<InspectorControls group="advanced">
+					<VisibilityPanel
+						value={props.attributes.dsgoVisibility}
+						onChange={(value) =>
+							props.setAttributes({ dsgoVisibility: value })
+						}
+					/>
+				</InspectorControls>
+			</Fragment>
+		);
+	},
+	'withDsgoVisibilityPanel'
+);
 
 addFilter(
 	'editor.BlockEdit',
@@ -58,43 +67,46 @@ addFilter(
  *      (meaning we are inside a query-item preview, not the main canvas), AND
  *   3. evaluateRules() returns false for the current item context.
  */
-const withVisibilityGate = createHigherOrderComponent( ( BlockListBlock ) => ( props ) => {
-	const visibility = props.attributes?.dsgoVisibility;
-	// props.context is populated by the editor.BlockListBlock filter in
-	// Gutenberg >= 16.x (WP 6.5+). It carries any context values declared
-	// via `usesContext` in the block's block.json.
-	const ctx = props.context || {};
+const withVisibilityGate = createHigherOrderComponent(
+	(BlockListBlock) => (props) => {
+		const visibility = props.attributes?.dsgoVisibility;
+		// props.context is populated by the editor.BlockListBlock filter in
+		// Gutenberg >= 16.x (WP 6.5+). It carries any context values declared
+		// via `usesContext` in the block's block.json.
+		const ctx = props.context || {};
 
-	// Only gate inside query-item previews. If the item index context key is
-	// absent we are on the main canvas and must not hide anything.
-	if ( ctx[ 'designsetgo/itemIndex' ] == null ) {
-		return <BlockListBlock { ...props } />;
-	}
+		// Only gate inside query-item previews. If the item index context key is
+		// absent we are on the main canvas and must not hide anything.
+		if (ctx['designsetgo/itemIndex'] == null) {
+			return <BlockListBlock {...props} />;
+		}
 
-	const evalCtx = {
-		index:           ctx[ 'designsetgo/itemIndex' ],
-		meta:            ctx[ 'designsetgo/itemMeta' ]  || {},
-		terms:           ctx[ 'designsetgo/itemTerms' ] || {},
-		postId:          ctx.postId,
-		postType:        ctx.postType,
-		isAuthenticated: ctx[ 'designsetgo/isAuthenticated' ] || false,
-	};
+		const evalCtx = {
+			index: ctx['designsetgo/itemIndex'],
+			meta: ctx['designsetgo/itemMeta'] || {},
+			terms: ctx['designsetgo/itemTerms'] || {},
+			postId: ctx.postId,
+			postType: ctx.postType,
+			isAuthenticated: ctx['designsetgo/isAuthenticated'] || false,
+		};
 
-	if ( ! evaluateRules( visibility, evalCtx ) ) {
-		// Return a hidden placeholder rather than null so the React tree stays
-		// stable. Returning null from editor.BlockListBlock can break tree
-		// diffing because Gutenberg expects a stable DOM node per slot.
-		return (
-			<div
-				className="dsgo-visibility-hidden"
-				style={ { display: 'none' } }
-				aria-hidden="true"
-			/>
-		);
-	}
+		if (!evaluateRules(visibility, evalCtx)) {
+			// Return a hidden placeholder rather than null so the React tree stays
+			// stable. Returning null from editor.BlockListBlock can break tree
+			// diffing because Gutenberg expects a stable DOM node per slot.
+			return (
+				<div
+					className="dsgo-visibility-hidden"
+					style={{ display: 'none' }}
+					aria-hidden="true"
+				/>
+			);
+		}
 
-	return <BlockListBlock { ...props } />;
-}, 'withDsgoVisibilityGate' );
+		return <BlockListBlock {...props} />;
+	},
+	'withDsgoVisibilityGate'
+);
 
 addFilter(
 	'editor.BlockListBlock',

--- a/tests/phpunit/blocks/query/item-hosts-test.php
+++ b/tests/phpunit/blocks/query/item-hosts-test.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Query item host registry + items_html stash contract.
+ *
+ * @group query-block
+ */
+class DesignSetGo_Query_Item_Hosts_Test extends WP_UnitTestCase {
+
+	private function load_helpers() {
+		$path = DESIGNSETGO_PATH . 'build/blocks/query/render-helpers.php';
+		$this->assertFileExists( $path, 'Run `npm run build` before PHPUnit — render helpers are served from build/.' );
+		require_once $path;
+	}
+
+	public function test_registry_defaults_to_query_results() {
+		$this->load_helpers();
+
+		$hosts = designsetgo_query_item_host_block_names();
+		$this->assertIsArray( $hosts );
+		$this->assertContains( 'designsetgo/query-results', $hosts );
+	}
+
+	public function test_filter_adds_block_name_to_registry() {
+		$this->load_helpers();
+
+		$cb = static function ( $hosts ) {
+			$hosts[] = 'designsetgo/slider';
+			return $hosts;
+		};
+		add_filter( 'designsetgo_query_item_host_block_names', $cb );
+
+		$hosts = designsetgo_query_item_host_block_names();
+		$this->assertContains( 'designsetgo/slider', $hosts );
+		$this->assertContains( 'designsetgo/query-results', $hosts );
+
+		remove_filter( 'designsetgo_query_item_host_block_names', $cb );
+	}
+
+	public function test_render_posts_returns_items_html_without_outer_wrap() {
+		self::factory()->post->create_many( 3, array( 'post_status' => 'publish' ) );
+		$this->load_helpers();
+
+		$result = designsetgo_query_render(
+			array(
+				'source'      => 'posts',
+				'postType'    => 'post',
+				'perPage'     => 3,
+				'tagName'     => 'ul',
+				'itemTagName' => 'li',
+			),
+			array(
+				'query_id'   => 'items-html-posts',
+				'page'       => 1,
+				'inner_html' => '<!-- wp:paragraph --><p>Item</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		$this->assertArrayHasKey( 'items_html', $result );
+		$this->assertIsString( $result['items_html'] );
+		// Raw items should include the per-item <li> wrappers but NOT the
+		// outer grid <ul class="dsgo-query-results">.
+		$this->assertSame( 3, substr_count( $result['items_html'], '<li' ) );
+		$this->assertStringNotContainsString( 'dsgo-query-results', $result['items_html'] );
+	}
+
+	public function test_render_users_returns_items_html_field() {
+		self::factory()->user->create_many( 2 );
+		$this->load_helpers();
+
+		$result = designsetgo_query_render(
+			array(
+				'source'      => 'users',
+				'perPage'     => 10,
+				'tagName'     => 'ul',
+				'itemTagName' => 'li',
+			),
+			array(
+				'query_id'   => 'items-html-users',
+				'page'       => 1,
+				'inner_html' => '<!-- wp:paragraph --><p>User</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		$this->assertArrayHasKey( 'items_html', $result );
+		$this->assertIsString( $result['items_html'] );
+		$this->assertStringNotContainsString( 'dsgo-query-results', $result['items_html'] );
+	}
+
+	public function test_render_terms_returns_items_html_field() {
+		self::factory()->term->create_many( 2, array( 'taxonomy' => 'category' ) );
+		$this->load_helpers();
+
+		$result = designsetgo_query_render(
+			array(
+				'source'      => 'terms',
+				'perPage'     => 10,
+				'tagName'     => 'ul',
+				'itemTagName' => 'li',
+				'taxQuery'    => array(
+					'relation' => 'AND',
+					'clauses'  => array( array( 'taxonomy' => 'category' ) ),
+				),
+			),
+			array(
+				'query_id'   => 'items-html-terms',
+				'page'       => 1,
+				'inner_html' => '<!-- wp:paragraph --><p>Term</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		$this->assertArrayHasKey( 'items_html', $result );
+		$this->assertIsString( $result['items_html'] );
+		$this->assertStringNotContainsString( 'dsgo-query-results', $result['items_html'] );
+	}
+
+	public function test_empty_source_fallback_returns_items_html_empty_string() {
+		$this->load_helpers();
+
+		$result = designsetgo_query_render(
+			array( 'source' => 'nonexistent-source' ),
+			array(
+				'query_id'   => 'empty',
+				'page'       => 1,
+				'inner_html' => '',
+			)
+		);
+
+		$this->assertArrayHasKey( 'items_html', $result );
+		$this->assertSame( '', $result['items_html'] );
+	}
+}

--- a/tests/phpunit/blocks/query/item-hosts-test.php
+++ b/tests/phpunit/blocks/query/item-hosts-test.php
@@ -179,7 +179,9 @@ class DesignSetGo_Query_Item_Hosts_Test extends WP_UnitTestCase {
 			'class="test-wrap"'
 		);
 
-		$this->assertSame( 2, substr_count( $html, '<p>Primary host</p>' ) );
+		// Match `Primary host</p>` so WP 6.8+'s added `wp-block-paragraph`
+		// class doesn't invalidate the count.
+		$this->assertSame( 2, substr_count( $html, 'Primary host</p>' ) );
 		$this->assertStringNotContainsString( 'Secondary host', $html );
 		$this->assertStringNotContainsString( 'dsgo-slider__track', $html );
 	}

--- a/tests/phpunit/blocks/query/item-hosts-test.php
+++ b/tests/phpunit/blocks/query/item-hosts-test.php
@@ -128,4 +128,59 @@ class DesignSetGo_Query_Item_Hosts_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'items_html', $result );
 		$this->assertSame( '', $result['items_html'] );
 	}
+
+	public function test_container_renders_only_the_first_registered_item_host() {
+		self::factory()->post->create_many( 2, array( 'post_status' => 'publish' ) );
+		$this->load_helpers();
+
+		$parsed_children = array(
+			array(
+				'blockName'   => 'designsetgo/query-results',
+				'attrs'       => array( 'itemTagName' => 'li' ),
+				'innerBlocks' => array(
+					array(
+						'blockName'    => 'core/paragraph',
+						'attrs'        => array(),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<p>Primary host</p>',
+						'innerContent' => array( '<p>Primary host</p>' ),
+					),
+				),
+				'innerHTML'    => '',
+				'innerContent' => array( '' ),
+			),
+			array(
+				'blockName'   => 'designsetgo/slider',
+				'attrs'       => array(),
+				'innerBlocks' => array(
+					array(
+						'blockName'    => 'core/paragraph',
+						'attrs'        => array(),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<p>Secondary host</p>',
+						'innerContent' => array( '<p>Secondary host</p>' ),
+					),
+				),
+				'innerHTML'    => '',
+				'innerContent' => array( '' ),
+			),
+		);
+
+		$html = designsetgo_query_render_container(
+			array(
+				'source'   => 'posts',
+				'postType' => 'post',
+				'perPage'  => 2,
+				'queryId'  => 'first-host-only',
+			),
+			$parsed_children,
+			1,
+			'first-host-only',
+			'class="test-wrap"'
+		);
+
+		$this->assertSame( 2, substr_count( $html, '<p>Primary host</p>' ) );
+		$this->assertStringNotContainsString( 'Secondary host', $html );
+		$this->assertStringNotContainsString( 'dsgo-slider__track', $html );
+	}
 }

--- a/tests/phpunit/blocks/query/scroll-slides-host-test.php
+++ b/tests/phpunit/blocks/query/scroll-slides-host-test.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Scroll-slides-as-query-item-host contract.
+ *
+ * @group query-block
+ */
+class DesignSetGo_Scroll_Slides_Host_Test extends WP_UnitTestCase {
+
+	private function load_helpers() {
+		$path = DESIGNSETGO_PATH . 'build/blocks/query/render-helpers.php';
+		$this->assertFileExists( $path, 'Run `npm run build` before PHPUnit — render helpers are served from build/.' );
+		require_once $path;
+	}
+
+	public function test_scroll_slides_registered_as_default_host() {
+		$this->load_helpers();
+		$this->assertContains(
+			'designsetgo/scroll-slides',
+			designsetgo_query_item_host_block_names()
+		);
+	}
+
+	public function test_block_type_registered_with_render_callback_and_query_context() {
+		$this->load_helpers();
+		$type = WP_Block_Type_Registry::get_instance()->get_registered( 'designsetgo/scroll-slides' );
+		$this->assertNotNull( $type );
+		$this->assertNotEmpty( $type->render_callback );
+		$this->assertContains( 'designsetgo/queryId', (array) $type->uses_context );
+	}
+
+	public function test_container_with_scroll_slides_host_iterates_and_chrome_renders() {
+		self::factory()->post->create_many( 3, array( 'post_status' => 'publish' ) );
+		$this->load_helpers();
+
+		$parsed_children = array(
+			array(
+				'blockName'   => 'designsetgo/scroll-slides',
+				'attrs'       => array( 'minHeight' => '80vh' ),
+				'innerBlocks' => array(
+					array(
+						'blockName'    => 'core/paragraph',
+						'attrs'        => array(),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<p>Panel template</p>',
+						'innerContent' => array( '<p>Panel template</p>' ),
+					),
+					array(
+						'blockName'    => 'core/paragraph',
+						'attrs'        => array(),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<p>Stray second child</p>',
+						'innerContent' => array( '<p>Stray second child</p>' ),
+					),
+				),
+				'innerHTML'    => '',
+				'innerContent' => array( '' ),
+			),
+		);
+
+		$html = designsetgo_query_render_container(
+			array(
+				'source'   => 'posts',
+				'postType' => 'post',
+				'perPage'  => 3,
+				'queryId'  => 'ss-host',
+			),
+			$parsed_children,
+			1,
+			'ss-host',
+			'class="test-wrap"'
+		);
+
+		$this->assertStringContainsString( 'dsgo-scroll-slides__panels', $html );
+		$this->assertStringContainsString( 'dsgo-scroll-slides__inner', $html );
+		// Chrome receives minHeight via data attr.
+		$this->assertStringContainsString( 'data-dsgo-min-height="80vh"', $html );
+		// Exactly one template block is used — 3 iterations of Panel template.
+		$this->assertSame( 3, substr_count( $html, '<p>Panel template</p>' ) );
+		// Non-template sibling never leaks.
+		$this->assertStringNotContainsString( 'Stray second child', $html );
+		// Non-grid host: no <li class="dsgo-query__item"> wrappers around items.
+		$this->assertStringNotContainsString( 'dsgo-query__item', $html );
+	}
+}

--- a/tests/phpunit/blocks/query/scroll-slides-host-test.php
+++ b/tests/phpunit/blocks/query/scroll-slides-host-test.php
@@ -75,7 +75,9 @@ class DesignSetGo_Scroll_Slides_Host_Test extends WP_UnitTestCase {
 		// Chrome receives minHeight via data attr.
 		$this->assertStringContainsString( 'data-dsgo-min-height="80vh"', $html );
 		// Exactly one template block is used — 3 iterations of Panel template.
-		$this->assertSame( 3, substr_count( $html, '<p>Panel template</p>' ) );
+		// Match `Panel template</p>` so WP 6.8+'s added `wp-block-paragraph`
+		// class doesn't invalidate the count.
+		$this->assertSame( 3, substr_count( $html, 'Panel template</p>' ) );
 		// Non-template sibling never leaks.
 		$this->assertStringNotContainsString( 'Stray second child', $html );
 		// Non-grid host: no <li class="dsgo-query__item"> wrappers around items.

--- a/tests/phpunit/blocks/query/slider-host-test.php
+++ b/tests/phpunit/blocks/query/slider-host-test.php
@@ -34,7 +34,10 @@ class DesignSetGo_Slider_Host_Test extends WP_UnitTestCase {
 			'none'
 		);
 
-		$this->assertStringContainsString( '<p>Bare</p>', $html );
+		// WP 6.8+ emits core/paragraph with a `wp-block-paragraph` class. Match
+		// the closing tag + content so both pre- and post-6.8 output pass.
+		$this->assertStringContainsString( 'Bare</p>', $html );
+		$this->assertMatchesRegularExpression( '#<p[^>]*>Bare</p>#', $html );
 		$this->assertStringNotContainsString( 'dsgo-query__item', $html );
 		// No leading <li, <div, or <article wrapper around the paragraph.
 		$this->assertStringStartsNotWith( '<li', $html );
@@ -109,7 +112,9 @@ class DesignSetGo_Slider_Host_Test extends WP_UnitTestCase {
 		// Slider chrome present (slider's render.php should have emitted it).
 		$this->assertStringContainsString( 'dsgo-slider__track', $html );
 		// Template is innerBlocks[0] only — 3 posts → 3 renderings of Slide one.
-		$this->assertSame( 3, substr_count( $html, '<p>Slide one</p>' ) );
+		// Match `Slide one</p>` so an added `wp-block-paragraph` class (WP 6.8+)
+		// doesn't invalidate the count.
+		$this->assertSame( 3, substr_count( $html, 'Slide one</p>' ) );
 		// The unused 2nd sibling never leaks into output.
 		$this->assertStringNotContainsString( 'Slide two', $html );
 		// Non-grid host should NOT double-wrap with <li class="dsgo-query__item">.
@@ -162,8 +167,9 @@ class DesignSetGo_Slider_Host_Test extends WP_UnitTestCase {
 
 		// Grid host keeps all innerBlocks as the template, wrapped per item.
 		$this->assertSame( 2, substr_count( $html, '<li class="dsgo-query__item">' ) );
-		// Both paragraphs render inside each <li>.
-		$this->assertStringContainsString( '<p>First</p>', $html );
-		$this->assertStringContainsString( '<p>Second</p>', $html );
+		// Both paragraphs render inside each <li>. Match closing tag + content
+		// so the WP 6.8+ `wp-block-paragraph` class doesn't break the assertion.
+		$this->assertStringContainsString( 'First</p>', $html );
+		$this->assertStringContainsString( 'Second</p>', $html );
 	}
 }

--- a/tests/phpunit/blocks/query/slider-host-test.php
+++ b/tests/phpunit/blocks/query/slider-host-test.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Slider-as-query-item-host contract.
+ *
+ * Verifies:
+ *  - itemTagName='none' passed to designsetgo_query_render_item skips the
+ *    per-item <li>/<div> wrapper.
+ *  - The registry default includes designsetgo/slider.
+ *  - designsetgo_query_render_container, when it finds a slider host, feeds
+ *    itemTagName='none' through to the source renderer and takes only the
+ *    first inner block as the template.
+ *
+ * @group query-block
+ */
+class DesignSetGo_Slider_Host_Test extends WP_UnitTestCase {
+
+	private function load_helpers() {
+		$path = DESIGNSETGO_PATH . 'build/blocks/query/render-helpers.php';
+		$this->assertFileExists( $path, 'Run `npm run build` before PHPUnit — render helpers are served from build/.' );
+		require_once $path;
+	}
+
+	public function test_slider_is_registered_as_default_host() {
+		$this->load_helpers();
+		$this->assertContains( 'designsetgo/slider', designsetgo_query_item_host_block_names() );
+	}
+
+	public function test_render_item_skips_wrapper_when_tag_is_none() {
+		$this->load_helpers();
+
+		$html = designsetgo_query_render_item(
+			'<!-- wp:paragraph --><p>Bare</p><!-- /wp:paragraph -->',
+			array( 'postId' => 0, 'postType' => 'post' ),
+			'none'
+		);
+
+		$this->assertStringContainsString( '<p>Bare</p>', $html );
+		$this->assertStringNotContainsString( 'dsgo-query__item', $html );
+		// No leading <li, <div, or <article wrapper around the paragraph.
+		$this->assertStringStartsNotWith( '<li', $html );
+		$this->assertStringStartsNotWith( '<article', $html );
+	}
+
+	public function test_render_item_defaults_to_li_when_tag_is_unknown() {
+		$this->load_helpers();
+
+		$html = designsetgo_query_render_item(
+			'<!-- wp:paragraph --><p>Wrapped</p><!-- /wp:paragraph -->',
+			array( 'postId' => 0 ),
+			'garbage-value'
+		);
+
+		$this->assertStringContainsString( '<li class="dsgo-query__item">', $html );
+	}
+
+	public function test_slider_block_type_registered_with_render_callback() {
+		$this->load_helpers();
+		$registry = WP_Block_Type_Registry::get_instance();
+		$type     = $registry->get_registered( 'designsetgo/slider' );
+		$this->assertNotNull( $type, 'designsetgo/slider must be registered for query integration.' );
+		$this->assertNotEmpty( $type->render_callback, 'Slider must have a render_callback (render.php).' );
+		$this->assertContains( 'designsetgo/queryId', (array) $type->uses_context, 'Slider must opt into queryId context.' );
+	}
+
+	public function test_container_with_slider_host_uses_first_inner_block_only() {
+		self::factory()->post->create_many( 3, array( 'post_status' => 'publish' ) );
+		$this->load_helpers();
+
+		// Emulate a parsed innerBlocks tree: designsetgo/slider containing two
+		// slides. Only the first slide should be used as the item template.
+		$parsed_children = array(
+			array(
+				'blockName'   => 'designsetgo/slider',
+				'attrs'       => array(),
+				'innerBlocks' => array(
+					array(
+						'blockName'    => 'core/paragraph',
+						'attrs'        => array(),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<p>Slide one</p>',
+						'innerContent' => array( '<p>Slide one</p>' ),
+					),
+					array(
+						'blockName'    => 'core/paragraph',
+						'attrs'        => array(),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<p>Slide two</p>',
+						'innerContent' => array( '<p>Slide two</p>' ),
+					),
+				),
+				'innerHTML'    => '',
+				'innerContent' => array( '' ),
+			),
+		);
+
+		$html = designsetgo_query_render_container(
+			array(
+				'source'   => 'posts',
+				'postType' => 'post',
+				'perPage'  => 3,
+				'queryId'  => 'slider-host',
+			),
+			$parsed_children,
+			1,
+			'slider-host',
+			'class="test-wrap"'
+		);
+
+		// Slider chrome present (slider's render.php should have emitted it).
+		$this->assertStringContainsString( 'dsgo-slider__track', $html );
+		// Template is innerBlocks[0] only — 3 posts → 3 renderings of Slide one.
+		$this->assertSame( 3, substr_count( $html, '<p>Slide one</p>' ) );
+		// The unused 2nd sibling never leaks into output.
+		$this->assertStringNotContainsString( 'Slide two', $html );
+		// Non-grid host should NOT double-wrap with <li class="dsgo-query__item">.
+		$this->assertStringNotContainsString( 'dsgo-query__item', $html );
+	}
+
+	public function test_container_with_grid_host_keeps_all_inner_blocks_as_template() {
+		self::factory()->post->create_many( 2, array( 'post_status' => 'publish' ) );
+		$this->load_helpers();
+
+		// designsetgo/query-results with TWO inner blocks — both should render
+		// inside the per-item <li> wrapper.
+		$parsed_children = array(
+			array(
+				'blockName'   => 'designsetgo/query-results',
+				'attrs'       => array( 'itemTagName' => 'li' ),
+				'innerBlocks' => array(
+					array(
+						'blockName'    => 'core/paragraph',
+						'attrs'        => array(),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<p>First</p>',
+						'innerContent' => array( '<p>First</p>' ),
+					),
+					array(
+						'blockName'    => 'core/paragraph',
+						'attrs'        => array(),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<p>Second</p>',
+						'innerContent' => array( '<p>Second</p>' ),
+					),
+				),
+				'innerHTML'    => '',
+				'innerContent' => array( '' ),
+			),
+		);
+
+		$html = designsetgo_query_render_container(
+			array(
+				'source'   => 'posts',
+				'postType' => 'post',
+				'perPage'  => 2,
+				'queryId'  => 'grid-host',
+			),
+			$parsed_children,
+			1,
+			'grid-host',
+			'class="test-wrap"'
+		);
+
+		// Grid host keeps all innerBlocks as the template, wrapped per item.
+		$this->assertSame( 2, substr_count( $html, '<li class="dsgo-query__item">' ) );
+		// Both paragraphs render inside each <li>.
+		$this->assertStringContainsString( '<p>First</p>', $html );
+		$this->assertStringContainsString( '<p>Second</p>', $html );
+	}
+}

--- a/tests/unit/blocks/query-group-header/edit.test.js
+++ b/tests/unit/blocks/query-group-header/edit.test.js
@@ -1,29 +1,29 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-jest.mock( '@wordpress/i18n', () => ( { __: ( t ) => t } ) );
+jest.mock('@wordpress/i18n', () => ({ __: (t) => t }));
 
-jest.mock( '@wordpress/block-editor', () => ( {
-	useBlockProps: () => ( { className: 'dsgo-query-group-header' } ),
-	useInnerBlocksProps: ( p = {} ) => ( {
+jest.mock('@wordpress/block-editor', () => ({
+	useBlockProps: () => ({ className: 'dsgo-query-group-header' }),
+	useInnerBlocksProps: (p = {}) => ({
 		...p,
 		children: <div data-testid="inner-blocks" />,
-	} ),
-} ) );
+	}),
+}));
 
 import Edit from '../../../../src/blocks/query-group-header/edit';
 
-describe( 'QueryGroupHeader edit', () => {
-	it( 'renders an InnerBlocks wrapper', () => {
-		render( <Edit attributes={ {} } context={ {} } clientId="g1" /> );
-		expect( screen.getByTestId( 'inner-blocks' ) ).toBeInTheDocument();
-	} );
+describe('QueryGroupHeader edit', () => {
+	it('renders an InnerBlocks wrapper', () => {
+		render(<Edit attributes={{}} context={{}} clientId="g1" />);
+		expect(screen.getByTestId('inner-blocks')).toBeInTheDocument();
+	});
 
-	it( 'applies the block class to the wrapper', () => {
+	it('applies the block class to the wrapper', () => {
 		const { container } = render(
-			<Edit attributes={ {} } context={ {} } clientId="g2" />
+			<Edit attributes={{}} context={{}} clientId="g2" />
 		);
 		const wrapper = container.firstChild;
-		expect( wrapper ).toHaveClass( 'dsgo-query-group-header' );
-	} );
-} );
+		expect(wrapper).toHaveClass('dsgo-query-group-header');
+	});
+});

--- a/tests/unit/blocks/query/NestedPreview.test.js
+++ b/tests/unit/blocks/query/NestedPreview.test.js
@@ -43,7 +43,7 @@ jest.mock('@wordpress/data', () => ({
 					},
 				};
 				return {
-					getBlock: ( clientId ) =>
+					getBlock: (clientId) =>
 						clientId === 'parent-client-id'
 							? parentQuery
 							: {
@@ -54,9 +54,9 @@ jest.mock('@wordpress/data', () => ({
 											attributes: {},
 										},
 									],
-							  },
+								},
 					getBlocks: () => [],
-					getBlockParents: () => [ 'parent-client-id' ],
+					getBlockParents: () => ['parent-client-id'],
 				};
 			}
 			// TemplateIO calls getCurrentPostId() on the editor store.
@@ -319,14 +319,14 @@ describe('QueryResultsEdit nested preview', () => {
 				attributes={DEFAULT_ATTRIBUTES}
 				setAttributes={jest.fn()}
 				clientId="cli-1"
-				context={{ 'designsetgo/parentItem': { postId: 99, postType: 'post' } }}
+				context={{
+					'designsetgo/parentItem': { postId: 99, postType: 'post' },
+				}}
 			/>
 		);
 		// At least one BlockContextProvider must have received the outer parentItem.
 		expect(
-			ctxCapture.some(
-				(c) => c?.['designsetgo/parentItem']?.postId === 99
-			)
+			ctxCapture.some((c) => c?.['designsetgo/parentItem']?.postId === 99)
 		).toBe(true);
 	});
 
@@ -396,9 +396,7 @@ describe('QueryResultsEdit nested preview', () => {
 		// Editor sessions are always authenticated; auth visibility rules should
 		// never hide content from the admin in the editor preview.
 		expect(
-			ctxCapture.some(
-				(c) => c?.['designsetgo/isAuthenticated'] === true
-			)
+			ctxCapture.some((c) => c?.['designsetgo/isAuthenticated'] === true)
 		).toBe(true);
 	});
 });

--- a/tests/unit/blocks/query/TemplateIO.test.js
+++ b/tests/unit/blocks/query/TemplateIO.test.js
@@ -38,7 +38,9 @@ jest.mock('@wordpress/block-editor', () => ({ store: 'core/block-editor' }));
 jest.mock('@wordpress/notices', () => ({ store: 'core/notices' }));
 jest.mock('@wordpress/blocks', () => ({
 	parse: jest.fn(() => [{ name: 'designsetgo/query' }]),
-	serialize: jest.fn(() => '<!-- wp:paragraph --><p>Item</p><!-- /wp:paragraph -->'),
+	serialize: jest.fn(
+		() => '<!-- wp:paragraph --><p>Item</p><!-- /wp:paragraph -->'
+	),
 }));
 
 jest.mock('@wordpress/components', () => ({
@@ -164,10 +166,9 @@ describe('TemplateIO', () => {
 		fireEvent.click(screen.getByText('Export template'));
 
 		await waitFor(() =>
-			expect(mockCreateErrorNotice).toHaveBeenCalledWith(
-				'Blob failure',
-				{ type: 'snackbar' }
-			)
+			expect(mockCreateErrorNotice).toHaveBeenCalledWith('Blob failure', {
+				type: 'snackbar',
+			})
 		);
 		global.Blob = originalBlob;
 	});
@@ -206,7 +207,10 @@ describe('TemplateIO', () => {
 		);
 
 		await waitFor(() =>
-			expect(mockReplaceBlocks).toHaveBeenCalledWith('c1', expect.any(Array))
+			expect(mockReplaceBlocks).toHaveBeenCalledWith(
+				'c1',
+				expect.any(Array)
+			)
 		);
 		expect(parse).toHaveBeenCalled();
 	});

--- a/tests/unit/blocks/query/advanced-panel.test.js
+++ b/tests/unit/blocks/query/advanced-panel.test.js
@@ -180,18 +180,10 @@ describe('AdvancedPanel', () => {
 		).toBeInTheDocument();
 	});
 
-	it('Wrapper tag SelectControl is present', () => {
-		renderWith();
-		// SelectControl uses label as aria-label — ToolsPanelItem default is isShownByDefault=true
-		// but our mock hides items with isShownByDefault=false; Wrapper tag has no explicit
-		// isShownByDefault so it defaults to truthy and renders.
-		expect(screen.getByLabelText(/wrapper tag/i)).toBeInTheDocument();
-	});
-
-	it('Item tag SelectControl is present', () => {
-		renderWith();
-		expect(screen.getByLabelText(/item tag/i)).toBeInTheDocument();
-	});
+	// Wrapper / Item tag SelectControls moved out of AdvancedPanel into the
+	// shared ResultsLayoutControls when the Results layout panel was added to
+	// both the parent query inspector and the query-results child inspector.
+	// Those controls are now covered by the ResultsLayoutControls-level tests.
 
 	it('Manual IDs filters out non-positive integers', () => {
 		const { setAttributes } = renderWith({

--- a/tests/unit/blocks/query/date-query-builder.test.js
+++ b/tests/unit/blocks/query/date-query-builder.test.js
@@ -3,104 +3,104 @@ import '@testing-library/jest-dom';
 
 // ─── WordPress module mocks ───────────────────────────────────────────────────
 
-jest.mock( '@wordpress/i18n', () => ( {
-	__: ( text ) => text,
-	sprintf: ( fmt, ...args ) => {
+jest.mock('@wordpress/i18n', () => ({
+	__: (text) => text,
+	sprintf: (fmt, ...args) => {
 		let i = 0;
-		return fmt.replace( /%[sd]/g, () => String( args[ i++ ] ?? '' ) );
+		return fmt.replace(/%[sd]/g, () => String(args[i++] ?? ''));
 	},
-} ) );
+}));
 
-jest.mock( '@wordpress/data', () => ( {
+jest.mock('@wordpress/data', () => ({
 	useSelect: () => undefined,
-	useDispatch: () => ( {} ),
-} ) );
+	useDispatch: () => ({}),
+}));
 
-jest.mock( '@wordpress/core-data', () => ( { store: 'core' } ) );
+jest.mock('@wordpress/core-data', () => ({ store: 'core' }));
 
-jest.mock( '@wordpress/block-editor', () => ( {
-	useBlockProps: () => ( {} ),
-	useInnerBlocksProps: ( p = {} ) => ( { ...p, children: null } ),
-	InspectorControls: ( { children } ) => <div>{ children }</div>,
+jest.mock('@wordpress/block-editor', () => ({
+	useBlockProps: () => ({}),
+	useInnerBlocksProps: (p = {}) => ({ ...p, children: null }),
+	InspectorControls: ({ children }) => <div>{children}</div>,
 	store: 'core/block-editor',
-} ) );
+}));
 
-jest.mock( '@wordpress/blocks', () => ( {
-	createBlocksFromInnerBlocksTemplate: jest.fn( ( t ) => t ),
-} ) );
+jest.mock('@wordpress/blocks', () => ({
+	createBlocksFromInnerBlocksTemplate: jest.fn((t) => t),
+}));
 
-jest.mock( '@wordpress/components', () => {
-	const SelectControl = ( { label, value, options, onChange } ) => (
+jest.mock('@wordpress/components', () => {
+	const SelectControl = ({ label, value, options, onChange }) => (
 		<label>
-			{ label }
+			{label}
 			<select
-				value={ value }
-				onChange={ ( e ) => onChange( e.target.value ) }
-				aria-label={ label }
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				aria-label={label}
 			>
-				{ ( options || [] ).map( ( opt ) => (
-					<option key={ opt.value } value={ opt.value }>
-						{ opt.label }
+				{(options || []).map((opt) => (
+					<option key={opt.value} value={opt.value}>
+						{opt.label}
 					</option>
-				) ) }
+				))}
 			</select>
 		</label>
 	);
 
-	const TextControl = ( { label, value, onChange } ) => (
+	const TextControl = ({ label, value, onChange }) => (
 		<label>
-			{ label }
+			{label}
 			<input
 				type="text"
-				value={ value }
-				onChange={ ( e ) => onChange( e.target.value ) }
-				aria-label={ label }
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				aria-label={label}
 			/>
 		</label>
 	);
 
-	const Button = ( {
+	const Button = ({
 		children,
 		onClick,
 		disabled,
 		'aria-label': ariaLabel,
 		isDestructive,
 		variant,
-	} ) => (
+	}) => (
 		<button
 			type="button"
-			onClick={ onClick }
-			disabled={ disabled }
-			aria-label={ ariaLabel }
-			data-destructive={ isDestructive ? 'true' : undefined }
-			data-variant={ variant }
+			onClick={onClick}
+			disabled={disabled}
+			aria-label={ariaLabel}
+			data-destructive={isDestructive ? 'true' : undefined}
+			data-variant={variant}
 		>
-			{ children }
+			{children}
 		</button>
 	);
 
-	const ToggleControl = ( { label, checked, onChange } ) => (
+	const ToggleControl = ({ label, checked, onChange }) => (
 		<label>
-			{ label }
+			{label}
 			<input
 				type="checkbox"
-				aria-label={ label }
-				checked={ checked }
-				onChange={ ( e ) => onChange( e.target.checked ) }
+				aria-label={label}
+				checked={checked}
+				onChange={(e) => onChange(e.target.checked)}
 			/>
 		</label>
 	);
 
 	// ToolsPanelItem: isShownByDefault=false items are hidden.
-	const ToolsPanelItem = ( { children, isShownByDefault } ) =>
-		isShownByDefault !== false ? <>{ children }</> : null;
+	const ToolsPanelItem = ({ children, isShownByDefault }) =>
+		isShownByDefault !== false ? <>{children}</> : null;
 
-	const ToolsPanel = ( { children, label } ) => (
-		<fieldset aria-label={ label }>{ children }</fieldset>
+	const ToolsPanel = ({ children, label }) => (
+		<fieldset aria-label={label}>{children}</fieldset>
 	);
 
-	const VStack = ( { children } ) => <div>{ children }</div>;
-	const HStack = ( { children } ) => <div>{ children }</div>;
+	const VStack = ({ children }) => <div>{children}</div>;
+	const HStack = ({ children }) => <div>{children}</div>;
 
 	return {
 		SelectControl,
@@ -112,9 +112,9 @@ jest.mock( '@wordpress/components', () => {
 		__experimentalHStack: HStack,
 		__experimentalVStack: VStack,
 	};
-} );
+});
 
-jest.mock( '@wordpress/element', () => jest.requireActual( '@wordpress/element' ) );
+jest.mock('@wordpress/element', () => jest.requireActual('@wordpress/element'));
 
 // ─── Component under test ─────────────────────────────────────────────────────
 import DateQueryBuilder from '../../../../src/blocks/query/components/DateQueryBuilder';
@@ -125,42 +125,44 @@ const defaultAttrs = {
 	dateQuery: { relation: 'AND', clauses: [] },
 };
 
-describe( 'DateQueryBuilder', () => {
-	it( 'renders empty state with an Add button', () => {
+describe('DateQueryBuilder', () => {
+	it('renders empty state with an Add button', () => {
 		render(
 			<DateQueryBuilder
-				attributes={ defaultAttrs }
-				setAttributes={ jest.fn() }
+				attributes={defaultAttrs}
+				setAttributes={jest.fn()}
 				clientId="test"
 			/>
 		);
 		expect(
-			screen.getByRole( 'button', { name: /add date clause/i } )
+			screen.getByRole('button', { name: /add date clause/i })
 		).toBeInTheDocument();
-	} );
+	});
 
-	it( 'seeds new clause with post_date / after / inclusive:true defaults', () => {
+	it('seeds new clause with post_date / after / inclusive:true defaults', () => {
 		const setAttributes = jest.fn();
 		render(
 			<DateQueryBuilder
-				attributes={ defaultAttrs }
-				setAttributes={ setAttributes }
+				attributes={defaultAttrs}
+				setAttributes={setAttributes}
 				clientId="test"
 			/>
 		);
-		fireEvent.click( screen.getByRole( 'button', { name: /add date clause/i } ) );
-		expect( setAttributes ).toHaveBeenCalledWith(
-			expect.objectContaining( {
-				dateQuery: expect.objectContaining( {
+		fireEvent.click(
+			screen.getByRole('button', { name: /add date clause/i })
+		);
+		expect(setAttributes).toHaveBeenCalledWith(
+			expect.objectContaining({
+				dateQuery: expect.objectContaining({
 					clauses: [
-						expect.objectContaining( {
+						expect.objectContaining({
 							column: 'post_date',
 							mode: 'after',
 							inclusive: true,
-						} ),
+						}),
 					],
-				} ),
-			} )
+				}),
+			})
 		);
-	} );
-} );
+	});
+});

--- a/tests/unit/blocks/query/edit.test.js
+++ b/tests/unit/blocks/query/edit.test.js
@@ -37,8 +37,8 @@ jest.mock('@wordpress/data', () => ({
 					attributes: {},
 				};
 				return {
-					getBlock: () => ({ innerBlocks: [ stubChild ] }),
-					getBlocks: () => [ stubChild ],
+					getBlock: () => ({ innerBlocks: [stubChild] }),
+					getBlocks: () => [stubChild],
 					getBlockParents: () => [],
 				};
 			}
@@ -322,17 +322,23 @@ describe('QueryEdit — Settings panel', () => {
 
 	it('renders the relationship field input when source is relationship', () => {
 		renderWith({ source: 'relationship' });
-		expect(screen.getByLabelText(/relationship field/i)).toBeInTheDocument();
+		expect(
+			screen.getByLabelText(/relationship field/i)
+		).toBeInTheDocument();
 	});
 
 	it('renders the fallback select when source is relationship', () => {
 		renderWith({ source: 'relationship' });
-		expect(screen.getByLabelText(/when no related items/i)).toBeInTheDocument();
+		expect(
+			screen.getByLabelText(/when no related items/i)
+		).toBeInTheDocument();
 	});
 
 	it('does not render relationship field input when source is posts', () => {
 		renderWith({ source: 'posts' });
-		expect(screen.queryByLabelText(/relationship field/i)).not.toBeInTheDocument();
+		expect(
+			screen.queryByLabelText(/relationship field/i)
+		).not.toBeInTheDocument();
 	});
 
 	it('shows the meta-key input only when orderBy is meta_value', () => {

--- a/tests/unit/blocks/query/tax-query-builder.test.js
+++ b/tests/unit/blocks/query/tax-query-builder.test.js
@@ -300,14 +300,17 @@ describe('TaxQueryBuilder', () => {
 		const setAttributes = jest.fn();
 		const { getByRole } = render(
 			<TaxQueryBuilder
-				attributes={ { taxQuery: { relation: 'AND', clauses: [] }, postType: 'post' } }
-				setAttributes={ setAttributes }
+				attributes={{
+					taxQuery: { relation: 'AND', clauses: [] },
+					postType: 'post',
+				}}
+				setAttributes={setAttributes}
 				clientId="test"
 			/>
 		);
-		fireEvent.click( getByRole( 'button', { name: /add group/i } ) );
+		fireEvent.click(getByRole('button', { name: /add group/i }));
 		const call = setAttributes.mock.calls[0][0];
-		expect( call.taxQuery.clauses[0] ).toHaveProperty( 'clauses' );
-		expect( call.taxQuery.clauses[0].relation ).toBe( 'AND' );
-	} );
+		expect(call.taxQuery.clauses[0]).toHaveProperty('clauses');
+		expect(call.taxQuery.clauses[0].relation).toBe('AND');
+	});
 });

--- a/tests/unit/blocks/query/useQueryHostPreview.test.js
+++ b/tests/unit/blocks/query/useQueryHostPreview.test.js
@@ -16,23 +16,19 @@ jest.mock('@wordpress/i18n', () => ({
 	sprintf: (text, value) => text.replace('%d', value),
 }));
 
-jest.mock(
-	'../../../../src/blocks/query/hooks/useQueryPreview',
-	() =>
-		jest.fn(() => ({
-			records: [],
-			hasResolved: true,
-		}))
+jest.mock('../../../../src/blocks/query/hooks/useQueryPreview', () =>
+	jest.fn(() => ({
+		records: [],
+		hasResolved: true,
+	}))
 );
 
-jest.mock(
-	'../../../../src/blocks/query/hooks/useRenderedItems',
-	() =>
-		jest.fn(() => ({
-			items: null,
-			loading: false,
-			error: null,
-		}))
+jest.mock('../../../../src/blocks/query/hooks/useRenderedItems', () =>
+	jest.fn(() => ({
+		items: null,
+		loading: false,
+		error: null,
+	}))
 );
 
 const { useEntityRecords } = require('@wordpress/core-data');

--- a/tests/unit/blocks/query/useQueryHostPreview.test.js
+++ b/tests/unit/blocks/query/useQueryHostPreview.test.js
@@ -1,0 +1,79 @@
+import { renderHook } from '@testing-library/react';
+import useQueryHostPreview from '../../../../src/blocks/query/hooks/useQueryHostPreview';
+
+jest.mock('@wordpress/core-data', () => ({
+	useEntityRecords: jest.fn(),
+}));
+
+jest.mock('@wordpress/api-fetch', () => jest.fn());
+
+jest.mock('@wordpress/url', () => ({
+	addQueryArgs: jest.fn((path) => path),
+}));
+
+jest.mock('@wordpress/i18n', () => ({
+	__: (text) => text,
+	sprintf: (text, value) => text.replace('%d', value),
+}));
+
+jest.mock(
+	'../../../../src/blocks/query/hooks/useQueryPreview',
+	() =>
+		jest.fn(() => ({
+			records: [],
+			hasResolved: true,
+		}))
+);
+
+jest.mock(
+	'../../../../src/blocks/query/hooks/useRenderedItems',
+	() =>
+		jest.fn(() => ({
+			items: null,
+			loading: false,
+			error: null,
+		}))
+);
+
+const { useEntityRecords } = require('@wordpress/core-data');
+const apiFetch = require('@wordpress/api-fetch');
+
+describe('useQueryHostPreview', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		useEntityRecords.mockReturnValue({
+			records: [],
+			hasResolved: true,
+		});
+	});
+
+	it.each(['manual', 'current'])(
+		'treats %s as a posts-family source for editor previews',
+		(source) => {
+			renderHook(() =>
+				useQueryHostPreview({
+					attributes: {
+						source,
+						postType: 'post',
+						perPage: 4,
+						orderBy: 'date',
+						order: 'DESC',
+					},
+					queryId: 'query-preview',
+					innerBlocks: [],
+				})
+			);
+
+			expect(useEntityRecords).toHaveBeenCalledWith(
+				'postType',
+				'post',
+				expect.objectContaining({
+					per_page: 4,
+					orderby: 'date',
+					order: 'desc',
+				})
+			);
+			expect(apiFetch).not.toHaveBeenCalled();
+		}
+	);
+});

--- a/tests/unit/blocks/query/useQueryPreview.test.js
+++ b/tests/unit/blocks/query/useQueryPreview.test.js
@@ -28,15 +28,15 @@ describe('normalizeRelationshipIds', () => {
 	});
 
 	it('handles array of WP_Post-style objects with .ID', () => {
-		expect(
-			normalizeRelationshipIds([{ ID: 12 }, { ID: 34 }])
-		).toEqual([12, 34]);
+		expect(normalizeRelationshipIds([{ ID: 12 }, { ID: 34 }])).toEqual([
+			12, 34,
+		]);
 	});
 
 	it('handles array of REST-style objects with .id (lowercase)', () => {
-		expect(
-			normalizeRelationshipIds([{ id: 12 }, { id: 34 }])
-		).toEqual([12, 34]);
+		expect(normalizeRelationshipIds([{ id: 12 }, { id: 34 }])).toEqual([
+			12, 34,
+		]);
 	});
 
 	it('handles comma-separated string', () => {

--- a/tests/unit/blocks/query/variations.test.js
+++ b/tests/unit/blocks/query/variations.test.js
@@ -1,8 +1,15 @@
 import variations from '../../../../src/blocks/query/variations';
 
+const ITEM_HOST_NAMES = [
+	'designsetgo/query-results',
+	'designsetgo/slider',
+	'designsetgo/scroll-slides',
+];
+
 describe('Query block variations', () => {
-	it('ships exactly six variations', () => {
-		expect(variations).toHaveLength(6);
+	it('ships at least the built-in variations', () => {
+		// Count floor: bump when a new built-in variation is added.
+		expect(variations.length).toBeGreaterThanOrEqual(8);
 	});
 
 	it.each(variations.map((v) => [v.name, v]))(
@@ -20,18 +27,20 @@ describe('Query block variations', () => {
 		}
 	);
 
-	it('wraps the item template in a designsetgo/query-results child', () => {
+	it('wraps the item template in a registered item-host child', () => {
+		// v2.6: accept any of the known item hosts (query-results, slider,
+		// scroll-slides). Mirrors designsetgo_query_item_host_block_names().
 		variations.forEach((v) => {
-			const resultsChild = v.innerBlocks.find(
-				(b) => Array.isArray(b) && b[0] === 'designsetgo/query-results'
+			const hostChild = v.innerBlocks.find(
+				(b) => Array.isArray(b) && ITEM_HOST_NAMES.includes(b[0])
 			);
-			expect(resultsChild).toBeDefined();
+			expect(hostChild).toBeDefined();
 		});
 	});
 
 	it('has unique names', () => {
 		const names = variations.map((v) => v.name);
-		expect(new Set(names).size).toBe(6);
+		expect(new Set(names).size).toBe(names.length);
 	});
 
 	it('related-posts variation has excludeCurrent: true', () => {

--- a/tests/unit/components/DsgoChildToolbar.test.js
+++ b/tests/unit/components/DsgoChildToolbar.test.js
@@ -224,6 +224,34 @@ describe('DsgoChildToolbar', () => {
 		expect(onActiveIndexChange).toHaveBeenCalledWith(1, null);
 	});
 
+	test('disable flags prevent the toolbar actions from dispatching', async () => {
+		setupSelect(makeChildren(3));
+		render(
+			<DsgoChildToolbar
+				parentClientId="parent"
+				childBlockName="designsetgo/tab"
+				activeIndex={1}
+				disableAdd
+				disableDuplicate
+				disableRemove
+				disableMove
+			/>
+		);
+
+		expect(screen.getByLabelText('Add item')).toBeDisabled();
+		expect(screen.getByLabelText('Duplicate item')).toBeDisabled();
+		expect(screen.getByLabelText('Remove item')).toBeDisabled();
+		expect(screen.getByLabelText('Move left')).toBeDisabled();
+		expect(screen.getByLabelText('Move right')).toBeDisabled();
+
+		await userEvent.click(screen.getByLabelText('Add item'));
+		await userEvent.click(screen.getByLabelText('Duplicate item'));
+		await userEvent.click(screen.getByLabelText('Remove item'));
+
+		expect(insertBlock).not.toHaveBeenCalled();
+		expect(removeBlock).not.toHaveBeenCalled();
+	});
+
 	test('Remove is disabled when only one child remains', () => {
 		setupSelect(makeChildren(1));
 		render(

--- a/tests/unit/extensions/style-binding/style-binding.test.js
+++ b/tests/unit/extensions/style-binding/style-binding.test.js
@@ -1,44 +1,48 @@
 import { applyFilters } from '@wordpress/hooks';
 import '../../../../src/extensions/style-binding/filters';
 
-describe( 'style-binding extension', () => {
-	it( 'registers dsgoStyleBinding attribute on block registration', () => {
+describe('style-binding extension', () => {
+	it('registers dsgoStyleBinding attribute on block registration', () => {
 		const result = applyFilters(
 			'blocks.registerBlockType',
 			{ attributes: {} },
 			'core/paragraph'
 		);
-		expect( result.attributes ).toHaveProperty( 'dsgoStyleBinding' );
-		expect( result.attributes.dsgoStyleBinding.type ).toBe( 'object' );
-	} );
+		expect(result.attributes).toHaveProperty('dsgoStyleBinding');
+		expect(result.attributes.dsgoStyleBinding.type).toBe('object');
+	});
 
-	it( 'sets dsgoStyleBinding default to empty object', () => {
+	it('sets dsgoStyleBinding default to empty object', () => {
 		const result = applyFilters(
 			'blocks.registerBlockType',
 			{ attributes: {} },
 			'core/group'
 		);
-		expect( result.attributes.dsgoStyleBinding.default ).toEqual( {} );
-	} );
+		expect(result.attributes.dsgoStyleBinding.default).toEqual({});
+	});
 
-	it( 'creates attributes object when settings.attributes is missing', () => {
+	it('creates attributes object when settings.attributes is missing', () => {
 		const result = applyFilters(
 			'blocks.registerBlockType',
 			{},
 			'core/paragraph'
 		);
-		expect( result.attributes ).toBeDefined();
-		expect( result.attributes.dsgoStyleBinding ).toBeDefined();
-	} );
+		expect(result.attributes).toBeDefined();
+		expect(result.attributes.dsgoStyleBinding).toBeDefined();
+	});
 
-	it( 'does not add dsgoStyleBinding to BLOCKED block types', () => {
-		for ( const name of [ 'core/freeform', 'core/missing', 'core/template-part' ] ) {
+	it('does not add dsgoStyleBinding to BLOCKED block types', () => {
+		for (const name of [
+			'core/freeform',
+			'core/missing',
+			'core/template-part',
+		]) {
 			const result = applyFilters(
 				'blocks.registerBlockType',
 				{ attributes: {} },
 				name
 			);
-			expect( result.attributes.dsgoStyleBinding ).toBeUndefined();
+			expect(result.attributes.dsgoStyleBinding).toBeUndefined();
 		}
-	} );
-} );
+	});
+});

--- a/tests/unit/extensions/visibility/VisibilityPanel.test.js
+++ b/tests/unit/extensions/visibility/VisibilityPanel.test.js
@@ -2,15 +2,37 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import VisibilityPanel from '../../../../src/extensions/visibility/VisibilityPanel';
 
-jest.mock('@wordpress/i18n', () => ({ __: (t) => t, sprintf: (t, a) => String(t).replace('%s', a) }));
+jest.mock('@wordpress/i18n', () => ({
+	__: (t) => t,
+	sprintf: (t, a) => String(t).replace('%s', a),
+}));
 jest.mock('@wordpress/components', () => ({
 	SelectControl: ({ label, value, onChange, options }) => (
-		<label>{label}<select value={value} onChange={(e) => onChange(e.target.value)}>{(options || []).map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}</select></label>
+		<label>
+			{label}
+			<select value={value} onChange={(e) => onChange(e.target.value)}>
+				{(options || []).map((o) => (
+					<option key={o.value} value={o.value}>
+						{o.label}
+					</option>
+				))}
+			</select>
+		</label>
 	),
 	TextControl: ({ label, value, onChange }) => (
-		<label>{label}<input value={value || ''} onChange={(e) => onChange(e.target.value)} /></label>
+		<label>
+			{label}
+			<input
+				value={value || ''}
+				onChange={(e) => onChange(e.target.value)}
+			/>
+		</label>
 	),
-	Button: ({ children, onClick }) => <button type="button" onClick={onClick}>{children}</button>,
+	Button: ({ children, onClick }) => (
+		<button type="button" onClick={onClick}>
+			{children}
+		</button>
+	),
 	__experimentalVStack: ({ children }) => <div>{children}</div>,
 	__experimentalHStack: ({ children }) => <div>{children}</div>,
 }));
@@ -34,9 +56,13 @@ describe('VisibilityPanel', () => {
 		const onChange = jest.fn();
 		render(<VisibilityPanel value={null} onChange={onChange} />);
 		fireEvent.click(screen.getByText(/add rule/i));
-		expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
-			operator: 'AND',
-			rules: expect.arrayContaining([expect.objectContaining({ type: 'meta' })]),
-		}));
+		expect(onChange).toHaveBeenCalledWith(
+			expect.objectContaining({
+				operator: 'AND',
+				rules: expect.arrayContaining([
+					expect.objectContaining({ type: 'meta' }),
+				]),
+			})
+		);
 	});
 });

--- a/tests/unit/extensions/visibility/evaluateRules.test.js
+++ b/tests/unit/extensions/visibility/evaluateRules.test.js
@@ -1,73 +1,296 @@
 import evaluateRules from '../../../../src/extensions/visibility/evaluateRules';
 
-describe( 'evaluateRules', () => {
-	it( 'defaults visible when rules null', () => {
-		expect( evaluateRules( null, { postId: 1 } ) ).toBe( true );
-	} );
+describe('evaluateRules', () => {
+	it('defaults visible when rules null', () => {
+		expect(evaluateRules(null, { postId: 1 })).toBe(true);
+	});
 
-	it( 'defaults visible when rules has empty array', () => {
-		expect( evaluateRules( { operator: 'AND', rules: [] }, {} ) ).toBe( true );
-	} );
+	it('defaults visible when rules has empty array', () => {
+		expect(evaluateRules({ operator: 'AND', rules: [] }, {})).toBe(true);
+	});
 
-	it( 'meta equals', () => {
+	it('meta equals', () => {
 		const ctx = { meta: { featured: '1' } };
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'featured', op: 'equals', value: '1' } ] }, ctx ) ).toBe( true );
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'featured', op: 'equals', value: '0' } ] }, ctx ) ).toBe( false );
-	} );
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [
+						{
+							type: 'meta',
+							key: 'featured',
+							op: 'equals',
+							value: '1',
+						},
+					],
+				},
+				ctx
+			)
+		).toBe(true);
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [
+						{
+							type: 'meta',
+							key: 'featured',
+							op: 'equals',
+							value: '0',
+						},
+					],
+				},
+				ctx
+			)
+		).toBe(false);
+	});
 
-	it( 'meta not_equals', () => {
+	it('meta not_equals', () => {
 		const ctx = { meta: { status: 'active' } };
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'status', op: 'not_equals', value: 'inactive' } ] }, ctx ) ).toBe( true );
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'status', op: 'not_equals', value: 'active' } ] }, ctx ) ).toBe( false );
-	} );
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [
+						{
+							type: 'meta',
+							key: 'status',
+							op: 'not_equals',
+							value: 'inactive',
+						},
+					],
+				},
+				ctx
+			)
+		).toBe(true);
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [
+						{
+							type: 'meta',
+							key: 'status',
+							op: 'not_equals',
+							value: 'active',
+						},
+					],
+				},
+				ctx
+			)
+		).toBe(false);
+	});
 
-	it( 'meta contains', () => {
+	it('meta contains', () => {
 		const ctx = { meta: { title: 'Hello World' } };
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'title', op: 'contains', value: 'world' } ] }, ctx ) ).toBe( true );
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'title', op: 'contains', value: 'foo' } ] }, ctx ) ).toBe( false );
-	} );
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [
+						{
+							type: 'meta',
+							key: 'title',
+							op: 'contains',
+							value: 'world',
+						},
+					],
+				},
+				ctx
+			)
+		).toBe(true);
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [
+						{
+							type: 'meta',
+							key: 'title',
+							op: 'contains',
+							value: 'foo',
+						},
+					],
+				},
+				ctx
+			)
+		).toBe(false);
+	});
 
-	it( 'meta empty / not_empty', () => {
+	it('meta empty / not_empty', () => {
 		const ctx = { meta: { filled: 'yes', blank: '' } };
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'blank', op: 'empty' } ] }, ctx ) ).toBe( true );
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'filled', op: 'not_empty' } ] }, ctx ) ).toBe( true );
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'meta', key: 'filled', op: 'empty' } ] }, ctx ) ).toBe( false );
-	} );
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [{ type: 'meta', key: 'blank', op: 'empty' }],
+				},
+				ctx
+			)
+		).toBe(true);
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [{ type: 'meta', key: 'filled', op: 'not_empty' }],
+				},
+				ctx
+			)
+		).toBe(true);
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [{ type: 'meta', key: 'filled', op: 'empty' }],
+				},
+				ctx
+			)
+		).toBe(false);
+	});
 
-	it( 'index equals', () => {
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'index', op: 'equals', value: 0 } ] }, { index: 0 } ) ).toBe( true );
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'index', op: 'equals', value: 0 } ] }, { index: 1 } ) ).toBe( false );
-	} );
+	it('index equals', () => {
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [{ type: 'index', op: 'equals', value: 0 }],
+				},
+				{ index: 0 }
+			)
+		).toBe(true);
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [{ type: 'index', op: 'equals', value: 0 }],
+				},
+				{ index: 1 }
+			)
+		).toBe(false);
+	});
 
-	it( 'index gt / lt', () => {
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'index', op: 'gt', value: 2 } ] }, { index: 5 } ) ).toBe( true );
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'index', op: 'lt', value: 3 } ] }, { index: 1 } ) ).toBe( true );
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'index', op: 'gt', value: 5 } ] }, { index: 3 } ) ).toBe( false );
-	} );
+	it('index gt / lt', () => {
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [{ type: 'index', op: 'gt', value: 2 }],
+				},
+				{ index: 5 }
+			)
+		).toBe(true);
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [{ type: 'index', op: 'lt', value: 3 }],
+				},
+				{ index: 1 }
+			)
+		).toBe(true);
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [{ type: 'index', op: 'gt', value: 5 }],
+				},
+				{ index: 3 }
+			)
+		).toBe(false);
+	});
 
-	it( 'taxonomy has / not_has', () => {
-		const ctx = { terms: { category: [ 'news', 'featured' ] } };
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'taxonomy', taxonomy: 'category', op: 'has', value: 'news' } ] }, ctx ) ).toBe( true );
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'taxonomy', taxonomy: 'category', op: 'not_has', value: 'sports' } ] }, ctx ) ).toBe( true );
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'taxonomy', taxonomy: 'category', op: 'has', value: 'sports' } ] }, ctx ) ).toBe( false );
-	} );
+	it('taxonomy has / not_has', () => {
+		const ctx = { terms: { category: ['news', 'featured'] } };
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [
+						{
+							type: 'taxonomy',
+							taxonomy: 'category',
+							op: 'has',
+							value: 'news',
+						},
+					],
+				},
+				ctx
+			)
+		).toBe(true);
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [
+						{
+							type: 'taxonomy',
+							taxonomy: 'category',
+							op: 'not_has',
+							value: 'sports',
+						},
+					],
+				},
+				ctx
+			)
+		).toBe(true);
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [
+						{
+							type: 'taxonomy',
+							taxonomy: 'category',
+							op: 'has',
+							value: 'sports',
+						},
+					],
+				},
+				ctx
+			)
+		).toBe(false);
+	});
 
-	it( 'auth rule', () => {
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'auth', value: true } ] }, { isAuthenticated: true } ) ).toBe( true );
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'auth', value: true } ] }, { isAuthenticated: false } ) ).toBe( false );
-	} );
+	it('auth rule', () => {
+		expect(
+			evaluateRules(
+				{ operator: 'AND', rules: [{ type: 'auth', value: true }] },
+				{ isAuthenticated: true }
+			)
+		).toBe(true);
+		expect(
+			evaluateRules(
+				{ operator: 'AND', rules: [{ type: 'auth', value: true }] },
+				{ isAuthenticated: false }
+			)
+		).toBe(false);
+	});
 
-	it( 'unknown rule type returns false', () => {
-		expect( evaluateRules( { operator: 'AND', rules: [ { type: 'unknown_type', op: 'equals', value: '1' } ] }, {} ) ).toBe( false );
-	} );
+	it('unknown rule type returns false', () => {
+		expect(
+			evaluateRules(
+				{
+					operator: 'AND',
+					rules: [{ type: 'unknown_type', op: 'equals', value: '1' }],
+				},
+				{}
+			)
+		).toBe(false);
+	});
 
-	it( 'OR relation', () => {
-		const rules = { operator: 'OR', rules: [ { type: 'index', op: 'equals', value: 0 }, { type: 'index', op: 'equals', value: 1 } ] };
-		expect( evaluateRules( rules, { index: 1 } ) ).toBe( true );
-		expect( evaluateRules( rules, { index: 5 } ) ).toBe( false );
-	} );
+	it('OR relation', () => {
+		const rules = {
+			operator: 'OR',
+			rules: [
+				{ type: 'index', op: 'equals', value: 0 },
+				{ type: 'index', op: 'equals', value: 1 },
+			],
+		};
+		expect(evaluateRules(rules, { index: 1 })).toBe(true);
+		expect(evaluateRules(rules, { index: 5 })).toBe(false);
+	});
 
-	it( 'AND relation requires all rules', () => {
+	it('AND relation requires all rules', () => {
 		const ctx = { index: 0, meta: { featured: '1' } };
 		const rules = {
 			operator: 'AND',
@@ -76,7 +299,9 @@ describe( 'evaluateRules', () => {
 				{ type: 'meta', key: 'featured', op: 'equals', value: '1' },
 			],
 		};
-		expect( evaluateRules( rules, ctx ) ).toBe( true );
-		expect( evaluateRules( rules, { index: 0, meta: { featured: '0' } } ) ).toBe( false );
-	} );
-} );
+		expect(evaluateRules(rules, ctx)).toBe(true);
+		expect(
+			evaluateRules(rules, { index: 0, meta: { featured: '0' } })
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Two themes in this branch:

1. **Layout-host variations** — `designsetgo/slider` and `designsetgo/scroll-slides` become Dynamic Query **item hosts** alongside `designsetgo/query-results`. A filterable registry + an `items_html` stash lets hosts iterate the result set through their own `render.php`. Surfaced in the onboarding picker as "Featured carousel" + "Post spotlight".
2. **Variation differentiation + filter/pagination UX polish** — each template-picker variation now carries a distinct `layoutVariant` with scoped SCSS so the inserter tiles read as visually different rather than "same grid, different columns"; the taxonomy filter block gets pill / underlined-tab styles; several pagination + filter bugs that surfaced during QA are fixed.

## Layout-host registry (theme 1)

- `designsetgo_query_item_host_block_names()` (filterable) in `render-helpers.php` — defaults: `query-results`, `slider`, `scroll-slides`.
- Container iterates the registry instead of a hardcoded child lookup; stashes raw per-item HTML in `$GLOBALS['designsetgo_query_items_html'][$queryId]` alongside the existing wrapped `query_results_html`.
- `designsetgo_query_render_item()` gains a `'none'` wrap option so hosts can receive unwrapped per-item HTML.
- Slider + scroll-slides each get a `render.php` (authored mode passes `$content` through; query mode rebuilds chrome in PHP mirroring `save.js` and injects items). `usesContext` declares the query keys.
- Editor preview: `useQueryHostPreview` + `QueryHostReadOnlyItem` iterate items in the editor (Posts via `useEntityRecords`, users/terms via `/designsetgo/v1/query/preview`). Item 0 is an editable InnerBlocks slot; items 1..N render as read-only HTML via a REST preview.

## Variation differentiation (theme 2)

- New `layoutVariant` attribute on `designsetgo/query-results` → `is-layout-<slug>` class on the grid wrapper, honored by both `editor.scss` preview and server render via `designsetgo_query_wrap()`.
- Scoped SCSS in `_layout-variants.scss` (frontend + editor): **magazine**, **avatar-grid** (centered circular avatars), **quote-card** (padded card + decorative `"` + em-dash attribution), **image-tile** (4/3 featured-image with gradient-scrim overlay title + hover zoom), **compact-row** (horizontal thumb + stacked text; works at any `columns` value), **date-forward** (inline-start accent rail + uppercase tracked date).
- Variations tuned to their layout: team uses `align: 'center'` on the featured image (native core centering); portfolio's category filter runs horizontal with `filterStyle: 'pill'`; related-posts excludes current + 3 columns; testimonials drops the image entirely.

## Filter block improvements

- New `filterStyle` attribute on `designsetgo/query-filter` (default `underline`): **Checkboxes**, **Pills**, **Underlined tabs**. Uses `:has(:checked)` for the active visual; native `<input type="checkbox">` stays in the DOM (clipped, not `display:none`) so keyboard + screen-reader users still toggle with Space.
- Filter-kind labels renamed to **"Taxonomy (multi-select)"** / **"Taxonomy (dropdown)"** (both block.json inspector + inserter-variation tile) so the distinction is about behavior, not the currently-rendered control style.
- Sibling blocks (`query-filter`, `query-no-results`, `query-pagination`) switched from `parent` to `ancestor` so authors can wrap them in `designsetgo/grid` / `section` / `row` to style freely — the `designsetgo/queryId` context still propagates down.
- `FilterRegistry::register` now calls `FilterIndexRebuilder::rebuild_filter` on first-time registration so pre-existing posts (e.g. Uncategorized) show accurate counts immediately instead of `(0)` until a manual CLI rebuild.
- Editor canvas pulls real taxonomy terms via `useEntityRecords('taxonomy', <slug>)` so the preview reflects actual content — "Category A/B/C" placeholders only when terms haven't resolved.
- Reset-button variation (and inspector switch) seed `label: 'Reset'` so freshly-inserted reset filters don't fall back to "Reset filters".

## Pagination fixes

- New `alignment` attribute (`left` | `center` | `right`) — `is-align-*` modifier emitted on all three pagination kinds (numbered uses `justify-content`, loadmore/infinite use `text-align`).
- Fixed BEM root: SCSS was rooted at `.wp-block-designsetgo-query-pagination` with `&--numbered` nesting, compiling to `.wp-block-designsetgo-query-pagination--numbered` — a class that doesn't exist in the rendered HTML. Without a match the `<ul>` fell back to browser default (vertical list with disc bullets — surfaced in QA as "pagination shows radio buttons and is all vertical"). Moved root to `.dsgo-query-pagination`.
- `dsgoGetQueryContainer` now scopes by `[data-dsgo-query-results-role="container"]` so **Load more** appends new items inside the grid `<ul>` instead of after the pagination wrapper.
- Focus handoff uses `focus({ preventScroll: true })` — viewport stays anchored on the Load more button instead of jumping to the first new item below the fold.

## Search input fix

- Removed the delegated `input` listener in `view.js` that debounced every keystroke into an AJAX DOM swap, which yanked focus out mid-typing. Search is now submit-only via the existing `dsgoDelegatedSubmit` (Enter / button).

## Editor preview fix

- `buildCoreDataQuery` maps REST-unsupported `orderby` values (`rand`, `menu_order`, `meta_value`, …) to `date` **for the editor preview only** — so team directory + related posts stop showing "No results found" when the frontend renders fine. Real value still flows to the server render.

## Test plan

- [ ] **Layout hosts**: Insert Dynamic Query → pick "Featured carousel" + "Post spotlight"; verify per-post templates iterate on frontend + editor. Authored slider/scroll-slides (non-query) still render identically.
- [ ] **Layout variants**: Insert each onboarding variation in the template picker; confirm each looks distinct (magazine / avatar-grid / quote-card / image-tile / compact-row / date-forward) in both editor preview and frontend.
- [ ] **Filter styles**: In a Portfolio variation, toggle checkbox/pill/underline in the inspector; verify active-state visuals + keyboard focus ring work. Confirm Uncategorized count matches actual post count on the frontend.
- [ ] **Filters in containers**: Wrap `designsetgo/query-filter` in a `designsetgo/section` or `designsetgo/grid`; confirm the inserter allows it and frontend still refreshes correctly.
- [ ] **Pagination**: With the Blog index variation, verify numbered list renders horizontally (not vertical disc bullets). Toggle alignment left/center/right. Switch to Load more; confirm new items land inside the grid + scroll position stays on the button.
- [ ] **Search**: Focus the search input and type a multi-character query; verify no mid-typing refresh, no focus loss. Submit via Enter or the button triggers the AJAX refresh.
- [ ] **PHPUnit**: `vendor/bin/phpunit --filter "ItemHosts|SliderHost|ScrollSlidesHost"` — 15 tests cover registry, 'none' wrap, and end-to-end rendering.
- [ ] **Jest**: `npx jest --testPathPatterns='query'` — 122 tests.