### PR TITLE
feat(dynamic-tags): Elementor-style dynamic tags system

### DIFF
--- a/includes/abilities/info/class-list-dynamic-tag-sources.php
+++ b/includes/abilities/info/class-list-dynamic-tag-sources.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * List Dynamic Tag Sources Ability.
+ *
+ * Returns the catalog of registered DesignSetGo Dynamic Tag sources —
+ * post / site / archive / user fields plus custom-field providers
+ * (ACF, Meta Box, Pods, JetEngine). AI agents use this to discover
+ * which `metadata.bindings.<attr>.source` values are available before
+ * writing bindings to a block via update-block.
+ *
+ * @package DesignSetGo
+ * @subpackage Abilities
+ * @since 2.2.0
+ */
+
+namespace DesignSetGo\Abilities\Info;
+
+use DesignSetGo\Abilities\Abstract_Ability;
+use DesignSetGo\Blocks\DynamicTags\Registry;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * List Dynamic Tag Sources ability.
+ */
+class List_Dynamic_Tag_Sources extends Abstract_Ability {
+
+	/**
+	 * Get ability name.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'designsetgo/list-dynamic-tag-sources';
+	}
+
+	/**
+	 * Get ability configuration.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_config(): array {
+		return array(
+			'label'               => __( 'List Dynamic Tag Sources', 'designsetgo' ),
+			'description'         => __( 'Returns the catalog of Dynamic Tag binding sources (post/site/archive/user fields, ACF, Meta Box, Pods, JetEngine). Each entry includes the source slug, label, group, return types, and arg schema. Use the slug as `metadata.bindings.<attribute>.source` when writing bindings via update-block.', 'designsetgo' ),
+			'category'            => 'info',
+			'input_schema'        => $this->get_input_schema(),
+			'output_schema'       => $this->get_output_schema(),
+			'permission_callback' => array( $this, 'check_permission_callback' ),
+			'show_in_rest'        => true,
+			'keywords'            => array( 'binding', 'dynamic', 'token', 'tag', 'source', 'data' ),
+			'annotations'         => array(
+				'readonly'     => true,
+				'instructions' => 'Read-only catalog. Filter by `returns` (text|image|url|number|date) to narrow to sources compatible with the bound attribute, or by `group` to scope to one family. To bind a source, write `attributes.metadata.bindings.<attr> = { source: "<slug>", args: { ... } }` via update-block.',
+			),
+		);
+	}
+
+	/**
+	 * Capability gate — same baseline as the editor.
+	 *
+	 * @return bool
+	 */
+	public function check_permission_callback(): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Input schema.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_input_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'returns' => array(
+					'type'        => 'string',
+					'enum'        => array( 'text', 'image', 'url', 'number', 'date' ),
+					'description' => __( 'Filter to sources that can return the given type.', 'designsetgo' ),
+				),
+				'group'   => array(
+					'type'        => 'string',
+					'enum'        => array( 'post', 'site', 'archive', 'user', 'custom-fields' ),
+					'description' => __( 'Filter to a single group.', 'designsetgo' ),
+				),
+			),
+			'additionalProperties' => false,
+		);
+	}
+
+	/**
+	 * Output schema.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_output_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'sources' => array(
+					'type'  => 'array',
+					'items' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'slug'    => array( 'type' => 'string' ),
+							'label'   => array( 'type' => 'string' ),
+							'group'   => array( 'type' => 'string' ),
+							'returns' => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'string' ),
+							),
+							'args'    => array( 'type' => 'object' ),
+						),
+					),
+				),
+				'groups'  => array(
+					'type'  => 'array',
+					'items' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'slug'  => array( 'type' => 'string' ),
+							'label' => array( 'type' => 'string' ),
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string, mixed> $input Input.
+	 * @return array<string, mixed>
+	 */
+	public function execute( array $input ) {
+		$registry = Registry::instance();
+
+		$filters = array();
+		if ( ! empty( $input['returns'] ) ) {
+			$filters['returns'] = (array) $input['returns'];
+		}
+		if ( ! empty( $input['group'] ) ) {
+			$filters['group'] = (string) $input['group'];
+		}
+
+		$sources = array_map(
+			static function ( $source ) {
+				return array(
+					'slug'    => $source['slug'],
+					'label'   => $source['label'],
+					'group'   => $source['group'],
+					'returns' => array_values( (array) $source['returns'] ),
+					'args'    => (object) ( $source['args'] ?? array() ),
+				);
+			},
+			$registry->all_sources( $filters )
+		);
+
+		$groups = array_map(
+			static function ( $group ) {
+				return array(
+					'slug'  => $group['slug'],
+					'label' => $group['label'],
+				);
+			},
+			$registry->all_groups()
+		);
+
+		return array(
+			'sources' => $sources,
+			'groups'  => $groups,
+		);
+	}
+}

--- a/includes/abilities/info/class-list-extensions.php
+++ b/includes/abilities/info/class-list-extensions.php
@@ -109,6 +109,11 @@ class List_Extensions extends Abstract_Ability {
 			'description' => 'Configuration for sticky/fixed header behavior.',
 			'keywords'    => array( 'sticky', 'fixed', 'header', 'navigation' ),
 		),
+		'dynamic-tags'           => array(
+			'label'       => 'Dynamic Tags',
+			'description' => 'Bind block attributes (paragraph content, heading content, image url/alt, button text/url, etc.) to post / site / archive / user data or custom fields (ACF, Meta Box, Pods, JetEngine). Authors trigger the picker from the inline toolbar (database icon) or the Inspector "Dynamic Tags" panel. Bindings are written to attributes.metadata.bindings; use designsetgo/list-dynamic-tag-sources to enumerate sources.',
+			'keywords'    => array( 'binding', 'dynamic', 'data', 'acf', 'meta', 'token' ),
+		),
 	);
 
 	/**

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -274,6 +274,11 @@ class Settings {
 				'title'       => __( 'Draft Mode', 'designsetgo' ),
 				'description' => __( 'Create draft versions of published pages for safe editing', 'designsetgo' ),
 			),
+			array(
+				'name'        => 'dynamic-tags',
+				'title'       => __( 'Dynamic Tags', 'designsetgo' ),
+				'description' => __( 'Bind block attributes to post / site / archive / user data or custom fields (ACF, Meta Box, Pods, JetEngine).', 'designsetgo' ),
+			),
 		);
 	}
 

--- a/includes/blocks/class-query-bindings-helpers.php
+++ b/includes/blocks/class-query-bindings-helpers.php
@@ -197,3 +197,73 @@ if ( ! function_exists( 'designsetgo_register_bindings_source' ) ) :
 	}
 
 endif;
+
+if ( ! function_exists( 'designsetgo_extract_bindings_subvalue' ) ) :
+
+	/**
+	 * Extracts a scalar sub-value from an array field (image, file, user, etc.).
+	 *
+	 * Custom-field plugins (ACF, Meta Box, Pods, JetEngine) return image and
+	 * file fields as arrays like `[ID, url, alt, width, height, sizes=>…]`.
+	 * The Block Bindings API requires scalar returns, so when a binding
+	 * needs a specific sub-value (e.g. image URL vs image ID), callers pass
+	 * `args.subkey` and this helper maps it to the right array key,
+	 * tolerating the various keys each plugin uses.
+	 *
+	 * Allowed subkey values: url, id, alt, width, height, title, caption.
+	 * Unknown subkeys are normalised to 'url'.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param array  $value  The raw array value returned by the field plugin.
+	 * @param string $subkey The requested sub-key.
+	 * @return mixed Scalar sub-value, or null when the sub-key is not present.
+	 */
+	function designsetgo_extract_bindings_subvalue( array $value, $subkey ) {
+		$subkey = strtolower( (string) $subkey );
+		$allowed = array( 'url', 'id', 'alt', 'width', 'height', 'title', 'caption' );
+		if ( ! in_array( $subkey, $allowed, true ) ) {
+			$subkey = 'url';
+		}
+
+		// Map to the various keys each plugin uses for the same concept.
+		$aliases = array(
+			'url'     => array( 'url', 'sizes.full', 'full_url', 'guid' ),
+			'id'      => array( 'ID', 'id', 'attachment_id' ),
+			'alt'     => array( 'alt', 'alt_text' ),
+			'width'   => array( 'width' ),
+			'height'  => array( 'height' ),
+			'title'   => array( 'title', 'name' ),
+			'caption' => array( 'caption', 'description' ),
+		);
+
+		foreach ( $aliases[ $subkey ] as $path ) {
+			// Support dotted paths for nested lookups like `sizes.full`.
+			$segments = explode( '.', $path );
+			$cursor   = $value;
+			$found    = true;
+			foreach ( $segments as $segment ) {
+				if ( is_array( $cursor ) && array_key_exists( $segment, $cursor ) ) {
+					$cursor = $cursor[ $segment ];
+				} else {
+					$found = false;
+					break;
+				}
+			}
+			if ( $found && is_scalar( $cursor ) && '' !== $cursor ) {
+				return $cursor;
+			}
+		}
+
+		// Fallback: when asked for url and we have an ID, resolve via WP.
+		if ( 'url' === $subkey && isset( $value['ID'] ) && is_numeric( $value['ID'] ) ) {
+			$url = wp_get_attachment_url( (int) $value['ID'] );
+			if ( $url ) {
+				return $url;
+			}
+		}
+
+		return null;
+	}
+
+endif;

