### PR TITLE
feat(bindings): opt DSGo blocks into native Block Bindings API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Native Block Bindings support for DesignSetGo blocks** — opts DesignSetGo blocks into the WordPress 6.9+ `block_bindings_supported_attributes` filter so their attributes can be driven by any registered Block Bindings source (core/post-meta, designsetgo/post-meta, designsetgo/acf, designsetgo/metabox, designsetgo/pods, designsetgo/jetengine, or any custom source). Initial coverage: `designsetgo/heading-segment.content`, `designsetgo/breadcrumbs.homeText` + `.prefixText`, and `designsetgo/query-pagination.labelLoadMore` + `.labelLoading` + `.buttonLabelWhenPaused`. Extensible via the new `designsetgo_block_bindings_supported_attributes` filter (block name → attribute names map). On WordPress < 6.9 this is inert and causes no behavior change.
 - **Per-URL Markdown content negotiation** — any published page/post URL now returns Markdown when the request sends `Accept: text/markdown` (or any Accept header where `text/markdown` outranks `text/html` via q-values). Responds with `Content-Type: text/markdown; charset=utf-8` and `Vary: Accept`. Returns `406 Not Acceptable` when the client rejects both `text/html` and `text/markdown`. Reuses the existing per-post Markdown files (falls back to live conversion). Respects the llms.txt enablement flag, post-type allowlist, exclusion meta, and password-protected posts. Passes the [acceptmarkdown.com](https://acceptmarkdown.com/) readiness contract.
 
 ### Removed

--- a/includes/class-block-bindings-support.php
+++ b/includes/class-block-bindings-support.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Native Block Bindings support for DesignSetGo blocks.
+ *
+ * WordPress 6.9 added the `block_bindings_supported_attributes` filter that
+ * lets non-core blocks opt their attributes into the native Block Bindings
+ * API (so authors can drive block values from post meta / ACF / custom
+ * sources via the editor's Connections panel). This class declares the
+ * DesignSetGo attributes that are safe to bind.
+ *
+ * Scope today:
+ *  - `designsetgo/heading-segment.content` — attribute is sourced from HTML,
+ *    so core's HTML API rewrites the rendered markup automatically.
+ *  - `designsetgo/breadcrumbs` + `designsetgo/query-pagination` — dynamic
+ *    (server-rendered) blocks where bound values flow into `render_callback`
+ *    via `$block->attributes` without any further plumbing.
+ *
+ * On WordPress < 6.9 the filter is inert — `add_filter()` simply registers a
+ * callback the core never invokes, so this file is safe to ship regardless.
+ *
+ * @package DesignSetGo
+ * @since   2.1.1
+ */
+
+namespace DesignSetGo;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Opts DesignSetGo block attributes into the native Block Bindings API.
+ */
+class Block_Bindings_Support {
+
+	/**
+	 * Default map of block name → supported attribute names.
+	 *
+	 * Attributes here MUST be renderable from `$block->attributes` at
+	 * render time — either via an HTML-sourced attribute selector or via a
+	 * `render_callback` that reads the attribute. Attributes that only live
+	 * in comment delimiters on a static block will NOT bind correctly.
+	 *
+	 * @var array<string, string[]>
+	 */
+	private const DEFAULT_SUPPORTED_ATTRIBUTES = array(
+		'designsetgo/heading-segment'  => array( 'content' ),
+		'designsetgo/breadcrumbs'      => array( 'homeText', 'prefixText' ),
+		'designsetgo/query-pagination' => array( 'labelLoadMore', 'labelLoading', 'buttonLabelWhenPaused' ),
+	);
+
+	/**
+	 * Register the filter hook.
+	 */
+	public function register() {
+		add_filter(
+			'block_bindings_supported_attributes',
+			array( $this, 'filter_supported_attributes' ),
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Append DesignSetGo bindable attributes to the core supported list.
+	 *
+	 * @param string[] $supported_attributes Attributes already registered as bindable for the block.
+	 * @param string   $block_type           Block type being filtered.
+	 * @return string[] Potentially extended list of bindable attribute names.
+	 */
+	public function filter_supported_attributes( $supported_attributes, $block_type ) {
+		if ( ! is_array( $supported_attributes ) ) {
+			$supported_attributes = array();
+		}
+
+		$map = $this->get_supported_map();
+		if ( empty( $map[ $block_type ] ) ) {
+			return $supported_attributes;
+		}
+
+		return array_values( array_unique( array_merge( $supported_attributes, $map[ $block_type ] ) ) );
+	}
+
+	/**
+	 * Resolve the full (block_name → attribute_names[]) map.
+	 *
+	 * Third parties can extend the list with:
+	 *
+	 *     add_filter(
+	 *         'designsetgo_block_bindings_supported_attributes',
+	 *         function ( $map ) {
+	 *             $map['designsetgo/my-block'][] = 'myAttr';
+	 *             return $map;
+	 *         }
+	 *     );
+	 *
+	 * @return array<string, string[]>
+	 */
+	public function get_supported_map() {
+		/**
+		 * Filter the DesignSetGo block bindings supported attributes map.
+		 *
+		 * @param array<string, string[]> $map Block name → list of bindable attribute names.
+		 */
+		$map = apply_filters(
+			'designsetgo_block_bindings_supported_attributes',
+			self::DEFAULT_SUPPORTED_ATTRIBUTES
+		);
+
+		return is_array( $map ) ? $map : array();
+	}
+}

--- a/includes/class-block-bindings-support.php
+++ b/includes/class-block-bindings-support.php
@@ -72,6 +72,7 @@ class Block_Bindings_Support {
 		}
 
 		$map = $this->get_supported_map();
+		// empty() covers both "not in map" and "explicitly cleared to []" by a filter.
 		if ( empty( $map[ $block_type ] ) ) {
 			return $supported_attributes;
 		}
@@ -94,7 +95,7 @@ class Block_Bindings_Support {
 	 *
 	 * @return array<string, string[]>
 	 */
-	public function get_supported_map() {
+	private function get_supported_map() {
 		/**
 		 * Filter the DesignSetGo block bindings supported attributes map.
 		 *

--- a/includes/class-block-bindings-support.php
+++ b/includes/class-block-bindings-support.php
@@ -100,11 +100,9 @@ class Block_Bindings_Support {
 		 *
 		 * @param array<string, string[]> $map Block name → list of bindable attribute names.
 		 */
-		$map = apply_filters(
+		return (array) apply_filters(
 			'designsetgo_block_bindings_supported_attributes',
 			self::DEFAULT_SUPPORTED_ATTRIBUTES
 		);
-
-		return is_array( $map ) ? $map : array();
 	}
 }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -644,7 +644,7 @@ class Plugin {
 		$this->blocks              = new Blocks\Loader();
 		$this->extension_attrs     = new Extension_Attributes();
 		$this->style_binding       = new StyleBinding();
-		$this->block_bindings_support  = new Block_Bindings_Support();
+		$this->block_bindings_support = new Block_Bindings_Support();
 		$this->block_bindings_support->register();
 		$this->modal_hooks         = new Blocks\Modal_Hooks();
 		$this->form_handler        = new Blocks\Form_Handler();

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -644,7 +644,7 @@ class Plugin {
 		$this->blocks              = new Blocks\Loader();
 		$this->extension_attrs     = new Extension_Attributes();
 		$this->style_binding       = new StyleBinding();
-		$this->block_bindings_support = new Block_Bindings_Support();
+		$this->block_bindings_support  = new Block_Bindings_Support();
 		$this->block_bindings_support->register();
 		$this->modal_hooks         = new Blocks\Modal_Hooks();
 		$this->form_handler        = new Blocks\Form_Handler();

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -466,6 +466,13 @@ class Plugin {
 	public $style_binding;
 
 	/**
+	 * Block Bindings Support instance.
+	 *
+	 * @var Block_Bindings_Support
+	 */
+	public $block_bindings_support;
+
+	/**
 	 * Query Block Controller instance.
 	 *
 	 * @var Blocks\Query\Controller
@@ -589,6 +596,7 @@ class Plugin {
 		require_once DESIGNSETGO_PATH . 'includes/class-button-global-styles.php';
 		require_once DESIGNSETGO_PATH . 'includes/class-extension-attributes.php';
 		require_once DESIGNSETGO_PATH . 'includes/class-style-binding.php';
+		require_once DESIGNSETGO_PATH . 'includes/class-block-bindings-support.php';
 		require_once DESIGNSETGO_PATH . 'includes/svg-pattern-data.php';
 		require_once DESIGNSETGO_PATH . 'includes/class-svg-pattern-renderer.php';
 
@@ -636,6 +644,8 @@ class Plugin {
 		$this->blocks              = new Blocks\Loader();
 		$this->extension_attrs     = new Extension_Attributes();
 		$this->style_binding       = new StyleBinding();
+		$this->block_bindings_support = new Block_Bindings_Support();
+		$this->block_bindings_support->register();
 		$this->modal_hooks         = new Blocks\Modal_Hooks();
 		$this->form_handler        = new Blocks\Form_Handler();
 		$this->form_submissions    = new Blocks\Form_Submissions();

--- a/tests/phpunit/block-bindings-support-test.php
+++ b/tests/phpunit/block-bindings-support-test.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Tests for the native Block Bindings opt-in layer.
+ *
+ * @package DesignSetGo
+ * @subpackage Tests
+ */
+
+/**
+ * Verifies that DesignSetGo blocks opt into the WordPress native Block
+ * Bindings API via the `block_bindings_supported_attributes` filter.
+ */
+class Test_Block_Bindings_Support extends WP_UnitTestCase {
+
+	/**
+	 * Instance under test.
+	 *
+	 * @var \DesignSetGo\Block_Bindings_Support
+	 */
+	private $support;
+
+	public function set_up() {
+		parent::set_up();
+		$this->support = new \DesignSetGo\Block_Bindings_Support();
+	}
+
+	public function test_heading_segment_content_is_bindable() {
+		$result = $this->support->filter_supported_attributes( array(), 'designsetgo/heading-segment' );
+		$this->assertContains( 'content', $result );
+	}
+
+	public function test_breadcrumbs_text_attributes_are_bindable() {
+		$result = $this->support->filter_supported_attributes( array(), 'designsetgo/breadcrumbs' );
+		$this->assertContains( 'homeText', $result );
+		$this->assertContains( 'prefixText', $result );
+	}
+
+	public function test_query_pagination_labels_are_bindable() {
+		$result = $this->support->filter_supported_attributes( array(), 'designsetgo/query-pagination' );
+		$this->assertContains( 'labelLoadMore', $result );
+		$this->assertContains( 'labelLoading', $result );
+		$this->assertContains( 'buttonLabelWhenPaused', $result );
+	}
+
+	public function test_unrelated_block_is_untouched() {
+		$result = $this->support->filter_supported_attributes( array( 'content' ), 'core/paragraph' );
+		$this->assertSame( array( 'content' ), $result );
+	}
+
+	public function test_preserves_core_supported_attributes() {
+		$result = $this->support->filter_supported_attributes(
+			array( 'content' ),
+			'designsetgo/heading-segment'
+		);
+		$this->assertContains( 'content', $result );
+		$this->assertCount( 1, $result, 'Duplicate attribute names should be merged.' );
+	}
+
+	public function test_non_array_supported_attributes_is_coerced() {
+		$result = $this->support->filter_supported_attributes( null, 'designsetgo/heading-segment' );
+		$this->assertIsArray( $result );
+		$this->assertContains( 'content', $result );
+	}
+
+	public function test_map_is_filterable() {
+		$filter = static function ( $map ) {
+			$map['designsetgo/test-ext'] = array( 'customAttr' );
+			return $map;
+		};
+		add_filter( 'designsetgo_block_bindings_supported_attributes', $filter );
+		try {
+			$result = $this->support->filter_supported_attributes( array(), 'designsetgo/test-ext' );
+			$this->assertContains( 'customAttr', $result );
+		} finally {
+			remove_filter( 'designsetgo_block_bindings_supported_attributes', $filter );
+		}
+	}
+
+	public function test_register_hooks_the_core_filter() {
+		$fresh = new \DesignSetGo\Block_Bindings_Support();
+		$fresh->register();
+
+		$this->assertNotFalse(
+			has_filter( 'block_bindings_supported_attributes', array( $fresh, 'filter_supported_attributes' ) ),
+			'Block_Bindings_Support::register() must hook into block_bindings_supported_attributes.'
+		);
+	}
+}

--- a/tests/phpunit/block-bindings-support-test.php
+++ b/tests/phpunit/block-bindings-support-test.php
@@ -80,9 +80,17 @@ class Test_Block_Bindings_Support extends WP_UnitTestCase {
 		$fresh = new \DesignSetGo\Block_Bindings_Support();
 		$fresh->register();
 
-		$this->assertNotFalse(
-			has_filter( 'block_bindings_supported_attributes', array( $fresh, 'filter_supported_attributes' ) ),
-			'Block_Bindings_Support::register() must hook into block_bindings_supported_attributes.'
-		);
+		try {
+			$this->assertNotFalse(
+				has_filter( 'block_bindings_supported_attributes', array( $fresh, 'filter_supported_attributes' ) ),
+				'Block_Bindings_Support::register() must hook into block_bindings_supported_attributes.'
+			);
+		} finally {
+			remove_filter(
+				'block_bindings_supported_attributes',
+				array( $fresh, 'filter_supported_attributes' ),
+				10
+			);
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds native [WordPress Block Bindings API](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-bindings/) support to DesignSetGo blocks. Until now, authors could *register* DSGo binding sources (`designsetgo/post-meta`, `designsetgo/acf`, `designsetgo/metabox`, `designsetgo/pods`, `designsetgo/jetengine`) but couldn't actually *bind* DSGo block attributes to them via the editor's Connections panel — only core blocks (paragraph, heading, image, button) were on the allow-list.

WordPress 6.9 added the [`block_bindings_supported_attributes`](https://developer.wordpress.org/reference/hooks/block_bindings_supported_attributes/) filter so non-core blocks can opt in. This PR wires DSGo blocks into it.

### What becomes bindable

| Block | Attribute(s) | Why it's safe |
| --- | --- | --- |
| `designsetgo/heading-segment` | `content` | Attribute already has `source: "html"` with a selector — core's HTML API rewrites the rendered markup automatically. |
| `designsetgo/breadcrumbs` | `homeText`, `prefixText` | Dynamic (`render.php`) block — bound values flow into `$block->attributes` before the render callback fires. |
| `designsetgo/query-pagination` | `labelLoadMore`, `labelLoading`, `buttonLabelWhenPaused` | Same — dynamic block. |

Other static blocks (`icon-button.text`, `pill.content`, etc.) are intentionally out of scope here because their attributes aren't HTML-sourced — enabling them cleanly would need a schema change + a deprecation. Planned for a follow-up.

### Extension point

Third parties can add their own DSGo block attributes to the bindable list:

```php
add_filter(
    'designsetgo_block_bindings_supported_attributes',
    function ( $map ) {
        $map['designsetgo/my-block'][] = 'myAttr';
        return $map;
    }
);
```

### Back-compat

On WordPress < 6.9 the core filter name doesn't exist, so our `add_filter()` call is never invoked — zero behavior change on older WP.

## Test plan

- [ ] PHPUnit: new `tests/phpunit/block-bindings-support-test.php` (8 assertions covering map resolution, extension filter, core filter registration, and unrelated-block passthrough).
- [ ] Manual: on WP 6.9+, insert an Advanced Heading → Heading Segment inside a post with a `subtitle` meta key set, bind the segment's content to `designsetgo/post-meta` with `key: subtitle` via the Connections panel, confirm the frontend shows the meta value.
- [ ] Manual: same flow with a Breadcrumbs block's `homeText` bound to `core/post-meta`.
- [ ] Regression: existing `designsetgo/post-meta`, `designsetgo/acf`, `designsetgo/metabox`, `designsetgo/pods`, `designsetgo/jetengine` source registrations unchanged — no test files touched in `tests/integration/blocks/query/`.

https://claude.ai/code/session_01RSpKMXJFcYHtYCJG4ya4uT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSpKMXJFcYHtYCJG4ya4uT)_