--- a/includes/blocks/class-query-bindings-helpers.php
+++ b/includes/blocks/class-query-bindings-helpers.php
@@ -139,6 +139,16 @@ if ( ! function_exists( 'designsetgo_register_bindings_source' ) ) :
 	 * @return int Resolved post ID, or 0 if not resolvable.
 	 */
 	function designsetgo_resolve_bindings_post_id( array $args, $block ) {
+		// Short-circuit: callers such as Registry::resolve() (invoked from
+		// the Dynamic Tags REST preview) have no WP_Block instance to
+		// provide, so they pre-resolve the post ID and stash it in
+		// $args['__dsgo_post_id']. Honour that first so the wrapper
+		// doesn't fall through to get_the_ID(), which returns 0 in a
+		// REST context and would cause every scalar source to return null.
+		if ( ! empty( $args['__dsgo_post_id'] ) ) {
+			return (int) $args['__dsgo_post_id'];
+		}
+
 		$scope = isset( $args['scope'] ) ? (string) $args['scope'] : 'self';
 
 		if ( 'parent' === $scope || 'root' === $scope ) {

--- a/includes/blocks/class-query-bindings-jetengine.php
+++ b/includes/blocks/class-query-bindings-jetengine.php
@@ -96,6 +96,10 @@ class JetEngineBindings {
 			$value = get_post_meta( $post_id, $key, true );
 		}
 
+		if ( is_array( $value ) && isset( $args['subkey'] ) && function_exists( 'designsetgo_extract_bindings_subvalue' ) ) {
+			$value = designsetgo_extract_bindings_subvalue( $value, (string) $args['subkey'] );
+		}
+
 		if ( is_array( $value ) || is_object( $value ) ) {
 			return null; // Complex fields need their own render path.
 		}

--- a/includes/blocks/class-query-bindings-metabox.php
+++ b/includes/blocks/class-query-bindings-metabox.php
@@ -87,6 +87,13 @@ class MetaBoxBindings {
 		}
 
 		$value = call_user_func( $reader, $key, array(), $post_id );
+
+		// Image / file-group fields may return arrays — extract a scalar
+		// sub-value (url, ID, alt, …) when the binding args request one.
+		if ( is_array( $value ) && isset( $args['subkey'] ) && function_exists( 'designsetgo_extract_bindings_subvalue' ) ) {
+			$value = designsetgo_extract_bindings_subvalue( $value, (string) $args['subkey'] );
+		}
+
 		if ( is_array( $value ) || is_object( $value ) ) {
 			return null; // Complex fields need their own render path.
 		}

--- a/includes/blocks/class-query-bindings-pods.php
+++ b/includes/blocks/class-query-bindings-pods.php
@@ -96,6 +96,10 @@ class PodsBindings {
 			$value     = ( $reader )( $post_type, $post_id, $key );
 		}
 
+		if ( is_array( $value ) && isset( $args['subkey'] ) && function_exists( 'designsetgo_extract_bindings_subvalue' ) ) {
+			$value = designsetgo_extract_bindings_subvalue( $value, (string) $args['subkey'] );
+		}
+
 		if ( is_array( $value ) || is_object( $value ) ) {
 			return null; // Complex fields need their own render path.
 		}

--- a/includes/blocks/class-query-bindings.php
+++ b/includes/blocks/class-query-bindings.php
@@ -57,6 +57,13 @@ class Bindings {
 						return null;
 					}
 					$value = get_field( $key, $post_id );
+
+					// Image / attachment fields are arrays — let callers extract a
+					// specific scalar sub-value via args.subkey (url, ID, alt, …).
+					if ( is_array( $value ) && isset( $args['subkey'] ) ) {
+						$value = designsetgo_extract_bindings_subvalue( $value, (string) $args['subkey'] );
+					}
+
 					if ( is_array( $value ) || is_object( $value ) ) {
 						return null;
 					}

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-bootstrap.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-bootstrap.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Dynamic Tags — bootstrap.
+ *
+ * Single entry point required from class-plugin.php. Instantiates the
+ * metadata registry, registers all source classes on `init` priority 6
+ * (after the existing query bindings on priority 5 so the ACF / meta /
+ * Pods / MetaBox / JetEngine sources — whose sub-key support Dynamic
+ * Tags adds metadata for — are already registered), and registers the
+ * REST controller on `rest_api_init`.
+ *
+ * @package DesignSetGo
+ * @since   2.2.0
+ */
+
+namespace DesignSetGo\Blocks\DynamicTags;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Boots the Dynamic Tags subsystem.
+ */
+class Bootstrap {
+
+	/**
+	 * REST controller instance (kept for test access).
+	 *
+	 * @var RestController|null
+	 */
+	public $rest;
+
+	/**
+	 * Wires the init and rest_api_init hooks.
+	 */
+	public function __construct() {
+		add_action( 'init', array( $this, 'register_sources' ), 6 );
+
+		$this->rest = new RestController( Registry::instance() );
+		$this->rest->register_hooks();
+	}
+
+	/**
+	 * Registers the four source families and the custom-field metadata.
+	 */
+	public function register_sources() {
+		$registry = Registry::instance();
+
+		PostSources::register( $registry );
+		SiteSources::register( $registry );
+		ArchiveSources::register( $registry );
+		UserSources::register( $registry );
+
+		$this->register_custom_field_metadata( $registry );
+
+		/**
+		 * Fires once all built-in Dynamic Tag sources are registered.
+		 *
+		 * Third-party plugins should hook here to register additional
+		 * sources via `$registry->register_source()` and (for bindings
+		 * value resolution) `designsetgo_register_bindings_source()`.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param Registry $registry Metadata registry.
+		 */
+		do_action( 'designsetgo_dynamic_tags_registered', $registry );
+	}
+
+	/**
+	 * Adds picker-side metadata for the pre-existing custom-field bindings
+	 * (post-meta, ACF, Meta Box, Pods, JetEngine) that were registered by
+	 * the Query Bindings subsystem. Value callbacks are already registered
+	 * there — this just gives the picker discovery + label info.
+	 *
+	 * @param Registry $registry Metadata registry.
+	 */
+	private function register_custom_field_metadata( Registry $registry ) {
+		$image_subkey_arg = array(
+			'subkey' => array(
+				'type' => 'string',
+				'enum' => array( 'url', 'id', 'alt', 'width', 'height', 'title', 'caption' ),
+			),
+		);
+		$key_arg = array(
+			'key' => array(
+				'type'     => 'string',
+				'required' => true,
+			),
+		);
+
+		$registry->register_source(
+			'designsetgo/post-meta',
+			array(
+				'label'        => __( 'Post meta', 'designsetgo' ),
+				'group'        => 'custom-fields',
+				'returns'      => array( 'text', 'url', 'number', 'date' ),
+				'args'         => array_merge( $key_arg, $image_subkey_arg ),
+				'discovery_cb' => array( FieldDiscovery::class, 'post_meta' ),
+			)
+		);
+
+		if ( function_exists( 'get_field' ) ) {
+			$registry->register_source(
+				'designsetgo/acf',
+				array(
+					'label'        => __( 'ACF field', 'designsetgo' ),
+					'group'        => 'custom-fields',
+					'returns'      => array( 'text', 'image', 'url', 'number', 'date' ),
+					'args'         => array_merge( $key_arg, $image_subkey_arg ),
+					'discovery_cb' => array( FieldDiscovery::class, 'acf' ),
+				)
+			);
+		}
+
+		if ( function_exists( 'rwmb_meta' ) ) {
+			$registry->register_source(
+				'designsetgo/metabox',
+				array(
+					'label'   => __( 'Meta Box field', 'designsetgo' ),
+					'group'   => 'custom-fields',
+					'returns' => array( 'text', 'image', 'url', 'number', 'date' ),
+					'args'    => array_merge( $key_arg, $image_subkey_arg ),
+				)
+			);
+		}
+
+		if ( function_exists( 'pods_field' ) ) {
+			$registry->register_source(
+				'designsetgo/pods',
+				array(
+					'label'   => __( 'Pods field', 'designsetgo' ),
+					'group'   => 'custom-fields',
+					'returns' => array( 'text', 'image', 'url', 'number', 'date' ),
+					'args'    => array_merge( $key_arg, $image_subkey_arg ),
+				)
+			);
+		}
+
+		if ( class_exists( 'Jet_Engine' ) && function_exists( 'jet_engine' ) ) {
+			$registry->register_source(
+				'designsetgo/jetengine',
+				array(
+					'label'   => __( 'JetEngine field', 'designsetgo' ),
+					'group'   => 'custom-fields',
+					'returns' => array( 'text', 'image', 'url', 'number', 'date' ),
+					'args'    => array_merge( $key_arg, $image_subkey_arg ),
+				)
+			);
+		}
+	}
+}

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-bootstrap.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-bootstrap.php
@@ -23,11 +23,11 @@ defined( 'ABSPATH' ) || exit;
 class Bootstrap {
 
 	/**
-	 * REST controller instance (kept for test access).
+	 * REST controller instance.
 	 *
 	 * @var RestController|null
 	 */
-	public $rest;
+	protected $rest;
 
 	/**
 	 * Wires the init and rest_api_init hooks.
@@ -37,6 +37,15 @@ class Bootstrap {
 
 		$this->rest = new RestController( Registry::instance() );
 		$this->rest->register_hooks();
+	}
+
+	/**
+	 * Returns the REST controller instance (test/debug accessor).
+	 *
+	 * @return RestController|null
+	 */
+	public function get_rest_controller() {
+		return $this->rest;
 	}
 
 	/**

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-field-discovery.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-field-discovery.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Dynamic Tags — field discovery callbacks.
+ *
+ * Each callback returns an array of `{ key, label, returns, group }`
+ * descriptors that the picker presents as a browsable field list.
+ *
+ * @package DesignSetGo
+ * @since   2.2.0
+ */
+
+namespace DesignSetGo\Blocks\DynamicTags;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Static helpers invoked as `discovery_cb` on registered sources.
+ */
+class FieldDiscovery {
+
+	/**
+	 * Field discovery for `designsetgo/acf`.
+	 *
+	 * Uses ACF's `acf_get_field_groups` + `acf_get_fields` APIs to enumerate
+	 * every field visible on the target post type, excluding internal
+	 * container types (group/repeater/flexible content) that don't resolve
+	 * to a scalar. Returns [] when ACF is inactive.
+	 *
+	 * @param array $context { post_type, returns }.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function acf( array $context ) {
+		if ( ! function_exists( 'acf_get_field_groups' ) || ! function_exists( 'acf_get_fields' ) ) {
+			return array();
+		}
+		$post_type = isset( $context['post_type'] ) ? (string) $context['post_type'] : 'post';
+		$returns   = isset( $context['returns'] ) ? (string) $context['returns'] : '';
+
+		$groups = \acf_get_field_groups( array( 'post_type' => $post_type ) );
+		$fields = array();
+		foreach ( $groups as $group ) {
+			$group_fields = \acf_get_fields( $group );
+			if ( ! is_array( $group_fields ) ) {
+				continue;
+			}
+			foreach ( $group_fields as $field ) {
+				$returns_type = self::acf_type_to_returns( $field['type'] ?? '' );
+				if ( null === $returns_type ) {
+					continue;
+				}
+				if ( '' !== $returns && $returns !== $returns_type ) {
+					continue;
+				}
+				$fields[] = array(
+					'key'     => (string) ( $field['name'] ?? '' ),
+					'label'   => (string) ( $field['label'] ?? $field['name'] ?? '' ),
+					'returns' => $returns_type,
+					'group'   => (string) ( $group['title'] ?? '' ),
+				);
+			}
+		}
+		return $fields;
+	}
+
+	/**
+	 * Field discovery for `designsetgo/post-meta`.
+	 *
+	 * Uses register_meta()-declared keys (public ones only, `show_in_rest`)
+	 * because the raw postmeta table can contain thousands of internal keys
+	 * across plugins. This matches WP core's own picker behavior.
+	 *
+	 * @param array $context { post_type, returns }.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function post_meta( array $context ) {
+		$post_type = isset( $context['post_type'] ) ? (string) $context['post_type'] : 'post';
+
+		$meta  = get_registered_meta_keys( 'post', $post_type );
+		$items = array();
+		foreach ( $meta as $key => $meta_data ) {
+			if ( 0 === strpos( (string) $key, '_' ) ) {
+				continue;
+			}
+			if ( empty( $meta_data['show_in_rest'] ) ) {
+				continue;
+			}
+			$items[] = array(
+				'key'     => (string) $key,
+				'label'   => (string) ( $meta_data['label'] ?? $key ),
+				'returns' => 'text',
+				'group'   => __( 'Registered meta', 'designsetgo' ),
+			);
+		}
+		return $items;
+	}
+
+	/**
+	 * Maps ACF field types to our return-type vocabulary.
+	 *
+	 * @param string $acf_type ACF field type name.
+	 * @return string|null Return type, or null when the field is skipped.
+	 */
+	private static function acf_type_to_returns( $acf_type ) {
+		switch ( $acf_type ) {
+			case 'text':
+			case 'textarea':
+			case 'email':
+			case 'password':
+			case 'wysiwyg':
+			case 'select':
+			case 'radio':
+			case 'button_group':
+			case 'color_picker':
+				return 'text';
+			case 'number':
+			case 'range':
+				return 'number';
+			case 'url':
+			case 'link':
+			case 'page_link':
+				return 'url';
+			case 'image':
+			case 'file':
+				return 'image';
+			case 'date_picker':
+			case 'time_picker':
+			case 'date_time_picker':
+				return 'date';
+			// Container/repeater/flexible types — skip.
+			case 'group':
+			case 'repeater':
+			case 'flexible_content':
+			case 'relationship':
+			case 'post_object':
+			case 'taxonomy':
+			case 'user':
+			case 'clone':
+				return null;
+		}
+		return 'text';
+	}
+}

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-field-discovery.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-field-discovery.php
@@ -105,7 +105,6 @@ class FieldDiscovery {
 			case 'text':
 			case 'textarea':
 			case 'email':
-			case 'password':
 			case 'wysiwyg':
 			case 'select':
 			case 'radio':
@@ -126,7 +125,10 @@ class FieldDiscovery {
 			case 'time_picker':
 			case 'date_time_picker':
 				return 'date';
-			// Container/repeater/flexible types — skip.
+			// Private / container / repeater / flexible types — skip so
+			// sensitive values (passwords) and non-scalar shapes never
+			// surface in the Dynamic Tag picker.
+			case 'password':
 			case 'group':
 			case 'repeater':
 			case 'flexible_content':

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-image-resolver.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-image-resolver.php
@@ -96,6 +96,52 @@ class ImageResolver {
 	}
 
 	/**
+	 * Resolves a scalar sub-value (url/id/alt/width/height/title/caption)
+	 * from an attachment ID. Used by image-typed Bindings sources that
+	 * need to project to a single scalar per the Block Bindings contract.
+	 *
+	 * @param int    $attachment_id Attachment post ID.
+	 * @param string $subkey        Sub-key: url|id|alt|width|height|title|caption.
+	 * @param string $size          Image size for url/width/height (default 'full').
+	 * @return string|null
+	 */
+	public static function resolve_subvalue( $attachment_id, $subkey, $size = 'full' ) {
+		$attachment_id = (int) $attachment_id;
+		if ( ! $attachment_id ) {
+			return null;
+		}
+		if ( ! in_array( $subkey, array( 'url', 'id', 'alt', 'width', 'height', 'title', 'caption' ), true ) ) {
+			$subkey = 'url';
+		}
+
+		switch ( $subkey ) {
+			case 'id':
+				return (string) $attachment_id;
+			case 'alt':
+				$alt = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+				return '' === $alt ? null : (string) $alt;
+			case 'title':
+				$title = get_the_title( $attachment_id );
+				return '' === $title ? null : (string) $title;
+			case 'caption':
+				$caption = wp_get_attachment_caption( $attachment_id );
+				return '' === $caption || false === $caption ? null : (string) $caption;
+			case 'width':
+			case 'height':
+				$src = wp_get_attachment_image_src( $attachment_id, $size );
+				if ( ! $src ) {
+					return null;
+				}
+				$idx = 'width' === $subkey ? 1 : 2;
+				return (string) $src[ $idx ];
+			case 'url':
+			default:
+				$src = wp_get_attachment_image_src( $attachment_id, $size );
+				return $src && ! empty( $src[0] ) ? (string) $src[0] : null;
+		}
+	}
+
+	/**
 	 * Builds an image descriptor from an attachment ID.
 	 *
 	 * @param int    $attachment_id Attachment post ID.

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-image-resolver.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-image-resolver.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Dynamic Tags — image resolver.
+ *
+ * Shared helper that, given a source slug and args, returns a full image
+ * descriptor (id, url, alt, width, height). Used both by the dynamic-image
+ * block's render.php and by the REST preview endpoint so the editor
+ * preview and the frontend always agree.
+ *
+ * @package DesignSetGo
+ * @since   2.2.0
+ */
+
+namespace DesignSetGo\Blocks\DynamicTags;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolves image-typed Dynamic Tag sources to full descriptors.
+ */
+class ImageResolver {
+
+	/**
+	 * Resolves a source to an image descriptor.
+	 *
+	 * @param string $slug    Source slug.
+	 * @param array  $args    Source args.
+	 * @param int    $post_id Current post ID (for context resolution).
+	 * @param string $size    Image size (default 'full').
+	 * @return array{id:int,url:string,alt:string,width:int,height:int}|null
+	 *         Descriptor or null when unresolvable.
+	 */
+	public static function resolve( $slug, array $args, $post_id = 0, $size = 'full' ) {
+		$attachment_id = self::resolve_attachment_id( $slug, $args, (int) $post_id );
+		if ( $attachment_id ) {
+			return self::descriptor_from_id( $attachment_id, $size );
+		}
+
+		// Fallback: resolve URL via the core Bindings API when the source
+		// has no attachment concept (e.g. an external URL stored in meta).
+		$url = self::resolve_url_via_bindings( $slug, $args, (int) $post_id );
+		if ( $url ) {
+			return array(
+				'id'     => 0,
+				'url'    => $url,
+				'alt'    => '',
+				'width'  => 0,
+				'height' => 0,
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Attempts to discover an attachment ID for image-typed sources.
+	 *
+	 * @param string $slug    Source slug.
+	 * @param array  $args    Source args.
+	 * @param int    $post_id Current post ID context.
+	 * @return int Attachment ID or 0.
+	 */
+	private static function resolve_attachment_id( $slug, array $args, $post_id ) {
+		switch ( $slug ) {
+			case 'designsetgo/post-featured-image':
+				return (int) get_post_thumbnail_id( $post_id );
+
+			case 'designsetgo/site-logo':
+				$logo = (int) get_option( 'site_logo' );
+				if ( ! $logo ) {
+					$logo = (int) get_theme_mod( 'custom_logo' );
+				}
+				return $logo;
+
+			case 'designsetgo/post-meta':
+				$key   = isset( $args['key'] ) ? (string) $args['key'] : '';
+				$value = $key && $post_id ? get_post_meta( $post_id, $key, true ) : '';
+				return is_numeric( $value ) ? (int) $value : 0;
+
+			case 'designsetgo/acf':
+				$key = isset( $args['key'] ) ? (string) $args['key'] : '';
+				if ( ! $key || ! $post_id || ! function_exists( 'get_field' ) ) {
+					return 0;
+				}
+				$value = \get_field( $key, $post_id );
+				if ( is_array( $value ) && isset( $value['ID'] ) ) {
+					return (int) $value['ID'];
+				}
+				if ( is_numeric( $value ) ) {
+					return (int) $value;
+				}
+				return 0;
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Builds an image descriptor from an attachment ID.
+	 *
+	 * @param int    $attachment_id Attachment post ID.
+	 * @param string $size          Image size.
+	 * @return array{id:int,url:string,alt:string,width:int,height:int}|null
+	 */
+	public static function descriptor_from_id( $attachment_id, $size = 'full' ) {
+		$attachment_id = (int) $attachment_id;
+		if ( ! $attachment_id ) {
+			return null;
+		}
+		$src = wp_get_attachment_image_src( $attachment_id, $size );
+		if ( ! $src || empty( $src[0] ) ) {
+			return null;
+		}
+		$alt = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+		return array(
+			'id'     => $attachment_id,
+			'url'    => (string) $src[0],
+			'alt'    => is_string( $alt ) ? $alt : '',
+			'width'  => isset( $src[1] ) ? (int) $src[1] : 0,
+			'height' => isset( $src[2] ) ? (int) $src[2] : 0,
+		);
+	}
+
+	/**
+	 * Falls back to the core Bindings API for a URL-only scalar.
+	 *
+	 * @param string $slug    Source slug.
+	 * @param array  $args    Source args.
+	 * @param int    $post_id Current post ID.
+	 * @return string Empty string when unresolvable.
+	 */
+	private static function resolve_url_via_bindings( $slug, array $args, $post_id ) {
+		if ( ! function_exists( 'get_block_bindings_source' ) ) {
+			return '';
+		}
+		$binding = get_block_bindings_source( $slug );
+		if ( ! $binding || ! isset( $binding->get_value_callback ) || ! is_callable( $binding->get_value_callback ) ) {
+			return '';
+		}
+		$args['__dsgo_post_id'] = $post_id;
+		$args['subkey']         = $args['subkey'] ?? 'url';
+		$value                  = call_user_func( $binding->get_value_callback, $args, null, 'url' );
+		if ( is_string( $value ) && '' !== $value && filter_var( $value, FILTER_VALIDATE_URL ) ) {
+			return $value;
+		}
+		return '';
+	}
+}

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-image-resolver.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-image-resolver.php
@@ -116,8 +116,8 @@ class ImageResolver {
 			'id'     => $attachment_id,
 			'url'    => (string) $src[0],
 			'alt'    => is_string( $alt ) ? $alt : '',
-			'width'  => isset( $src[1] ) ? (int) $src[1] : 0,
-			'height' => isset( $src[2] ) ? (int) $src[2] : 0,
+			'width'  => (int) $src[1],
+			'height' => (int) $src[2],
 		);
 	}
 

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-registry.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-registry.php
@@ -206,7 +206,17 @@ class Registry {
 	 * Resolves a source value for a given post context.
 	 *
 	 * Prefers a direct resolver when registered, otherwise falls back to
-	 * apply_filters on the core Bindings source the same way core does.
+	 * the core Bindings source's get_value_callback (which is the wrapped
+	 * closure from designsetgo_register_bindings_source() and therefore
+	 * applies the shared password / viewable / protected-meta gates).
+	 *
+	 * NOTE ON DIRECT RESOLVERS: when a source registers its own
+	 * $source['resolver'], this method invokes it without the shared
+	 * gates. Callers registering a direct resolver MUST apply their own
+	 * password / viewability / protected-meta checks — or, more commonly,
+	 * omit the resolver and rely on the Bindings callback path. Callers
+	 * of this method (e.g. RestController::get_preview) must also apply
+	 * the password / viewable gate before invoking resolve().
 	 *
 	 * @param string $slug    Source slug.
 	 * @param array  $args    Source args.

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-registry.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-registry.php
@@ -1,0 +1,242 @@
+<?php
+/**
+ * Dynamic Tags — central registry.
+ *
+ * Stores metadata (label, group, return types, arg schema, discovery
+ * callback, capability) for every Dynamic Tag source. The source's
+ * value callback itself is registered with WP Core's Block Bindings
+ * API via designsetgo_register_bindings_source(); this registry sits
+ * alongside the core registry and provides the information the REST
+ * endpoints and the editor picker need but core doesn't store.
+ *
+ * @package DesignSetGo
+ * @since   2.2.0
+ */
+
+namespace DesignSetGo\Blocks\DynamicTags;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * In-memory registry for Dynamic Tag sources.
+ */
+class Registry {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var Registry|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Registered sources keyed by slug.
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	private $sources = array();
+
+	/**
+	 * Registered groups keyed by slug.
+	 *
+	 * @var array<string, array{slug:string,label:string,order:int}>
+	 */
+	private $groups = array();
+
+	/**
+	 * Returns the singleton instance.
+	 *
+	 * @return Registry
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+			self::$instance->register_default_groups();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Seed the default group list so sources can reference them.
+	 */
+	private function register_default_groups() {
+		$this->register_group( 'post', __( 'Post', 'designsetgo' ), 10 );
+		$this->register_group( 'site', __( 'Site', 'designsetgo' ), 20 );
+		$this->register_group( 'archive', __( 'Archive', 'designsetgo' ), 30 );
+		$this->register_group( 'user', __( 'User', 'designsetgo' ), 40 );
+		$this->register_group( 'custom-fields', __( 'Custom Fields', 'designsetgo' ), 50 );
+	}
+
+	/**
+	 * Registers (or re-orders) a source group.
+	 *
+	 * @param string $slug  Group slug, e.g. 'post'.
+	 * @param string $label Display label.
+	 * @param int    $order Sort order (lower first).
+	 */
+	public function register_group( $slug, $label, $order = 100 ) {
+		$this->groups[ $slug ] = array(
+			'slug'  => $slug,
+			'label' => $label,
+			'order' => (int) $order,
+		);
+	}
+
+	/**
+	 * Registers a Dynamic Tag source.
+	 *
+	 * @param string $slug Source slug (must match the slug passed to
+	 *                     designsetgo_register_bindings_source()).
+	 * @param array  $meta {
+	 *     Source metadata.
+	 *
+	 *     @type string   $label        Human-readable label.
+	 *     @type string   $group        Group slug (must be registered).
+	 *     @type string[] $returns      Return types: text|image|url|number|date.
+	 *     @type array    $args         Arg schema keyed by arg name.
+	 *     @type callable $discovery_cb Optional callback returning
+	 *                                  an array of fields for field discovery.
+	 *                                  Signature: function( array $context ): array.
+	 *     @type callable $resolver     Optional direct resolver. When present,
+	 *                                  the image resolver prefers this over
+	 *                                  round-tripping the core Bindings API.
+	 *                                  Signature: function( array $args, int $post_id ): mixed.
+	 *     @type string   $capability   Optional capability required to read.
+	 * }
+	 */
+	public function register_source( $slug, array $meta ) {
+		$defaults = array(
+			'label'        => $slug,
+			'group'        => 'post',
+			'returns'      => array( 'text' ),
+			'args'         => array(),
+			'discovery_cb' => null,
+			'resolver'     => null,
+			'capability'   => '',
+		);
+		$this->sources[ $slug ] = array_merge( $defaults, $meta, array( 'slug' => $slug ) );
+	}
+
+	/**
+	 * Returns all registered sources as a list.
+	 *
+	 * @param array $filters Optional filters: 'returns' (string|string[]),
+	 *                       'group' (string).
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function all_sources( array $filters = array() ) {
+		$sources = array_values( $this->sources );
+
+		if ( isset( $filters['group'] ) && '' !== $filters['group'] ) {
+			$group   = (string) $filters['group'];
+			$sources = array_values(
+				array_filter(
+					$sources,
+					static function ( $source ) use ( $group ) {
+						return $source['group'] === $group;
+					}
+				)
+			);
+		}
+
+		if ( isset( $filters['returns'] ) ) {
+			$wanted  = (array) $filters['returns'];
+			$sources = array_values(
+				array_filter(
+					$sources,
+					static function ( $source ) use ( $wanted ) {
+						$returns = (array) ( $source['returns'] ?? array() );
+						foreach ( $wanted as $type ) {
+							if ( in_array( $type, $returns, true ) ) {
+								return true;
+							}
+						}
+						return false;
+					}
+				)
+			);
+		}
+
+		return $sources;
+	}
+
+	/**
+	 * Returns a single source by slug or null.
+	 *
+	 * @param string $slug Source slug.
+	 * @return array<string, mixed>|null
+	 */
+	public function get_source( $slug ) {
+		return $this->sources[ $slug ] ?? null;
+	}
+
+	/**
+	 * Returns the group list sorted by order.
+	 *
+	 * @return array<int, array{slug:string,label:string,order:int}>
+	 */
+	public function all_groups() {
+		$groups = array_values( $this->groups );
+		usort(
+			$groups,
+			static function ( $a, $b ) {
+				return $a['order'] <=> $b['order'];
+			}
+		);
+		return $groups;
+	}
+
+	/**
+	 * Runs a source's field-discovery callback if registered.
+	 *
+	 * @param string $slug    Source slug.
+	 * @param array  $context Context array (post_type, post_id, returns).
+	 * @return array<int, array<string, mixed>> Fields discovered; empty on failure.
+	 */
+	public function discover_fields( $slug, array $context = array() ) {
+		$source = $this->get_source( $slug );
+		if ( null === $source || ! is_callable( $source['discovery_cb'] ?? null ) ) {
+			return array();
+		}
+		$result = call_user_func( $source['discovery_cb'], $context );
+		return is_array( $result ) ? $result : array();
+	}
+
+	/**
+	 * Resolves a source value for a given post context.
+	 *
+	 * Prefers a direct resolver when registered, otherwise falls back to
+	 * apply_filters on the core Bindings source the same way core does.
+	 *
+	 * @param string $slug    Source slug.
+	 * @param array  $args    Source args.
+	 * @param int    $post_id Post ID context.
+	 * @return mixed|null Resolved value or null if unresolvable.
+	 */
+	public function resolve( $slug, array $args, $post_id = 0 ) {
+		$source = $this->get_source( $slug );
+		if ( null === $source ) {
+			return null;
+		}
+
+		// Capability gate for sensitive sources.
+		if ( ! empty( $source['capability'] ) && ! current_user_can( (string) $source['capability'] ) ) {
+			return null;
+		}
+
+		if ( is_callable( $source['resolver'] ?? null ) ) {
+			return call_user_func( $source['resolver'], $args, (int) $post_id );
+		}
+
+		// Fall back to the core Bindings API value callback.
+		if ( function_exists( 'get_block_bindings_source' ) ) {
+			$binding = get_block_bindings_source( $slug );
+			if ( $binding && isset( $binding->get_value_callback ) && is_callable( $binding->get_value_callback ) ) {
+				$args['__dsgo_post_id'] = (int) $post_id;
+				return call_user_func( $binding->get_value_callback, $args, null, 'content' );
+			}
+		}
+
+		return null;
+	}
+}

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-rest.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-rest.php
@@ -182,9 +182,9 @@ class RestController {
 	 * @return \WP_REST_Response
 	 */
 	public function get_fields( \WP_REST_Request $request ) {
-		$slug      = (string) $request->get_param( 'source' );
-		$post_type = (string) $request->get_param( 'postType' );
-		$returns   = (string) $request->get_param( 'returns' );
+		$slug      = sanitize_text_field( (string) $request->get_param( 'source' ) );
+		$post_type = sanitize_key( (string) $request->get_param( 'postType' ) );
+		$returns   = sanitize_key( (string) $request->get_param( 'returns' ) );
 
 		$context = array(
 			'post_type' => $post_type,

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-rest.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-rest.php
@@ -1,0 +1,285 @@
+<?php
+/**
+ * Dynamic Tags — REST controller.
+ *
+ * Three endpoints under `designsetgo/v1/dynamic-tags/*` power the
+ * editor-side Dynamic Tag Picker:
+ *
+ *  - GET /sources   catalog of registered sources with metadata
+ *  - GET /fields    field discovery for a given source (ACF/meta/etc.)
+ *  - GET /preview   resolve a source against a post context
+ *
+ * All endpoints require `edit_posts` — they expose data the editor can
+ * already see and never widen access beyond the site's baseline editor
+ * capability. The preview endpoint additionally honors the same
+ * password / viewable / protected-meta gates as the Bindings sources.
+ *
+ * @package DesignSetGo
+ * @since   2.2.0
+ */
+
+namespace DesignSetGo\Blocks\DynamicTags;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the Dynamic Tags REST routes.
+ */
+class RestController {
+
+	private const NS = 'designsetgo/v1';
+
+	/**
+	 * Metadata registry used for source lookups.
+	 *
+	 * @var Registry
+	 */
+	private $registry;
+
+	/**
+	 * @param Registry $registry Metadata registry instance.
+	 */
+	public function __construct( Registry $registry ) {
+		$this->registry = $registry;
+	}
+
+	/**
+	 * Hook into rest_api_init.
+	 */
+	public function register_hooks() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Registers all three routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			self::NS,
+			'/dynamic-tags/sources',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_sources' ),
+				'permission_callback' => array( $this, 'permission_check' ),
+				'args'                => array(
+					'returns'  => array(
+						'type'        => 'string',
+						'description' => __( 'Comma-separated return types to filter by (text|image|url|number|date).', 'designsetgo' ),
+					),
+					'postType' => array(
+						'type'        => 'string',
+						'description' => __( 'Post type context for field discovery.', 'designsetgo' ),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NS,
+			'/dynamic-tags/fields',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_fields' ),
+				'permission_callback' => array( $this, 'permission_check' ),
+				'args'                => array(
+					'source'   => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+					'postType' => array(
+						'type'    => 'string',
+						'default' => 'post',
+					),
+					'returns'  => array(
+						'type' => 'string',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NS,
+			'/dynamic-tags/preview',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_preview' ),
+				'permission_callback' => array( $this, 'permission_check' ),
+				'args'                => array(
+					'source' => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+					'args'   => array(
+						'type'    => 'object',
+						'default' => array(),
+					),
+					'postId' => array(
+						'type' => 'integer',
+					),
+					'size'   => array(
+						'type'    => 'string',
+						'default' => 'medium',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Editor-baseline capability gate.
+	 *
+	 * @return bool
+	 */
+	public function permission_check() {
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * GET /dynamic-tags/sources
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response
+	 */
+	public function get_sources( \WP_REST_Request $request ) {
+		$filters = array();
+		$returns = $request->get_param( 'returns' );
+		if ( is_string( $returns ) && '' !== $returns ) {
+			$filters['returns'] = array_values(
+				array_filter(
+					array_map( 'trim', explode( ',', $returns ) )
+				)
+			);
+		}
+
+		$sources = array_map(
+			static function ( $source ) {
+				return array(
+					'slug'                   => $source['slug'],
+					'label'                  => $source['label'],
+					'group'                  => $source['group'],
+					'returns'                => array_values( (array) $source['returns'] ),
+					'args'                   => (object) ( $source['args'] ?? array() ),
+					'supportsFieldDiscovery' => is_callable( $source['discovery_cb'] ?? null ),
+				);
+			},
+			$this->registry->all_sources( $filters )
+		);
+
+		return rest_ensure_response(
+			array(
+				'groups'  => array_values( $this->registry->all_groups() ),
+				'sources' => $sources,
+			)
+		);
+	}
+
+	/**
+	 * GET /dynamic-tags/fields
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response
+	 */
+	public function get_fields( \WP_REST_Request $request ) {
+		$slug      = (string) $request->get_param( 'source' );
+		$post_type = (string) $request->get_param( 'postType' );
+		$returns   = (string) $request->get_param( 'returns' );
+
+		$context = array(
+			'post_type' => $post_type,
+			'returns'   => $returns,
+		);
+
+		$fields = $this->registry->discover_fields( $slug, $context );
+
+		// Strip protected meta keys defensively.
+		$fields = array_values(
+			array_filter(
+				$fields,
+				static function ( $field ) {
+					$key = isset( $field['key'] ) ? (string) $field['key'] : '';
+					return '' !== $key && 0 !== strpos( $key, '_' );
+				}
+			)
+		);
+
+		return rest_ensure_response( array( 'fields' => $fields ) );
+	}
+
+	/**
+	 * GET /dynamic-tags/preview
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response
+	 */
+	public function get_preview( \WP_REST_Request $request ) {
+		$slug    = (string) $request->get_param( 'source' );
+		$args    = (array) $request->get_param( 'args' );
+		$post_id = (int) $request->get_param( 'postId' );
+		$size    = (string) $request->get_param( 'size' );
+
+		$source = $this->registry->get_source( $slug );
+		if ( ! $source ) {
+			return rest_ensure_response(
+				array(
+					'status' => 'error',
+					'error'  => 'unknown_source',
+				)
+			);
+		}
+
+		if ( $post_id ) {
+			$post = get_post( $post_id );
+			if ( ! $post ) {
+				return rest_ensure_response(
+					array(
+						'status' => 'error',
+						'error'  => 'unknown_post',
+					)
+				);
+			}
+			if ( post_password_required( $post ) || ( ! is_post_publicly_viewable( $post ) && ! current_user_can( 'read_post', $post_id ) ) ) {
+				return rest_ensure_response( array( 'status' => 'unauthorized' ) );
+			}
+		}
+
+		$returns = (array) ( $source['returns'] ?? array() );
+
+		if ( in_array( 'image', $returns, true ) ) {
+			$descriptor = ImageResolver::resolve( $slug, $args, $post_id, $size );
+			if ( null === $descriptor ) {
+				return rest_ensure_response(
+					array(
+						'status'  => 'empty',
+						'returns' => 'image',
+					)
+				);
+			}
+			return rest_ensure_response(
+				array(
+					'status'  => 'resolved',
+					'returns' => 'image',
+					'value'   => $descriptor,
+				)
+			);
+		}
+
+		// Scalar source — delegate to the core Bindings callback.
+		$value = $this->registry->resolve( $slug, $args, $post_id );
+		if ( null === $value || '' === $value ) {
+			return rest_ensure_response(
+				array(
+					'status'  => 'empty',
+					'returns' => $returns[0] ?? 'text',
+				)
+			);
+		}
+
+		return rest_ensure_response(
+			array(
+				'status'  => 'resolved',
+				'returns' => $returns[0] ?? 'text',
+				'value'   => $value,
+			)
+		);
+	}
+}

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-rest.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-rest.php
@@ -37,6 +37,8 @@ class RestController {
 	private $registry;
 
 	/**
+	 * Constructor.
+	 *
 	 * @param Registry $registry Metadata registry instance.
 	 */
 	public function __construct( Registry $registry ) {

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-sources-archive.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-sources-archive.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Dynamic Tags — archive-family sources.
+ *
+ * Resolves values from the current archive queried object. When used
+ * outside an archive context (e.g. on a singular post) these return null.
+ *
+ * @package DesignSetGo
+ * @since   2.2.0
+ */
+
+namespace DesignSetGo\Blocks\DynamicTags;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the `designsetgo/archive-*` binding sources.
+ */
+class ArchiveSources {
+
+	/**
+	 * Registers archive-family sources.
+	 *
+	 * @param Registry $registry Metadata registry.
+	 */
+	public static function register( Registry $registry ) {
+		if ( ! function_exists( 'designsetgo_register_bindings_source' ) ) {
+			return;
+		}
+
+		self::register_one(
+			$registry,
+			'designsetgo/archive-title',
+			__( 'Archive title', 'designsetgo' ),
+			array( 'text' ),
+			static function ( $args, $block, $attr ) {
+				if ( ! self::is_archive_context() ) {
+					return null;
+				}
+				$title = wp_strip_all_tags( (string) get_the_archive_title() );
+				return '' === $title ? null : $title;
+			}
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/archive-description',
+			__( 'Archive description', 'designsetgo' ),
+			array( 'text' ),
+			static function ( $args, $block, $attr ) {
+				if ( ! self::is_archive_context() ) {
+					return null;
+				}
+				$desc = get_the_archive_description();
+				if ( ! $desc ) {
+					return null;
+				}
+				return wp_strip_all_tags( (string) $desc );
+			}
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/archive-url',
+			__( 'Archive URL', 'designsetgo' ),
+			array( 'url' ),
+			static function ( $args, $block, $attr ) {
+				$object = get_queried_object();
+				if ( $object instanceof \WP_Term ) {
+					$url = get_term_link( $object );
+					return is_wp_error( $url ) ? null : (string) $url;
+				}
+				if ( $object instanceof \WP_Post_Type ) {
+					$url = get_post_type_archive_link( $object->name );
+					return $url ? (string) $url : null;
+				}
+				if ( $object instanceof \WP_User ) {
+					return (string) get_author_posts_url( $object->ID );
+				}
+				return null;
+			}
+		);
+	}
+
+	/**
+	 * Whether the current request is an archive of any kind.
+	 *
+	 * @return bool
+	 */
+	private static function is_archive_context() {
+		return is_archive() || is_home() || is_search();
+	}
+
+	/**
+	 * Registers one source with both core Bindings and our metadata registry.
+	 *
+	 * @param Registry $registry Metadata registry.
+	 * @param string   $slug     Binding source slug.
+	 * @param string   $label    Display label.
+	 * @param string[] $returns  Return types.
+	 * @param callable $callback Value callback.
+	 */
+	private static function register_one( Registry $registry, $slug, $label, array $returns, callable $callback ) {
+		designsetgo_register_bindings_source(
+			$slug,
+			$callback,
+			array( 'label' => $label )
+		);
+		$registry->register_source(
+			$slug,
+			array(
+				'label'   => $label,
+				'group'   => 'archive',
+				'returns' => $returns,
+			)
+		);
+	}
+}

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-sources-post.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-sources-post.php
@@ -1,0 +1,344 @@
+<?php
+/**
+ * Dynamic Tags — post-family sources.
+ *
+ * Registers scalar binding sources covering the most common post fields:
+ * title, excerpt, date, permalink, author info, featured image parts,
+ * taxonomy terms. All wrap designsetgo_register_bindings_source() so
+ * the shared security gates (password, viewable, protected-meta) apply.
+ *
+ * @package DesignSetGo
+ * @since   2.2.0
+ */
+
+namespace DesignSetGo\Blocks\DynamicTags;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the `designsetgo/post-*` binding sources.
+ */
+class PostSources {
+
+	/**
+	 * Registers all post-family sources and their registry metadata.
+	 *
+	 * @param Registry $registry Metadata registry.
+	 */
+	public static function register( Registry $registry ) {
+		if ( ! function_exists( 'designsetgo_register_bindings_source' ) ) {
+			return;
+		}
+
+		self::register_one(
+			$registry,
+			'designsetgo/post-title',
+			__( 'Post title', 'designsetgo' ),
+			array( 'text' ),
+			static function ( $args, $block, $attr ) {
+				$post_id = (int) ( $args['__dsgo_post_id'] ?? 0 );
+				if ( ! $post_id ) {
+					return null;
+				}
+				$title = get_the_title( $post_id );
+				return '' === $title ? null : (string) $title;
+			}
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/post-excerpt',
+			__( 'Post excerpt', 'designsetgo' ),
+			array( 'text' ),
+			static function ( $args, $block, $attr ) {
+				$post_id = (int) ( $args['__dsgo_post_id'] ?? 0 );
+				if ( ! $post_id ) {
+					return null;
+				}
+				$post = get_post( $post_id );
+				if ( ! $post ) {
+					return null;
+				}
+				$excerpt = has_excerpt( $post ) ? get_the_excerpt( $post ) : wp_trim_words( wp_strip_all_tags( $post->post_content ), 40, '…' );
+				return '' === $excerpt ? null : (string) $excerpt;
+			}
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/post-date',
+			__( 'Post publish date', 'designsetgo' ),
+			array( 'text', 'date' ),
+			static function ( $args, $block, $attr ) {
+				$post_id = (int) ( $args['__dsgo_post_id'] ?? 0 );
+				if ( ! $post_id ) {
+					return null;
+				}
+				$format = isset( $args['format'] ) ? (string) $args['format'] : '';
+				if ( 'datetime' === $attr || '' === $format ) {
+					return (string) get_the_date( 'c', $post_id );
+				}
+				return (string) get_the_date( $format, $post_id );
+			},
+			array(
+				'format' => array(
+					'type'        => 'string',
+					'description' => __( 'PHP date format; defaults to the site setting.', 'designsetgo' ),
+				),
+			)
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/post-modified-date',
+			__( 'Post modified date', 'designsetgo' ),
+			array( 'text', 'date' ),
+			static function ( $args, $block, $attr ) {
+				$post_id = (int) ( $args['__dsgo_post_id'] ?? 0 );
+				if ( ! $post_id ) {
+					return null;
+				}
+				$format = isset( $args['format'] ) ? (string) $args['format'] : '';
+				if ( 'datetime' === $attr || '' === $format ) {
+					return (string) get_the_modified_date( 'c', $post_id );
+				}
+				return (string) get_the_modified_date( $format, $post_id );
+			},
+			array(
+				'format' => array( 'type' => 'string' ),
+			)
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/post-permalink',
+			__( 'Post permalink', 'designsetgo' ),
+			array( 'url' ),
+			static function ( $args, $block, $attr ) {
+				$post_id = (int) ( $args['__dsgo_post_id'] ?? 0 );
+				if ( ! $post_id ) {
+					return null;
+				}
+				$url = get_permalink( $post_id );
+				return $url ? (string) $url : null;
+			}
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/post-id',
+			__( 'Post ID', 'designsetgo' ),
+			array( 'text', 'number' ),
+			static function ( $args, $block, $attr ) {
+				$post_id = (int) ( $args['__dsgo_post_id'] ?? 0 );
+				return $post_id ? (string) $post_id : null;
+			}
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/post-type',
+			__( 'Post type', 'designsetgo' ),
+			array( 'text' ),
+			static function ( $args, $block, $attr ) {
+				$post_id = (int) ( $args['__dsgo_post_id'] ?? 0 );
+				if ( ! $post_id ) {
+					return null;
+				}
+				$type = get_post_type( $post_id );
+				return $type ? (string) $type : null;
+			}
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/post-author-name',
+			__( 'Post author name', 'designsetgo' ),
+			array( 'text' ),
+			static function ( $args, $block, $attr ) {
+				$post_id = (int) ( $args['__dsgo_post_id'] ?? 0 );
+				if ( ! $post_id ) {
+					return null;
+				}
+				$author_id = (int) get_post_field( 'post_author', $post_id );
+				if ( ! $author_id ) {
+					return null;
+				}
+				$name = get_the_author_meta( 'display_name', $author_id );
+				return '' === $name ? null : (string) $name;
+			}
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/post-author-url',
+			__( 'Post author archive URL', 'designsetgo' ),
+			array( 'url' ),
+			static function ( $args, $block, $attr ) {
+				$post_id = (int) ( $args['__dsgo_post_id'] ?? 0 );
+				if ( ! $post_id ) {
+					return null;
+				}
+				$author_id = (int) get_post_field( 'post_author', $post_id );
+				if ( ! $author_id ) {
+					return null;
+				}
+				$url = get_author_posts_url( $author_id );
+				return $url ? (string) $url : null;
+			}
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/post-author-avatar-url',
+			__( 'Post author avatar', 'designsetgo' ),
+			array( 'image', 'url' ),
+			static function ( $args, $block, $attr ) {
+				$post_id = (int) ( $args['__dsgo_post_id'] ?? 0 );
+				if ( ! $post_id ) {
+					return null;
+				}
+				$author_id = (int) get_post_field( 'post_author', $post_id );
+				if ( ! $author_id ) {
+					return null;
+				}
+				$size = isset( $args['size'] ) ? (int) $args['size'] : 96;
+				$url  = get_avatar_url( $author_id, array( 'size' => max( 24, $size ) ) );
+				return $url ? (string) $url : null;
+			},
+			array(
+				'size' => array( 'type' => 'integer' ),
+			)
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/post-featured-image',
+			__( 'Post featured image', 'designsetgo' ),
+			array( 'image' ),
+			static function ( $args, $block, $attr ) {
+				$post_id = (int) ( $args['__dsgo_post_id'] ?? 0 );
+				if ( ! $post_id ) {
+					return null;
+				}
+				$attachment_id = (int) get_post_thumbnail_id( $post_id );
+				if ( ! $attachment_id ) {
+					return null;
+				}
+				$subkey = isset( $args['subkey'] ) ? (string) $args['subkey'] : 'url';
+				$size   = isset( $args['size'] ) ? (string) $args['size'] : 'full';
+				return self::resolve_image_subvalue( $attachment_id, $subkey, $size );
+			},
+			array(
+				'subkey' => array(
+					'type' => 'string',
+					'enum' => array( 'url', 'id', 'alt', 'width', 'height', 'title', 'caption' ),
+				),
+				'size'   => array( 'type' => 'string' ),
+			)
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/post-taxonomy',
+			__( 'Post taxonomy terms', 'designsetgo' ),
+			array( 'text' ),
+			static function ( $args, $block, $attr ) {
+				$post_id  = (int) ( $args['__dsgo_post_id'] ?? 0 );
+				$taxonomy = isset( $args['taxonomy'] ) ? sanitize_key( (string) $args['taxonomy'] ) : 'category';
+				if ( ! $post_id || '' === $taxonomy || ! taxonomy_exists( $taxonomy ) ) {
+					return null;
+				}
+				$separator = isset( $args['separator'] ) ? (string) $args['separator'] : ', ';
+				$terms     = get_the_term_list( $post_id, $taxonomy, '', $separator );
+				if ( is_wp_error( $terms ) || ! $terms ) {
+					return null;
+				}
+				return wp_strip_all_tags( (string) $terms );
+			},
+			array(
+				'taxonomy'  => array(
+					'type'     => 'string',
+					'required' => true,
+				),
+				'separator' => array( 'type' => 'string' ),
+			)
+		);
+	}
+
+	/**
+	 * Shared helper that registers one source with both core Bindings and
+	 * our metadata registry, using the identical slug and default group.
+	 *
+	 * @param Registry $registry     Metadata registry.
+	 * @param string   $slug         Binding source slug.
+	 * @param string   $label        Display label.
+	 * @param string[] $returns      Return types.
+	 * @param callable $callback     Value callback. Receives
+	 *                               ($args, $block, $attribute_name); the
+	 *                               helper has already injected
+	 *                               $args['__dsgo_post_id'].
+	 * @param array    $args_schema  Optional arg schema for UI discovery.
+	 */
+	private static function register_one( Registry $registry, $slug, $label, array $returns, callable $callback, array $args_schema = array() ) {
+		designsetgo_register_bindings_source(
+			$slug,
+			$callback,
+			array( 'label' => $label )
+		);
+
+		$registry->register_source(
+			$slug,
+			array(
+				'label'   => $label,
+				'group'   => 'post',
+				'returns' => $returns,
+				'args'    => $args_schema,
+			)
+		);
+	}
+
+	/**
+	 * Resolves a scalar sub-value from an attachment ID.
+	 *
+	 * @param int    $attachment_id Attachment post ID.
+	 * @param string $subkey        Sub-key: url|id|alt|width|height|title|caption.
+	 * @param string $size          Image size for url/width/height.
+	 * @return string|null
+	 */
+	public static function resolve_image_subvalue( $attachment_id, $subkey, $size = 'full' ) {
+		$attachment_id = (int) $attachment_id;
+		if ( ! $attachment_id ) {
+			return null;
+		}
+		if ( ! in_array( $subkey, array( 'url', 'id', 'alt', 'width', 'height', 'title', 'caption' ), true ) ) {
+			$subkey = 'url';
+		}
+
+		switch ( $subkey ) {
+			case 'id':
+				return (string) $attachment_id;
+			case 'alt':
+				$alt = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+				return '' === $alt ? null : (string) $alt;
+			case 'title':
+				$title = get_the_title( $attachment_id );
+				return '' === $title ? null : (string) $title;
+			case 'caption':
+				$caption = wp_get_attachment_caption( $attachment_id );
+				return '' === $caption || false === $caption ? null : (string) $caption;
+			case 'width':
+			case 'height':
+				$src = wp_get_attachment_image_src( $attachment_id, $size );
+				if ( ! $src ) {
+					return null;
+				}
+				$idx = 'width' === $subkey ? 1 : 2;
+				return isset( $src[ $idx ] ) ? (string) $src[ $idx ] : null;
+			case 'url':
+			default:
+				$src = wp_get_attachment_image_src( $attachment_id, $size );
+				return $src && ! empty( $src[0] ) ? (string) $src[0] : null;
+		}
+	}
+}

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-sources-post.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-sources-post.php
@@ -227,7 +227,7 @@ class PostSources {
 				}
 				$subkey = isset( $args['subkey'] ) ? (string) $args['subkey'] : 'url';
 				$size   = isset( $args['size'] ) ? (string) $args['size'] : 'full';
-				return self::resolve_image_subvalue( $attachment_id, $subkey, $size );
+				return ImageResolver::resolve_subvalue( $attachment_id, $subkey, $size );
 			},
 			array(
 				'subkey' => array(
@@ -296,49 +296,5 @@ class PostSources {
 				'args'    => $args_schema,
 			)
 		);
-	}
-
-	/**
-	 * Resolves a scalar sub-value from an attachment ID.
-	 *
-	 * @param int    $attachment_id Attachment post ID.
-	 * @param string $subkey        Sub-key: url|id|alt|width|height|title|caption.
-	 * @param string $size          Image size for url/width/height.
-	 * @return string|null
-	 */
-	public static function resolve_image_subvalue( $attachment_id, $subkey, $size = 'full' ) {
-		$attachment_id = (int) $attachment_id;
-		if ( ! $attachment_id ) {
-			return null;
-		}
-		if ( ! in_array( $subkey, array( 'url', 'id', 'alt', 'width', 'height', 'title', 'caption' ), true ) ) {
-			$subkey = 'url';
-		}
-
-		switch ( $subkey ) {
-			case 'id':
-				return (string) $attachment_id;
-			case 'alt':
-				$alt = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
-				return '' === $alt ? null : (string) $alt;
-			case 'title':
-				$title = get_the_title( $attachment_id );
-				return '' === $title ? null : (string) $title;
-			case 'caption':
-				$caption = wp_get_attachment_caption( $attachment_id );
-				return '' === $caption || false === $caption ? null : (string) $caption;
-			case 'width':
-			case 'height':
-				$src = wp_get_attachment_image_src( $attachment_id, $size );
-				if ( ! $src ) {
-					return null;
-				}
-				$idx = 'width' === $subkey ? 1 : 2;
-				return (string) $src[ $idx ];
-			case 'url':
-			default:
-				$src = wp_get_attachment_image_src( $attachment_id, $size );
-				return $src && ! empty( $src[0] ) ? (string) $src[0] : null;
-		}
 	}
 }

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-sources-post.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-sources-post.php
@@ -249,7 +249,7 @@ class PostSources {
 				if ( ! $post_id || '' === $taxonomy || ! taxonomy_exists( $taxonomy ) ) {
 					return null;
 				}
-				$separator = isset( $args['separator'] ) ? (string) $args['separator'] : ', ';
+				$separator = isset( $args['separator'] ) ? sanitize_text_field( (string) $args['separator'] ) : ', ';
 				$terms     = get_the_term_list( $post_id, $taxonomy, '', $separator );
 				if ( is_wp_error( $terms ) || ! $terms ) {
 					return null;
@@ -334,7 +334,7 @@ class PostSources {
 					return null;
 				}
 				$idx = 'width' === $subkey ? 1 : 2;
-				return isset( $src[ $idx ] ) ? (string) $src[ $idx ] : null;
+				return (string) $src[ $idx ];
 			case 'url':
 			default:
 				$src = wp_get_attachment_image_src( $attachment_id, $size );

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-sources-site.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-sources-site.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Dynamic Tags — site-family sources.
+ *
+ * @package DesignSetGo
+ * @since   2.2.0
+ */
+
+namespace DesignSetGo\Blocks\DynamicTags;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the `designsetgo/site-*` binding sources.
+ */
+class SiteSources {
+
+	/**
+	 * Registers site-family sources.
+	 *
+	 * @param Registry $registry Metadata registry.
+	 */
+	public static function register( Registry $registry ) {
+		if ( ! function_exists( 'designsetgo_register_bindings_source' ) ) {
+			return;
+		}
+
+		self::register_one(
+			$registry,
+			'designsetgo/site-title',
+			__( 'Site title', 'designsetgo' ),
+			array( 'text' ),
+			static function ( $args, $block, $attr ) {
+				$value = get_bloginfo( 'name' );
+				return '' === $value ? null : (string) $value;
+			}
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/site-tagline',
+			__( 'Site tagline', 'designsetgo' ),
+			array( 'text' ),
+			static function ( $args, $block, $attr ) {
+				$value = get_bloginfo( 'description' );
+				return '' === $value ? null : (string) $value;
+			}
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/site-url',
+			__( 'Site URL', 'designsetgo' ),
+			array( 'url' ),
+			static function ( $args, $block, $attr ) {
+				$url = home_url( '/' );
+				return $url ? (string) $url : null;
+			}
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/site-logo',
+			__( 'Site logo', 'designsetgo' ),
+			array( 'image' ),
+			static function ( $args, $block, $attr ) {
+				$logo_id = (int) get_option( 'site_logo' );
+				if ( ! $logo_id ) {
+					$logo_id = (int) get_theme_mod( 'custom_logo' );
+				}
+				if ( ! $logo_id ) {
+					return null;
+				}
+				$subkey = isset( $args['subkey'] ) ? (string) $args['subkey'] : 'url';
+				$size   = isset( $args['size'] ) ? (string) $args['size'] : 'full';
+				return PostSources::resolve_image_subvalue( $logo_id, $subkey, $size );
+			},
+			array(
+				'subkey' => array(
+					'type' => 'string',
+					'enum' => array( 'url', 'id', 'alt', 'width', 'height' ),
+				),
+				'size'   => array( 'type' => 'string' ),
+			)
+		);
+	}
+
+	/**
+	 * Registers one source with both core Bindings and our metadata registry.
+	 *
+	 * @param Registry $registry    Metadata registry.
+	 * @param string   $slug        Binding source slug.
+	 * @param string   $label       Display label.
+	 * @param string[] $returns     Return types.
+	 * @param callable $callback    Value callback.
+	 * @param array    $args_schema Optional arg schema.
+	 */
+	private static function register_one( Registry $registry, $slug, $label, array $returns, callable $callback, array $args_schema = array() ) {
+		designsetgo_register_bindings_source(
+			$slug,
+			$callback,
+			array( 'label' => $label )
+		);
+		$registry->register_source(
+			$slug,
+			array(
+				'label'   => $label,
+				'group'   => 'site',
+				'returns' => $returns,
+				'args'    => $args_schema,
+			)
+		);
+	}
+}

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-sources-site.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-sources-site.php
@@ -73,7 +73,7 @@ class SiteSources {
 				}
 				$subkey = isset( $args['subkey'] ) ? (string) $args['subkey'] : 'url';
 				$size   = isset( $args['size'] ) ? (string) $args['size'] : 'full';
-				return PostSources::resolve_image_subvalue( $logo_id, $subkey, $size );
+				return ImageResolver::resolve_subvalue( $logo_id, $subkey, $size );
 			},
 			array(
 				'subkey' => array(

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-sources-user.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-sources-user.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Dynamic Tags — user-family sources.
+ *
+ * Resolves values from the currently logged-in user. These sources
+ * produce nothing for anonymous visitors, which is the intended
+ * behavior for members-area UIs.
+ *
+ * @package DesignSetGo
+ * @since   2.2.0
+ */
+
+namespace DesignSetGo\Blocks\DynamicTags;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the `designsetgo/current-user-*` binding sources.
+ */
+class UserSources {
+
+	/**
+	 * Registers user-family sources.
+	 *
+	 * @param Registry $registry Metadata registry.
+	 */
+	public static function register( Registry $registry ) {
+		if ( ! function_exists( 'designsetgo_register_bindings_source' ) ) {
+			return;
+		}
+
+		self::register_one(
+			$registry,
+			'designsetgo/current-user-name',
+			__( 'Current user name', 'designsetgo' ),
+			array( 'text' ),
+			static function ( $args, $block, $attr ) {
+				$user = wp_get_current_user();
+				if ( ! $user || 0 === (int) $user->ID ) {
+					return null;
+				}
+				return (string) $user->display_name;
+			}
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/current-user-avatar',
+			__( 'Current user avatar', 'designsetgo' ),
+			array( 'image', 'url' ),
+			static function ( $args, $block, $attr ) {
+				$user = wp_get_current_user();
+				if ( ! $user || 0 === (int) $user->ID ) {
+					return null;
+				}
+				$size = isset( $args['size'] ) ? (int) $args['size'] : 96;
+				$url  = get_avatar_url( $user->ID, array( 'size' => max( 24, $size ) ) );
+				return $url ? (string) $url : null;
+			},
+			array(
+				'size' => array( 'type' => 'integer' ),
+			)
+		);
+
+		self::register_one(
+			$registry,
+			'designsetgo/current-user-url',
+			__( 'Current user website URL', 'designsetgo' ),
+			array( 'url' ),
+			static function ( $args, $block, $attr ) {
+				$user = wp_get_current_user();
+				if ( ! $user || 0 === (int) $user->ID ) {
+					return null;
+				}
+				$url = (string) $user->user_url;
+				return '' === $url ? null : $url;
+			}
+		);
+
+		/**
+		 * Controls whether the `designsetgo/current-user-email` source is
+		 * enabled. Disabled by default because exposing an email address on
+		 * the public frontend is almost always a privacy mistake.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param bool $enabled Whether to register the email source.
+		 */
+		if ( apply_filters( 'designsetgo_dynamic_tags_allow_email', false ) ) {
+			self::register_one(
+				$registry,
+				'designsetgo/current-user-email',
+				__( 'Current user email', 'designsetgo' ),
+				array( 'text' ),
+				static function ( $args, $block, $attr ) {
+					$user = wp_get_current_user();
+					if ( ! $user || 0 === (int) $user->ID ) {
+						return null;
+					}
+					return (string) $user->user_email;
+				},
+				'read'
+			);
+		}
+	}
+
+	/**
+	 * Registers one source with both core Bindings and our metadata registry.
+	 *
+	 * @param Registry $registry     Metadata registry.
+	 * @param string   $slug         Binding source slug.
+	 * @param string   $label        Display label.
+	 * @param string[] $returns      Return types.
+	 * @param callable $callback     Value callback.
+	 * @param array    $args_schema  Optional arg schema.
+	 * @param string   $capability   Optional capability gate.
+	 */
+	private static function register_one( Registry $registry, $slug, $label, array $returns, callable $callback, $args_schema = array(), $capability = '' ) {
+		// Allow callers to pass capability as the 6th positional arg (string) or
+		// in the args_schema slot when there are no args.
+		if ( is_string( $args_schema ) ) {
+			$capability  = $args_schema;
+			$args_schema = array();
+		}
+
+		designsetgo_register_bindings_source(
+			$slug,
+			$callback,
+			array( 'label' => $label )
+		);
+		$registry->register_source(
+			$slug,
+			array(
+				'label'      => $label,
+				'group'      => 'user',
+				'returns'    => $returns,
+				'args'       => $args_schema,
+				'capability' => $capability,
+			)
+		);
+	}
+}

--- a/includes/blocks/dynamic-tags/class-dynamic-tags-sources-user.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-sources-user.php
@@ -36,7 +36,7 @@ class UserSources {
 			array( 'text' ),
 			static function ( $args, $block, $attr ) {
 				$user = wp_get_current_user();
-				if ( ! $user || 0 === (int) $user->ID ) {
+				if ( 0 === (int) $user->ID ) {
 					return null;
 				}
 				return (string) $user->display_name;
@@ -50,7 +50,7 @@ class UserSources {
 			array( 'image', 'url' ),
 			static function ( $args, $block, $attr ) {
 				$user = wp_get_current_user();
-				if ( ! $user || 0 === (int) $user->ID ) {
+				if ( 0 === (int) $user->ID ) {
 					return null;
 				}
 				$size = isset( $args['size'] ) ? (int) $args['size'] : 96;
@@ -69,7 +69,7 @@ class UserSources {
 			array( 'url' ),
 			static function ( $args, $block, $attr ) {
 				$user = wp_get_current_user();
-				if ( ! $user || 0 === (int) $user->ID ) {
+				if ( 0 === (int) $user->ID ) {
 					return null;
 				}
 				$url = (string) $user->user_url;
@@ -77,52 +77,50 @@ class UserSources {
 			}
 		);
 
-		/**
-		 * Controls whether the `designsetgo/current-user-email` source is
-		 * enabled. Disabled by default because exposing an email address on
-		 * the public frontend is almost always a privacy mistake.
-		 *
-		 * @since 2.2.0
-		 *
-		 * @param bool $enabled Whether to register the email source.
-		 */
-		if ( apply_filters( 'designsetgo_dynamic_tags_allow_email', false ) ) {
-			self::register_one(
-				$registry,
-				'designsetgo/current-user-email',
-				__( 'Current user email', 'designsetgo' ),
-				array( 'text' ),
-				static function ( $args, $block, $attr ) {
-					$user = wp_get_current_user();
-					if ( ! $user || 0 === (int) $user->ID ) {
-						return null;
-					}
-					return (string) $user->user_email;
-				},
-				'read'
-			);
-		}
+		// Always register the email source so plugins hooking `init` at the
+		// default priority (10) can still enable it; the value callback
+		// evaluates `designsetgo_dynamic_tags_allow_email` lazily at render
+		// time. Disabled by default because exposing an email on the public
+		// frontend is almost always a privacy mistake.
+		self::register_one(
+			$registry,
+			'designsetgo/current-user-email',
+			__( 'Current user email', 'designsetgo' ),
+			array( 'text' ),
+			static function ( $args, $block, $attr ) {
+				/**
+				 * Enables the `designsetgo/current-user-email` source.
+				 *
+				 * @since 2.2.0
+				 *
+				 * @param bool $enabled Whether to resolve the email source.
+				 */
+				if ( ! apply_filters( 'designsetgo_dynamic_tags_allow_email', false ) ) {
+					return null;
+				}
+				$user = wp_get_current_user();
+				if ( 0 === (int) $user->ID ) {
+					return null;
+				}
+				return (string) $user->user_email;
+			},
+			array(),
+			'read'
+		);
 	}
 
 	/**
 	 * Registers one source with both core Bindings and our metadata registry.
 	 *
-	 * @param Registry $registry     Metadata registry.
-	 * @param string   $slug         Binding source slug.
-	 * @param string   $label        Display label.
-	 * @param string[] $returns      Return types.
-	 * @param callable $callback     Value callback.
-	 * @param array    $args_schema  Optional arg schema.
-	 * @param string   $capability   Optional capability gate.
+	 * @param Registry $registry    Metadata registry.
+	 * @param string   $slug        Binding source slug.
+	 * @param string   $label       Display label.
+	 * @param string[] $returns     Return types.
+	 * @param callable $callback    Value callback.
+	 * @param array    $args_schema Optional arg schema.
+	 * @param string   $capability  Optional capability gate.
 	 */
-	private static function register_one( Registry $registry, $slug, $label, array $returns, callable $callback, $args_schema = array(), $capability = '' ) {
-		// Allow callers to pass capability as the 6th positional arg (string) or
-		// in the args_schema slot when there are no args.
-		if ( is_string( $args_schema ) ) {
-			$capability  = $args_schema;
-			$args_schema = array();
-		}
-
+	private static function register_one( Registry $registry, $slug, $label, array $returns, callable $callback, array $args_schema = array(), $capability = '' ) {
 		designsetgo_register_bindings_source(
 			$slug,
 			$callback,

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -841,6 +841,8 @@ class Plugin {
 			$settings        = $settings ?? \DesignSetGo\Admin\Settings::get_settings();
 			$excluded_blocks = isset( $settings['excluded_blocks'] ) ? $settings['excluded_blocks'] : array();
 
+			$enabled_extensions = isset( $settings['enabled_extensions'] ) ? (array) $settings['enabled_extensions'] : array();
+
 			wp_localize_script(
 				'designsetgo-extensions',
 				'dsgoSettings',
@@ -849,6 +851,9 @@ class Plugin {
 					'defaultIconButtonHover' => isset( $settings['animations']['default_icon_button_hover'] )
 						? sanitize_key( $settings['animations']['default_icon_button_hover'] )
 						: 'fill-diagonal',
+					// Empty list = all extensions enabled (matches the
+					// PHP convention in Block_Manager::should_load_extension).
+					'enabledExtensions'      => array_values( array_map( 'sanitize_key', $enabled_extensions ) ),
 				)
 			);
 		}

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -480,6 +480,13 @@ class Plugin {
 	public $query_bindings;
 
 	/**
+	 * Dynamic Tags bootstrap instance.
+	 *
+	 * @var Blocks\DynamicTags\Bootstrap
+	 */
+	public $dynamic_tags;
+
+	/**
 	 * Query Filter Index instance.
 	 *
 	 * @var Blocks\Query\FilterIndex
@@ -543,6 +550,18 @@ class Plugin {
 		\DesignSetGo\Blocks\Query\PodsBindings::bootstrap();
 		require_once DESIGNSETGO_PATH . 'includes/blocks/class-query-bindings-jetengine.php';
 		\DesignSetGo\Blocks\Query\JetEngineBindings::bootstrap();
+
+		// Dynamic Tags subsystem (registry, source catalog, REST, image resolver).
+		require_once DESIGNSETGO_PATH . 'includes/blocks/dynamic-tags/class-dynamic-tags-registry.php';
+		require_once DESIGNSETGO_PATH . 'includes/blocks/dynamic-tags/class-dynamic-tags-sources-post.php';
+		require_once DESIGNSETGO_PATH . 'includes/blocks/dynamic-tags/class-dynamic-tags-sources-site.php';
+		require_once DESIGNSETGO_PATH . 'includes/blocks/dynamic-tags/class-dynamic-tags-sources-archive.php';
+		require_once DESIGNSETGO_PATH . 'includes/blocks/dynamic-tags/class-dynamic-tags-sources-user.php';
+		require_once DESIGNSETGO_PATH . 'includes/blocks/dynamic-tags/class-dynamic-tags-field-discovery.php';
+		require_once DESIGNSETGO_PATH . 'includes/blocks/dynamic-tags/class-dynamic-tags-image-resolver.php';
+		require_once DESIGNSETGO_PATH . 'includes/blocks/dynamic-tags/class-dynamic-tags-rest.php';
+		require_once DESIGNSETGO_PATH . 'includes/blocks/dynamic-tags/class-dynamic-tags-bootstrap.php';
+
 		require_once DESIGNSETGO_PATH . 'includes/blocks/class-query-filter-index.php';
 		require_once DESIGNSETGO_PATH . 'includes/blocks/class-query-filter-index-hooks.php';
 		require_once DESIGNSETGO_PATH . 'includes/blocks/class-query-filter-index-rebuilder.php';
@@ -642,6 +661,7 @@ class Plugin {
 		$this->query_controller          = new Blocks\Query\Controller();
 		add_action( 'rest_api_init', array( 'DesignSetGo\Blocks\Query\Template_Controller', 'register_routes' ) );
 		$this->query_bindings      = new Blocks\Query\Bindings();
+		$this->dynamic_tags        = new Blocks\DynamicTags\Bootstrap();
 		$this->filter_index         = new Blocks\Query\FilterIndex();
 		Blocks\Query\FilterIndexHooks::register_hooks();
 		$this->filter_registry      = new Blocks\Query\FilterRegistry();

--- a/src/blocks/dynamic-image/block.json
+++ b/src/blocks/dynamic-image/block.json
@@ -1,0 +1,85 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "designsetgo/dynamic-image",
+	"version": "1.0.0",
+	"title": "Dynamic Image",
+	"category": "designsetgo",
+	"description": "An image block whose source resolves at render time from the post, site, user, or a custom field (ACF, Meta Box, Pods, JetEngine).",
+	"keywords": [ "image", "dynamic", "featured", "acf", "tag" ],
+	"textdomain": "designsetgo",
+	"icon": "format-image",
+	"usesContext": [ "postId", "postType" ],
+	"supports": {
+		"align": [ "wide", "full" ],
+		"anchor": true,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true
+		}
+	},
+	"attributes": {
+		"source": {
+			"type": "string",
+			"default": ""
+		},
+		"sourceArgs": {
+			"type": "object",
+			"default": {}
+		},
+		"size": {
+			"type": "string",
+			"default": "full"
+		},
+		"altOverride": {
+			"type": "string",
+			"default": ""
+		},
+		"focalPoint": {
+			"type": "object",
+			"default": { "x": 0.5, "y": 0.5 }
+		},
+		"aspectRatio": {
+			"type": "string",
+			"default": ""
+		},
+		"objectFit": {
+			"type": "string",
+			"default": "cover"
+		},
+		"fallbackId": {
+			"type": "number",
+			"default": 0
+		},
+		"fallbackUrl": {
+			"type": "string",
+			"default": ""
+		},
+		"fallbackAlt": {
+			"type": "string",
+			"default": ""
+		},
+		"href": {
+			"type": "string",
+			"default": ""
+		},
+		"linkTarget": {
+			"type": "string",
+			"default": ""
+		},
+		"rel": {
+			"type": "string",
+			"default": ""
+		}
+	},
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./editor.css",
+	"style": "file:./style-index.css",
+	"render": "file:./render.php"
+}

--- a/src/blocks/dynamic-image/edit.js
+++ b/src/blocks/dynamic-image/edit.js
@@ -1,0 +1,285 @@
+/**
+ * Dynamic Image block — editor.
+ *
+ * Authors pick a Dynamic Tag source (featured image, ACF image,
+ * site logo, etc.), optionally configure a size and focal point,
+ * and set a fallback image for when the source is empty.
+ *
+ * The editor preview hits REST /dynamic-tags/preview so what you see
+ * here matches what render.php will output on the frontend.
+ */
+import {
+	InspectorControls,
+	useBlockProps,
+	MediaUpload,
+	MediaUploadCheck,
+} from '@wordpress/block-editor';
+import {
+	PanelBody,
+	Button,
+	SelectControl,
+	TextControl,
+	FocalPointPicker,
+	Placeholder,
+	Spinner,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+
+import { DynamicTagButton, useDynamicTagPreview } from '../../components/DynamicTagPicker';
+
+const SIZE_OPTIONS = [
+	{ label: __( 'Thumbnail', 'designsetgo' ), value: 'thumbnail' },
+	{ label: __( 'Medium', 'designsetgo' ), value: 'medium' },
+	{ label: __( 'Large', 'designsetgo' ), value: 'large' },
+	{ label: __( 'Full', 'designsetgo' ), value: 'full' },
+];
+
+const OBJECT_FIT_OPTIONS = [
+	{ label: __( 'Cover', 'designsetgo' ), value: 'cover' },
+	{ label: __( 'Contain', 'designsetgo' ), value: 'contain' },
+	{ label: __( 'Fill', 'designsetgo' ), value: 'fill' },
+	{ label: __( 'Scale down', 'designsetgo' ), value: 'scale-down' },
+];
+
+export default function Edit( { attributes, setAttributes, context } ) {
+	const {
+		source,
+		sourceArgs,
+		size,
+		altOverride,
+		focalPoint,
+		aspectRatio,
+		objectFit,
+		fallbackId,
+		fallbackUrl,
+		fallbackAlt,
+		href,
+		linkTarget,
+		rel,
+	} = attributes;
+
+	const editorPostId = useSelect(
+		( select ) => select( editorStore )?.getCurrentPostId?.() || 0,
+		[]
+	);
+	const postId = context?.postId || editorPostId;
+
+	const preview = useDynamicTagPreview( {
+		source,
+		args: sourceArgs,
+		postId,
+		size,
+	} );
+
+	const blockProps = useBlockProps( {
+		style: aspectRatio ? { aspectRatio } : undefined,
+	} );
+
+	const sourceValue = source ? { source, args: sourceArgs } : null;
+
+	const handleSourceChange = ( next ) => {
+		if ( ! next ) {
+			setAttributes( { source: '', sourceArgs: {} } );
+			return;
+		}
+		setAttributes( { source: next.source, sourceArgs: next.args || {} } );
+	};
+
+	const resolvedImage =
+		preview.status === 'resolved' && preview.returns === 'image' && preview.value
+			? preview.value
+			: null;
+
+	const displayImage = resolvedImage
+		|| ( fallbackUrl
+			? { url: fallbackUrl, alt: fallbackAlt || '', width: 0, height: 0 }
+			: null );
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Dynamic Source', 'designsetgo' ) } initialOpen>
+					<VStack spacing={ 3 }>
+						<DynamicTagButton
+							value={ sourceValue }
+							onChange={ handleSourceChange }
+							returns="image"
+							postId={ postId }
+						/>
+						{ source && (
+							<p className="dsgo-dynamic-image__source-summary">
+								<code>{ source }</code>
+							</p>
+						) }
+
+						<SelectControl
+							label={ __( 'Image size', 'designsetgo' ) }
+							value={ size }
+							options={ SIZE_OPTIONS }
+							onChange={ ( value ) => setAttributes( { size: value } ) }
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+
+						<TextControl
+							label={ __( 'Alt text override', 'designsetgo' ) }
+							help={ __( 'Leave blank to use the alt text from the source.', 'designsetgo' ) }
+							value={ altOverride }
+							onChange={ ( value ) => setAttributes( { altOverride: value } ) }
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+					</VStack>
+				</PanelBody>
+
+				<PanelBody title={ __( 'Display', 'designsetgo' ) } initialOpen={ false }>
+					<VStack spacing={ 3 }>
+						<TextControl
+							label={ __( 'Aspect ratio', 'designsetgo' ) }
+							help={ __( 'e.g. 16/9, 1/1. Leave blank for natural.', 'designsetgo' ) }
+							value={ aspectRatio }
+							onChange={ ( value ) => setAttributes( { aspectRatio: value } ) }
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+						<SelectControl
+							label={ __( 'Object fit', 'designsetgo' ) }
+							value={ objectFit }
+							options={ OBJECT_FIT_OPTIONS }
+							onChange={ ( value ) => setAttributes( { objectFit: value } ) }
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+						{ displayImage?.url && (
+							<FocalPointPicker
+								label={ __( 'Focal point', 'designsetgo' ) }
+								url={ displayImage.url }
+								value={ focalPoint }
+								onChange={ ( value ) => setAttributes( { focalPoint: value } ) }
+								__nextHasNoMarginBottom
+							/>
+						) }
+					</VStack>
+				</PanelBody>
+
+				<PanelBody title={ __( 'Fallback image', 'designsetgo' ) } initialOpen={ false }>
+					<p className="dsgo-dynamic-image__help">
+						{ __( 'Shown when the dynamic source is empty — e.g. a post without a featured image.', 'designsetgo' ) }
+					</p>
+					<MediaUploadCheck>
+						<MediaUpload
+							onSelect={ ( media ) =>
+								setAttributes( {
+									fallbackId: media.id,
+									fallbackUrl: media.url,
+									fallbackAlt: media.alt || '',
+								} )
+							}
+							allowedTypes={ [ 'image' ] }
+							value={ fallbackId }
+							render={ ( { open } ) => (
+								<HStack>
+									<Button variant="secondary" onClick={ open }>
+										{ fallbackId ? __( 'Replace', 'designsetgo' ) : __( 'Select image', 'designsetgo' ) }
+									</Button>
+									{ fallbackId && (
+										<Button
+											variant="tertiary"
+											isDestructive
+											onClick={ () =>
+												setAttributes( { fallbackId: 0, fallbackUrl: '', fallbackAlt: '' } )
+											}
+										>
+											{ __( 'Remove', 'designsetgo' ) }
+										</Button>
+									) }
+								</HStack>
+							) }
+						/>
+					</MediaUploadCheck>
+					{ fallbackUrl && (
+						<img src={ fallbackUrl } alt="" className="dsgo-dynamic-image__fallback-preview" />
+					) }
+				</PanelBody>
+
+				<PanelBody title={ __( 'Link', 'designsetgo' ) } initialOpen={ false }>
+					<VStack spacing={ 3 }>
+						<TextControl
+							label={ __( 'URL', 'designsetgo' ) }
+							value={ href }
+							onChange={ ( value ) => setAttributes( { href: value } ) }
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+						<SelectControl
+							label={ __( 'Open in', 'designsetgo' ) }
+							value={ linkTarget }
+							options={ [
+								{ label: __( 'Same tab', 'designsetgo' ), value: '' },
+								{ label: __( 'New tab', 'designsetgo' ), value: '_blank' },
+							] }
+							onChange={ ( value ) => setAttributes( { linkTarget: value } ) }
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+						<TextControl
+							label={ __( 'Rel attribute', 'designsetgo' ) }
+							value={ rel }
+							onChange={ ( value ) => setAttributes( { rel: value } ) }
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+					</VStack>
+				</PanelBody>
+			</InspectorControls>
+
+			<figure { ...blockProps }>
+				{ ! source && ! fallbackUrl && (
+					<Placeholder
+						icon="format-image"
+						label={ __( 'Dynamic Image', 'designsetgo' ) }
+						instructions={ __( 'Pick a dynamic source (featured image, ACF field, site logo, …).', 'designsetgo' ) }
+					>
+						<DynamicTagButton
+							value={ null }
+							onChange={ handleSourceChange }
+							returns="image"
+							postId={ postId }
+							size="default"
+							variant="primary"
+						/>
+					</Placeholder>
+				) }
+
+				{ preview.status === 'loading' && source && ! displayImage && (
+					<div className="dsgo-dynamic-image__loading">
+						<Spinner />
+					</div>
+				) }
+
+				{ displayImage?.url && (
+					<img
+						src={ displayImage.url }
+						alt={ altOverride || displayImage.alt || '' }
+						style={ {
+							objectFit,
+							objectPosition: focalPoint
+								? `${ Math.round( focalPoint.x * 100 ) }% ${ Math.round( focalPoint.y * 100 ) }%`
+								: undefined,
+						} }
+					/>
+				) }
+
+				{ source && preview.status === 'empty' && ! displayImage && (
+					<div className="dsgo-dynamic-image__empty">
+						{ __( 'Source is empty on this post. Add a fallback image to always show something.', 'designsetgo' ) }
+					</div>
+				) }
+			</figure>
+		</>
+	);
+}

--- a/src/blocks/dynamic-image/edit.js
+++ b/src/blocks/dynamic-image/edit.js
@@ -13,6 +13,7 @@ import {
 	useBlockProps,
 	MediaUpload,
 	MediaUploadCheck,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -31,18 +32,36 @@ import { store as editorStore } from '@wordpress/editor';
 
 import { DynamicTagButton, useDynamicTagPreview } from '../../components/DynamicTagPicker';
 
-const SIZE_OPTIONS = [
-	{ label: __( 'Thumbnail', 'designsetgo' ), value: 'thumbnail' },
-	{ label: __( 'Medium', 'designsetgo' ), value: 'medium' },
-	{ label: __( 'Large', 'designsetgo' ), value: 'large' },
-	{ label: __( 'Full', 'designsetgo' ), value: 'full' },
-];
-
 const OBJECT_FIT_OPTIONS = [
 	{ label: __( 'Cover', 'designsetgo' ), value: 'cover' },
 	{ label: __( 'Contain', 'designsetgo' ), value: 'contain' },
 	{ label: __( 'Fill', 'designsetgo' ), value: 'fill' },
 	{ label: __( 'Scale down', 'designsetgo' ), value: 'scale-down' },
+];
+
+const ASPECT_RATIO_OPTIONS = [
+	{ label: __( 'Original', 'designsetgo' ), value: '' },
+	{ label: __( 'Square (1 : 1)', 'designsetgo' ), value: '1/1' },
+	{ label: __( 'Landscape (16 : 9)', 'designsetgo' ), value: '16/9' },
+	{ label: __( 'Landscape (4 : 3)', 'designsetgo' ), value: '4/3' },
+	{ label: __( 'Landscape (3 : 2)', 'designsetgo' ), value: '3/2' },
+	{ label: __( 'Portrait (3 : 4)', 'designsetgo' ), value: '3/4' },
+	{ label: __( 'Portrait (2 : 3)', 'designsetgo' ), value: '2/3' },
+	{ label: __( 'Portrait (9 : 16)', 'designsetgo' ), value: '9/16' },
+];
+
+const LINK_TARGET_OPTIONS = [
+	{ label: __( 'Same tab', 'designsetgo' ), value: '' },
+	{ label: __( 'New tab', 'designsetgo' ), value: '_blank' },
+];
+
+const REL_OPTIONS = [
+	{ label: __( 'None', 'designsetgo' ), value: '' },
+	{ label: 'nofollow', value: 'nofollow' },
+	{ label: 'noopener noreferrer', value: 'noopener noreferrer' },
+	{ label: 'nofollow noopener noreferrer', value: 'nofollow noopener noreferrer' },
+	{ label: 'sponsored', value: 'sponsored' },
+	{ label: 'ugc', value: 'ugc' },
 ];
 
 export default function Edit( { attributes, setAttributes, context } ) {
@@ -62,11 +81,24 @@ export default function Edit( { attributes, setAttributes, context } ) {
 		rel,
 	} = attributes;
 
-	const editorPostId = useSelect(
-		( select ) => select( editorStore )?.getCurrentPostId?.() || 0,
-		[]
-	);
+	const { editorPostId, imageSizes } = useSelect( ( select ) => {
+		const editor = select( editorStore );
+		const blockEditor = select( blockEditorStore );
+		return {
+			editorPostId: editor?.getCurrentPostId?.() || 0,
+			imageSizes: blockEditor?.getSettings?.()?.imageSizes || [],
+		};
+	}, [] );
 	const postId = context?.postId || editorPostId;
+
+	const sizeOptions = imageSizes.length
+		? imageSizes.map( ( s ) => ( { label: s.name, value: s.slug } ) )
+		: [
+				{ label: __( 'Thumbnail', 'designsetgo' ), value: 'thumbnail' },
+				{ label: __( 'Medium', 'designsetgo' ), value: 'medium' },
+				{ label: __( 'Large', 'designsetgo' ), value: 'large' },
+				{ label: __( 'Full', 'designsetgo' ), value: 'full' },
+		  ];
 
 	const preview = useDynamicTagPreview( {
 		source,
@@ -119,7 +151,7 @@ export default function Edit( { attributes, setAttributes, context } ) {
 						<SelectControl
 							label={ __( 'Image size', 'designsetgo' ) }
 							value={ size }
-							options={ SIZE_OPTIONS }
+							options={ sizeOptions }
 							onChange={ ( value ) => setAttributes( { size: value } ) }
 							__nextHasNoMarginBottom
 							__next40pxDefaultSize
@@ -138,10 +170,10 @@ export default function Edit( { attributes, setAttributes, context } ) {
 
 				<PanelBody title={ __( 'Display', 'designsetgo' ) } initialOpen={ false }>
 					<VStack spacing={ 3 }>
-						<TextControl
+						<SelectControl
 							label={ __( 'Aspect ratio', 'designsetgo' ) }
-							help={ __( 'e.g. 16/9, 1/1. Leave blank for natural.', 'designsetgo' ) }
 							value={ aspectRatio }
+							options={ ASPECT_RATIO_OPTIONS }
 							onChange={ ( value ) => setAttributes( { aspectRatio: value } ) }
 							__nextHasNoMarginBottom
 							__next40pxDefaultSize
@@ -218,17 +250,15 @@ export default function Edit( { attributes, setAttributes, context } ) {
 						<SelectControl
 							label={ __( 'Open in', 'designsetgo' ) }
 							value={ linkTarget }
-							options={ [
-								{ label: __( 'Same tab', 'designsetgo' ), value: '' },
-								{ label: __( 'New tab', 'designsetgo' ), value: '_blank' },
-							] }
+							options={ LINK_TARGET_OPTIONS }
 							onChange={ ( value ) => setAttributes( { linkTarget: value } ) }
 							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 						/>
-						<TextControl
+						<SelectControl
 							label={ __( 'Rel attribute', 'designsetgo' ) }
 							value={ rel }
+							options={ REL_OPTIONS }
 							onChange={ ( value ) => setAttributes( { rel: value } ) }
 							__nextHasNoMarginBottom
 							__next40pxDefaultSize

--- a/src/blocks/dynamic-image/edit.js
+++ b/src/blocks/dynamic-image/edit.js
@@ -27,8 +27,9 @@ import {
 	Spinner,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
 
 import {
@@ -123,6 +124,30 @@ export default function Edit({ attributes, setAttributes, clientId, context }) {
 				{ label: __('Large', 'designsetgo'), value: 'large' },
 				{ label: __('Full', 'designsetgo'), value: 'full' },
 			];
+
+	// If a stored aspectRatio value isn't one of our presets (e.g. a
+	// custom 4/5 saved by an earlier free-text version of this control),
+	// surface it as an extra option so authors can still see and edit
+	// it instead of the dropdown silently snapping to "Original".
+	const aspectRatioOptions = useMemo(() => {
+		if (
+			!aspectRatio ||
+			ASPECT_RATIO_OPTIONS.some((opt) => opt.value === aspectRatio)
+		) {
+			return ASPECT_RATIO_OPTIONS;
+		}
+		return [
+			...ASPECT_RATIO_OPTIONS,
+			{
+				label: sprintf(
+					/* translators: %s: custom aspect-ratio value such as 4/5 */
+					__('Custom (%s)', 'designsetgo'),
+					aspectRatio
+				),
+				value: aspectRatio,
+			},
+		];
+	}, [aspectRatio]);
 
 	const preview = useDynamicTagPreview({
 		source,
@@ -236,7 +261,7 @@ export default function Edit({ attributes, setAttributes, clientId, context }) {
 						<SelectControl
 							label={__('Aspect ratio', 'designsetgo')}
 							value={aspectRatio}
-							options={ASPECT_RATIO_OPTIONS}
+							options={aspectRatioOptions}
 							onChange={(value) =>
 								setAttributes({ aspectRatio: value })
 							}

--- a/src/blocks/dynamic-image/edit.js
+++ b/src/blocks/dynamic-image/edit.js
@@ -7,6 +7,9 @@
  *
  * The editor preview hits REST /dynamic-tags/preview so what you see
  * here matches what render.php will output on the frontend.
+ *
+ * Inspector follows the Theme 3 IA convention: a single canonical
+ * Settings ToolsPanel with one DsgoInspectorPanel.Item per attribute.
  */
 import {
 	InspectorControls,
@@ -16,55 +19,76 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
-	PanelBody,
 	Button,
 	SelectControl,
 	TextControl,
 	FocalPointPicker,
 	Placeholder,
 	Spinner,
-	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 
-import { DynamicTagButton, useDynamicTagPreview } from '../../components/DynamicTagPicker';
+import {
+	DynamicTagButton,
+	useDynamicTagPreview,
+} from '../../components/DynamicTagPicker';
+import { DsgoInspectorPanel } from '../../components/shared';
 
 const OBJECT_FIT_OPTIONS = [
-	{ label: __( 'Cover', 'designsetgo' ), value: 'cover' },
-	{ label: __( 'Contain', 'designsetgo' ), value: 'contain' },
-	{ label: __( 'Fill', 'designsetgo' ), value: 'fill' },
-	{ label: __( 'Scale down', 'designsetgo' ), value: 'scale-down' },
+	{ label: __('Cover', 'designsetgo'), value: 'cover' },
+	{ label: __('Contain', 'designsetgo'), value: 'contain' },
+	{ label: __('Fill', 'designsetgo'), value: 'fill' },
+	{ label: __('Scale down', 'designsetgo'), value: 'scale-down' },
 ];
 
 const ASPECT_RATIO_OPTIONS = [
-	{ label: __( 'Original', 'designsetgo' ), value: '' },
-	{ label: __( 'Square (1 : 1)', 'designsetgo' ), value: '1/1' },
-	{ label: __( 'Landscape (16 : 9)', 'designsetgo' ), value: '16/9' },
-	{ label: __( 'Landscape (4 : 3)', 'designsetgo' ), value: '4/3' },
-	{ label: __( 'Landscape (3 : 2)', 'designsetgo' ), value: '3/2' },
-	{ label: __( 'Portrait (3 : 4)', 'designsetgo' ), value: '3/4' },
-	{ label: __( 'Portrait (2 : 3)', 'designsetgo' ), value: '2/3' },
-	{ label: __( 'Portrait (9 : 16)', 'designsetgo' ), value: '9/16' },
+	{ label: __('Original', 'designsetgo'), value: '' },
+	{ label: __('Square (1 : 1)', 'designsetgo'), value: '1/1' },
+	{ label: __('Landscape (16 : 9)', 'designsetgo'), value: '16/9' },
+	{ label: __('Landscape (4 : 3)', 'designsetgo'), value: '4/3' },
+	{ label: __('Landscape (3 : 2)', 'designsetgo'), value: '3/2' },
+	{ label: __('Portrait (3 : 4)', 'designsetgo'), value: '3/4' },
+	{ label: __('Portrait (2 : 3)', 'designsetgo'), value: '2/3' },
+	{ label: __('Portrait (9 : 16)', 'designsetgo'), value: '9/16' },
 ];
 
 const LINK_TARGET_OPTIONS = [
-	{ label: __( 'Same tab', 'designsetgo' ), value: '' },
-	{ label: __( 'New tab', 'designsetgo' ), value: '_blank' },
+	{ label: __('Same tab', 'designsetgo'), value: '' },
+	{ label: __('New tab', 'designsetgo'), value: '_blank' },
 ];
 
 const REL_OPTIONS = [
-	{ label: __( 'None', 'designsetgo' ), value: '' },
+	{ label: __('None', 'designsetgo'), value: '' },
 	{ label: 'nofollow', value: 'nofollow' },
 	{ label: 'noopener noreferrer', value: 'noopener noreferrer' },
-	{ label: 'nofollow noopener noreferrer', value: 'nofollow noopener noreferrer' },
+	{
+		label: 'nofollow noopener noreferrer',
+		value: 'nofollow noopener noreferrer',
+	},
 	{ label: 'sponsored', value: 'sponsored' },
 	{ label: 'ugc', value: 'ugc' },
 ];
 
-export default function Edit( { attributes, setAttributes, context } ) {
+const DEFAULTS = {
+	source: '',
+	sourceArgs: {},
+	size: 'full',
+	altOverride: '',
+	focalPoint: { x: 0.5, y: 0.5 },
+	aspectRatio: '',
+	objectFit: 'cover',
+	fallbackId: 0,
+	fallbackUrl: '',
+	fallbackAlt: '',
+	href: '',
+	linkTarget: '',
+	rel: '',
+};
+
+export default function Edit({ attributes, setAttributes, clientId, context }) {
 	const {
 		source,
 		sourceArgs,
@@ -81,234 +105,364 @@ export default function Edit( { attributes, setAttributes, context } ) {
 		rel,
 	} = attributes;
 
-	const { editorPostId, imageSizes } = useSelect( ( select ) => {
-		const editor = select( editorStore );
-		const blockEditor = select( blockEditorStore );
+	const { editorPostId, imageSizes } = useSelect((select) => {
+		const editor = select(editorStore);
+		const blockEditor = select(blockEditorStore);
 		return {
 			editorPostId: editor?.getCurrentPostId?.() || 0,
 			imageSizes: blockEditor?.getSettings?.()?.imageSizes || [],
 		};
-	}, [] );
+	}, []);
 	const postId = context?.postId || editorPostId;
 
 	const sizeOptions = imageSizes.length
-		? imageSizes.map( ( s ) => ( { label: s.name, value: s.slug } ) )
+		? imageSizes.map((s) => ({ label: s.name, value: s.slug }))
 		: [
-				{ label: __( 'Thumbnail', 'designsetgo' ), value: 'thumbnail' },
-				{ label: __( 'Medium', 'designsetgo' ), value: 'medium' },
-				{ label: __( 'Large', 'designsetgo' ), value: 'large' },
-				{ label: __( 'Full', 'designsetgo' ), value: 'full' },
-		  ];
+				{ label: __('Thumbnail', 'designsetgo'), value: 'thumbnail' },
+				{ label: __('Medium', 'designsetgo'), value: 'medium' },
+				{ label: __('Large', 'designsetgo'), value: 'large' },
+				{ label: __('Full', 'designsetgo'), value: 'full' },
+			];
 
-	const preview = useDynamicTagPreview( {
+	const preview = useDynamicTagPreview({
 		source,
 		args: sourceArgs,
 		postId,
 		size,
-	} );
+	});
 
-	const blockProps = useBlockProps( {
+	const blockProps = useBlockProps({
 		style: aspectRatio ? { aspectRatio } : undefined,
-	} );
+	});
 
 	const sourceValue = source ? { source, args: sourceArgs } : null;
 
-	const handleSourceChange = ( next ) => {
-		if ( ! next ) {
-			setAttributes( { source: '', sourceArgs: {} } );
+	const handleSourceChange = (next) => {
+		if (!next) {
+			setAttributes({ source: '', sourceArgs: {} });
 			return;
 		}
-		setAttributes( { source: next.source, sourceArgs: next.args || {} } );
+		setAttributes({ source: next.source, sourceArgs: next.args || {} });
 	};
 
 	const resolvedImage =
-		preview.status === 'resolved' && preview.returns === 'image' && preview.value
+		preview.status === 'resolved' &&
+		preview.returns === 'image' &&
+		preview.value
 			? preview.value
 			: null;
 
-	const displayImage = resolvedImage
-		|| ( fallbackUrl
+	const displayImage =
+		resolvedImage ||
+		(fallbackUrl
 			? { url: fallbackUrl, alt: fallbackAlt || '', width: 0, height: 0 }
-			: null );
+			: null);
+
+	const isDefaultFocalPoint = (fp) => !fp || (fp.x === 0.5 && fp.y === 0.5);
 
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Dynamic Source', 'designsetgo' ) } initialOpen>
-					<VStack spacing={ 3 }>
-						<DynamicTagButton
-							value={ sourceValue }
-							onChange={ handleSourceChange }
-							returns="image"
-							postId={ postId }
-						/>
-						{ source && (
-							<p className="dsgo-dynamic-image__source-summary">
-								<code>{ source }</code>
-							</p>
-						) }
-
-						<SelectControl
-							label={ __( 'Image size', 'designsetgo' ) }
-							value={ size }
-							options={ sizeOptions }
-							onChange={ ( value ) => setAttributes( { size: value } ) }
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-						/>
-
-						<TextControl
-							label={ __( 'Alt text override', 'designsetgo' ) }
-							help={ __( 'Leave blank to use the alt text from the source.', 'designsetgo' ) }
-							value={ altOverride }
-							onChange={ ( value ) => setAttributes( { altOverride: value } ) }
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-						/>
-					</VStack>
-				</PanelBody>
-
-				<PanelBody title={ __( 'Display', 'designsetgo' ) } initialOpen={ false }>
-					<VStack spacing={ 3 }>
-						<SelectControl
-							label={ __( 'Aspect ratio', 'designsetgo' ) }
-							value={ aspectRatio }
-							options={ ASPECT_RATIO_OPTIONS }
-							onChange={ ( value ) => setAttributes( { aspectRatio: value } ) }
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-						/>
-						<SelectControl
-							label={ __( 'Object fit', 'designsetgo' ) }
-							value={ objectFit }
-							options={ OBJECT_FIT_OPTIONS }
-							onChange={ ( value ) => setAttributes( { objectFit: value } ) }
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-						/>
-						{ displayImage?.url && (
-							<FocalPointPicker
-								label={ __( 'Focal point', 'designsetgo' ) }
-								url={ displayImage.url }
-								value={ focalPoint }
-								onChange={ ( value ) => setAttributes( { focalPoint: value } ) }
-								__nextHasNoMarginBottom
-							/>
-						) }
-					</VStack>
-				</PanelBody>
-
-				<PanelBody title={ __( 'Fallback image', 'designsetgo' ) } initialOpen={ false }>
-					<p className="dsgo-dynamic-image__help">
-						{ __( 'Shown when the dynamic source is empty — e.g. a post without a featured image.', 'designsetgo' ) }
-					</p>
-					<MediaUploadCheck>
-						<MediaUpload
-							onSelect={ ( media ) =>
-								setAttributes( {
-									fallbackId: media.id,
-									fallbackUrl: media.url,
-									fallbackAlt: media.alt || '',
-								} )
-							}
-							allowedTypes={ [ 'image' ] }
-							value={ fallbackId }
-							render={ ( { open } ) => (
-								<HStack>
-									<Button variant="secondary" onClick={ open }>
-										{ fallbackId ? __( 'Replace', 'designsetgo' ) : __( 'Select image', 'designsetgo' ) }
-									</Button>
-									{ fallbackId && (
-										<Button
-											variant="tertiary"
-											isDestructive
-											onClick={ () =>
-												setAttributes( { fallbackId: 0, fallbackUrl: '', fallbackAlt: '' } )
-											}
-										>
-											{ __( 'Remove', 'designsetgo' ) }
-										</Button>
-									) }
-								</HStack>
-							) }
-						/>
-					</MediaUploadCheck>
-					{ fallbackUrl && (
-						<img src={ fallbackUrl } alt="" className="dsgo-dynamic-image__fallback-preview" />
-					) }
-				</PanelBody>
-
-				<PanelBody title={ __( 'Link', 'designsetgo' ) } initialOpen={ false }>
-					<VStack spacing={ 3 }>
-						<TextControl
-							label={ __( 'URL', 'designsetgo' ) }
-							value={ href }
-							onChange={ ( value ) => setAttributes( { href: value } ) }
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-						/>
-						<SelectControl
-							label={ __( 'Open in', 'designsetgo' ) }
-							value={ linkTarget }
-							options={ LINK_TARGET_OPTIONS }
-							onChange={ ( value ) => setAttributes( { linkTarget: value } ) }
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-						/>
-						<SelectControl
-							label={ __( 'Rel attribute', 'designsetgo' ) }
-							value={ rel }
-							options={ REL_OPTIONS }
-							onChange={ ( value ) => setAttributes( { rel: value } ) }
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-						/>
-					</VStack>
-				</PanelBody>
-			</InspectorControls>
-
-			<figure { ...blockProps }>
-				{ ! source && ! fallbackUrl && (
-					<Placeholder
-						icon="format-image"
-						label={ __( 'Dynamic Image', 'designsetgo' ) }
-						instructions={ __( 'Pick a dynamic source (featured image, ACF field, site logo, …).', 'designsetgo' ) }
+				<DsgoInspectorPanel
+					title={__('Settings', 'designsetgo')}
+					panelName="settings"
+					panelId={clientId}
+					resetAll={() => setAttributes(DEFAULTS)}
+				>
+					<DsgoInspectorPanel.Item
+						label={__('Dynamic source', 'designsetgo')}
+						hasValue={() => source !== ''}
+						onDeselect={() =>
+							setAttributes({ source: '', sourceArgs: {} })
+						}
+						isShownByDefault
 					>
 						<DynamicTagButton
-							value={ null }
-							onChange={ handleSourceChange }
+							value={sourceValue}
+							onChange={handleSourceChange}
 							returns="image"
-							postId={ postId }
+							postId={postId}
+						/>
+						{source && (
+							<p className="dsgo-dynamic-image__source-summary">
+								<code>{source}</code>
+							</p>
+						)}
+					</DsgoInspectorPanel.Item>
+
+					<DsgoInspectorPanel.Item
+						label={__('Image size', 'designsetgo')}
+						hasValue={() => size !== 'full'}
+						onDeselect={() => setAttributes({ size: 'full' })}
+						isShownByDefault
+					>
+						<SelectControl
+							label={__('Image size', 'designsetgo')}
+							value={size}
+							options={sizeOptions}
+							onChange={(value) => setAttributes({ size: value })}
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+					</DsgoInspectorPanel.Item>
+
+					<DsgoInspectorPanel.Item
+						label={__('Alt text override', 'designsetgo')}
+						hasValue={() => altOverride !== ''}
+						onDeselect={() => setAttributes({ altOverride: '' })}
+						isShownByDefault
+					>
+						<TextControl
+							label={__('Alt text override', 'designsetgo')}
+							help={__(
+								'Leave blank to use the alt text from the source.',
+								'designsetgo'
+							)}
+							value={altOverride}
+							onChange={(value) =>
+								setAttributes({ altOverride: value })
+							}
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+					</DsgoInspectorPanel.Item>
+
+					<DsgoInspectorPanel.Item
+						label={__('Aspect ratio', 'designsetgo')}
+						hasValue={() => aspectRatio !== ''}
+						onDeselect={() => setAttributes({ aspectRatio: '' })}
+						isShownByDefault
+					>
+						<SelectControl
+							label={__('Aspect ratio', 'designsetgo')}
+							value={aspectRatio}
+							options={ASPECT_RATIO_OPTIONS}
+							onChange={(value) =>
+								setAttributes({ aspectRatio: value })
+							}
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+					</DsgoInspectorPanel.Item>
+
+					<DsgoInspectorPanel.Item
+						label={__('Object fit', 'designsetgo')}
+						hasValue={() => objectFit !== 'cover'}
+						onDeselect={() => setAttributes({ objectFit: 'cover' })}
+						isShownByDefault
+					>
+						<SelectControl
+							label={__('Object fit', 'designsetgo')}
+							value={objectFit}
+							options={OBJECT_FIT_OPTIONS}
+							onChange={(value) =>
+								setAttributes({ objectFit: value })
+							}
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+					</DsgoInspectorPanel.Item>
+
+					{displayImage?.url && (
+						<DsgoInspectorPanel.Item
+							label={__('Focal point', 'designsetgo')}
+							hasValue={() => !isDefaultFocalPoint(focalPoint)}
+							onDeselect={() =>
+								setAttributes({
+									focalPoint: { x: 0.5, y: 0.5 },
+								})
+							}
+							isShownByDefault={false}
+						>
+							<FocalPointPicker
+								label={__('Focal point', 'designsetgo')}
+								url={displayImage.url}
+								value={focalPoint}
+								onChange={(value) =>
+									setAttributes({ focalPoint: value })
+								}
+								__nextHasNoMarginBottom
+							/>
+						</DsgoInspectorPanel.Item>
+					)}
+
+					<DsgoInspectorPanel.Item
+						label={__('Fallback image', 'designsetgo')}
+						hasValue={() => fallbackId !== 0 || fallbackUrl !== ''}
+						onDeselect={() =>
+							setAttributes({
+								fallbackId: 0,
+								fallbackUrl: '',
+								fallbackAlt: '',
+							})
+						}
+						isShownByDefault
+					>
+						<p className="dsgo-dynamic-image__help">
+							{__(
+								'Shown when the source is empty — e.g. a post without a featured image.',
+								'designsetgo'
+							)}
+						</p>
+						<MediaUploadCheck>
+							<MediaUpload
+								onSelect={(media) =>
+									setAttributes({
+										fallbackId: media.id,
+										fallbackUrl: media.url,
+										fallbackAlt: media.alt || '',
+									})
+								}
+								allowedTypes={['image']}
+								value={fallbackId}
+								render={({ open }) => (
+									<HStack>
+										<Button
+											variant="secondary"
+											onClick={open}
+										>
+											{fallbackId
+												? __('Replace', 'designsetgo')
+												: __(
+														'Select image',
+														'designsetgo'
+													)}
+										</Button>
+										{fallbackId && (
+											<Button
+												variant="tertiary"
+												isDestructive
+												onClick={() =>
+													setAttributes({
+														fallbackId: 0,
+														fallbackUrl: '',
+														fallbackAlt: '',
+													})
+												}
+											>
+												{__('Remove', 'designsetgo')}
+											</Button>
+										)}
+									</HStack>
+								)}
+							/>
+						</MediaUploadCheck>
+						{fallbackUrl && (
+							<img
+								src={fallbackUrl}
+								alt=""
+								className="dsgo-dynamic-image__fallback-preview"
+							/>
+						)}
+					</DsgoInspectorPanel.Item>
+
+					<DsgoInspectorPanel.Item
+						label={__('Link URL', 'designsetgo')}
+						hasValue={() => href !== ''}
+						onDeselect={() =>
+							setAttributes({ href: '', linkTarget: '', rel: '' })
+						}
+						isShownByDefault={false}
+					>
+						<TextControl
+							label={__('Link URL', 'designsetgo')}
+							value={href}
+							onChange={(value) => setAttributes({ href: value })}
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+					</DsgoInspectorPanel.Item>
+
+					{href && (
+						<DsgoInspectorPanel.Item
+							label={__('Open in', 'designsetgo')}
+							hasValue={() => linkTarget !== ''}
+							onDeselect={() => setAttributes({ linkTarget: '' })}
+							isShownByDefault={false}
+						>
+							<SelectControl
+								label={__('Open in', 'designsetgo')}
+								value={linkTarget}
+								options={LINK_TARGET_OPTIONS}
+								onChange={(value) =>
+									setAttributes({ linkTarget: value })
+								}
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+							/>
+						</DsgoInspectorPanel.Item>
+					)}
+
+					{href && (
+						<DsgoInspectorPanel.Item
+							label={__('Rel attribute', 'designsetgo')}
+							hasValue={() => rel !== ''}
+							onDeselect={() => setAttributes({ rel: '' })}
+							isShownByDefault={false}
+						>
+							<SelectControl
+								label={__('Rel attribute', 'designsetgo')}
+								value={rel}
+								options={REL_OPTIONS}
+								onChange={(value) =>
+									setAttributes({ rel: value })
+								}
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+							/>
+						</DsgoInspectorPanel.Item>
+					)}
+				</DsgoInspectorPanel>
+			</InspectorControls>
+
+			<figure {...blockProps}>
+				{!source && !fallbackUrl && (
+					<Placeholder
+						icon="format-image"
+						label={__('Dynamic Image', 'designsetgo')}
+						instructions={__(
+							'Pick a dynamic source (featured image, ACF field, site logo, …).',
+							'designsetgo'
+						)}
+					>
+						<DynamicTagButton
+							value={null}
+							onChange={handleSourceChange}
+							returns="image"
+							postId={postId}
 							size="default"
 							variant="primary"
 						/>
 					</Placeholder>
-				) }
+				)}
 
-				{ preview.status === 'loading' && source && ! displayImage && (
+				{preview.status === 'loading' && source && !displayImage && (
 					<div className="dsgo-dynamic-image__loading">
 						<Spinner />
 					</div>
-				) }
+				)}
 
-				{ displayImage?.url && (
+				{displayImage?.url && (
 					<img
-						src={ displayImage.url }
-						alt={ altOverride || displayImage.alt || '' }
-						style={ {
+						src={displayImage.url}
+						alt={altOverride || displayImage.alt || ''}
+						style={{
 							objectFit,
 							objectPosition: focalPoint
-								? `${ Math.round( focalPoint.x * 100 ) }% ${ Math.round( focalPoint.y * 100 ) }%`
+								? `${Math.round(focalPoint.x * 100)}% ${Math.round(focalPoint.y * 100)}%`
 								: undefined,
-						} }
+						}}
 					/>
-				) }
+				)}
 
-				{ source && preview.status === 'empty' && ! displayImage && (
+				{source && preview.status === 'empty' && !displayImage && (
 					<div className="dsgo-dynamic-image__empty">
-						{ __( 'Source is empty on this post. Add a fallback image to always show something.', 'designsetgo' ) }
+						{__(
+							'Source is empty on this post. Add a fallback image to always show something.',
+							'designsetgo'
+						)}
 					</div>
-				) }
+				)}
 			</figure>
 		</>
 	);

--- a/src/blocks/dynamic-image/editor.scss
+++ b/src/blocks/dynamic-image/editor.scss
@@ -1,0 +1,47 @@
+.wp-block-designsetgo-dynamic-image {
+	position: relative;
+	margin: 0;
+
+	> img {
+		display: block;
+		max-width: 100%;
+		height: auto;
+	}
+
+	.dsgo-dynamic-image__loading {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 120px;
+		background: #f0f0f1;
+	}
+
+	.dsgo-dynamic-image__empty {
+		padding: 20px;
+		color: #757575;
+		font-style: italic;
+		background: #f6f7f7;
+		border: 1px dashed #ccc;
+		border-radius: 4px;
+		text-align: center;
+	}
+
+	.dsgo-dynamic-image__source-summary code {
+		font-size: 11px;
+		color: #757575;
+	}
+
+	.dsgo-dynamic-image__help {
+		margin-top: 0;
+		color: #757575;
+		font-size: 12px;
+	}
+
+	.dsgo-dynamic-image__fallback-preview {
+		margin-top: 12px;
+		max-width: 100%;
+		max-height: 120px;
+		display: block;
+		border-radius: 2px;
+	}
+}

--- a/src/blocks/dynamic-image/index.js
+++ b/src/blocks/dynamic-image/index.js
@@ -1,0 +1,34 @@
+/**
+ * Dynamic Image block — registration.
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+import edit from './edit';
+import save from './save';
+import metadata from './block.json';
+
+import './editor.scss';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+	...metadata,
+	icon: {
+		src: (
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.75"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			>
+				<rect x="3" y="4" width="18" height="16" rx="2" />
+				<path d="M3 16l5-5 4 4 3-3 6 6" />
+				<circle cx="9" cy="9" r="1.5" fill="currentColor" />
+			</svg>
+		),
+	},
+	edit,
+	save,
+} );

--- a/src/blocks/dynamic-image/index.js
+++ b/src/blocks/dynamic-image/index.js
@@ -10,7 +10,7 @@ import metadata from './block.json';
 import './editor.scss';
 import './style.scss';
 
-registerBlockType( metadata.name, {
+registerBlockType(metadata.name, {
 	...metadata,
 	icon: {
 		src: (
@@ -31,4 +31,4 @@ registerBlockType( metadata.name, {
 	},
 	edit,
 	save,
-} );
+});

--- a/src/blocks/dynamic-image/render.php
+++ b/src/blocks/dynamic-image/render.php
@@ -69,11 +69,11 @@ $alt = '' !== $alt_override ? $alt_override : (string) ( $descriptor['alt'] ?? '
 
 $figure_style = array();
 if ( '' !== $aspect_ratio ) {
-	$figure_style[] = 'aspect-ratio:' . esc_attr( $aspect_ratio );
+	$figure_style[] = 'aspect-ratio:' . $aspect_ratio;
 }
 
 $img_style = array(
-	'object-fit:' . esc_attr( $object_fit ),
+	'object-fit:' . $object_fit,
 );
 if ( isset( $focal['x'], $focal['y'] ) ) {
 	$img_style[] = sprintf(
@@ -120,7 +120,7 @@ if ( '' !== $href ) {
 	if ( '' !== $rel ) {
 		$link_attrs['rel'] = esc_attr( $rel );
 	} elseif ( '_blank' === $link_target ) {
-		$link_attrs['rel'] = 'noopener';
+		$link_attrs['rel'] = 'noopener noreferrer';
 	}
 	$link_open = '<a';
 	foreach ( $link_attrs as $key => $val ) {

--- a/src/blocks/dynamic-image/render.php
+++ b/src/blocks/dynamic-image/render.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Dynamic Image block — server render.
+ *
+ * Resolves the configured Dynamic Tag source at render time and emits
+ * a standard <img> (with optional <figure>/<a> wrapping). Falls back to
+ * a fallback image when the source is empty. Never emits anything when
+ * both source and fallback are empty so authors can rely on it to hide
+ * gracefully on posts that don't have the field.
+ *
+ * @package DesignSetGo
+ * @since   2.2.0
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block save content (empty — this block is server-rendered).
+ * @var WP_Block $block      Block instance.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use DesignSetGo\Blocks\DynamicTags\ImageResolver;
+
+$source       = isset( $attributes['source'] ) ? (string) $attributes['source'] : '';
+$source_args  = isset( $attributes['sourceArgs'] ) && is_array( $attributes['sourceArgs'] ) ? $attributes['sourceArgs'] : array();
+$size         = isset( $attributes['size'] ) ? (string) $attributes['size'] : 'full';
+$alt_override = isset( $attributes['altOverride'] ) ? (string) $attributes['altOverride'] : '';
+$fallback_id  = isset( $attributes['fallbackId'] ) ? (int) $attributes['fallbackId'] : 0;
+$fallback_url = isset( $attributes['fallbackUrl'] ) ? (string) $attributes['fallbackUrl'] : '';
+$fallback_alt = isset( $attributes['fallbackAlt'] ) ? (string) $attributes['fallbackAlt'] : '';
+$focal        = isset( $attributes['focalPoint'] ) && is_array( $attributes['focalPoint'] ) ? $attributes['focalPoint'] : array();
+$aspect_ratio = isset( $attributes['aspectRatio'] ) ? (string) $attributes['aspectRatio'] : '';
+$object_fit   = isset( $attributes['objectFit'] ) ? (string) $attributes['objectFit'] : 'cover';
+$href         = isset( $attributes['href'] ) ? (string) $attributes['href'] : '';
+$link_target  = isset( $attributes['linkTarget'] ) ? (string) $attributes['linkTarget'] : '';
+$rel          = isset( $attributes['rel'] ) ? (string) $attributes['rel'] : '';
+
+$post_id = 0;
+if ( isset( $block->context['postId'] ) ) {
+	$post_id = (int) $block->context['postId'];
+} elseif ( get_the_ID() ) {
+	$post_id = (int) get_the_ID();
+}
+
+$descriptor = null;
+if ( '' !== $source ) {
+	$descriptor = ImageResolver::resolve( $source, $source_args, $post_id, $size );
+}
+
+// Fallback lookup.
+if ( null === $descriptor ) {
+	if ( $fallback_id ) {
+		$descriptor = ImageResolver::descriptor_from_id( $fallback_id, $size );
+	} elseif ( '' !== $fallback_url ) {
+		$descriptor = array(
+			'id'     => 0,
+			'url'    => $fallback_url,
+			'alt'    => $fallback_alt,
+			'width'  => 0,
+			'height' => 0,
+		);
+	}
+}
+
+if ( null === $descriptor || empty( $descriptor['url'] ) ) {
+	return '';
+}
+
+$alt = '' !== $alt_override ? $alt_override : (string) ( $descriptor['alt'] ?? '' );
+
+$figure_style = array();
+if ( '' !== $aspect_ratio ) {
+	$figure_style[] = 'aspect-ratio:' . esc_attr( $aspect_ratio );
+}
+
+$img_style = array(
+	'object-fit:' . esc_attr( $object_fit ),
+);
+if ( isset( $focal['x'], $focal['y'] ) ) {
+	$img_style[] = sprintf(
+		'object-position:%s%% %s%%',
+		round( (float) $focal['x'] * 100 ),
+		round( (float) $focal['y'] * 100 )
+	);
+}
+
+$wrapper_attrs = get_block_wrapper_attributes(
+	array(
+		'class' => 'wp-block-designsetgo-dynamic-image',
+		'style' => implode( ';', $figure_style ),
+	)
+);
+
+$img_attrs = array(
+	'src'      => esc_url( $descriptor['url'] ),
+	'alt'      => esc_attr( $alt ),
+	'loading'  => 'lazy',
+	'decoding' => 'async',
+	'style'    => esc_attr( implode( ';', $img_style ) ),
+);
+if ( ! empty( $descriptor['width'] ) ) {
+	$img_attrs['width'] = (int) $descriptor['width'];
+}
+if ( ! empty( $descriptor['height'] ) ) {
+	$img_attrs['height'] = (int) $descriptor['height'];
+}
+
+$img_html = '<img';
+foreach ( $img_attrs as $key => $val ) {
+	$img_html .= ' ' . $key . '="' . $val . '"';
+}
+$img_html .= ' />';
+
+if ( '' !== $href ) {
+	$link_attrs = array(
+		'href' => esc_url( $href ),
+	);
+	if ( '' !== $link_target ) {
+		$link_attrs['target'] = esc_attr( $link_target );
+	}
+	if ( '' !== $rel ) {
+		$link_attrs['rel'] = esc_attr( $rel );
+	} elseif ( '_blank' === $link_target ) {
+		$link_attrs['rel'] = 'noopener';
+	}
+	$link_open = '<a';
+	foreach ( $link_attrs as $key => $val ) {
+		$link_open .= ' ' . $key . '="' . $val . '"';
+	}
+	$link_open .= '>';
+	$img_html = $link_open . $img_html . '</a>';
+}
+
+printf(
+	'<figure %s>%s</figure>',
+	$wrapper_attrs, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() output is pre-escaped.
+	$img_html // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- all attribute values above are esc_* escaped.
+);

--- a/src/blocks/dynamic-image/save.js
+++ b/src/blocks/dynamic-image/save.js
@@ -1,0 +1,8 @@
+/**
+ * Dynamic Image block — save.
+ *
+ * Server-rendered via render.php, so save returns null.
+ */
+export default function save() {
+	return null;
+}

--- a/src/blocks/dynamic-image/style.scss
+++ b/src/blocks/dynamic-image/style.scss
@@ -9,6 +9,7 @@
 	}
 
 	&[style*="aspect-ratio"] {
+
 		> img {
 			width: 100%;
 			height: 100%;

--- a/src/blocks/dynamic-image/style.scss
+++ b/src/blocks/dynamic-image/style.scss
@@ -1,0 +1,18 @@
+.wp-block-designsetgo-dynamic-image {
+	margin: 0;
+	display: block;
+
+	> img {
+		display: block;
+		max-width: 100%;
+		height: auto;
+	}
+
+	&[style*="aspect-ratio"] {
+		> img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
+	}
+}

--- a/src/components/DynamicTagPicker/DynamicTagButton.js
+++ b/src/components/DynamicTagPicker/DynamicTagButton.js
@@ -13,55 +13,66 @@ import { Icon } from '@wordpress/icons';
 import DynamicTagPicker from './DynamicTagPicker';
 
 const databaseIcon = (
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
-		<path fill="currentColor" d="M12 2C8.13 2 5 3.57 5 5.5V7c0 1.93 3.13 3.5 7 3.5s7-1.57 7-3.5V5.5C19 3.57 15.87 2 12 2zm0 10c-3.87 0-7-1.57-7-3.5V11c0 1.93 3.13 3.5 7 3.5s7-1.57 7-3.5V8.5C19 10.43 15.87 12 12 12zm0 4c-3.87 0-7-1.57-7-3.5V15c0 1.93 3.13 3.5 7 3.5s7-1.57 7-3.5v-2.5c0 1.93-3.13 3.5-7 3.5zm0 4c-3.87 0-7-1.57-7-3.5V19c0 1.93 3.13 3.5 7 3.5s7-1.57 7-3.5v-2.5c0 1.93-3.13 3.5-7 3.5z" />
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		width="20"
+		height="20"
+		aria-hidden="true"
+	>
+		<path
+			fill="currentColor"
+			d="M12 2C8.13 2 5 3.57 5 5.5V7c0 1.93 3.13 3.5 7 3.5s7-1.57 7-3.5V5.5C19 3.57 15.87 2 12 2zm0 10c-3.87 0-7-1.57-7-3.5V11c0 1.93 3.13 3.5 7 3.5s7-1.57 7-3.5V8.5C19 10.43 15.87 12 12 12zm0 4c-3.87 0-7-1.57-7-3.5V15c0 1.93 3.13 3.5 7 3.5s7-1.57 7-3.5v-2.5c0 1.93-3.13 3.5-7 3.5zm0 4c-3.87 0-7-1.57-7-3.5V19c0 1.93 3.13 3.5 7 3.5s7-1.57 7-3.5v-2.5c0 1.93-3.13 3.5-7 3.5z"
+		/>
 	</svg>
 );
 
-export default function DynamicTagButton( {
+export default function DynamicTagButton({
 	value,
 	onChange,
 	returns,
 	postType,
 	postId,
-	label = __( 'Connect to Dynamic Tag', 'designsetgo' ),
+	label = __('Connect to Dynamic Tag', 'designsetgo'),
 	connectedLabel,
 	size = 'small',
 	variant,
-} ) {
-	const [ isOpen, setIsOpen ] = useState( false );
-	const isConnected = Boolean( value?.source );
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+	const isConnected = Boolean(value?.source);
 
 	const resolvedLabel = isConnected
-		? ( connectedLabel
-			|| sprintf(
+		? connectedLabel ||
+			sprintf(
 				/* translators: %s: source slug, e.g. designsetgo/post-title */
-				__( 'Bound to %s', 'designsetgo' ),
+				__('Bound to %s', 'designsetgo'),
 				value.source
-			) )
+			)
 		: label;
 
 	return (
 		<>
 			<Button
-				size={ size }
-				variant={ variant || ( isConnected ? 'primary' : 'tertiary' ) }
-				onClick={ () => setIsOpen( true ) }
-				icon={ <Icon icon={ databaseIcon } /> }
-				className={ `dsgo-dynamic-tag-button${ isConnected ? ' is-connected' : '' }` }
-				aria-label={ resolvedLabel }
+				size={size}
+				variant={variant || (isConnected ? 'primary' : 'tertiary')}
+				onClick={() => setIsOpen(true)}
+				icon={<Icon icon={databaseIcon} />}
+				className={`dsgo-dynamic-tag-button${isConnected ? ' is-connected' : ''}`}
+				aria-label={resolvedLabel}
 				showTooltip
 			>
-				{ isConnected ? __( 'Dynamic', 'designsetgo' ) : __( 'Connect', 'designsetgo' ) }
+				{isConnected
+					? __('Dynamic', 'designsetgo')
+					: __('Connect', 'designsetgo')}
 			</Button>
 			<DynamicTagPicker
-				isOpen={ isOpen }
-				onClose={ () => setIsOpen( false ) }
-				value={ value }
-				onChange={ onChange }
-				returns={ returns }
-				postType={ postType }
-				postId={ postId }
+				isOpen={isOpen}
+				onClose={() => setIsOpen(false)}
+				value={value}
+				onChange={onChange}
+				returns={returns}
+				postType={postType}
+				postId={postId}
 			/>
 		</>
 	);

--- a/src/components/DynamicTagPicker/DynamicTagButton.js
+++ b/src/components/DynamicTagPicker/DynamicTagButton.js
@@ -1,9 +1,11 @@
 /**
- * DynamicTagButton — inline "⚡ Connect" trigger that opens the picker.
+ * DynamicTagButton — inline "Connect" trigger that opens the picker.
  *
- * Mirrors Elementor's per-attribute dynamic-tag toggle. Callers pass the
- * current binding value and receive the new value via onChange; this
- * component owns the modal open/close state.
+ * Mirrors Elementor's per-attribute dynamic-tag toggle. Uses a database
+ * cylinder icon — the conventional "dynamic data" symbol; deliberately
+ * distinct from the lightning bolt used by the block-animations
+ * extension. Callers pass the current binding value and receive the
+ * new value via onChange; this component owns the modal open/close state.
  */
 import { useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';

--- a/src/components/DynamicTagPicker/DynamicTagButton.js
+++ b/src/components/DynamicTagPicker/DynamicTagButton.js
@@ -1,0 +1,68 @@
+/**
+ * DynamicTagButton — inline "⚡ Connect" trigger that opens the picker.
+ *
+ * Mirrors Elementor's per-attribute dynamic-tag toggle. Callers pass the
+ * current binding value and receive the new value via onChange; this
+ * component owns the modal open/close state.
+ */
+import { useState } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { Icon } from '@wordpress/icons';
+
+import DynamicTagPicker from './DynamicTagPicker';
+
+const databaseIcon = (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+		<path fill="currentColor" d="M12 2C8.13 2 5 3.57 5 5.5V7c0 1.93 3.13 3.5 7 3.5s7-1.57 7-3.5V5.5C19 3.57 15.87 2 12 2zm0 10c-3.87 0-7-1.57-7-3.5V11c0 1.93 3.13 3.5 7 3.5s7-1.57 7-3.5V8.5C19 10.43 15.87 12 12 12zm0 4c-3.87 0-7-1.57-7-3.5V15c0 1.93 3.13 3.5 7 3.5s7-1.57 7-3.5v-2.5c0 1.93-3.13 3.5-7 3.5zm0 4c-3.87 0-7-1.57-7-3.5V19c0 1.93 3.13 3.5 7 3.5s7-1.57 7-3.5v-2.5c0 1.93-3.13 3.5-7 3.5z" />
+	</svg>
+);
+
+export default function DynamicTagButton( {
+	value,
+	onChange,
+	returns,
+	postType,
+	postId,
+	label = __( 'Connect to Dynamic Tag', 'designsetgo' ),
+	connectedLabel,
+	size = 'small',
+	variant,
+} ) {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const isConnected = Boolean( value?.source );
+
+	const resolvedLabel = isConnected
+		? ( connectedLabel
+			|| sprintf(
+				/* translators: %s: source slug, e.g. designsetgo/post-title */
+				__( 'Bound to %s', 'designsetgo' ),
+				value.source
+			) )
+		: label;
+
+	return (
+		<>
+			<Button
+				size={ size }
+				variant={ variant || ( isConnected ? 'primary' : 'tertiary' ) }
+				onClick={ () => setIsOpen( true ) }
+				icon={ <Icon icon={ databaseIcon } /> }
+				className={ `dsgo-dynamic-tag-button${ isConnected ? ' is-connected' : '' }` }
+				aria-label={ resolvedLabel }
+				showTooltip
+			>
+				{ isConnected ? __( 'Dynamic', 'designsetgo' ) : __( 'Connect', 'designsetgo' ) }
+			</Button>
+			<DynamicTagPicker
+				isOpen={ isOpen }
+				onClose={ () => setIsOpen( false ) }
+				value={ value }
+				onChange={ onChange }
+				returns={ returns }
+				postType={ postType }
+				postId={ postId }
+			/>
+		</>
+	);
+}

--- a/src/components/DynamicTagPicker/DynamicTagPicker.js
+++ b/src/components/DynamicTagPicker/DynamicTagPicker.js
@@ -34,146 +34,169 @@ import SourceArgsForm from './SourceArgsForm';
 import PreviewPanel from './PreviewPanel';
 import './style.scss';
 
-const DEFAULT_RETURNS = [ 'text', 'url', 'image', 'number', 'date' ];
+const DEFAULT_RETURNS = ['text', 'url', 'image', 'number', 'date'];
 
-export default function DynamicTagPicker( {
+export default function DynamicTagPicker({
 	value,
 	onChange,
 	returns = DEFAULT_RETURNS,
 	postId: postIdProp,
 	postType: postTypeProp,
-	title = __( 'Dynamic Tag', 'designsetgo' ),
+	title = __('Dynamic Tag', 'designsetgo'),
 	allowClear = true,
 	isOpen,
 	onClose,
-} ) {
-	const editorContext = useSelect( ( select ) => {
-		const editor = select( editorStore );
-		if ( ! editor ) {
+}) {
+	const editorContext = useSelect((select) => {
+		const editor = select(editorStore);
+		if (!editor) {
 			return {};
 		}
 		return {
 			postId: editor.getCurrentPostId?.(),
 			postType: editor.getCurrentPostType?.(),
 		};
-	}, [] );
+	}, []);
 
 	const postId = postIdProp || editorContext.postId;
 	const postType = postTypeProp || editorContext.postType || 'post';
 
-	const { status: sourcesStatus, groups, sources } = useDynamicTagSources( { returns } );
+	const {
+		status: sourcesStatus,
+		groups,
+		sources,
+	} = useDynamicTagSources({ returns });
 
-	const [ selectedSource, setSelectedSource ] = useState( value?.source || '' );
-	const [ draftArgs, setDraftArgs ] = useState( value?.args || {} );
-	const [ search, setSearch ] = useState( '' );
+	const [selectedSource, setSelectedSource] = useState(value?.source || '');
+	const [draftArgs, setDraftArgs] = useState(value?.args || {});
+	const [search, setSearch] = useState('');
 
-	useEffect( () => {
-		if ( isOpen ) {
-			setSelectedSource( value?.source || '' );
-			setDraftArgs( value?.args || {} );
-			setSearch( '' );
+	useEffect(() => {
+		if (isOpen) {
+			setSelectedSource(value?.source || '');
+			setDraftArgs(value?.args || {});
+			setSearch('');
 		}
-	}, [ isOpen, value?.source, value?.args ] );
+	}, [isOpen, value?.source, value?.args]);
 
 	const activeSource = useMemo(
-		() => sources.find( ( s ) => s.slug === selectedSource ) || null,
-		[ sources, selectedSource ]
+		() => sources.find((s) => s.slug === selectedSource) || null,
+		[sources, selectedSource]
 	);
 
-	const fieldDiscovery = useDynamicTagFields( {
+	const fieldDiscovery = useDynamicTagFields({
 		source: selectedSource,
 		postType,
-		returns: Array.isArray( returns ) ? returns[ 0 ] : returns,
+		returns: Array.isArray(returns) ? returns[0] : returns,
 		supportsFieldDiscovery: activeSource?.supportsFieldDiscovery || false,
-	} );
+	});
 
-	const preview = useDynamicTagPreview( {
+	const preview = useDynamicTagPreview({
 		source: selectedSource,
 		args: draftArgs,
 		postId,
 		size: draftArgs?.size,
-	} );
+	});
 
-	if ( ! isOpen ) {
+	if (!isOpen) {
 		return null;
 	}
 
 	const handleApply = () => {
-		if ( ! selectedSource ) {
+		if (!selectedSource) {
 			return;
 		}
-		onChange( { source: selectedSource, args: draftArgs } );
+		onChange({ source: selectedSource, args: draftArgs });
 		onClose?.();
 	};
 
 	const handleClear = () => {
-		onChange( null );
+		onChange(null);
 		onClose?.();
 	};
 
-	const handleSelectSource = ( slug ) => {
-		setSelectedSource( slug );
-		setDraftArgs( {} );
+	const handleSelectSource = (slug) => {
+		setSelectedSource(slug);
+		setDraftArgs({});
 	};
 
 	return (
 		<Modal
-			title={ title }
-			onRequestClose={ onClose }
+			title={title}
+			onRequestClose={onClose}
 			className="dsgo-dynamic-tag-picker"
 			size="large"
 		>
 			<div className="dsgo-dynamic-tag-picker__layout">
 				<SourceSidebar
-					status={ sourcesStatus }
-					groups={ groups }
-					sources={ sources }
-					search={ search }
-					onSearchChange={ setSearch }
-					selectedSource={ selectedSource }
-					onSelectSource={ handleSelectSource }
+					status={sourcesStatus}
+					groups={groups}
+					sources={sources}
+					search={search}
+					onSearchChange={setSearch}
+					selectedSource={selectedSource}
+					onSelectSource={handleSelectSource}
 				/>
 
 				<div className="dsgo-dynamic-tag-picker__detail">
-					{ ! activeSource && (
+					{!activeSource && (
 						<p className="dsgo-dynamic-tag-picker__prompt">
-							{ __( 'Pick a source on the left to continue.', 'designsetgo' ) }
+							{__(
+								'Pick a source on the left to continue.',
+								'designsetgo'
+							)}
 						</p>
-					) }
+					)}
 
-					{ activeSource && (
-						<VStack spacing={ 4 }>
+					{activeSource && (
+						<VStack spacing={4}>
 							<header>
-								<h2 className="dsgo-dynamic-tag-picker__title">{ activeSource.label }</h2>
+								<h2 className="dsgo-dynamic-tag-picker__title">
+									{activeSource.label}
+								</h2>
 								<p className="dsgo-dynamic-tag-picker__subtitle">
-									<code>{ activeSource.slug }</code>
+									<code>{activeSource.slug}</code>
 								</p>
 							</header>
 
 							<SourceArgsForm
-								source={ activeSource }
-								args={ draftArgs }
-								onChange={ setDraftArgs }
-								fieldDiscovery={ fieldDiscovery }
+								source={activeSource}
+								args={draftArgs}
+								onChange={setDraftArgs}
+								fieldDiscovery={fieldDiscovery}
 							/>
 
-							<PreviewPanel preview={ preview } returns={ activeSource.returns } />
+							<PreviewPanel
+								preview={preview}
+								returns={activeSource.returns}
+							/>
 						</VStack>
-					) }
+					)}
 				</div>
 			</div>
 
-			<HStack justify="flex-end" className="dsgo-dynamic-tag-picker__footer">
-				{ allowClear && value && (
-					<Button variant="tertiary" isDestructive onClick={ handleClear }>
-						{ __( 'Remove binding', 'designsetgo' ) }
+			<HStack
+				justify="flex-end"
+				className="dsgo-dynamic-tag-picker__footer"
+			>
+				{allowClear && value && (
+					<Button
+						variant="tertiary"
+						isDestructive
+						onClick={handleClear}
+					>
+						{__('Remove binding', 'designsetgo')}
 					</Button>
-				) }
-				<Button variant="tertiary" onClick={ onClose }>
-					{ __( 'Cancel', 'designsetgo' ) }
+				)}
+				<Button variant="tertiary" onClick={onClose}>
+					{__('Cancel', 'designsetgo')}
 				</Button>
-				<Button variant="primary" onClick={ handleApply } disabled={ ! selectedSource }>
-					{ __( 'Use this source', 'designsetgo' ) }
+				<Button
+					variant="primary"
+					onClick={handleApply}
+					disabled={!selectedSource}
+				>
+					{__('Use this source', 'designsetgo')}
 				</Button>
 			</HStack>
 		</Modal>

--- a/src/components/DynamicTagPicker/DynamicTagPicker.js
+++ b/src/components/DynamicTagPicker/DynamicTagPicker.js
@@ -1,0 +1,401 @@
+/**
+ * DynamicTagPicker — modal-based source + field picker.
+ *
+ * Consumed by both the Dynamic Image block's inspector and the extension
+ * that binds dynamic tags to core/heading, core/paragraph, core/image etc.
+ *
+ * Public props:
+ *  - value:     { source, args } | null
+ *  - onChange:  fn({ source, args } | null)
+ *  - returns:   return-type filter ('text' | 'image' | 'url' | …)
+ *  - postId:    preview post ID (defaults to the current editor post)
+ *  - postType:  for field discovery
+ *  - title:     modal title
+ *  - allowClear: boolean
+ *  - isOpen:    boolean (controlled)
+ *  - onClose:   fn()
+ */
+import { useState, useEffect, useMemo } from '@wordpress/element';
+import {
+	Modal,
+	Button,
+	SelectControl,
+	TextControl,
+	SearchControl,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Spinner,
+	Notice,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+
+import { useDynamicTagSources } from './useDynamicTagSources';
+import { useDynamicTagFields } from './useDynamicTagFields';
+import { useDynamicTagPreview } from './useDynamicTagPreview';
+import './style.scss';
+
+const DEFAULT_RETURNS = [ 'text', 'url', 'image', 'number', 'date' ];
+
+export default function DynamicTagPicker( {
+	value,
+	onChange,
+	returns = DEFAULT_RETURNS,
+	postId: postIdProp,
+	postType: postTypeProp,
+	title = __( 'Dynamic Tag', 'designsetgo' ),
+	allowClear = true,
+	isOpen,
+	onClose,
+} ) {
+	const editorContext = useSelect( ( select ) => {
+		const editor = select( editorStore );
+		if ( ! editor ) {
+			return {};
+		}
+		return {
+			postId: editor.getCurrentPostId?.(),
+			postType: editor.getCurrentPostType?.(),
+		};
+	}, [] );
+
+	const postId = postIdProp || editorContext.postId;
+	const postType = postTypeProp || editorContext.postType || 'post';
+
+	const { status: sourcesStatus, groups, sources, error: sourcesError } = useDynamicTagSources( { returns } );
+
+	const [ selectedSource, setSelectedSource ] = useState( value?.source || '' );
+	const [ draftArgs, setDraftArgs ] = useState( value?.args || {} );
+	const [ search, setSearch ] = useState( '' );
+
+	useEffect( () => {
+		if ( isOpen ) {
+			setSelectedSource( value?.source || '' );
+			setDraftArgs( value?.args || {} );
+			setSearch( '' );
+		}
+	}, [ isOpen, value?.source ] );
+
+	const activeSource = useMemo(
+		() => sources.find( ( s ) => s.slug === selectedSource ) || null,
+		[ sources, selectedSource ]
+	);
+
+	const fieldDiscovery = useDynamicTagFields( {
+		source: selectedSource,
+		postType,
+		returns: Array.isArray( returns ) ? returns[ 0 ] : returns,
+		supportsFieldDiscovery: activeSource?.supportsFieldDiscovery || false,
+	} );
+
+	const preview = useDynamicTagPreview( {
+		source: selectedSource,
+		args: draftArgs,
+		postId,
+		size: draftArgs?.size,
+	} );
+
+	const filteredSources = useMemo( () => {
+		if ( ! search ) {
+			return sources;
+		}
+		const needle = search.toLowerCase();
+		return sources.filter( ( s ) => s.label.toLowerCase().includes( needle ) || s.slug.toLowerCase().includes( needle ) );
+	}, [ sources, search ] );
+
+	const groupedSources = useMemo( () => {
+		const bucket = {};
+		filteredSources.forEach( ( s ) => {
+			( bucket[ s.group ] = bucket[ s.group ] || [] ).push( s );
+		} );
+		return groups
+			.filter( ( g ) => bucket[ g.slug ]?.length )
+			.map( ( g ) => ( { ...g, sources: bucket[ g.slug ] } ) );
+	}, [ filteredSources, groups ] );
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	const handleApply = () => {
+		if ( ! selectedSource ) {
+			return;
+		}
+		onChange( {
+			source: selectedSource,
+			args: draftArgs,
+		} );
+		onClose?.();
+	};
+
+	const handleClear = () => {
+		onChange( null );
+		onClose?.();
+	};
+
+	return (
+		<Modal
+			title={ title }
+			onRequestClose={ onClose }
+			className="dsgo-dynamic-tag-picker"
+			size="large"
+		>
+			<div className="dsgo-dynamic-tag-picker__layout">
+				<div className="dsgo-dynamic-tag-picker__sidebar">
+					<SearchControl
+						value={ search }
+						onChange={ setSearch }
+						placeholder={ __( 'Search sources…', 'designsetgo' ) }
+						__nextHasNoMarginBottom
+					/>
+
+					{ sourcesStatus === 'loading' && (
+						<div className="dsgo-dynamic-tag-picker__loading"><Spinner /></div>
+					) }
+
+					{ sourcesStatus === 'error' && (
+						<Notice status="error" isDismissible={ false }>
+							{ __( 'Unable to load Dynamic Tag sources.', 'designsetgo' ) }
+						</Notice>
+					) }
+
+					{ sourcesStatus === 'ready' && groupedSources.length === 0 && (
+						<p className="dsgo-dynamic-tag-picker__empty">
+							{ __( 'No sources match.', 'designsetgo' ) }
+						</p>
+					) }
+
+					{ groupedSources.map( ( group ) => (
+						<div key={ group.slug } className="dsgo-dynamic-tag-picker__group">
+							<h3 className="dsgo-dynamic-tag-picker__group-title">{ group.label }</h3>
+							<ul className="dsgo-dynamic-tag-picker__source-list">
+								{ group.sources.map( ( source ) => (
+									<li key={ source.slug }>
+										<Button
+											variant={ source.slug === selectedSource ? 'primary' : 'tertiary' }
+											onClick={ () => {
+												setSelectedSource( source.slug );
+												setDraftArgs( {} );
+											} }
+											className="dsgo-dynamic-tag-picker__source-button"
+										>
+											{ source.label }
+										</Button>
+									</li>
+								) ) }
+							</ul>
+						</div>
+					) ) }
+				</div>
+
+				<div className="dsgo-dynamic-tag-picker__detail">
+					{ ! activeSource && (
+						<p className="dsgo-dynamic-tag-picker__prompt">
+							{ __( 'Pick a source on the left to continue.', 'designsetgo' ) }
+						</p>
+					) }
+
+					{ activeSource && (
+						<VStack spacing={ 4 }>
+							<header>
+								<h2 className="dsgo-dynamic-tag-picker__title">{ activeSource.label }</h2>
+								<p className="dsgo-dynamic-tag-picker__subtitle">
+									<code>{ activeSource.slug }</code>
+								</p>
+							</header>
+
+							<SourceArgsForm
+								source={ activeSource }
+								args={ draftArgs }
+								onChange={ setDraftArgs }
+								fieldDiscovery={ fieldDiscovery }
+							/>
+
+							<PreviewPanel preview={ preview } returns={ activeSource.returns } />
+						</VStack>
+					) }
+				</div>
+			</div>
+
+			<HStack justify="flex-end" className="dsgo-dynamic-tag-picker__footer">
+				{ allowClear && value && (
+					<Button variant="tertiary" isDestructive onClick={ handleClear }>
+						{ __( 'Remove binding', 'designsetgo' ) }
+					</Button>
+				) }
+				<Button variant="tertiary" onClick={ onClose }>
+					{ __( 'Cancel', 'designsetgo' ) }
+				</Button>
+				<Button variant="primary" onClick={ handleApply } disabled={ ! selectedSource }>
+					{ __( 'Use this source', 'designsetgo' ) }
+				</Button>
+			</HStack>
+		</Modal>
+	);
+}
+
+function SourceArgsForm( { source, args, onChange, fieldDiscovery } ) {
+	const schema = source.args || {};
+	const entries = Object.entries( schema );
+
+	if ( entries.length === 0 ) {
+		return null;
+	}
+
+	const setArg = ( key, value ) => {
+		const next = { ...args };
+		if ( value === '' || value === undefined || value === null ) {
+			delete next[ key ];
+		} else {
+			next[ key ] = value;
+		}
+		onChange( next );
+	};
+
+	return (
+		<VStack spacing={ 3 }>
+			{ entries.map( ( [ argName, argSchema ] ) => {
+				// ACF/meta "key" field — surface discovered fields as a select when available.
+				if ( argName === 'key' && source.supportsFieldDiscovery ) {
+					const fieldOptions = [
+						{ label: __( '— Select a field —', 'designsetgo' ), value: '' },
+						...fieldDiscovery.fields.map( ( f ) => ( {
+							label: f.group ? `${ f.group } — ${ f.label }` : f.label,
+							value: f.key,
+						} ) ),
+					];
+					return (
+						<div key={ argName }>
+							{ fieldDiscovery.status === 'loading' ? (
+								<Spinner />
+							) : (
+								<SelectControl
+									label={ __( 'Field', 'designsetgo' ) }
+									value={ args[ argName ] || '' }
+									options={ fieldOptions }
+									onChange={ ( value ) => setArg( argName, value ) }
+									__nextHasNoMarginBottom
+									__next40pxDefaultSize
+								/>
+							) }
+							<TextControl
+								label={ __( 'Or enter a field key manually', 'designsetgo' ) }
+								value={ args[ argName ] || '' }
+								onChange={ ( value ) => setArg( argName, value ) }
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+							/>
+						</div>
+					);
+				}
+
+				if ( Array.isArray( argSchema.enum ) && argSchema.enum.length > 0 ) {
+					return (
+						<SelectControl
+							key={ argName }
+							label={ argLabel( argName ) }
+							value={ args[ argName ] ?? argSchema.default ?? '' }
+							options={ [
+								{ label: __( '— Default —', 'designsetgo' ), value: '' },
+								...argSchema.enum.map( ( v ) => ( { label: v, value: v } ) ),
+							] }
+							onChange={ ( value ) => setArg( argName, value ) }
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+					);
+				}
+
+				return (
+					<TextControl
+						key={ argName }
+						label={ argLabel( argName ) }
+						help={ argSchema.description || '' }
+						value={ args[ argName ] ?? '' }
+						onChange={ ( value ) => setArg( argName, value ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+				);
+			} ) }
+		</VStack>
+	);
+}
+
+function argLabel( name ) {
+	const map = {
+		key: __( 'Field key', 'designsetgo' ),
+		subkey: __( 'Sub-value', 'designsetgo' ),
+		size: __( 'Image size', 'designsetgo' ),
+		scope: __( 'Scope', 'designsetgo' ),
+		format: __( 'Date format', 'designsetgo' ),
+		taxonomy: __( 'Taxonomy', 'designsetgo' ),
+		separator: __( 'Separator', 'designsetgo' ),
+	};
+	return map[ name ] || name;
+}
+
+function PreviewPanel( { preview, returns = [] } ) {
+	const isImage = returns.includes( 'image' );
+
+	if ( preview.status === 'idle' ) {
+		return null;
+	}
+
+	if ( preview.status === 'loading' ) {
+		return (
+			<div className="dsgo-dynamic-tag-picker__preview">
+				<Spinner />
+			</div>
+		);
+	}
+
+	if ( preview.status === 'empty' ) {
+		return (
+			<Notice status="info" isDismissible={ false }>
+				{ __( 'Preview is empty for the current post.', 'designsetgo' ) }
+			</Notice>
+		);
+	}
+
+	if ( preview.status === 'unauthorized' ) {
+		return (
+			<Notice status="warning" isDismissible={ false }>
+				{ __( 'Preview is hidden because the post is password-protected or private.', 'designsetgo' ) }
+			</Notice>
+		);
+	}
+
+	if ( preview.status !== 'resolved' ) {
+		return (
+			<Notice status="error" isDismissible={ false }>
+				{ __( 'Unable to preview this source.', 'designsetgo' ) }
+			</Notice>
+		);
+	}
+
+	if ( isImage && preview.value && typeof preview.value === 'object' ) {
+		return (
+			<div className="dsgo-dynamic-tag-picker__preview">
+				<h4>{ __( 'Preview', 'designsetgo' ) }</h4>
+				<img src={ preview.value.url } alt={ preview.value.alt || '' } />
+				<p className="dsgo-dynamic-tag-picker__preview-meta">
+					{ sprintf(
+						/* translators: %1$s image width, %2$s image height */
+						__( '%1$s × %2$s', 'designsetgo' ),
+						preview.value.width || '?',
+						preview.value.height || '?'
+					) }
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="dsgo-dynamic-tag-picker__preview">
+			<h4>{ __( 'Preview', 'designsetgo' ) }</h4>
+			<p className="dsgo-dynamic-tag-picker__preview-value">{ String( preview.value ) }</p>
+		</div>
+	);
+}

--- a/src/components/DynamicTagPicker/DynamicTagPicker.js
+++ b/src/components/DynamicTagPicker/DynamicTagPicker.js
@@ -75,7 +75,7 @@ export default function DynamicTagPicker( {
 			setDraftArgs( value?.args || {} );
 			setSearch( '' );
 		}
-	}, [ isOpen, value?.source ] );
+	}, [ isOpen, value?.source, value?.args ] );
 
 	const activeSource = useMemo(
 		() => sources.find( ( s ) => s.slug === selectedSource ) || null,

--- a/src/components/DynamicTagPicker/DynamicTagPicker.js
+++ b/src/components/DynamicTagPicker/DynamicTagPicker.js
@@ -19,21 +19,19 @@ import { useState, useEffect, useMemo } from '@wordpress/element';
 import {
 	Modal,
 	Button,
-	SelectControl,
-	TextControl,
-	SearchControl,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
-	Spinner,
-	Notice,
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 
 import { useDynamicTagSources } from './useDynamicTagSources';
 import { useDynamicTagFields } from './useDynamicTagFields';
 import { useDynamicTagPreview } from './useDynamicTagPreview';
+import SourceSidebar from './SourceSidebar';
+import SourceArgsForm from './SourceArgsForm';
+import PreviewPanel from './PreviewPanel';
 import './style.scss';
 
 const DEFAULT_RETURNS = [ 'text', 'url', 'image', 'number', 'date' ];
@@ -63,7 +61,7 @@ export default function DynamicTagPicker( {
 	const postId = postIdProp || editorContext.postId;
 	const postType = postTypeProp || editorContext.postType || 'post';
 
-	const { status: sourcesStatus, groups, sources, error: sourcesError } = useDynamicTagSources( { returns } );
+	const { status: sourcesStatus, groups, sources } = useDynamicTagSources( { returns } );
 
 	const [ selectedSource, setSelectedSource ] = useState( value?.source || '' );
 	const [ draftArgs, setDraftArgs ] = useState( value?.args || {} );
@@ -96,24 +94,6 @@ export default function DynamicTagPicker( {
 		size: draftArgs?.size,
 	} );
 
-	const filteredSources = useMemo( () => {
-		if ( ! search ) {
-			return sources;
-		}
-		const needle = search.toLowerCase();
-		return sources.filter( ( s ) => s.label.toLowerCase().includes( needle ) || s.slug.toLowerCase().includes( needle ) );
-	}, [ sources, search ] );
-
-	const groupedSources = useMemo( () => {
-		const bucket = {};
-		filteredSources.forEach( ( s ) => {
-			( bucket[ s.group ] = bucket[ s.group ] || [] ).push( s );
-		} );
-		return groups
-			.filter( ( g ) => bucket[ g.slug ]?.length )
-			.map( ( g ) => ( { ...g, sources: bucket[ g.slug ] } ) );
-	}, [ filteredSources, groups ] );
-
 	if ( ! isOpen ) {
 		return null;
 	}
@@ -122,16 +102,18 @@ export default function DynamicTagPicker( {
 		if ( ! selectedSource ) {
 			return;
 		}
-		onChange( {
-			source: selectedSource,
-			args: draftArgs,
-		} );
+		onChange( { source: selectedSource, args: draftArgs } );
 		onClose?.();
 	};
 
 	const handleClear = () => {
 		onChange( null );
 		onClose?.();
+	};
+
+	const handleSelectSource = ( slug ) => {
+		setSelectedSource( slug );
+		setDraftArgs( {} );
 	};
 
 	return (
@@ -142,52 +124,15 @@ export default function DynamicTagPicker( {
 			size="large"
 		>
 			<div className="dsgo-dynamic-tag-picker__layout">
-				<div className="dsgo-dynamic-tag-picker__sidebar">
-					<SearchControl
-						value={ search }
-						onChange={ setSearch }
-						placeholder={ __( 'Search sources…', 'designsetgo' ) }
-						__nextHasNoMarginBottom
-					/>
-
-					{ sourcesStatus === 'loading' && (
-						<div className="dsgo-dynamic-tag-picker__loading"><Spinner /></div>
-					) }
-
-					{ sourcesStatus === 'error' && (
-						<Notice status="error" isDismissible={ false }>
-							{ __( 'Unable to load Dynamic Tag sources.', 'designsetgo' ) }
-						</Notice>
-					) }
-
-					{ sourcesStatus === 'ready' && groupedSources.length === 0 && (
-						<p className="dsgo-dynamic-tag-picker__empty">
-							{ __( 'No sources match.', 'designsetgo' ) }
-						</p>
-					) }
-
-					{ groupedSources.map( ( group ) => (
-						<div key={ group.slug } className="dsgo-dynamic-tag-picker__group">
-							<h3 className="dsgo-dynamic-tag-picker__group-title">{ group.label }</h3>
-							<ul className="dsgo-dynamic-tag-picker__source-list">
-								{ group.sources.map( ( source ) => (
-									<li key={ source.slug }>
-										<Button
-											variant={ source.slug === selectedSource ? 'primary' : 'tertiary' }
-											onClick={ () => {
-												setSelectedSource( source.slug );
-												setDraftArgs( {} );
-											} }
-											className="dsgo-dynamic-tag-picker__source-button"
-										>
-											{ source.label }
-										</Button>
-									</li>
-								) ) }
-							</ul>
-						</div>
-					) ) }
-				</div>
+				<SourceSidebar
+					status={ sourcesStatus }
+					groups={ groups }
+					sources={ sources }
+					search={ search }
+					onSearchChange={ setSearch }
+					selectedSource={ selectedSource }
+					onSelectSource={ handleSelectSource }
+				/>
 
 				<div className="dsgo-dynamic-tag-picker__detail">
 					{ ! activeSource && (
@@ -232,170 +177,5 @@ export default function DynamicTagPicker( {
 				</Button>
 			</HStack>
 		</Modal>
-	);
-}
-
-function SourceArgsForm( { source, args, onChange, fieldDiscovery } ) {
-	const schema = source.args || {};
-	const entries = Object.entries( schema );
-
-	if ( entries.length === 0 ) {
-		return null;
-	}
-
-	const setArg = ( key, value ) => {
-		const next = { ...args };
-		if ( value === '' || value === undefined || value === null ) {
-			delete next[ key ];
-		} else {
-			next[ key ] = value;
-		}
-		onChange( next );
-	};
-
-	return (
-		<VStack spacing={ 3 }>
-			{ entries.map( ( [ argName, argSchema ] ) => {
-				// ACF/meta "key" field — surface discovered fields as a select when available.
-				if ( argName === 'key' && source.supportsFieldDiscovery ) {
-					const fieldOptions = [
-						{ label: __( '— Select a field —', 'designsetgo' ), value: '' },
-						...fieldDiscovery.fields.map( ( f ) => ( {
-							label: f.group ? `${ f.group } — ${ f.label }` : f.label,
-							value: f.key,
-						} ) ),
-					];
-					return (
-						<div key={ argName }>
-							{ fieldDiscovery.status === 'loading' ? (
-								<Spinner />
-							) : (
-								<SelectControl
-									label={ __( 'Field', 'designsetgo' ) }
-									value={ args[ argName ] || '' }
-									options={ fieldOptions }
-									onChange={ ( value ) => setArg( argName, value ) }
-									__nextHasNoMarginBottom
-									__next40pxDefaultSize
-								/>
-							) }
-							<TextControl
-								label={ __( 'Or enter a field key manually', 'designsetgo' ) }
-								value={ args[ argName ] || '' }
-								onChange={ ( value ) => setArg( argName, value ) }
-								__nextHasNoMarginBottom
-								__next40pxDefaultSize
-							/>
-						</div>
-					);
-				}
-
-				if ( Array.isArray( argSchema.enum ) && argSchema.enum.length > 0 ) {
-					return (
-						<SelectControl
-							key={ argName }
-							label={ argLabel( argName ) }
-							value={ args[ argName ] ?? argSchema.default ?? '' }
-							options={ [
-								{ label: __( '— Default —', 'designsetgo' ), value: '' },
-								...argSchema.enum.map( ( v ) => ( { label: v, value: v } ) ),
-							] }
-							onChange={ ( value ) => setArg( argName, value ) }
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-						/>
-					);
-				}
-
-				return (
-					<TextControl
-						key={ argName }
-						label={ argLabel( argName ) }
-						help={ argSchema.description || '' }
-						value={ args[ argName ] ?? '' }
-						onChange={ ( value ) => setArg( argName, value ) }
-						__nextHasNoMarginBottom
-						__next40pxDefaultSize
-					/>
-				);
-			} ) }
-		</VStack>
-	);
-}
-
-function argLabel( name ) {
-	const map = {
-		key: __( 'Field key', 'designsetgo' ),
-		subkey: __( 'Sub-value', 'designsetgo' ),
-		size: __( 'Image size', 'designsetgo' ),
-		scope: __( 'Scope', 'designsetgo' ),
-		format: __( 'Date format', 'designsetgo' ),
-		taxonomy: __( 'Taxonomy', 'designsetgo' ),
-		separator: __( 'Separator', 'designsetgo' ),
-	};
-	return map[ name ] || name;
-}
-
-function PreviewPanel( { preview, returns = [] } ) {
-	const isImage = returns.includes( 'image' );
-
-	if ( preview.status === 'idle' ) {
-		return null;
-	}
-
-	if ( preview.status === 'loading' ) {
-		return (
-			<div className="dsgo-dynamic-tag-picker__preview">
-				<Spinner />
-			</div>
-		);
-	}
-
-	if ( preview.status === 'empty' ) {
-		return (
-			<Notice status="info" isDismissible={ false }>
-				{ __( 'Preview is empty for the current post.', 'designsetgo' ) }
-			</Notice>
-		);
-	}
-
-	if ( preview.status === 'unauthorized' ) {
-		return (
-			<Notice status="warning" isDismissible={ false }>
-				{ __( 'Preview is hidden because the post is password-protected or private.', 'designsetgo' ) }
-			</Notice>
-		);
-	}
-
-	if ( preview.status !== 'resolved' ) {
-		return (
-			<Notice status="error" isDismissible={ false }>
-				{ __( 'Unable to preview this source.', 'designsetgo' ) }
-			</Notice>
-		);
-	}
-
-	if ( isImage && preview.value && typeof preview.value === 'object' ) {
-		return (
-			<div className="dsgo-dynamic-tag-picker__preview">
-				<h4>{ __( 'Preview', 'designsetgo' ) }</h4>
-				<img src={ preview.value.url } alt={ preview.value.alt || '' } />
-				<p className="dsgo-dynamic-tag-picker__preview-meta">
-					{ sprintf(
-						/* translators: %1$s image width, %2$s image height */
-						__( '%1$s × %2$s', 'designsetgo' ),
-						preview.value.width || '?',
-						preview.value.height || '?'
-					) }
-				</p>
-			</div>
-		);
-	}
-
-	return (
-		<div className="dsgo-dynamic-tag-picker__preview">
-			<h4>{ __( 'Preview', 'designsetgo' ) }</h4>
-			<p className="dsgo-dynamic-tag-picker__preview-value">{ String( preview.value ) }</p>
-		</div>
 	);
 }

--- a/src/components/DynamicTagPicker/PreviewPanel.js
+++ b/src/components/DynamicTagPicker/PreviewPanel.js
@@ -9,14 +9,14 @@
 import { Spinner, Notice } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
-export default function PreviewPanel( { preview, returns = [] } ) {
-	const isImage = returns.includes( 'image' );
+export default function PreviewPanel({ preview, returns = [] }) {
+	const isImage = returns.includes('image');
 
-	if ( preview.status === 'idle' ) {
+	if (preview.status === 'idle') {
 		return null;
 	}
 
-	if ( preview.status === 'loading' ) {
+	if (preview.status === 'loading') {
 		return (
 			<div className="dsgo-dynamic-tag-picker__preview">
 				<Spinner />
@@ -24,42 +24,45 @@ export default function PreviewPanel( { preview, returns = [] } ) {
 		);
 	}
 
-	if ( preview.status === 'empty' ) {
+	if (preview.status === 'empty') {
 		return (
-			<Notice status="info" isDismissible={ false }>
-				{ __( 'Preview is empty for the current post.', 'designsetgo' ) }
+			<Notice status="info" isDismissible={false}>
+				{__('Preview is empty for the current post.', 'designsetgo')}
 			</Notice>
 		);
 	}
 
-	if ( preview.status === 'unauthorized' ) {
+	if (preview.status === 'unauthorized') {
 		return (
-			<Notice status="warning" isDismissible={ false }>
-				{ __( 'Preview is hidden because the post is password-protected or private.', 'designsetgo' ) }
+			<Notice status="warning" isDismissible={false}>
+				{__(
+					'Preview is hidden because the post is password-protected or private.',
+					'designsetgo'
+				)}
 			</Notice>
 		);
 	}
 
-	if ( preview.status !== 'resolved' ) {
+	if (preview.status !== 'resolved') {
 		return (
-			<Notice status="error" isDismissible={ false }>
-				{ __( 'Unable to preview this source.', 'designsetgo' ) }
+			<Notice status="error" isDismissible={false}>
+				{__('Unable to preview this source.', 'designsetgo')}
 			</Notice>
 		);
 	}
 
-	if ( isImage && preview.value && typeof preview.value === 'object' ) {
+	if (isImage && preview.value && typeof preview.value === 'object') {
 		return (
 			<div className="dsgo-dynamic-tag-picker__preview">
-				<h4>{ __( 'Preview', 'designsetgo' ) }</h4>
-				<img src={ preview.value.url } alt={ preview.value.alt || '' } />
+				<h4>{__('Preview', 'designsetgo')}</h4>
+				<img src={preview.value.url} alt={preview.value.alt || ''} />
 				<p className="dsgo-dynamic-tag-picker__preview-meta">
-					{ sprintf(
+					{sprintf(
 						/* translators: %1$s image width, %2$s image height */
-						__( '%1$s × %2$s', 'designsetgo' ),
+						__('%1$s × %2$s', 'designsetgo'),
 						preview.value.width || '?',
 						preview.value.height || '?'
-					) }
+					)}
 				</p>
 			</div>
 		);
@@ -67,8 +70,10 @@ export default function PreviewPanel( { preview, returns = [] } ) {
 
 	return (
 		<div className="dsgo-dynamic-tag-picker__preview">
-			<h4>{ __( 'Preview', 'designsetgo' ) }</h4>
-			<p className="dsgo-dynamic-tag-picker__preview-value">{ String( preview.value ) }</p>
+			<h4>{__('Preview', 'designsetgo')}</h4>
+			<p className="dsgo-dynamic-tag-picker__preview-value">
+				{String(preview.value)}
+			</p>
 		</div>
 	);
 }

--- a/src/components/DynamicTagPicker/PreviewPanel.js
+++ b/src/components/DynamicTagPicker/PreviewPanel.js
@@ -1,0 +1,74 @@
+/**
+ * PreviewPanel — live preview of a Dynamic Tag source.
+ *
+ * Renders an image preview for image-typed sources or the scalar
+ * value for text/url/number/date sources. Displays appropriate
+ * states for loading, empty, unauthorized, and error responses
+ * from the REST preview endpoint.
+ */
+import { Spinner, Notice } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+export default function PreviewPanel( { preview, returns = [] } ) {
+	const isImage = returns.includes( 'image' );
+
+	if ( preview.status === 'idle' ) {
+		return null;
+	}
+
+	if ( preview.status === 'loading' ) {
+		return (
+			<div className="dsgo-dynamic-tag-picker__preview">
+				<Spinner />
+			</div>
+		);
+	}
+
+	if ( preview.status === 'empty' ) {
+		return (
+			<Notice status="info" isDismissible={ false }>
+				{ __( 'Preview is empty for the current post.', 'designsetgo' ) }
+			</Notice>
+		);
+	}
+
+	if ( preview.status === 'unauthorized' ) {
+		return (
+			<Notice status="warning" isDismissible={ false }>
+				{ __( 'Preview is hidden because the post is password-protected or private.', 'designsetgo' ) }
+			</Notice>
+		);
+	}
+
+	if ( preview.status !== 'resolved' ) {
+		return (
+			<Notice status="error" isDismissible={ false }>
+				{ __( 'Unable to preview this source.', 'designsetgo' ) }
+			</Notice>
+		);
+	}
+
+	if ( isImage && preview.value && typeof preview.value === 'object' ) {
+		return (
+			<div className="dsgo-dynamic-tag-picker__preview">
+				<h4>{ __( 'Preview', 'designsetgo' ) }</h4>
+				<img src={ preview.value.url } alt={ preview.value.alt || '' } />
+				<p className="dsgo-dynamic-tag-picker__preview-meta">
+					{ sprintf(
+						/* translators: %1$s image width, %2$s image height */
+						__( '%1$s × %2$s', 'designsetgo' ),
+						preview.value.width || '?',
+						preview.value.height || '?'
+					) }
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="dsgo-dynamic-tag-picker__preview">
+			<h4>{ __( 'Preview', 'designsetgo' ) }</h4>
+			<p className="dsgo-dynamic-tag-picker__preview-value">{ String( preview.value ) }</p>
+		</div>
+	);
+}

--- a/src/components/DynamicTagPicker/SourceArgsForm.js
+++ b/src/components/DynamicTagPicker/SourceArgsForm.js
@@ -13,6 +13,8 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 const ARG_LABEL_MAP = {
 	key: __( 'Field key', 'designsetgo' ),
@@ -31,6 +33,11 @@ function argLabel( name ) {
 export default function SourceArgsForm( { source, args, onChange, fieldDiscovery } ) {
 	const schema = source.args || {};
 	const entries = Object.entries( schema );
+
+	const imageSizes = useSelect(
+		( select ) => select( blockEditorStore )?.getSettings?.()?.imageSizes || [],
+		[]
+	);
 
 	if ( entries.length === 0 ) {
 		return null;
@@ -91,6 +98,26 @@ export default function SourceArgsForm( { source, args, onChange, fieldDiscovery
 							options={ [
 								{ label: __( '— Default —', 'designsetgo' ), value: '' },
 								...argSchema.enum.map( ( v ) => ( { label: v, value: v } ) ),
+							] }
+							onChange={ ( value ) => setArg( argName, value ) }
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+					);
+				}
+
+				// `size` argument: project the editor's registered image sizes
+				// (core + theme + plugin add_image_size()) into a Select so
+				// authors don't have to remember or type slugs.
+				if ( argName === 'size' && imageSizes.length ) {
+					return (
+						<SelectControl
+							key={ argName }
+							label={ argLabel( argName ) }
+							value={ args[ argName ] ?? '' }
+							options={ [
+								{ label: __( '— Default —', 'designsetgo' ), value: '' },
+								...imageSizes.map( ( s ) => ( { label: s.name, value: s.slug } ) ),
 							] }
 							onChange={ ( value ) => setArg( argName, value ) }
 							__nextHasNoMarginBottom

--- a/src/components/DynamicTagPicker/SourceArgsForm.js
+++ b/src/components/DynamicTagPicker/SourceArgsForm.js
@@ -1,0 +1,116 @@
+/**
+ * SourceArgsForm — argument inputs for a selected Dynamic Tag source.
+ *
+ * Renders one control per declared arg in the source's `args` schema.
+ * Sources that opt into field discovery (ACF, post-meta, …) get a
+ * combined Select + TextControl for the `key` argument so authors can
+ * pick from discovered fields or type a key manually.
+ */
+import {
+	SelectControl,
+	TextControl,
+	Spinner,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const ARG_LABEL_MAP = {
+	key: __( 'Field key', 'designsetgo' ),
+	subkey: __( 'Sub-value', 'designsetgo' ),
+	size: __( 'Image size', 'designsetgo' ),
+	scope: __( 'Scope', 'designsetgo' ),
+	format: __( 'Date format', 'designsetgo' ),
+	taxonomy: __( 'Taxonomy', 'designsetgo' ),
+	separator: __( 'Separator', 'designsetgo' ),
+};
+
+function argLabel( name ) {
+	return ARG_LABEL_MAP[ name ] || name;
+}
+
+export default function SourceArgsForm( { source, args, onChange, fieldDiscovery } ) {
+	const schema = source.args || {};
+	const entries = Object.entries( schema );
+
+	if ( entries.length === 0 ) {
+		return null;
+	}
+
+	const setArg = ( key, value ) => {
+		const next = { ...args };
+		if ( value === '' || value === undefined || value === null ) {
+			delete next[ key ];
+		} else {
+			next[ key ] = value;
+		}
+		onChange( next );
+	};
+
+	return (
+		<VStack spacing={ 3 }>
+			{ entries.map( ( [ argName, argSchema ] ) => {
+				if ( argName === 'key' && source.supportsFieldDiscovery ) {
+					const fieldOptions = [
+						{ label: __( '— Select a field —', 'designsetgo' ), value: '' },
+						...fieldDiscovery.fields.map( ( f ) => ( {
+							label: f.group ? `${ f.group } — ${ f.label }` : f.label,
+							value: f.key,
+						} ) ),
+					];
+					return (
+						<div key={ argName }>
+							{ fieldDiscovery.status === 'loading' ? (
+								<Spinner />
+							) : (
+								<SelectControl
+									label={ __( 'Field', 'designsetgo' ) }
+									value={ args[ argName ] || '' }
+									options={ fieldOptions }
+									onChange={ ( value ) => setArg( argName, value ) }
+									__nextHasNoMarginBottom
+									__next40pxDefaultSize
+								/>
+							) }
+							<TextControl
+								label={ __( 'Or enter a field key manually', 'designsetgo' ) }
+								value={ args[ argName ] || '' }
+								onChange={ ( value ) => setArg( argName, value ) }
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+							/>
+						</div>
+					);
+				}
+
+				if ( Array.isArray( argSchema.enum ) && argSchema.enum.length > 0 ) {
+					return (
+						<SelectControl
+							key={ argName }
+							label={ argLabel( argName ) }
+							value={ args[ argName ] ?? argSchema.default ?? '' }
+							options={ [
+								{ label: __( '— Default —', 'designsetgo' ), value: '' },
+								...argSchema.enum.map( ( v ) => ( { label: v, value: v } ) ),
+							] }
+							onChange={ ( value ) => setArg( argName, value ) }
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+					);
+				}
+
+				return (
+					<TextControl
+						key={ argName }
+						label={ argLabel( argName ) }
+						help={ argSchema.description || '' }
+						value={ args[ argName ] ?? '' }
+						onChange={ ( value ) => setArg( argName, value ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+				);
+			} ) }
+		</VStack>
+	);
+}

--- a/src/components/DynamicTagPicker/SourceArgsForm.js
+++ b/src/components/DynamicTagPicker/SourceArgsForm.js
@@ -17,71 +17,84 @@ import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 const ARG_LABEL_MAP = {
-	key: __( 'Field key', 'designsetgo' ),
-	subkey: __( 'Sub-value', 'designsetgo' ),
-	size: __( 'Image size', 'designsetgo' ),
-	scope: __( 'Scope', 'designsetgo' ),
-	format: __( 'Date format', 'designsetgo' ),
-	taxonomy: __( 'Taxonomy', 'designsetgo' ),
-	separator: __( 'Separator', 'designsetgo' ),
+	key: __('Field key', 'designsetgo'),
+	subkey: __('Sub-value', 'designsetgo'),
+	size: __('Image size', 'designsetgo'),
+	scope: __('Scope', 'designsetgo'),
+	format: __('Date format', 'designsetgo'),
+	taxonomy: __('Taxonomy', 'designsetgo'),
+	separator: __('Separator', 'designsetgo'),
 };
 
-function argLabel( name ) {
-	return ARG_LABEL_MAP[ name ] || name;
+function argLabel(name) {
+	return ARG_LABEL_MAP[name] || name;
 }
 
-export default function SourceArgsForm( { source, args, onChange, fieldDiscovery } ) {
+export default function SourceArgsForm({
+	source,
+	args,
+	onChange,
+	fieldDiscovery,
+}) {
 	const schema = source.args || {};
-	const entries = Object.entries( schema );
+	const entries = Object.entries(schema);
 
 	const imageSizes = useSelect(
-		( select ) => select( blockEditorStore )?.getSettings?.()?.imageSizes || [],
+		(select) => select(blockEditorStore)?.getSettings?.()?.imageSizes || [],
 		[]
 	);
 
-	if ( entries.length === 0 ) {
+	if (entries.length === 0) {
 		return null;
 	}
 
-	const setArg = ( key, value ) => {
+	const setArg = (key, value) => {
 		const next = { ...args };
-		if ( value === '' || value === undefined || value === null ) {
-			delete next[ key ];
+		if (value === '' || value === undefined || value === null) {
+			delete next[key];
 		} else {
-			next[ key ] = value;
+			next[key] = value;
 		}
-		onChange( next );
+		onChange(next);
 	};
 
 	return (
-		<VStack spacing={ 3 }>
-			{ entries.map( ( [ argName, argSchema ] ) => {
-				if ( argName === 'key' && source.supportsFieldDiscovery ) {
+		<VStack spacing={3}>
+			{entries.map(([argName, argSchema]) => {
+				if (argName === 'key' && source.supportsFieldDiscovery) {
 					const fieldOptions = [
-						{ label: __( '— Select a field —', 'designsetgo' ), value: '' },
-						...fieldDiscovery.fields.map( ( f ) => ( {
-							label: f.group ? `${ f.group } — ${ f.label }` : f.label,
+						{
+							label: __('— Select a field —', 'designsetgo'),
+							value: '',
+						},
+						...fieldDiscovery.fields.map((f) => ({
+							label: f.group
+								? `${f.group} — ${f.label}`
+								: f.label,
 							value: f.key,
-						} ) ),
+						})),
 					];
 					return (
-						<div key={ argName }>
-							{ fieldDiscovery.status === 'loading' ? (
+						<div key={argName}>
+							{fieldDiscovery.status === 'loading' ? (
 								<Spinner />
 							) : (
 								<SelectControl
-									label={ __( 'Field', 'designsetgo' ) }
-									value={ args[ argName ] || '' }
-									options={ fieldOptions }
-									onChange={ ( value ) => setArg( argName, value ) }
+									label={__('Field', 'designsetgo')}
+									value={args[argName] || ''}
+									options={fieldOptions}
+									onChange={(value) => setArg(argName, value)}
 									__nextHasNoMarginBottom
 									__next40pxDefaultSize
 								/>
-							) }
+							)}
 							<TextControl
-								label={ __( 'Or enter a field key manually', 'designsetgo' ) }
-								value={ args[ argName ] || '' }
-								onChange={ ( value ) => setArg( argName, value ) }
+								label={__(
+									'Or enter a field key manually',
+									'designsetgo'
+								)}
+								value={args[argName] || ''}
+								onChange={(value) => setArg(argName, value)}
 								__nextHasNoMarginBottom
 								__next40pxDefaultSize
 							/>
@@ -89,17 +102,26 @@ export default function SourceArgsForm( { source, args, onChange, fieldDiscovery
 					);
 				}
 
-				if ( Array.isArray( argSchema.enum ) && argSchema.enum.length > 0 ) {
+				if (
+					Array.isArray(argSchema.enum) &&
+					argSchema.enum.length > 0
+				) {
 					return (
 						<SelectControl
-							key={ argName }
-							label={ argLabel( argName ) }
-							value={ args[ argName ] ?? argSchema.default ?? '' }
-							options={ [
-								{ label: __( '— Default —', 'designsetgo' ), value: '' },
-								...argSchema.enum.map( ( v ) => ( { label: v, value: v } ) ),
-							] }
-							onChange={ ( value ) => setArg( argName, value ) }
+							key={argName}
+							label={argLabel(argName)}
+							value={args[argName] ?? argSchema.default ?? ''}
+							options={[
+								{
+									label: __('— Default —', 'designsetgo'),
+									value: '',
+								},
+								...argSchema.enum.map((v) => ({
+									label: v,
+									value: v,
+								})),
+							]}
+							onChange={(value) => setArg(argName, value)}
 							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 						/>
@@ -109,17 +131,23 @@ export default function SourceArgsForm( { source, args, onChange, fieldDiscovery
 				// `size` argument: project the editor's registered image sizes
 				// (core + theme + plugin add_image_size()) into a Select so
 				// authors don't have to remember or type slugs.
-				if ( argName === 'size' && imageSizes.length ) {
+				if (argName === 'size' && imageSizes.length) {
 					return (
 						<SelectControl
-							key={ argName }
-							label={ argLabel( argName ) }
-							value={ args[ argName ] ?? '' }
-							options={ [
-								{ label: __( '— Default —', 'designsetgo' ), value: '' },
-								...imageSizes.map( ( s ) => ( { label: s.name, value: s.slug } ) ),
-							] }
-							onChange={ ( value ) => setArg( argName, value ) }
+							key={argName}
+							label={argLabel(argName)}
+							value={args[argName] ?? ''}
+							options={[
+								{
+									label: __('— Default —', 'designsetgo'),
+									value: '',
+								},
+								...imageSizes.map((s) => ({
+									label: s.name,
+									value: s.slug,
+								})),
+							]}
+							onChange={(value) => setArg(argName, value)}
 							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 						/>
@@ -128,16 +156,16 @@ export default function SourceArgsForm( { source, args, onChange, fieldDiscovery
 
 				return (
 					<TextControl
-						key={ argName }
-						label={ argLabel( argName ) }
-						help={ argSchema.description || '' }
-						value={ args[ argName ] ?? '' }
-						onChange={ ( value ) => setArg( argName, value ) }
+						key={argName}
+						label={argLabel(argName)}
+						help={argSchema.description || ''}
+						value={args[argName] ?? ''}
+						onChange={(value) => setArg(argName, value)}
 						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 					/>
 				);
-			} ) }
+			})}
 		</VStack>
 	);
 }

--- a/src/components/DynamicTagPicker/SourceSidebar.js
+++ b/src/components/DynamicTagPicker/SourceSidebar.js
@@ -2,15 +2,10 @@
  * SourceSidebar — searchable grouped list of Dynamic Tag sources.
  */
 import { useMemo } from '@wordpress/element';
-import {
-	Button,
-	SearchControl,
-	Spinner,
-	Notice,
-} from '@wordpress/components';
+import { Button, SearchControl, Spinner, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export default function SourceSidebar( {
+export default function SourceSidebar({
 	status,
 	groups,
 	sources,
@@ -18,70 +13,83 @@ export default function SourceSidebar( {
 	onSearchChange,
 	selectedSource,
 	onSelectSource,
-} ) {
-	const filteredSources = useMemo( () => {
-		if ( ! search ) {
+}) {
+	const filteredSources = useMemo(() => {
+		if (!search) {
 			return sources;
 		}
 		const needle = search.toLowerCase();
 		return sources.filter(
-			( s ) => s.label.toLowerCase().includes( needle ) || s.slug.toLowerCase().includes( needle )
+			(s) =>
+				s.label.toLowerCase().includes(needle) ||
+				s.slug.toLowerCase().includes(needle)
 		);
-	}, [ sources, search ] );
+	}, [sources, search]);
 
-	const groupedSources = useMemo( () => {
+	const groupedSources = useMemo(() => {
 		const bucket = {};
-		filteredSources.forEach( ( s ) => {
-			( bucket[ s.group ] = bucket[ s.group ] || [] ).push( s );
-		} );
+		filteredSources.forEach((s) => {
+			(bucket[s.group] = bucket[s.group] || []).push(s);
+		});
 		return groups
-			.filter( ( g ) => bucket[ g.slug ]?.length )
-			.map( ( g ) => ( { ...g, sources: bucket[ g.slug ] } ) );
-	}, [ filteredSources, groups ] );
+			.filter((g) => bucket[g.slug]?.length)
+			.map((g) => ({ ...g, sources: bucket[g.slug] }));
+	}, [filteredSources, groups]);
 
 	return (
 		<div className="dsgo-dynamic-tag-picker__sidebar">
 			<SearchControl
-				value={ search }
-				onChange={ onSearchChange }
-				placeholder={ __( 'Search sources…', 'designsetgo' ) }
+				value={search}
+				onChange={onSearchChange}
+				placeholder={__('Search sources…', 'designsetgo')}
 				__nextHasNoMarginBottom
 			/>
 
-			{ status === 'loading' && (
-				<div className="dsgo-dynamic-tag-picker__loading"><Spinner /></div>
-			) }
+			{status === 'loading' && (
+				<div className="dsgo-dynamic-tag-picker__loading">
+					<Spinner />
+				</div>
+			)}
 
-			{ status === 'error' && (
-				<Notice status="error" isDismissible={ false }>
-					{ __( 'Unable to load Dynamic Tag sources.', 'designsetgo' ) }
+			{status === 'error' && (
+				<Notice status="error" isDismissible={false}>
+					{__('Unable to load Dynamic Tag sources.', 'designsetgo')}
 				</Notice>
-			) }
+			)}
 
-			{ status === 'ready' && groupedSources.length === 0 && (
+			{status === 'ready' && groupedSources.length === 0 && (
 				<p className="dsgo-dynamic-tag-picker__empty">
-					{ __( 'No sources match.', 'designsetgo' ) }
+					{__('No sources match.', 'designsetgo')}
 				</p>
-			) }
+			)}
 
-			{ groupedSources.map( ( group ) => (
-				<div key={ group.slug } className="dsgo-dynamic-tag-picker__group">
-					<h3 className="dsgo-dynamic-tag-picker__group-title">{ group.label }</h3>
+			{groupedSources.map((group) => (
+				<div
+					key={group.slug}
+					className="dsgo-dynamic-tag-picker__group"
+				>
+					<h3 className="dsgo-dynamic-tag-picker__group-title">
+						{group.label}
+					</h3>
 					<ul className="dsgo-dynamic-tag-picker__source-list">
-						{ group.sources.map( ( source ) => (
-							<li key={ source.slug }>
+						{group.sources.map((source) => (
+							<li key={source.slug}>
 								<Button
-									variant={ source.slug === selectedSource ? 'primary' : 'tertiary' }
-									onClick={ () => onSelectSource( source.slug ) }
+									variant={
+										source.slug === selectedSource
+											? 'primary'
+											: 'tertiary'
+									}
+									onClick={() => onSelectSource(source.slug)}
 									className="dsgo-dynamic-tag-picker__source-button"
 								>
-									{ source.label }
+									{source.label}
 								</Button>
 							</li>
-						) ) }
+						))}
 					</ul>
 				</div>
-			) ) }
+			))}
 		</div>
 	);
 }

--- a/src/components/DynamicTagPicker/SourceSidebar.js
+++ b/src/components/DynamicTagPicker/SourceSidebar.js
@@ -1,0 +1,87 @@
+/**
+ * SourceSidebar — searchable grouped list of Dynamic Tag sources.
+ */
+import { useMemo } from '@wordpress/element';
+import {
+	Button,
+	SearchControl,
+	Spinner,
+	Notice,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export default function SourceSidebar( {
+	status,
+	groups,
+	sources,
+	search,
+	onSearchChange,
+	selectedSource,
+	onSelectSource,
+} ) {
+	const filteredSources = useMemo( () => {
+		if ( ! search ) {
+			return sources;
+		}
+		const needle = search.toLowerCase();
+		return sources.filter(
+			( s ) => s.label.toLowerCase().includes( needle ) || s.slug.toLowerCase().includes( needle )
+		);
+	}, [ sources, search ] );
+
+	const groupedSources = useMemo( () => {
+		const bucket = {};
+		filteredSources.forEach( ( s ) => {
+			( bucket[ s.group ] = bucket[ s.group ] || [] ).push( s );
+		} );
+		return groups
+			.filter( ( g ) => bucket[ g.slug ]?.length )
+			.map( ( g ) => ( { ...g, sources: bucket[ g.slug ] } ) );
+	}, [ filteredSources, groups ] );
+
+	return (
+		<div className="dsgo-dynamic-tag-picker__sidebar">
+			<SearchControl
+				value={ search }
+				onChange={ onSearchChange }
+				placeholder={ __( 'Search sources…', 'designsetgo' ) }
+				__nextHasNoMarginBottom
+			/>
+
+			{ status === 'loading' && (
+				<div className="dsgo-dynamic-tag-picker__loading"><Spinner /></div>
+			) }
+
+			{ status === 'error' && (
+				<Notice status="error" isDismissible={ false }>
+					{ __( 'Unable to load Dynamic Tag sources.', 'designsetgo' ) }
+				</Notice>
+			) }
+
+			{ status === 'ready' && groupedSources.length === 0 && (
+				<p className="dsgo-dynamic-tag-picker__empty">
+					{ __( 'No sources match.', 'designsetgo' ) }
+				</p>
+			) }
+
+			{ groupedSources.map( ( group ) => (
+				<div key={ group.slug } className="dsgo-dynamic-tag-picker__group">
+					<h3 className="dsgo-dynamic-tag-picker__group-title">{ group.label }</h3>
+					<ul className="dsgo-dynamic-tag-picker__source-list">
+						{ group.sources.map( ( source ) => (
+							<li key={ source.slug }>
+								<Button
+									variant={ source.slug === selectedSource ? 'primary' : 'tertiary' }
+									onClick={ () => onSelectSource( source.slug ) }
+									className="dsgo-dynamic-tag-picker__source-button"
+								>
+									{ source.label }
+								</Button>
+							</li>
+						) ) }
+					</ul>
+				</div>
+			) ) }
+		</div>
+	);
+}

--- a/src/components/DynamicTagPicker/index.js
+++ b/src/components/DynamicTagPicker/index.js
@@ -1,0 +1,11 @@
+/**
+ * DynamicTagPicker — public entry point.
+ *
+ * Exposes the modal picker component, the inline trigger button, and the
+ * data hooks so callers can compose their own triggers when needed.
+ */
+export { default as DynamicTagPicker } from './DynamicTagPicker';
+export { default as DynamicTagButton } from './DynamicTagButton';
+export { useDynamicTagSources } from './useDynamicTagSources';
+export { useDynamicTagFields } from './useDynamicTagFields';
+export { useDynamicTagPreview } from './useDynamicTagPreview';

--- a/src/components/DynamicTagPicker/style.scss
+++ b/src/components/DynamicTagPicker/style.scss
@@ -18,6 +18,17 @@
 		overflow: hidden;
 	}
 
+	// WP Modal wraps our children in an unclassed <div> sibling to
+	// __header. Without flexing it, the layout grid grows past the frame
+	// and pushes the footer below the fold.
+	.components-modal__content > div:not(.components-modal__header) {
+		flex: 1 1 auto;
+		min-height: 0;
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+	}
+
 	&__layout {
 		display: grid;
 		grid-template-columns: 260px 1fr;

--- a/src/components/DynamicTagPicker/style.scss
+++ b/src/components/DynamicTagPicker/style.scss
@@ -1,13 +1,22 @@
 .dsgo-dynamic-tag-picker {
+	// WordPress's Modal sets its own internal max-height; force the content
+	// region to a flex column so the layout grid scrolls inside the modal
+	// while the footer stays pinned at the bottom — otherwise the
+	// Cancel / Use this source CTAs land below the fold whenever the
+	// source list or argument form grows past ~440px.
 	.components-modal__content {
 		padding: 0;
+		display: flex;
+		flex-direction: column;
+		max-height: calc(80vh - 60px);
 	}
 
 	&__layout {
 		display: grid;
 		grid-template-columns: 260px 1fr;
-		min-height: 440px;
-		max-height: 70vh;
+		flex: 1 1 auto;
+		min-height: 0;
+		overflow: hidden;
 		border-top: 1px solid #ddd;
 	}
 
@@ -130,8 +139,10 @@
 	}
 
 	&__footer {
+		flex: 0 0 auto;
 		padding: 12px 24px;
 		border-top: 1px solid #e0e0e0;
+		background: #fff;
 	}
 }
 

--- a/src/components/DynamicTagPicker/style.scss
+++ b/src/components/DynamicTagPicker/style.scss
@@ -1,11 +1,11 @@
 .dsgo-dynamic-tag-picker {
-	// `className` on WP's Modal lands on `.components-modal__frame`, so
-	// these rules cap the OUTER frame to the viewport. Without this the
-	// modal grows with its content, the Cancel / Use this source CTAs
-	// land below the bottom edge, and authors have to page-scroll to
-	// reach them.
+	// `className` on WP's Modal lands on `.components-modal__frame`. Pin
+	// the frame to a sensible fraction of the viewport (rather than
+	// auto-sizing) so the inner sidebar/detail scroll INSIDE the modal
+	// and the footer is always visible — auto-sizing pushed the footer
+	// below the screen on tall source lists.
+	height: min(640px, 80vh);
 	max-height: calc(100vh - 64px);
-	height: auto;
 	display: flex;
 	flex-direction: column;
 
@@ -21,7 +21,7 @@
 	&__layout {
 		display: grid;
 		grid-template-columns: 260px 1fr;
-		flex: 1 1 auto;
+		flex: 1 1 0;
 		min-height: 0;
 		overflow: hidden;
 		border-top: 1px solid #ddd;

--- a/src/components/DynamicTagPicker/style.scss
+++ b/src/components/DynamicTagPicker/style.scss
@@ -1,14 +1,21 @@
 .dsgo-dynamic-tag-picker {
-	// WordPress's Modal sets its own internal max-height; force the content
-	// region to a flex column so the layout grid scrolls inside the modal
-	// while the footer stays pinned at the bottom — otherwise the
-	// Cancel / Use this source CTAs land below the fold whenever the
-	// source list or argument form grows past ~440px.
+	// `className` on WP's Modal lands on `.components-modal__frame`, so
+	// these rules cap the OUTER frame to the viewport. Without this the
+	// modal grows with its content, the Cancel / Use this source CTAs
+	// land below the bottom edge, and authors have to page-scroll to
+	// reach them.
+	max-height: calc(100vh - 64px);
+	height: auto;
+	display: flex;
+	flex-direction: column;
+
 	.components-modal__content {
+		flex: 1 1 auto;
+		min-height: 0;
 		padding: 0;
 		display: flex;
 		flex-direction: column;
-		max-height: calc(80vh - 60px);
+		overflow: hidden;
 	}
 
 	&__layout {
@@ -147,6 +154,7 @@
 }
 
 .dsgo-dynamic-tag-button {
+
 	&.is-connected {
 		background: #2271b1;
 		color: #fff;

--- a/src/components/DynamicTagPicker/style.scss
+++ b/src/components/DynamicTagPicker/style.scss
@@ -1,0 +1,148 @@
+.dsgo-dynamic-tag-picker {
+	.components-modal__content {
+		padding: 0;
+	}
+
+	&__layout {
+		display: grid;
+		grid-template-columns: 260px 1fr;
+		min-height: 440px;
+		max-height: 70vh;
+		border-top: 1px solid #ddd;
+	}
+
+	&__sidebar {
+		padding: 16px;
+		border-right: 1px solid #e0e0e0;
+		overflow-y: auto;
+		background: #f6f7f7;
+	}
+
+	&__detail {
+		padding: 20px 24px;
+		overflow-y: auto;
+	}
+
+	&__group {
+		margin-top: 16px;
+
+		&:first-of-type {
+			margin-top: 12px;
+		}
+	}
+
+	&__group-title {
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: #757575;
+		margin: 0 0 6px;
+		padding: 0 4px;
+	}
+
+	&__source-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+
+		li {
+			margin: 0;
+		}
+	}
+
+	&__source-button {
+		width: 100%;
+		justify-content: flex-start;
+		text-align: left;
+		margin-bottom: 2px;
+	}
+
+	&__loading {
+		display: flex;
+		justify-content: center;
+		padding: 24px 0;
+	}
+
+	&__empty {
+		color: #757575;
+		font-size: 13px;
+		padding: 12px 4px;
+	}
+
+	&__prompt {
+		color: #757575;
+		text-align: center;
+		padding: 80px 24px;
+	}
+
+	&__title {
+		font-size: 16px;
+		margin: 0 0 4px;
+	}
+
+	&__subtitle {
+		margin: 0 0 12px;
+		color: #757575;
+		font-size: 12px;
+
+		code {
+			background: #f0f0f1;
+			padding: 2px 6px;
+			border-radius: 2px;
+		}
+	}
+
+	&__preview {
+		padding: 12px;
+		background: #f6f7f7;
+		border: 1px solid #e0e0e0;
+		border-radius: 4px;
+
+		h4 {
+			font-size: 11px;
+			text-transform: uppercase;
+			letter-spacing: 0.04em;
+			color: #757575;
+			margin: 0 0 8px;
+		}
+
+		img {
+			max-width: 100%;
+			max-height: 240px;
+			display: block;
+			border-radius: 2px;
+		}
+	}
+
+	&__preview-value {
+		margin: 0;
+		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+		font-size: 13px;
+		white-space: pre-wrap;
+		word-break: break-word;
+	}
+
+	&__preview-meta {
+		margin: 8px 0 0;
+		color: #757575;
+		font-size: 12px;
+	}
+
+	&__footer {
+		padding: 12px 24px;
+		border-top: 1px solid #e0e0e0;
+	}
+}
+
+.dsgo-dynamic-tag-button {
+	&.is-connected {
+		background: #2271b1;
+		color: #fff;
+
+		&:hover:not(:disabled) {
+			background: #135e96;
+			color: #fff;
+		}
+	}
+}

--- a/src/components/DynamicTagPicker/useDynamicTagFields.js
+++ b/src/components/DynamicTagPicker/useDynamicTagFields.js
@@ -1,0 +1,61 @@
+/**
+ * useDynamicTagFields — hook that lazily loads discovered fields for a source.
+ *
+ * Results are cached by `${source}|${postType}|${returns}`.
+ */
+import { useEffect, useState, useRef } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+
+const cache = new Map();
+
+export function useDynamicTagFields( { source, postType, returns, supportsFieldDiscovery } ) {
+	const [ state, setState ] = useState( { status: 'idle', fields: [], error: null } );
+	const keyRef = useRef( '' );
+
+	useEffect( () => {
+		if ( ! source || ! supportsFieldDiscovery ) {
+			setState( { status: 'idle', fields: [], error: null } );
+			return undefined;
+		}
+
+		const key = `${ source }|${ postType || '' }|${ returns || '' }`;
+		keyRef.current = key;
+
+		if ( cache.has( key ) ) {
+			setState( { status: 'ready', fields: cache.get( key ), error: null } );
+			return undefined;
+		}
+
+		setState( { status: 'loading', fields: [], error: null } );
+		let cancelled = false;
+
+		apiFetch( {
+			path: addQueryArgs( '/designsetgo/v1/dynamic-tags/fields', {
+				source,
+				postType,
+				returns,
+			} ),
+		} )
+			.then( ( response ) => {
+				if ( cancelled || keyRef.current !== key ) {
+					return;
+				}
+				const fields = response.fields || [];
+				cache.set( key, fields );
+				setState( { status: 'ready', fields, error: null } );
+			} )
+			.catch( ( error ) => {
+				if ( cancelled || keyRef.current !== key ) {
+					return;
+				}
+				setState( { status: 'error', fields: [], error } );
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ source, postType, returns, supportsFieldDiscovery ] );
+
+	return state;
+}

--- a/src/components/DynamicTagPicker/useDynamicTagFields.js
+++ b/src/components/DynamicTagPicker/useDynamicTagFields.js
@@ -9,53 +9,62 @@ import { addQueryArgs } from '@wordpress/url';
 
 const cache = new Map();
 
-export function useDynamicTagFields( { source, postType, returns, supportsFieldDiscovery } ) {
-	const [ state, setState ] = useState( { status: 'idle', fields: [], error: null } );
-	const keyRef = useRef( '' );
+export function useDynamicTagFields({
+	source,
+	postType,
+	returns,
+	supportsFieldDiscovery,
+}) {
+	const [state, setState] = useState({
+		status: 'idle',
+		fields: [],
+		error: null,
+	});
+	const keyRef = useRef('');
 
-	useEffect( () => {
-		if ( ! source || ! supportsFieldDiscovery ) {
-			setState( { status: 'idle', fields: [], error: null } );
+	useEffect(() => {
+		if (!source || !supportsFieldDiscovery) {
+			setState({ status: 'idle', fields: [], error: null });
 			return undefined;
 		}
 
-		const key = `${ source }|${ postType || '' }|${ returns || '' }`;
+		const key = `${source}|${postType || ''}|${returns || ''}`;
 		keyRef.current = key;
 
-		if ( cache.has( key ) ) {
-			setState( { status: 'ready', fields: cache.get( key ), error: null } );
+		if (cache.has(key)) {
+			setState({ status: 'ready', fields: cache.get(key), error: null });
 			return undefined;
 		}
 
-		setState( { status: 'loading', fields: [], error: null } );
+		setState({ status: 'loading', fields: [], error: null });
 		let cancelled = false;
 
-		apiFetch( {
-			path: addQueryArgs( '/designsetgo/v1/dynamic-tags/fields', {
+		apiFetch({
+			path: addQueryArgs('/designsetgo/v1/dynamic-tags/fields', {
 				source,
 				postType,
 				returns,
-			} ),
-		} )
-			.then( ( response ) => {
-				if ( cancelled || keyRef.current !== key ) {
+			}),
+		})
+			.then((response) => {
+				if (cancelled || keyRef.current !== key) {
 					return;
 				}
 				const fields = response.fields || [];
-				cache.set( key, fields );
-				setState( { status: 'ready', fields, error: null } );
-			} )
-			.catch( ( error ) => {
-				if ( cancelled || keyRef.current !== key ) {
+				cache.set(key, fields);
+				setState({ status: 'ready', fields, error: null });
+			})
+			.catch((error) => {
+				if (cancelled || keyRef.current !== key) {
 					return;
 				}
-				setState( { status: 'error', fields: [], error } );
-			} );
+				setState({ status: 'error', fields: [], error });
+			});
 
 		return () => {
 			cancelled = true;
 		};
-	}, [ source, postType, returns, supportsFieldDiscovery ] );
+	}, [source, postType, returns, supportsFieldDiscovery]);
 
 	return state;
 }

--- a/src/components/DynamicTagPicker/useDynamicTagPreview.js
+++ b/src/components/DynamicTagPicker/useDynamicTagPreview.js
@@ -1,68 +1,161 @@
 /**
- * useDynamicTagPreview — debounced live-preview fetcher.
+ * useDynamicTagPreview — debounced live-preview fetcher with editor fallback.
  *
  * Given a source + args + postId, returns the resolved preview value
  * (scalar string or image descriptor) so the picker can show users
  * exactly what will render on the frontend.
+ *
+ * For sources that read post-intrinsic fields, an in-editor value from
+ * `core/editor`'s edited (unsaved) post attributes is preferred over the
+ * REST round-trip — this keeps the preview live as authors type a title
+ * or excerpt, and works even on auto-drafts whose persisted DB row is
+ * still empty.
  */
 import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 const DEBOUNCE_MS = 250;
 
-export function useDynamicTagPreview( { source, args, postId, size } ) {
-	const [ state, setState ] = useState( { status: 'idle', value: null, returns: null, error: null } );
-	const timerRef = useRef( null );
-	const requestRef = useRef( 0 );
+// Sources that map directly to an editor post attribute. Resolving these
+// client-side from the editor store sidesteps two REST round-trip hazards:
+//   1. auto-draft posts whose title hasn't been saved yet,
+//   2. unauthenticated/CORS edge cases on REST.
+function resolveFromEditor(source, editedPost) {
+	if (!editedPost) {
+		return undefined;
+	}
+	switch (source) {
+		case 'designsetgo/post-title':
+			return typeof editedPost.title === 'string' ? editedPost.title : '';
+		case 'designsetgo/post-excerpt':
+			return typeof editedPost.excerpt === 'string'
+				? editedPost.excerpt
+				: '';
+		case 'designsetgo/post-id':
+			return editedPost.id ? String(editedPost.id) : '';
+		case 'designsetgo/post-type':
+			return editedPost.type || '';
+		case 'designsetgo/post-permalink':
+			return editedPost.link || '';
+		default:
+			return undefined;
+	}
+}
+
+export function useDynamicTagPreview({ source, args, postId, size }) {
+	const [state, setState] = useState({
+		status: 'idle',
+		value: null,
+		returns: null,
+		error: null,
+	});
+	const timerRef = useRef(null);
+	const requestRef = useRef(0);
+
+	const editedPost = useSelect((select) => {
+		const editor = select(editorStore);
+		if (!editor || !editor.getCurrentPost) {
+			return null;
+		}
+		const current = editor.getCurrentPost();
+		if (!current) {
+			return null;
+		}
+		return {
+			id: editor.getCurrentPostId?.() || current.id || 0,
+			type: editor.getCurrentPostType?.() || current.type || '',
+			title: editor.getEditedPostAttribute?.('title') ?? current.title ?? '',
+			excerpt:
+				editor.getEditedPostAttribute?.('excerpt') ??
+				current.excerpt ??
+				'',
+			link: current.link || '',
+		};
+	}, []);
 
 	// Stabilise the args dependency — serialising inside the effect would
 	// re-run JSON.stringify on every render, including renders where args
 	// has not changed.
-	const argsKey = useMemo( () => JSON.stringify( args || {} ), [ args ] );
+	const argsKey = useMemo(() => JSON.stringify(args || {}), [args]);
 
-	useEffect( () => {
-		if ( ! source ) {
-			setState( { status: 'idle', value: null, returns: null, error: null } );
+	useEffect(() => {
+		if (!source) {
+			setState({
+				status: 'idle',
+				value: null,
+				returns: null,
+				error: null,
+			});
 			return undefined;
 		}
 
-		clearTimeout( timerRef.current );
-		const requestId = ++requestRef.current;
-		setState( ( prev ) => ( { ...prev, status: 'loading' } ) );
+		// Editor-side shortcut: post-intrinsic scalar sources resolve from
+		// the live editor state so the preview reflects unsaved edits.
+		const editorValue = resolveFromEditor(source, editedPost);
+		if (editorValue !== undefined) {
+			setState({
+				status: editorValue === '' ? 'empty' : 'resolved',
+				value: editorValue === '' ? null : editorValue,
+				returns: 'text',
+				error: null,
+			});
+			return undefined;
+		}
 
-		timerRef.current = setTimeout( () => {
-			apiFetch( {
-				path: addQueryArgs( '/designsetgo/v1/dynamic-tags/preview', {
+		clearTimeout(timerRef.current);
+		const requestId = ++requestRef.current;
+		setState((prev) => ({ ...prev, status: 'loading' }));
+
+		timerRef.current = setTimeout(() => {
+			apiFetch({
+				path: addQueryArgs('/designsetgo/v1/dynamic-tags/preview', {
 					source,
 					args: args || {},
 					postId: postId || undefined,
 					size: size || undefined,
-				} ),
-			} )
-				.then( ( response ) => {
-					if ( requestRef.current !== requestId ) {
+				}),
+			})
+				.then((response) => {
+					if (requestRef.current !== requestId) {
 						return;
 					}
-					setState( {
+					setState({
 						status: response.status || 'resolved',
 						value: response.value ?? null,
 						returns: response.returns || null,
 						error: null,
-					} );
-				} )
-				.catch( ( error ) => {
-					if ( requestRef.current !== requestId ) {
+					});
+				})
+				.catch((error) => {
+					if (requestRef.current !== requestId) {
 						return;
 					}
-					setState( { status: 'error', value: null, returns: null, error } );
-				} );
-		}, DEBOUNCE_MS );
+					setState({
+						status: 'error',
+						value: null,
+						returns: null,
+						error,
+					});
+				});
+		}, DEBOUNCE_MS);
 
 		return () => {
-			clearTimeout( timerRef.current );
+			clearTimeout(timerRef.current);
 		};
-	}, [ source, argsKey, postId, size ] );
+	}, [
+		source,
+		argsKey,
+		postId,
+		size,
+		editedPost?.title,
+		editedPost?.excerpt,
+		editedPost?.id,
+		editedPost?.type,
+		editedPost?.link,
+	]);
 
 	return state;
 }

--- a/src/components/DynamicTagPicker/useDynamicTagPreview.js
+++ b/src/components/DynamicTagPicker/useDynamicTagPreview.js
@@ -5,7 +5,7 @@
  * (scalar string or image descriptor) so the picker can show users
  * exactly what will render on the frontend.
  */
-import { useEffect, useState, useRef } from '@wordpress/element';
+import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -15,6 +15,11 @@ export function useDynamicTagPreview( { source, args, postId, size } ) {
 	const [ state, setState ] = useState( { status: 'idle', value: null, returns: null, error: null } );
 	const timerRef = useRef( null );
 	const requestRef = useRef( 0 );
+
+	// Stabilise the args dependency — serialising inside the effect would
+	// re-run JSON.stringify on every render, including renders where args
+	// has not changed.
+	const argsKey = useMemo( () => JSON.stringify( args || {} ), [ args ] );
 
 	useEffect( () => {
 		if ( ! source ) {
@@ -57,7 +62,7 @@ export function useDynamicTagPreview( { source, args, postId, size } ) {
 		return () => {
 			clearTimeout( timerRef.current );
 		};
-	}, [ source, JSON.stringify( args || {} ), postId, size ] );
+	}, [ source, argsKey, postId, size ] );
 
 	return state;
 }

--- a/src/components/DynamicTagPicker/useDynamicTagPreview.js
+++ b/src/components/DynamicTagPicker/useDynamicTagPreview.js
@@ -1,0 +1,63 @@
+/**
+ * useDynamicTagPreview — debounced live-preview fetcher.
+ *
+ * Given a source + args + postId, returns the resolved preview value
+ * (scalar string or image descriptor) so the picker can show users
+ * exactly what will render on the frontend.
+ */
+import { useEffect, useState, useRef } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+
+const DEBOUNCE_MS = 250;
+
+export function useDynamicTagPreview( { source, args, postId, size } ) {
+	const [ state, setState ] = useState( { status: 'idle', value: null, returns: null, error: null } );
+	const timerRef = useRef( null );
+	const requestRef = useRef( 0 );
+
+	useEffect( () => {
+		if ( ! source ) {
+			setState( { status: 'idle', value: null, returns: null, error: null } );
+			return undefined;
+		}
+
+		clearTimeout( timerRef.current );
+		const requestId = ++requestRef.current;
+		setState( ( prev ) => ( { ...prev, status: 'loading' } ) );
+
+		timerRef.current = setTimeout( () => {
+			apiFetch( {
+				path: addQueryArgs( '/designsetgo/v1/dynamic-tags/preview', {
+					source,
+					args: args || {},
+					postId: postId || undefined,
+					size: size || undefined,
+				} ),
+			} )
+				.then( ( response ) => {
+					if ( requestRef.current !== requestId ) {
+						return;
+					}
+					setState( {
+						status: response.status || 'resolved',
+						value: response.value ?? null,
+						returns: response.returns || null,
+						error: null,
+					} );
+				} )
+				.catch( ( error ) => {
+					if ( requestRef.current !== requestId ) {
+						return;
+					}
+					setState( { status: 'error', value: null, returns: null, error } );
+				} );
+		}, DEBOUNCE_MS );
+
+		return () => {
+			clearTimeout( timerRef.current );
+		};
+	}, [ source, JSON.stringify( args || {} ), postId, size ] );
+
+	return state;
+}

--- a/src/components/DynamicTagPicker/useDynamicTagSources.js
+++ b/src/components/DynamicTagPicker/useDynamicTagSources.js
@@ -9,64 +9,66 @@ import apiFetch from '@wordpress/api-fetch';
 
 let cachedPromise = null;
 
-export function useDynamicTagSources( { returns } = {} ) {
-	const [ state, setState ] = useState( () => ( {
+export function useDynamicTagSources({ returns } = {}) {
+	const [state, setState] = useState(() => ({
 		status: 'loading',
 		groups: [],
 		sources: [],
 		error: null,
-	} ) );
+	}));
 
-	useEffect( () => {
+	useEffect(() => {
 		let cancelled = false;
 
-		if ( ! cachedPromise ) {
-			cachedPromise = apiFetch( {
+		if (!cachedPromise) {
+			cachedPromise = apiFetch({
 				path: '/designsetgo/v1/dynamic-tags/sources',
-			} ).catch( ( error ) => {
+			}).catch((error) => {
 				cachedPromise = null;
 				throw error;
-			} );
+			});
 		}
 
 		cachedPromise
-			.then( ( response ) => {
-				if ( cancelled ) {
+			.then((response) => {
+				if (cancelled) {
 					return;
 				}
-				setState( {
+				setState({
 					status: 'ready',
 					groups: response.groups || [],
 					sources: response.sources || [],
 					error: null,
-				} );
-			} )
-			.catch( ( error ) => {
-				if ( cancelled ) {
+				});
+			})
+			.catch((error) => {
+				if (cancelled) {
 					return;
 				}
-				setState( {
+				setState({
 					status: 'error',
 					groups: [],
 					sources: [],
 					error,
-				} );
-			} );
+				});
+			});
 
 		return () => {
 			cancelled = true;
 		};
-	}, [] );
+	}, []);
 
-	if ( state.status !== 'ready' || ! returns ) {
+	if (state.status !== 'ready' || !returns) {
 		return state;
 	}
 
-	const wanted = Array.isArray( returns ) ? returns : [ returns ];
-	const filtered = state.sources.filter( ( source ) => {
-		const sourceReturns = Array.isArray( source.returns ) ? source.returns : [];
-		return wanted.some( ( type ) => sourceReturns.includes( type ) );
-	} );
+	const wanted = Array.isArray(returns) ? returns : [returns];
+	const filtered = state.sources.filter((source) => {
+		const sourceReturns = Array.isArray(source.returns)
+			? source.returns
+			: [];
+		return wanted.some((type) => sourceReturns.includes(type));
+	});
 
 	return { ...state, sources: filtered };
 }

--- a/src/components/DynamicTagPicker/useDynamicTagSources.js
+++ b/src/components/DynamicTagPicker/useDynamicTagSources.js
@@ -1,0 +1,72 @@
+/**
+ * useDynamicTagSources — hook that fetches the Dynamic Tag source catalog.
+ *
+ * Caches the response at module scope so opening the picker multiple
+ * times doesn't hit REST repeatedly.
+ */
+import { useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+let cachedPromise = null;
+
+export function useDynamicTagSources( { returns } = {} ) {
+	const [ state, setState ] = useState( () => ( {
+		status: 'loading',
+		groups: [],
+		sources: [],
+		error: null,
+	} ) );
+
+	useEffect( () => {
+		let cancelled = false;
+
+		if ( ! cachedPromise ) {
+			cachedPromise = apiFetch( {
+				path: '/designsetgo/v1/dynamic-tags/sources',
+			} ).catch( ( error ) => {
+				cachedPromise = null;
+				throw error;
+			} );
+		}
+
+		cachedPromise
+			.then( ( response ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setState( {
+					status: 'ready',
+					groups: response.groups || [],
+					sources: response.sources || [],
+					error: null,
+				} );
+			} )
+			.catch( ( error ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setState( {
+					status: 'error',
+					groups: [],
+					sources: [],
+					error,
+				} );
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [] );
+
+	if ( state.status !== 'ready' || ! returns ) {
+		return state;
+	}
+
+	const wanted = Array.isArray( returns ) ? returns : [ returns ];
+	const filtered = state.sources.filter( ( source ) => {
+		const sourceReturns = Array.isArray( source.returns ) ? source.returns : [];
+		return wanted.some( ( type ) => sourceReturns.includes( type ) );
+	} );
+
+	return { ...state, sources: filtered };
+}

--- a/src/extensions/dynamic-tags/bindable-attributes.js
+++ b/src/extensions/dynamic-tags/bindable-attributes.js
@@ -1,0 +1,34 @@
+/**
+ * Allowlist of bindable attributes per core block, per the WordPress
+ * Block Bindings API. Keep in sync with WP core — extending an
+ * unsupported attribute would write bindings that core silently ignores.
+ *
+ * https://developer.wordpress.org/block-editor/reference-guides/block-api/block-bindings/
+ */
+export const BINDABLE_ATTRIBUTES = {
+	'core/paragraph': [
+		{ attribute: 'content', returns: [ 'text' ], label: 'Content' },
+	],
+	'core/heading': [
+		{ attribute: 'content', returns: [ 'text' ], label: 'Content' },
+	],
+	'core/image': [
+		{ attribute: 'url', returns: [ 'image', 'url' ], label: 'Image URL', subkey: 'url' },
+		{ attribute: 'id', returns: [ 'image', 'number' ], label: 'Attachment ID', subkey: 'id' },
+		{ attribute: 'alt', returns: [ 'text' ], label: 'Alt text', subkey: 'alt' },
+		{ attribute: 'title', returns: [ 'text' ], label: 'Title', subkey: 'title' },
+	],
+	'core/button': [
+		{ attribute: 'url', returns: [ 'url' ], label: 'URL' },
+		{ attribute: 'text', returns: [ 'text' ], label: 'Text' },
+		{ attribute: 'linkTarget', returns: [ 'text' ], label: 'Link target' },
+		{ attribute: 'rel', returns: [ 'text' ], label: 'Rel' },
+	],
+	'core/post-date': [
+		{ attribute: 'datetime', returns: [ 'date', 'text' ], label: 'Date' },
+	],
+};
+
+export function getBindableAttributes( blockName ) {
+	return BINDABLE_ATTRIBUTES[ blockName ] || null;
+}

--- a/src/extensions/dynamic-tags/bindable-attributes.js
+++ b/src/extensions/dynamic-tags/bindable-attributes.js
@@ -1,3 +1,5 @@
+import { __ } from '@wordpress/i18n';
+
 /**
  * Allowlist of bindable attributes per core block, per the WordPress
  * Block Bindings API. Keep in sync with WP core — extending an
@@ -7,25 +9,25 @@
  */
 export const BINDABLE_ATTRIBUTES = {
 	'core/paragraph': [
-		{ attribute: 'content', returns: [ 'text' ], label: 'Content' },
+		{ attribute: 'content', returns: [ 'text' ], label: __( 'Content', 'designsetgo' ) },
 	],
 	'core/heading': [
-		{ attribute: 'content', returns: [ 'text' ], label: 'Content' },
+		{ attribute: 'content', returns: [ 'text' ], label: __( 'Content', 'designsetgo' ) },
 	],
 	'core/image': [
-		{ attribute: 'url', returns: [ 'image', 'url' ], label: 'Image URL', subkey: 'url' },
-		{ attribute: 'id', returns: [ 'image', 'number' ], label: 'Attachment ID', subkey: 'id' },
-		{ attribute: 'alt', returns: [ 'text' ], label: 'Alt text', subkey: 'alt' },
-		{ attribute: 'title', returns: [ 'text' ], label: 'Title', subkey: 'title' },
+		{ attribute: 'url', returns: [ 'image', 'url' ], label: __( 'Image URL', 'designsetgo' ), subkey: 'url' },
+		{ attribute: 'id', returns: [ 'image', 'number' ], label: __( 'Attachment ID', 'designsetgo' ), subkey: 'id' },
+		{ attribute: 'alt', returns: [ 'text' ], label: __( 'Alt text', 'designsetgo' ), subkey: 'alt' },
+		{ attribute: 'title', returns: [ 'text' ], label: __( 'Title', 'designsetgo' ), subkey: 'title' },
 	],
 	'core/button': [
-		{ attribute: 'url', returns: [ 'url' ], label: 'URL' },
-		{ attribute: 'text', returns: [ 'text' ], label: 'Text' },
-		{ attribute: 'linkTarget', returns: [ 'text' ], label: 'Link target' },
-		{ attribute: 'rel', returns: [ 'text' ], label: 'Rel' },
+		{ attribute: 'url', returns: [ 'url' ], label: __( 'URL', 'designsetgo' ) },
+		{ attribute: 'text', returns: [ 'text' ], label: __( 'Text', 'designsetgo' ) },
+		{ attribute: 'linkTarget', returns: [ 'text' ], label: __( 'Link target', 'designsetgo' ) },
+		{ attribute: 'rel', returns: [ 'text' ], label: __( 'Rel', 'designsetgo' ) },
 	],
 	'core/post-date': [
-		{ attribute: 'datetime', returns: [ 'date', 'text' ], label: 'Date' },
+		{ attribute: 'datetime', returns: [ 'date', 'text' ], label: __( 'Date', 'designsetgo' ) },
 	],
 };
 

--- a/src/extensions/dynamic-tags/bindable-attributes.js
+++ b/src/extensions/dynamic-tags/bindable-attributes.js
@@ -9,28 +9,72 @@ import { __ } from '@wordpress/i18n';
  */
 export const BINDABLE_ATTRIBUTES = {
 	'core/paragraph': [
-		{ attribute: 'content', returns: [ 'text' ], label: __( 'Content', 'designsetgo' ) },
+		{
+			attribute: 'content',
+			returns: ['text'],
+			label: __('Content', 'designsetgo'),
+		},
 	],
 	'core/heading': [
-		{ attribute: 'content', returns: [ 'text' ], label: __( 'Content', 'designsetgo' ) },
+		{
+			attribute: 'content',
+			returns: ['text'],
+			label: __('Content', 'designsetgo'),
+		},
 	],
 	'core/image': [
-		{ attribute: 'url', returns: [ 'image', 'url' ], label: __( 'Image URL', 'designsetgo' ), subkey: 'url' },
-		{ attribute: 'id', returns: [ 'image', 'number' ], label: __( 'Attachment ID', 'designsetgo' ), subkey: 'id' },
-		{ attribute: 'alt', returns: [ 'text' ], label: __( 'Alt text', 'designsetgo' ), subkey: 'alt' },
-		{ attribute: 'title', returns: [ 'text' ], label: __( 'Title', 'designsetgo' ), subkey: 'title' },
+		{
+			attribute: 'url',
+			returns: ['image', 'url'],
+			label: __('Image URL', 'designsetgo'),
+			subkey: 'url',
+		},
+		{
+			attribute: 'id',
+			returns: ['image', 'number'],
+			label: __('Attachment ID', 'designsetgo'),
+			subkey: 'id',
+		},
+		{
+			attribute: 'alt',
+			returns: ['text'],
+			label: __('Alt text', 'designsetgo'),
+			subkey: 'alt',
+		},
+		{
+			attribute: 'title',
+			returns: ['text'],
+			label: __('Title', 'designsetgo'),
+			subkey: 'title',
+		},
 	],
 	'core/button': [
-		{ attribute: 'url', returns: [ 'url' ], label: __( 'URL', 'designsetgo' ) },
-		{ attribute: 'text', returns: [ 'text' ], label: __( 'Text', 'designsetgo' ) },
-		{ attribute: 'linkTarget', returns: [ 'text' ], label: __( 'Link target', 'designsetgo' ) },
-		{ attribute: 'rel', returns: [ 'text' ], label: __( 'Rel', 'designsetgo' ) },
+		{ attribute: 'url', returns: ['url'], label: __('URL', 'designsetgo') },
+		{
+			attribute: 'text',
+			returns: ['text'],
+			label: __('Text', 'designsetgo'),
+		},
+		{
+			attribute: 'linkTarget',
+			returns: ['text'],
+			label: __('Link target', 'designsetgo'),
+		},
+		{
+			attribute: 'rel',
+			returns: ['text'],
+			label: __('Rel', 'designsetgo'),
+		},
 	],
 	'core/post-date': [
-		{ attribute: 'datetime', returns: [ 'date', 'text' ], label: __( 'Date', 'designsetgo' ) },
+		{
+			attribute: 'datetime',
+			returns: ['date', 'text'],
+			label: __('Date', 'designsetgo'),
+		},
 	],
 };
 
-export function getBindableAttributes( blockName ) {
-	return BINDABLE_ATTRIBUTES[ blockName ] || null;
+export function getBindableAttributes(blockName) {
+	return BINDABLE_ATTRIBUTES[blockName] || null;
 }

--- a/src/extensions/dynamic-tags/filters.js
+++ b/src/extensions/dynamic-tags/filters.js
@@ -4,10 +4,12 @@
  * Adds two ways to bind any of a core block's bindable attributes to a
  * Dynamic Tag source:
  *
- *  1. A toolbar icon in the block's inline BlockControls (lightning-bolt
- *     for unbound, filled state for bound). Single-attribute blocks open
- *     the picker directly; multi-attribute blocks (image, button) open a
- *     dropdown menu of attribute names that each open the picker.
+ *  1. A toolbar icon in the block's inline BlockControls (database
+ *     cylinder — the conventional "dynamic data" symbol; deliberately
+ *     distinct from the lightning-bolt used by the block-animations
+ *     extension). Single-attribute blocks open the picker directly;
+ *     multi-attribute blocks (image, button) open a dropdown menu of
+ *     attribute names that each open the picker.
  *
  *  2. An Inspector "Dynamic Tags" panel listing every bindable attribute.
  *
@@ -31,11 +33,40 @@ import { Fragment, useState } from '@wordpress/element';
 import { DynamicTagButton, DynamicTagPicker } from '../../components/DynamicTagPicker';
 import { getBindableAttributes } from './bindable-attributes';
 
+// Database cylinder — the conventional "dynamic data" icon used by
+// Elementor and other page builders, and matches the icon already on
+// our DynamicTagButton in the inspector. Deliberately distinct from
+// the block-animations extension's lightning bolt.
 const dynamicIcon = (
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		width="20"
+		height="20"
+		aria-hidden="true"
+	>
+		<ellipse
+			cx="12"
+			cy="5"
+			rx="7"
+			ry="2.5"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.6"
+		/>
 		<path
-			fill="currentColor"
-			d="M13 2L3 14h7l-1 8 10-12h-7l1-8z"
+			d="M5 5v6c0 1.38 3.13 2.5 7 2.5s7-1.12 7-2.5V5"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.6"
+			strokeLinecap="round"
+		/>
+		<path
+			d="M5 11v6c0 1.38 3.13 2.5 7 2.5s7-1.12 7-2.5v-6"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.6"
+			strokeLinecap="round"
 		/>
 	</svg>
 );

--- a/src/extensions/dynamic-tags/filters.js
+++ b/src/extensions/dynamic-tags/filters.js
@@ -1,0 +1,100 @@
+/**
+ * Dynamic Tags extension — inline "Connect" button per bindable attribute.
+ *
+ * Adds a picker trigger to the Inspector sidebar for every core block
+ * whose attribute schema supports the WP Block Bindings API. Writes
+ * directly to the native `attributes.metadata.bindings` object so the
+ * binding resolves through core's own pipeline on both preview and render.
+ */
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { InspectorControls } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+
+import { DynamicTagButton } from '../../components/DynamicTagPicker';
+import { getBindableAttributes } from './bindable-attributes';
+
+const withDynamicTagsInspector = createHigherOrderComponent( ( BlockEdit ) => {
+	return function WithDynamicTagsInspector( props ) {
+		const bindable = getBindableAttributes( props.name );
+		if ( ! bindable ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		const { attributes, setAttributes } = props;
+		const metadata = attributes.metadata || {};
+		const bindings = metadata.bindings || {};
+
+		const setBinding = ( attributeName, nextBinding, subkey ) => {
+			const nextBindings = { ...bindings };
+
+			if ( ! nextBinding ) {
+				delete nextBindings[ attributeName ];
+			} else {
+				const args = { ...( nextBinding.args || {} ) };
+				// Image-typed attributes need a subkey to project the source's
+				// array value into a scalar. Merge the per-attribute default.
+				if ( subkey && ! args.subkey ) {
+					args.subkey = subkey;
+				}
+				nextBindings[ attributeName ] = {
+					source: nextBinding.source,
+					args,
+				};
+			}
+
+			const nextMetadata = { ...metadata };
+			if ( Object.keys( nextBindings ).length === 0 ) {
+				delete nextMetadata.bindings;
+			} else {
+				nextMetadata.bindings = nextBindings;
+			}
+
+			setAttributes( {
+				metadata: Object.keys( nextMetadata ).length ? nextMetadata : undefined,
+			} );
+		};
+
+		return (
+			<Fragment>
+				<BlockEdit { ...props } />
+				<InspectorControls>
+					<PanelBody
+						title={ __( 'Dynamic Tags', 'designsetgo' ) }
+						initialOpen={ Object.keys( bindings ).length > 0 }
+					>
+						<VStack spacing={ 3 }>
+							{ bindable.map( ( { attribute, returns, label, subkey } ) => {
+								const current = bindings[ attribute ] || null;
+								return (
+									<HStack key={ attribute } justify="space-between" alignment="center">
+										<span className="dsgo-dynamic-tags-extension__label">
+											{ label }
+										</span>
+										<DynamicTagButton
+											value={ current }
+											onChange={ ( next ) => setBinding( attribute, next, subkey ) }
+											returns={ returns }
+										/>
+									</HStack>
+								);
+							} ) }
+						</VStack>
+					</PanelBody>
+				</InspectorControls>
+			</Fragment>
+		);
+	};
+}, 'withDynamicTagsInspector' );
+
+addFilter(
+	'editor.BlockEdit',
+	'designsetgo/dynamic-tags-inspector',
+	withDynamicTagsInspector
+);

--- a/src/extensions/dynamic-tags/filters.js
+++ b/src/extensions/dynamic-tags/filters.js
@@ -1,114 +1,235 @@
 /**
- * Dynamic Tags extension — inline "Connect" button per bindable attribute.
+ * Dynamic Tags extension — inline toolbar + Inspector picker.
  *
- * Adds a picker trigger to the Inspector sidebar for every core block
- * whose attribute schema supports the WP Block Bindings API. Writes
- * directly to the native `attributes.metadata.bindings` object so the
- * binding resolves through core's own pipeline on both preview and render.
+ * Adds two ways to bind any of a core block's bindable attributes to a
+ * Dynamic Tag source:
+ *
+ *  1. A toolbar icon in the block's inline BlockControls (lightning-bolt
+ *     for unbound, filled state for bound). Single-attribute blocks open
+ *     the picker directly; multi-attribute blocks (image, button) open a
+ *     dropdown menu of attribute names that each open the picker.
+ *
+ *  2. An Inspector "Dynamic Tags" panel listing every bindable attribute.
+ *
+ * Both paths write to native `attributes.metadata.bindings` so the value
+ * resolves through WP core's own bindings pipeline.
  */
 import { addFilter } from '@wordpress/hooks';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { InspectorControls } from '@wordpress/block-editor';
+import { InspectorControls, BlockControls } from '@wordpress/block-editor';
 import {
 	PanelBody,
+	ToolbarGroup,
+	ToolbarButton,
+	ToolbarDropdownMenu,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { Fragment, useState } from '@wordpress/element';
 
-import { DynamicTagButton } from '../../components/DynamicTagPicker';
+import { DynamicTagButton, DynamicTagPicker } from '../../components/DynamicTagPicker';
 import { getBindableAttributes } from './bindable-attributes';
 
-const withDynamicTagsInspector = createHigherOrderComponent((BlockEdit) => {
-	return function WithDynamicTagsInspector(props) {
+const dynamicIcon = (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+		<path
+			fill="currentColor"
+			d="M13 2L3 14h7l-1 8 10-12h-7l1-8z"
+		/>
+	</svg>
+);
+
+function withDynamicTagsBindingsState({ attributes, setAttributes }) {
+	const metadata = attributes.metadata || {};
+	const bindings = metadata.bindings || {};
+
+	const setBinding = (attributeName, nextBinding, subkey) => {
+		const nextBindings = { ...bindings };
+
+		if (!nextBinding) {
+			delete nextBindings[attributeName];
+		} else {
+			const args = { ...(nextBinding.args || {}) };
+			// Image-typed attributes need a subkey to project the source's
+			// array value into a scalar. Merge the per-attribute default.
+			if (subkey && !args.subkey) {
+				args.subkey = subkey;
+			}
+			nextBindings[attributeName] = {
+				source: nextBinding.source,
+				args,
+			};
+		}
+
+		const nextMetadata = { ...metadata };
+		if (Object.keys(nextBindings).length === 0) {
+			delete nextMetadata.bindings;
+		} else {
+			nextMetadata.bindings = nextBindings;
+		}
+
+		setAttributes({
+			metadata: Object.keys(nextMetadata).length ? nextMetadata : undefined,
+		});
+	};
+
+	return { bindings, setBinding };
+}
+
+function DynamicTagsToolbar({ bindable, bindings, setBinding }) {
+	const [pickerAttribute, setPickerAttribute] = useState(null);
+
+	const isAnyConnected = Object.keys(bindings).length > 0;
+	const active = bindable.find((b) => b.attribute === pickerAttribute) || null;
+	const currentValue = active ? bindings[active.attribute] || null : null;
+
+	const closePicker = () => setPickerAttribute(null);
+
+	// Single bindable attribute (paragraph, heading, post-date): one button.
+	if (bindable.length === 1) {
+		const only = bindable[0];
+		const isConnected = Boolean(bindings[only.attribute]);
+		return (
+			<>
+				<BlockControls group="other">
+					<ToolbarGroup>
+						<ToolbarButton
+							icon={dynamicIcon}
+							label={
+								isConnected
+									? sprintf(
+											/* translators: %s: bound source slug */
+											__('Dynamic — bound to %s', 'designsetgo'),
+											bindings[only.attribute].source
+										)
+									: __('Connect to Dynamic Tag', 'designsetgo')
+							}
+							isActive={isConnected}
+							onClick={() => setPickerAttribute(only.attribute)}
+						/>
+					</ToolbarGroup>
+				</BlockControls>
+				{pickerAttribute && (
+					<DynamicTagPicker
+						isOpen
+						onClose={closePicker}
+						value={currentValue}
+						onChange={(next) =>
+							setBinding(active.attribute, next, active.subkey)
+						}
+						returns={active.returns}
+						title={sprintf(
+							/* translators: %s: bindable attribute label */
+							__('Dynamic Tag — %s', 'designsetgo'),
+							active.label
+						)}
+					/>
+				)}
+			</>
+		);
+	}
+
+	// Multi-attribute block (image, button): dropdown menu.
+	const controls = bindable.map((b) => ({
+		title: bindings[b.attribute]
+			? sprintf(
+					/* translators: 1: attribute label, 2: bound source slug */
+					__('%1$s — %2$s', 'designsetgo'),
+					b.label,
+					bindings[b.attribute].source
+				)
+			: b.label,
+		icon: bindings[b.attribute] ? dynamicIcon : undefined,
+		onClick: () => setPickerAttribute(b.attribute),
+	}));
+
+	return (
+		<>
+			<BlockControls group="other">
+				<ToolbarGroup>
+					<ToolbarDropdownMenu
+						icon={dynamicIcon}
+						label={__('Connect to Dynamic Tag', 'designsetgo')}
+						toggleProps={{ isActive: isAnyConnected }}
+						controls={controls}
+					/>
+				</ToolbarGroup>
+			</BlockControls>
+			{pickerAttribute && active && (
+				<DynamicTagPicker
+					isOpen
+					onClose={closePicker}
+					value={currentValue}
+					onChange={(next) =>
+						setBinding(active.attribute, next, active.subkey)
+					}
+					returns={active.returns}
+					title={sprintf(
+						/* translators: %s: bindable attribute label */
+						__('Dynamic Tag — %s', 'designsetgo'),
+						active.label
+					)}
+				/>
+			)}
+		</>
+	);
+}
+
+const withDynamicTagsControls = createHigherOrderComponent((BlockEdit) => {
+	return function WithDynamicTagsControls(props) {
 		const bindable = getBindableAttributes(props.name);
 		if (!bindable) {
 			return <BlockEdit {...props} />;
 		}
 
-		const { attributes, setAttributes } = props;
-		const metadata = attributes.metadata || {};
-		const bindings = metadata.bindings || {};
-
-		const setBinding = (attributeName, nextBinding, subkey) => {
-			const nextBindings = { ...bindings };
-
-			if (!nextBinding) {
-				delete nextBindings[attributeName];
-			} else {
-				const args = { ...(nextBinding.args || {}) };
-				// Image-typed attributes need a subkey to project the source's
-				// array value into a scalar. Merge the per-attribute default.
-				if (subkey && !args.subkey) {
-					args.subkey = subkey;
-				}
-				nextBindings[attributeName] = {
-					source: nextBinding.source,
-					args,
-				};
-			}
-
-			const nextMetadata = { ...metadata };
-			if (Object.keys(nextBindings).length === 0) {
-				delete nextMetadata.bindings;
-			} else {
-				nextMetadata.bindings = nextBindings;
-			}
-
-			setAttributes({
-				metadata: Object.keys(nextMetadata).length
-					? nextMetadata
-					: undefined,
-			});
-		};
+		const { bindings, setBinding } = withDynamicTagsBindingsState(props);
 
 		return (
 			<Fragment>
 				<BlockEdit {...props} />
+				<DynamicTagsToolbar
+					bindable={bindable}
+					bindings={bindings}
+					setBinding={setBinding}
+				/>
 				<InspectorControls>
 					<PanelBody
 						title={__('Dynamic Tags', 'designsetgo')}
 						initialOpen={Object.keys(bindings).length > 0}
 					>
 						<VStack spacing={3}>
-							{bindable.map(
-								({ attribute, returns, label, subkey }) => {
-									const current = bindings[attribute] || null;
-									return (
-										<HStack
-											key={attribute}
-											justify="space-between"
-											alignment="center"
-										>
-											<span className="dsgo-dynamic-tags-extension__label">
-												{label}
-											</span>
-											<DynamicTagButton
-												value={current}
-												onChange={(next) =>
-													setBinding(
-														attribute,
-														next,
-														subkey
-													)
-												}
-												returns={returns}
-											/>
-										</HStack>
-									);
-								}
-							)}
+							{bindable.map(({ attribute, returns, label, subkey }) => {
+								const current = bindings[attribute] || null;
+								return (
+									<HStack
+										key={attribute}
+										justify="space-between"
+										alignment="center"
+									>
+										<span className="dsgo-dynamic-tags-extension__label">
+											{label}
+										</span>
+										<DynamicTagButton
+											value={current}
+											onChange={(next) =>
+												setBinding(attribute, next, subkey)
+											}
+											returns={returns}
+										/>
+									</HStack>
+								);
+							})}
 						</VStack>
 					</PanelBody>
 				</InspectorControls>
 			</Fragment>
 		);
 	};
-}, 'withDynamicTagsInspector');
+}, 'withDynamicTagsControls');
 
 addFilter(
 	'editor.BlockEdit',
-	'designsetgo/dynamic-tags-inspector',
-	withDynamicTagsInspector
+	'designsetgo/dynamic-tags-controls',
+	withDynamicTagsControls
 );

--- a/src/extensions/dynamic-tags/filters.js
+++ b/src/extensions/dynamic-tags/filters.js
@@ -20,78 +20,92 @@ import { Fragment } from '@wordpress/element';
 import { DynamicTagButton } from '../../components/DynamicTagPicker';
 import { getBindableAttributes } from './bindable-attributes';
 
-const withDynamicTagsInspector = createHigherOrderComponent( ( BlockEdit ) => {
-	return function WithDynamicTagsInspector( props ) {
-		const bindable = getBindableAttributes( props.name );
-		if ( ! bindable ) {
-			return <BlockEdit { ...props } />;
+const withDynamicTagsInspector = createHigherOrderComponent((BlockEdit) => {
+	return function WithDynamicTagsInspector(props) {
+		const bindable = getBindableAttributes(props.name);
+		if (!bindable) {
+			return <BlockEdit {...props} />;
 		}
 
 		const { attributes, setAttributes } = props;
 		const metadata = attributes.metadata || {};
 		const bindings = metadata.bindings || {};
 
-		const setBinding = ( attributeName, nextBinding, subkey ) => {
+		const setBinding = (attributeName, nextBinding, subkey) => {
 			const nextBindings = { ...bindings };
 
-			if ( ! nextBinding ) {
-				delete nextBindings[ attributeName ];
+			if (!nextBinding) {
+				delete nextBindings[attributeName];
 			} else {
-				const args = { ...( nextBinding.args || {} ) };
+				const args = { ...(nextBinding.args || {}) };
 				// Image-typed attributes need a subkey to project the source's
 				// array value into a scalar. Merge the per-attribute default.
-				if ( subkey && ! args.subkey ) {
+				if (subkey && !args.subkey) {
 					args.subkey = subkey;
 				}
-				nextBindings[ attributeName ] = {
+				nextBindings[attributeName] = {
 					source: nextBinding.source,
 					args,
 				};
 			}
 
 			const nextMetadata = { ...metadata };
-			if ( Object.keys( nextBindings ).length === 0 ) {
+			if (Object.keys(nextBindings).length === 0) {
 				delete nextMetadata.bindings;
 			} else {
 				nextMetadata.bindings = nextBindings;
 			}
 
-			setAttributes( {
-				metadata: Object.keys( nextMetadata ).length ? nextMetadata : undefined,
-			} );
+			setAttributes({
+				metadata: Object.keys(nextMetadata).length
+					? nextMetadata
+					: undefined,
+			});
 		};
 
 		return (
 			<Fragment>
-				<BlockEdit { ...props } />
+				<BlockEdit {...props} />
 				<InspectorControls>
 					<PanelBody
-						title={ __( 'Dynamic Tags', 'designsetgo' ) }
-						initialOpen={ Object.keys( bindings ).length > 0 }
+						title={__('Dynamic Tags', 'designsetgo')}
+						initialOpen={Object.keys(bindings).length > 0}
 					>
-						<VStack spacing={ 3 }>
-							{ bindable.map( ( { attribute, returns, label, subkey } ) => {
-								const current = bindings[ attribute ] || null;
-								return (
-									<HStack key={ attribute } justify="space-between" alignment="center">
-										<span className="dsgo-dynamic-tags-extension__label">
-											{ label }
-										</span>
-										<DynamicTagButton
-											value={ current }
-											onChange={ ( next ) => setBinding( attribute, next, subkey ) }
-											returns={ returns }
-										/>
-									</HStack>
-								);
-							} ) }
+						<VStack spacing={3}>
+							{bindable.map(
+								({ attribute, returns, label, subkey }) => {
+									const current = bindings[attribute] || null;
+									return (
+										<HStack
+											key={attribute}
+											justify="space-between"
+											alignment="center"
+										>
+											<span className="dsgo-dynamic-tags-extension__label">
+												{label}
+											</span>
+											<DynamicTagButton
+												value={current}
+												onChange={(next) =>
+													setBinding(
+														attribute,
+														next,
+														subkey
+													)
+												}
+												returns={returns}
+											/>
+										</HStack>
+									);
+								}
+							)}
 						</VStack>
 					</PanelBody>
 				</InspectorControls>
 			</Fragment>
 		);
 	};
-}, 'withDynamicTagsInspector' );
+}, 'withDynamicTagsInspector');
 
 addFilter(
 	'editor.BlockEdit',

--- a/src/extensions/dynamic-tags/filters.js
+++ b/src/extensions/dynamic-tags/filters.js
@@ -71,7 +71,7 @@ const dynamicIcon = (
 	</svg>
 );
 
-function withDynamicTagsBindingsState({ attributes, setAttributes }) {
+function getDynamicTagsBindings({ attributes, setAttributes }) {
 	const metadata = attributes.metadata || {};
 	const bindings = metadata.bindings || {};
 
@@ -214,7 +214,7 @@ const withDynamicTagsControls = createHigherOrderComponent((BlockEdit) => {
 			return <BlockEdit {...props} />;
 		}
 
-		const { bindings, setBinding } = withDynamicTagsBindingsState(props);
+		const { bindings, setBinding } = getDynamicTagsBindings(props);
 
 		return (
 			<Fragment>

--- a/src/extensions/dynamic-tags/index.js
+++ b/src/extensions/dynamic-tags/index.js
@@ -1,0 +1,7 @@
+/**
+ * Dynamic Tags extension — boot.
+ *
+ * Adds a per-attribute Dynamic Tag picker to the Inspector for every
+ * core block that supports the WordPress Block Bindings API.
+ */
+import './filters.js';

--- a/src/extensions/dynamic-tags/index.js
+++ b/src/extensions/dynamic-tags/index.js
@@ -1,7 +1,25 @@
 /**
  * Dynamic Tags extension — boot.
  *
- * Adds a per-attribute Dynamic Tag picker to the Inspector for every
- * core block that supports the WordPress Block Bindings API.
+ * Adds a per-attribute Dynamic Tag picker to the Inspector and the
+ * inline toolbar of every core block that supports the WordPress Block
+ * Bindings API, plus JS-side bindings sources so the editor canvas
+ * shows the resolved value live (rather than the source label as a
+ * placeholder).
+ *
+ * Honours the admin Block Manager's enabledExtensions allowlist —
+ * if `dynamic-tags` is explicitly excluded by the site, none of the
+ * editor UI or live-preview bindings register.
  */
-import './filters.js';
+const enabled =
+	typeof window !== 'undefined' &&
+	window.dsgoSettings?.enabledExtensions !== undefined
+		? // Empty list = all extensions enabled (mirrors the PHP default).
+			!window.dsgoSettings.enabledExtensions.length ||
+			window.dsgoSettings.enabledExtensions.includes('dynamic-tags')
+		: true;
+
+if (enabled) {
+	require('./filters.js');
+	require('./register-bindings-sources.js');
+}

--- a/src/extensions/dynamic-tags/register-bindings-sources.js
+++ b/src/extensions/dynamic-tags/register-bindings-sources.js
@@ -27,6 +27,7 @@
  */
 import {
 	registerBlockBindingsSource,
+	unregisterBlockBindingsSource,
 	getBlockBindingsSource,
 } from '@wordpress/blocks';
 import { store as editorStore } from '@wordpress/editor';
@@ -173,11 +174,13 @@ function buildGetValues(resolver) {
 
 export function registerEditorBindings() {
 	Object.entries(SCALAR_RESOLVERS).forEach(([slug, resolver]) => {
-		// Avoid double-registration (HMR / double-import) without
-		// swallowing any other error registerBlockBindingsSource may
-		// throw — narrow catch only after a positive existence check.
+		// PHP `register_block_bindings_source()` ships the source to the
+		// editor without a `getValues` resolver, so the canvas falls back
+		// to the source label as a placeholder. Re-register the JS side
+		// (unregister first; `registerBlockBindingsSource` rejects
+		// already-registered slugs) so the editor renders the live value.
 		if (getBlockBindingsSource?.(slug)) {
-			return;
+			unregisterBlockBindingsSource(slug);
 		}
 		registerBlockBindingsSource({
 			name: slug,

--- a/src/extensions/dynamic-tags/register-bindings-sources.js
+++ b/src/extensions/dynamic-tags/register-bindings-sources.js
@@ -1,0 +1,132 @@
+/**
+ * JS-side Block Bindings registration.
+ *
+ * Each `register_block_bindings_source()` call on the PHP side handles
+ * the FRONTEND render. To get a live, in-canvas preview of the resolved
+ * value while authors edit a post, WordPress also needs a JS-side
+ * `registerBlockBindingsSource` with a `getValues` callback — without
+ * it the editor falls back to the source's label (e.g. "Post title")
+ * as a placeholder.
+ *
+ * For post / site sources we resolve from the editor's live state
+ * (unsaved title, etc.) so the preview tracks the author's edits in
+ * real time. For sources that depend on data the editor doesn't have
+ * locally (ACF, post-meta, archive) we omit the JS-side getValues so
+ * core falls back to the placeholder until save → render pulls the
+ * real value through PHP.
+ *
+ * Registers on `dom-ready` so the @wordpress/blocks store is fully
+ * initialised before we register, regardless of script load order.
+ */
+import { registerBlockBindingsSource } from '@wordpress/blocks';
+import { store as editorStore } from '@wordpress/editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+import domReady from '@wordpress/dom-ready';
+
+// Each entry: PHP source slug → label + a getValue function that returns
+// a single resolved scalar from the editor / core-data stores. The
+// runner below maps the scalar across whichever block attributes the
+// binding is wired to.
+const SCALAR_RESOLVERS = {
+	'designsetgo/post-title': {
+		label: __('Post title', 'designsetgo'),
+		getValue: (select) => {
+			const editor = select(editorStore);
+			const title = editor?.getEditedPostAttribute?.('title');
+			if (typeof title === 'string') {
+				return title;
+			}
+			return editor?.getCurrentPost?.()?.title ?? '';
+		},
+	},
+	'designsetgo/post-excerpt': {
+		label: __('Post excerpt', 'designsetgo'),
+		getValue: (select) => {
+			const editor = select(editorStore);
+			const excerpt = editor?.getEditedPostAttribute?.('excerpt');
+			if (typeof excerpt === 'string') {
+				return excerpt;
+			}
+			return editor?.getCurrentPost?.()?.excerpt ?? '';
+		},
+	},
+	'designsetgo/post-id': {
+		label: __('Post ID', 'designsetgo'),
+		getValue: (select) =>
+			String(select(editorStore)?.getCurrentPostId?.() ?? ''),
+	},
+	'designsetgo/post-type': {
+		label: __('Post type', 'designsetgo'),
+		getValue: (select) => select(editorStore)?.getCurrentPostType?.() ?? '',
+	},
+	'designsetgo/post-permalink': {
+		label: __('Post permalink', 'designsetgo'),
+		getValue: (select) =>
+			select(editorStore)?.getCurrentPost?.()?.link ?? '',
+	},
+	'designsetgo/post-date': {
+		label: __('Post publish date', 'designsetgo'),
+		getValue: (select) => {
+			const editor = select(editorStore);
+			const date = editor?.getEditedPostAttribute?.('date');
+			if (typeof date === 'string' && date) {
+				return date;
+			}
+			return editor?.getCurrentPost?.()?.date ?? '';
+		},
+	},
+	'designsetgo/post-modified-date': {
+		label: __('Post modified date', 'designsetgo'),
+		getValue: (select) =>
+			select(editorStore)?.getCurrentPost?.()?.modified ?? '',
+	},
+	'designsetgo/site-title': {
+		label: __('Site title', 'designsetgo'),
+		getValue: (select) =>
+			select(coreStore)?.getEntityRecord?.('root', 'site')?.title ?? '',
+	},
+	'designsetgo/site-tagline': {
+		label: __('Site tagline', 'designsetgo'),
+		getValue: (select) =>
+			select(coreStore)?.getEntityRecord?.('root', 'site')?.description ??
+			'',
+	},
+	'designsetgo/site-url': {
+		label: __('Site URL', 'designsetgo'),
+		getValue: (select) =>
+			select(coreStore)?.getEntityRecord?.('root', 'site')?.url ?? '',
+	},
+};
+
+function buildGetValues(slug, getValue) {
+	return ({ bindings, select }) => {
+		const value = getValue(select) ?? '';
+		// `bindings` is the per-block-attribute binding object. Project the
+		// single scalar across every attribute the user wired up so the
+		// editor canvas reflects the resolved value live, regardless of
+		// which attribute (content / url / alt / …) the binding targets.
+		const out = {};
+		Object.keys(bindings || {}).forEach((attr) => {
+			out[attr] = value;
+		});
+		return out;
+	};
+}
+
+export function registerEditorBindings() {
+	Object.entries(SCALAR_RESOLVERS).forEach(([slug, { label, getValue }]) => {
+		try {
+			registerBlockBindingsSource({
+				name: slug,
+				label,
+				usesContext: ['postId', 'postType'],
+				getValues: buildGetValues(slug, getValue),
+			});
+		} catch (e) {
+			// Already registered (HMR / double-import) — ignore.
+		}
+	});
+}
+
+domReady(registerEditorBindings);

--- a/src/extensions/dynamic-tags/register-bindings-sources.js
+++ b/src/extensions/dynamic-tags/register-bindings-sources.js
@@ -8,104 +8,161 @@
  * it the editor falls back to the source's label (e.g. "Post title")
  * as a placeholder.
  *
- * For post / site sources we resolve from the editor's live state
- * (unsaved title, etc.) so the preview tracks the author's edits in
- * real time. For sources that depend on data the editor doesn't have
- * locally (ACF, post-meta, archive) we omit the JS-side getValues so
- * core falls back to the placeholder until save → render pulls the
- * real value through PHP.
+ * Resolution rules:
+ *  - When a block declares `context.postId` (Query Loop inner blocks,
+ *    template parts, etc.) AND that ID differs from the main editor
+ *    post, resolve via `core-data` `getEntityRecord` so each loop item
+ *    renders its own data instead of all showing the editor post.
+ *  - When the context post matches the main editor post (the default
+ *    case for a regular post being edited), prefer the editor store's
+ *    edited attributes so the preview tracks unsaved title/excerpt
+ *    edits in real time.
+ *  - Sources that depend on data the editor doesn't have locally (ACF,
+ *    post-meta, archive, user) have no JS resolver — core falls back
+ *    to the source label until save → render pulls the real value
+ *    through PHP.
  *
  * Registers on `dom-ready` so the @wordpress/blocks store is fully
  * initialised before we register, regardless of script load order.
  */
-import { registerBlockBindingsSource } from '@wordpress/blocks';
+import {
+	registerBlockBindingsSource,
+	getBlockBindingsSource,
+} from '@wordpress/blocks';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import domReady from '@wordpress/dom-ready';
 
-// Each entry: PHP source slug → label + a getValue function that returns
-// a single resolved scalar from the editor / core-data stores. The
-// runner below maps the scalar across whichever block attributes the
-// binding is wired to.
+// Each entry: PHP source slug → label + a resolver that returns a
+// scalar from the right source. The runner below maps the scalar
+// across whichever block attributes the binding is wired to.
 const SCALAR_RESOLVERS = {
 	'designsetgo/post-title': {
 		label: __('Post title', 'designsetgo'),
-		getValue: (select) => {
-			const editor = select(editorStore);
-			const title = editor?.getEditedPostAttribute?.('title');
-			if (typeof title === 'string') {
-				return title;
+		entityField: (record) =>
+			record?.title?.rendered ?? record?.title ?? '',
+		editorField: (editor) => {
+			const live = editor?.getEditedPostAttribute?.('title');
+			if (typeof live === 'string') {
+				return live;
 			}
 			return editor?.getCurrentPost?.()?.title ?? '';
 		},
 	},
 	'designsetgo/post-excerpt': {
 		label: __('Post excerpt', 'designsetgo'),
-		getValue: (select) => {
-			const editor = select(editorStore);
-			const excerpt = editor?.getEditedPostAttribute?.('excerpt');
-			if (typeof excerpt === 'string') {
-				return excerpt;
+		entityField: (record) =>
+			record?.excerpt?.rendered ?? record?.excerpt ?? '',
+		editorField: (editor) => {
+			const live = editor?.getEditedPostAttribute?.('excerpt');
+			if (typeof live === 'string') {
+				return live;
 			}
 			return editor?.getCurrentPost?.()?.excerpt ?? '';
 		},
 	},
 	'designsetgo/post-id': {
 		label: __('Post ID', 'designsetgo'),
-		getValue: (select) =>
-			String(select(editorStore)?.getCurrentPostId?.() ?? ''),
+		// Return the per-block context post ID directly when present —
+		// no entity-record fetch needed.
+		fromContext: (context) =>
+			context?.postId ? String(context.postId) : '',
+		editorField: (editor) => {
+			const id = editor?.getCurrentPostId?.();
+			return id ? String(id) : '';
+		},
 	},
 	'designsetgo/post-type': {
 		label: __('Post type', 'designsetgo'),
-		getValue: (select) => select(editorStore)?.getCurrentPostType?.() ?? '',
+		fromContext: (context) => context?.postType ?? '',
+		editorField: (editor) => editor?.getCurrentPostType?.() ?? '',
 	},
 	'designsetgo/post-permalink': {
 		label: __('Post permalink', 'designsetgo'),
-		getValue: (select) =>
-			select(editorStore)?.getCurrentPost?.()?.link ?? '',
+		entityField: (record) => record?.link ?? '',
+		editorField: (editor) => editor?.getCurrentPost?.()?.link ?? '',
 	},
 	'designsetgo/post-date': {
 		label: __('Post publish date', 'designsetgo'),
-		getValue: (select) => {
-			const editor = select(editorStore);
-			const date = editor?.getEditedPostAttribute?.('date');
-			if (typeof date === 'string' && date) {
-				return date;
+		entityField: (record) => record?.date ?? '',
+		editorField: (editor) => {
+			const live = editor?.getEditedPostAttribute?.('date');
+			if (typeof live === 'string' && live) {
+				return live;
 			}
 			return editor?.getCurrentPost?.()?.date ?? '';
 		},
 	},
 	'designsetgo/post-modified-date': {
 		label: __('Post modified date', 'designsetgo'),
-		getValue: (select) =>
-			select(editorStore)?.getCurrentPost?.()?.modified ?? '',
+		entityField: (record) => record?.modified ?? '',
+		editorField: (editor) => editor?.getCurrentPost?.()?.modified ?? '',
 	},
 	'designsetgo/site-title': {
 		label: __('Site title', 'designsetgo'),
-		getValue: (select) =>
-			select(coreStore)?.getEntityRecord?.('root', 'site')?.title ?? '',
+		fromSite: (site) => site?.title ?? '',
 	},
 	'designsetgo/site-tagline': {
 		label: __('Site tagline', 'designsetgo'),
-		getValue: (select) =>
-			select(coreStore)?.getEntityRecord?.('root', 'site')?.description ??
-			'',
+		fromSite: (site) => site?.description ?? '',
 	},
 	'designsetgo/site-url': {
 		label: __('Site URL', 'designsetgo'),
-		getValue: (select) =>
-			select(coreStore)?.getEntityRecord?.('root', 'site')?.url ?? '',
+		fromSite: (site) => site?.url ?? '',
 	},
 };
 
-function buildGetValues(slug, getValue) {
-	return ({ bindings, select }) => {
-		const value = getValue(select) ?? '';
-		// `bindings` is the per-block-attribute binding object. Project the
-		// single scalar across every attribute the user wired up so the
-		// editor canvas reflects the resolved value live, regardless of
-		// which attribute (content / url / alt / …) the binding targets.
+function resolveValue(resolver, { context, select }) {
+	// Site-level sources don't depend on a post.
+	if (typeof resolver.fromSite === 'function') {
+		const site = select(coreStore)?.getEntityRecord?.('root', 'site');
+		return resolver.fromSite(site) ?? '';
+	}
+
+	const editor = select(editorStore);
+	const editorPostId = editor?.getCurrentPostId?.() || 0;
+	const ctxPostId = context?.postId || 0;
+	const ctxPostType = context?.postType || '';
+
+	const isLoopItem = ctxPostId && ctxPostId !== editorPostId;
+
+	// Pure-context sources (post-id, post-type) read the per-block context
+	// directly without touching either store.
+	if (typeof resolver.fromContext === 'function') {
+		if (isLoopItem) {
+			return resolver.fromContext(context) ?? '';
+		}
+		return resolver.editorField(editor) ?? '';
+	}
+
+	// Loop items: pull the queried post's record so every item shows its
+	// own data instead of the editor post's.
+	if (isLoopItem && typeof resolver.entityField === 'function') {
+		const record = ctxPostType
+			? select(coreStore)?.getEntityRecord?.(
+					'postType',
+					ctxPostType,
+					ctxPostId
+				)
+			: null;
+		// Returning empty string lets WP fall back to the source label
+		// placeholder while core-data fetches the record (entity records
+		// load lazily); once loaded, getValues re-runs.
+		return record ? (resolver.entityField(record) ?? '') : '';
+	}
+
+	// Default: live editor state (tracks unsaved edits in real time).
+	if (typeof resolver.editorField === 'function') {
+		return resolver.editorField(editor) ?? '';
+	}
+
+	return '';
+}
+
+function buildGetValues(resolver) {
+	return ({ bindings, context, select }) => {
+		const value = resolveValue(resolver, { context, select });
 		const out = {};
 		Object.keys(bindings || {}).forEach((attr) => {
 			out[attr] = value;
@@ -115,17 +172,19 @@ function buildGetValues(slug, getValue) {
 }
 
 export function registerEditorBindings() {
-	Object.entries(SCALAR_RESOLVERS).forEach(([slug, { label, getValue }]) => {
-		try {
-			registerBlockBindingsSource({
-				name: slug,
-				label,
-				usesContext: ['postId', 'postType'],
-				getValues: buildGetValues(slug, getValue),
-			});
-		} catch (e) {
-			// Already registered (HMR / double-import) — ignore.
+	Object.entries(SCALAR_RESOLVERS).forEach(([slug, resolver]) => {
+		// Avoid double-registration (HMR / double-import) without
+		// swallowing any other error registerBlockBindingsSource may
+		// throw — narrow catch only after a positive existence check.
+		if (getBlockBindingsSource?.(slug)) {
+			return;
 		}
+		registerBlockBindingsSource({
+			name: slug,
+			label: resolver.label,
+			usesContext: ['postId', 'postType'],
+			getValues: buildGetValues(resolver),
+		});
 	});
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,9 @@ import './extensions/visibility';
 // Style Binding - maps CSS properties to dynamic data sources (post-meta, ACF, MetaBox, Pods, JetEngine)
 import './extensions/style-binding';
 
+// Dynamic Tags - Elementor-style per-attribute dynamic bindings on core blocks
+import './extensions/dynamic-tags';
+
 // ===== RICH TEXT FORMATS =====
 // Text Style - adds inline text styling (color, gradient, size) to selected text
 import './formats/text-style';

--- a/tests/unit/blocks/inspector-ia.test.js
+++ b/tests/unit/blocks/inspector-ia.test.js
@@ -132,6 +132,7 @@ const MIGRATED_BLOCKS = [
 	'product-showcase-hero',
 	'map',
 	'countdown-timer',
+	'dynamic-image',
 ];
 
 // Blocks whose inspector items live in sub-components under


### PR DESCRIPTION
## Summary

Adds a full Elementor-style Dynamic Tags subsystem so authors can bind block content to post/site/archive/user fields or custom fields (ACF, Meta Box, Pods, JetEngine) without writing code. Built on WordPress's native Block Bindings API plus a thin metadata layer that gives us the picker UI, field discovery, and live preview that core doesn't ship yet.

### What ships

**1. A showcase block** — `designsetgo/dynamic-image`
  - Server-rendered via `render.php`
  - Source picker (featured image, site logo, ACF image, post-meta image, author avatar, …)
  - Size, focal point, aspect ratio, object-fit, fallback image, link-wrap

**2. Extension for core blocks** (`src/extensions/dynamic-tags/`)
  - Adds a per-attribute "⚡ Connect" button in the Inspector for every bindable attribute on `core/paragraph`, `core/heading`, `core/image`, `core/button`, `core/post-date`
  - Writes directly to native `attributes.metadata.bindings` so WP core renders through its own pipeline

**3. ~22 intrinsic binding sources**
  - Post: title, excerpt, date, modified-date, permalink, id, type, author-name, author-url, author-avatar-url, featured-image (url/id/alt/width/height/title/caption via `subkey`), taxonomy
  - Site: title, tagline, url, logo
  - Archive: title, description, url
  - User: current-user-name, current-user-avatar, current-user-url, current-user-email (opt-in via filter)

**4. Extension to existing custom-field sources**
  - ACF / Meta Box / Pods / JetEngine sources now accept `args.subkey` so image-type fields (which these plugins return as arrays) can resolve to `url` / `id` / `alt` / etc. through the scalar-only Bindings API

**5. REST API** (`/wp-json/designsetgo/v1/dynamic-tags/…`)
  - `/sources` — catalog with labels, groups, return types, arg schemas
  - `/fields` — discovered fields for a given source + post type
  - `/preview` — resolves the exact value `render.php` will emit, so the editor preview and the frontend can't drift

**6. Reusable React picker**
  - `src/components/DynamicTagPicker/` exposes `DynamicTagPicker`, `DynamicTagButton`, and three data hooks

### Architecture notes

- All new sources register via the pre-existing `designsetgo_register_bindings_source()` helper — they inherit post-password, viewability, and protected-meta gates for free.
- The Dynamic Image block does **not** render through `core/image` bindings. The scalar-only constraint of the Bindings API would force three round-trips (url/id/alt) and still not cover size variants or fallback. Instead, `render.php` calls `ImageResolver::resolve()` directly and the same resolver powers `/preview`, so editor and frontend always agree.
- The Dynamic Tags registry is kept *alongside* WP core's Bindings registry, not as a replacement — generic core bindings continue to work exactly as they do today.

### Out of scope (follow-ups)

- Binding DesignSetGo's own image-bearing blocks (card, media-text). The plan is to refactor those blocks onto the native Block Bindings API in a separate PR.
- Repeaters / arrays — WP core Bindings doesn't support them yet either.
- Global plugin-level fallback image (today: per-block only).

## Test plan

- [ ] `npm run build` — builds without errors (verified: passes with only pre-existing Sass `@import` deprecation warnings)
- [ ] PHP `-l` syntax check on every new/modified file — clean
- [ ] Insert Dynamic Image block → pick "Post featured image" → verify it renders the featured image on the frontend
- [ ] Insert Dynamic Image on a post with no featured image + a fallback → verify fallback renders
- [ ] Bind `core/heading` content to `designsetgo/post-title` via the Inspector → verify it serializes as `metadata.bindings` and renders the post title
- [ ] Bind `core/image` URL to `designsetgo/acf` with `subkey=url` on an ACF image field → verify the image renders
- [ ] Hit `/wp-json/designsetgo/v1/dynamic-tags/sources` logged out → expect 401; logged in as editor → expect JSON catalog
- [ ] Password-protect a post, set an image binding → verify `/preview` returns `{status: "unauthorized"}` and the frontend hides the image
- [ ] Verify `/preview` result for a source matches what `render.php` outputs on the frontend (parity check)
- [ ] Check `current-user-email` source is absent unless the `designsetgo_dynamic_tags_allow_email` filter is set to true

https://claude.ai/code/session_01HXWvVyvftute8yXbAtc53Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXWvVyvftute8yXbAtc53Y)_