### PR TITLE
2.1.0 prep: Dynamic Query/Section authoring + security & perf hardening

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -147,3 +147,9 @@ npm-debug.log*
 # ===================
 languages/*.po
 languages/*.pot
+
+# ===================
+# Source Maps (never ship to production)
+# ===================
+*.js.map
+*.css.map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Patterns: removed leftover `id="contact-professional"` on the form-builder root in starter patterns; aligned form block markup with current `save.js` output.
 - Abilities API add-block output round-tripped through `save()` to prevent block validation failures (#355).
 - Abilities JSON Schema — inline `required:true` migrated to JSON Schema compliant form (#352).
+- llms.txt generation now writes reliably on managed hosts (WP Engine, Kinsta, Pantheon) that don't define FTP constants — file writes go through the WordPress filesystem API with a safe fallback for environments where it's unavailable.
+- Sticky header: a typo in the Settings → DesignSetGo custom selector field no longer throws an exception that breaks all frontend JavaScript; an invalid selector silently falls back to the default header detection.
 
 ### Removed
 - **Visual Revision Comparison** — Removed in favor of WordPress 7.0's native visual diff for revisions. Also removed the associated admin page, block differ, revision renderer, REST endpoints (`/designsetgo/v1/revisions/*`), and settings (`revisions.enable_visual_comparison`, `revisions.default_to_visual`).
@@ -82,6 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Draft Mode REST permission callbacks** — Added nonce verification to all Draft Mode REST routes.
 - **Form submissions** — Redirect URLs normalized and validated against an allowlist of safe protocols before navigation.
 - **Dynamic Query style bindings** — CSS value injection blocked; dangerous CSS functions and protocols cannot be passed through a binding.
+- **Global Styles sanitization** — Stored Global Styles values are now validated against a CSS-value allowlist (numeric+units, `var()`/`calc()`/`clamp()`/`min()`/`max()`, hex/rgb/hsl colors, named keywords, font-family lists). Every functional form rejects `url(`, `expression(`, `javascript:`, `<`, and `;` regardless of the wrapping function.
+- **Sticky header custom selector** — Settings input now rejects HTML angle brackets, `javascript:`, `expression(`, `url(`, and `@import` patterns before the value reaches the frontend.
 
 ### Changed
 - `designsetgo/post-meta` and `designsetgo/acf` binding sources accept an optional `scope` arg — defaults to `'self'`; existing bindings unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,126 @@ All notable changes to the DesignSetGo plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — target: 2.1.0
+
+### New Blocks
+- **Dynamic Query** — Container block that iterates Posts, Users, Terms, Manual selections, or the Current archive, with `tax_query`, `meta_query`, search, author, date, and offset controls. Server-rendered with an editable template and pluggable sources.
+- **Query Pagination** — Sibling block with numbered, load-more, and infinite-scroll variations (infinite scroll uses `IntersectionObserver`, auto-pauses after 3 loads, respects `prefers-reduced-motion`).
+- **Query Filter** — Sibling block with 6 variations: checkbox, select, search, sort, active-filters, and reset. Per-option counts that stay intersection-aware across multiple active filters.
+- **Query No Results** — Sibling block for zero-result states.
+- **Query Group Header** — Sibling block that renders once per group when group-by is enabled; receives `designsetgo/groupLabel` + `designsetgo/groupValue` context so bindings can display the current group.
+- **Query Results** — Child of `designsetgo/query` that renders the iterated items; split out so non-grid hosts (Slider, Scroll Slides) can take over rendering while sharing the same source + filters.
+
+### New Features
+- **Dynamic Tags** — Inline toolbar picker for binding any block's text, title, URL, or image to dynamic data (DesignSetGo, core, ACF, Meta Box, Pods, JetEngine, or any custom source). Live preview in the editor; works on DesignSetGo blocks and any core block that opts into the WordPress 6.9 Block Bindings API.
+- **Native Block Bindings support** — DesignSetGo blocks now participate in the WordPress 6.9 `block_bindings_supported_attributes` filter so their attributes can be driven by any Block Bindings source. Initial coverage includes Advanced Heading Segment, Breadcrumbs home/prefix text, and Query Pagination labels. Extensible via the `designsetgo_block_bindings_supported_attributes` filter. Inert on WordPress < 6.9.
+- **DesignSetGo post-meta + ACF binding sources** — Always available (ACF source auto-registers when ACF is active). Both accept an optional `scope` arg (`self` / `parent` / `root`) for nested loop scenarios.
+- **Third-party field sources — Meta Box, Pods, and JetEngine** — Three new Block Bindings sources (`designsetgo/metabox`, `designsetgo/pods`, `designsetgo/jetengine`) that delegate to each plugin's formatting API (`rwmb_meta()`, `pods_field()`, `jet_engine()->listings->data->get_meta()`) so formatted dates, files, and relationships render correctly. Each registers only when the host plugin is active.
+- **Conditional block visibility** — Every block carries a `dsgoVisibility` attribute with an Advanced → Visibility inspector panel. Rule types: meta / taxonomy / index / auth, combined with AND/OR relations and ops (`equals`, `not_equals`, `contains`, `gt`, `lt`, `empty`, `not_empty`, `has`, `not_has`). Editor previews mirror server-side evaluation.
+- **Per-URL Markdown content negotiation** — Any published page/post URL returns Markdown when the request sends `Accept: text/markdown` (or outranks `text/html` via q-values). Responds with `Content-Type: text/markdown; charset=utf-8` and `Vary: Accept`. Reuses the existing per-post Markdown files (falls back to live conversion), respects the llms.txt enablement flag, post-type allowlist, exclusion meta, and password-protected posts. Passes the [acceptmarkdown.com](https://acceptmarkdown.com/) readiness contract.
+- **Hover Effects extension** — New universal extension for animated hover interactions (works with any block, including core).
+- **Grid: column toolbar buttons** — Pick 1–6 columns directly from the Grid block's toolbar (switches to a dropdown above 6).
+- **Grid: row span control** — Grid children can now span multiple rows alongside the existing column span.
+- **Form builder: persist confirmation across reloads** — Submitters see the confirmation message even after refreshing the page.
+
+### Dynamic Query
+- **Filter index with per-option counts** — Persistent `{$wpdb->prefix}dsgo_query_filter_index` table auto-maintained on `save_post` / taxonomy / meta changes. Renders `(N)` counts next to each filter option; counts are intersection-aware across active filters.
+- **Admin dashboard** — Settings → DesignSetGo → Dynamic Query for rebuilding the filter index and managing ad-hoc filter registrations.
+- **WP-CLI** — `wp dsgo query index rebuild/rebuild-filter/status/drop`.
+- **Editor live preview** — Posts use `useEntityRecords`; users and terms go through a new `/designsetgo/v1/query/preview` REST route. The first item wraps an editable `InnerBlocks`; items 2..N render server-rendered HTML (exact editor/frontend parity).
+- **Template picker onboarding** — Fresh Dynamic Query inserts open a template picker (Minimal, Blog Index, Team, Portfolio, Testimonials, Related Posts, Events) instead of a grid of inserter variations.
+- **Relationship source** — `source: 'relationship'` reads a relationship field (meta or ACF) on the parent post and iterates the referenced posts via `post__in`. Configurable fallback (`'empty'` / `'all'` / `'parent'`).
+- **Nested loops with parent context** — Outer Query's current item flows into inner Queries via `designsetgo/parentItem` block context and `$GLOBALS['designsetgo_parent_stack']`.
+- **Group-by partitioning** — `groupBy` attribute partitions iterated items by taxonomy / meta / date (year / year-month / year-month-day precision). Server wraps each group in `<section class="dsgo-query-group">` and renders the new Query Group Header block once per group.
+- **Date Query builder** — Inspector UI for `before` / `after` / `between` date filters with relative expression support (`-30 days`, `today`, ISO dates).
+- **Multi-level AND/OR filter groups** — Taxonomy and Meta clause builders support nested `{relation, clauses}` groups at any depth.
+- **Include-children toggle** — Per-clause control on taxonomy clauses (defaults `true`).
+- **Query Monitor debug panel** — When Query Monitor is active, a "DSGo (N)" panel shows per-render query args, found-posts count, duration, and SQL.
+- **Template export/import** — REST routes `GET /designsetgo/v1/query/template` and `POST /designsetgo/v1/query/template` plus Export/Import buttons in the Template I/O section. JSON `schemaVersion: 1`, attribute allowlist enforced via `WP_Block_Type_Registry`, fresh `queryId` generated on import.
+- **Dynamic CSS style bindings** — `dsgoStyleBinding` attribute maps CSS property names (including CSS custom properties) to a DSGo binding source + key. Values injected as inline styles on the block root via `render_block`, with `url(`, `expression(`, `javascript:` rejected.
+- **Query-bound Slider and Scroll Slides** — Both blocks can act as item hosts, iterating query items as slides with exact editor-to-frontend parity.
+- **CSS-only loading skeletons** — Shown via `aria-busy="true"` state during filter/pagination refreshes.
+- **Interactivity API load-more + URL state** — Filter state synchronized to URL params (`q`, `sort`, `filter_<taxonomy>`). Extensible via `designsetgo_query_url_params` filter.
+- **ItemList schema.org markup** for Posts queries (emitSchema attribute, default on).
+- **Filter UX polish** — Distinct titles for taxonomy / meta / date filter panels, visible unchecked checkboxes, optional horizontal orientation, and modern inputs that inherit theme.json presets.
+
+### Editor UX foundations (Themes 1–6)
+- **Theme 1** — First-insert placeholder & onboarding parity: `DsgoBlockPlaceholder` wizard rolled out to accordion, flip-card, image-accordion, scroll-accordion, and slider (#356).
+- **Theme 2** — Flip Card front/back child blocks consolidated into a single `designsetgo/flip-card-face` with a `side` attribute; starter colors + i18n polish (#357).
+- **Theme 3** — Inspector IA standardization: every block's sidebar migrated to the Settings → Style → Advanced three-panel convention via `DsgoInspectorPanel`, with per-control reset-to-default (#360 plus rollout PRs).
+- **Theme 4** — Discoverability polish: block icons, category registration, and naming cleaned up across ~30 blocks (#358, #362).
+- **Theme 5** — Shared tablist keyboard hook + child toolbar: `useTablistKeyboard` and `DsgoChildToolbar` rolled out to tabs and slider with full test coverage (#359).
+- **Theme 6** — Shared authoring primitives: `DsgoBlockPlaceholder`, `DsgoChildToolbar`, `DsgoInspectorPanel`, `useBlockColors`, `useTablistKeyboard`, and `useUniqueBlockId` extracted into canonical `src/hooks/` and `src/components/shared/` homes (#354).
+
+### Improvements
+- **Dynamic Image** — Theme 3 inspector with sticky footer, live editor preview, and Select-based controls for every finite-option setting.
+- **Sticky header** — Smooth logo shrink transition in both scroll directions.
+- **Heading Segment** — Default segment gap is now 0 so adjacent segments read as a single heading.
+- **Section** — Clears default padding automatically when nested inside another Section.
+- **Row** — Inner `flex-direction` now flips correctly on mobile stack.
+- **Advanced Heading** — Segment appender restored on the canvas so authors can add more segments without digging into the inspector.
+- **Image Accordion** — "Default Expanded Item" picker now shows item headings (no more 0–10 numeric slider).
+- **Grid** — Empty appender width fix so the "+" target isn't squeezed.
+- **Inspector panel controls** render full-width correctly; Tabs `activeTab` index clamped defensively on editor and frontend (#361).
+
+### Fixed
+- Form submissions: redirect URL normalized before navigation (blocks `javascript:` and other unsafe protocols).
+- Dynamic Query style bindings: CSS value injection blocked (`url(`, `expression(`, `javascript:` rejected) and an explicit property BLOCKED set prevents behavioral style leaks.
+- Form builder: stale confirmation cleared when the form is re-opened with a different unique key.
+- Patterns: removed leftover `id="contact-professional"` on the form-builder root in starter patterns; aligned form block markup with current `save.js` output.
+- Abilities API add-block output round-tripped through `save()` to prevent block validation failures (#355).
+- Abilities JSON Schema — inline `required:true` migrated to JSON Schema compliant form (#352).
+
+### Removed
+- **Visual Revision Comparison** — Removed in favor of WordPress 7.0's native visual diff for revisions. Also removed the associated admin page, block differ, revision renderer, REST endpoints (`/designsetgo/v1/revisions/*`), and settings (`revisions.enable_visual_comparison`, `revisions.default_to_visual`).
+
+### Security
+- **Draft Mode REST permission callbacks** — Added nonce verification to all Draft Mode REST routes.
+- **Form submissions** — Redirect URLs normalized and validated against an allowlist of safe protocols before navigation.
+- **Dynamic Query style bindings** — CSS value injection blocked; dangerous CSS functions and protocols cannot be passed through a binding.
+
+### Changed
+- `designsetgo/post-meta` and `designsetgo/acf` binding sources accept an optional `scope` arg — defaults to `'self'`; existing bindings unchanged.
+- `designsetgo/post-meta` and `designsetgo/acf` internally refactored to use the new `designsetgo_register_bindings_source()` helper — single source of truth for security gates and scope resolution; externally observable behavior is identical.
+
+### Developer
+- `designsetgo_register_bindings_source( $slug, callable $callback, array $options )` — public PHP helper wrapping `register_block_bindings_source()` with DSGo's shared post-password / viewable / protected-meta gates and the `scope` arg.
+- `designsetgo_resolve_bindings_post_id( $args, $block )` — free function exposing the scope-aware post-ID resolution for callers that register via `register_block_bindings_source()` directly.
+- `designsetgo_visibility_rule` filter — add custom visibility rule types by returning a bool from `($match, $rule, $context) → bool|null`.
+- `designsetgo_query_args` + `designsetgo/query/{queryId}/args` — pre-`WP_Query` filter hooks (global + per-queryId).
+- `designsetgo_query_partition_items( $post_ids, $group_spec )` — public PHP helper for custom group-by integrations.
+- `designsetgo_query_registered_filters` filter — programmatic filter registration for the Dynamic Query filter index.
+- `designsetgo_query_url_params` filter — extend the URL params the Dynamic Query IAPI store syncs to.
+- `designsetgo_block_bindings_supported_attributes` filter — map block names to attribute names for native Block Bindings support.
+- `$GLOBALS['designsetgo_parent_stack']` — ordered list of `{ postId, postType }` contexts available during any `render_block` hook fired inside a query item.
+- REST endpoints: `/designsetgo/v1/query/render`, `/preview`, `/filter-register`, `/filter-status`, `/filter-rebuild`, `/filters`, `/template` (GET + POST).
+
+## [2.0.51] - 2026-04-16
+
+### Added
+- Slider: editor-only slide navigator strip below the track with per-slide duplicate/remove actions and an "Add slide" button
+- Slider: slide "+" appender pinned to the bottom-center of each slide so it no longer collides with the preview arrows
+- Form Builder: skippable first-insert template chooser with Blank, Contact, Newsletter, Event Registration, and Lead Capture presets
+- Form Builder: "Reply-To Field" is now a structured dropdown populated from actual form fields (was a raw text input)
+- Image Accordion: "Default Expanded Item" is now a named item picker showing each item's heading text (was a 0–10 numeric slider)
+- Tabs: inline-editable tab titles in the nav strip, per-tab duplicate/remove on hover, and an "Add tab" button
+- Advanced Heading: segment appender restored so authors can add more heading segments from the canvas
+
+### Security
+- Background-video overlay color validated against an explicit CSS color grammar before assigning to the DOM — blocks `url()` / `expression()` / `javascript:` injection
+- Replaced `innerHTML` with DOM APIs (`createElement` / `createElementNS`) in slider and modal frontend scripts
+- LLMS Markdown REST endpoint gated at feature-disabled check before the rate-limiter to prevent post-existence enumeration on disabled installations
+- Normalized CSS unicode escapes and null bytes before the custom CSS sanitizer's regex pipeline; added a final defense pass after the filter hook
+
+### Fixed
+- Tabs frontend no longer showed "Click the + button below to add content to this tab" — the `block.json` style asset was pointing at the editor CSS bundle
+- An empty Form Builder (placeholder dismissed without picking a template) no longer renders an orphan submit button on the frontend
+
+## [2.0.50] - 2026-04-14
+
+### Fixed
+- Form submissions not sending email notifications — server-side block attribute lookup now honors `block.json` defaults so forms with default settings correctly trigger admin email on submit
+
 ## [2.0.49] - 2026-04-12
 
 ### Fixed
@@ -22,44 +142,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SMTP plugin compatibility notice in Email Notifications panel
 - User-friendly error messages for rate-limited form submissions
 - Form status query params cleaned from URL after displaying messages
-
-## [Unreleased]
-
-### Added
-- **Native Block Bindings support for DesignSetGo blocks** — opts DesignSetGo blocks into the WordPress 6.9+ `block_bindings_supported_attributes` filter so their attributes can be driven by any registered Block Bindings source (core/post-meta, designsetgo/post-meta, designsetgo/acf, designsetgo/metabox, designsetgo/pods, designsetgo/jetengine, or any custom source). Initial coverage: `designsetgo/heading-segment.content`, `designsetgo/breadcrumbs.homeText` + `.prefixText`, and `designsetgo/query-pagination.labelLoadMore` + `.labelLoading` + `.buttonLabelWhenPaused`. Extensible via the new `designsetgo_block_bindings_supported_attributes` filter (block name → attribute names map). On WordPress < 6.9 this is inert and causes no behavior change.
-- **Per-URL Markdown content negotiation** — any published page/post URL now returns Markdown when the request sends `Accept: text/markdown` (or any Accept header where `text/markdown` outranks `text/html` via q-values). Responds with `Content-Type: text/markdown; charset=utf-8` and `Vary: Accept`. Returns `406 Not Acceptable` when the client rejects both `text/html` and `text/markdown`. Reuses the existing per-post Markdown files (falls back to live conversion). Respects the llms.txt enablement flag, post-type allowlist, exclusion meta, and password-protected posts. Passes the [acceptmarkdown.com](https://acceptmarkdown.com/) readiness contract.
-
-### Removed
-- **Visual Revision Comparison** - Deprecated and removed in favor of WordPress 7.0's native visual diff for revisions. Removed the visual comparison admin page, block differ, revision renderer, REST API endpoints (`/designsetgo/v1/revisions/*`), and associated settings (`revisions.enable_visual_comparison`, `revisions.default_to_visual`)
-
-### New Blocks
-- **Fifty Fifty** - Full-width 50/50 split layout with edge-to-edge media on one side and constrained content on the other — includes media position toggle (left/right), focal point picker, configurable min height, content vertical alignment, and mobile-responsive stacking
-- **Query Group Header** - Sibling block for the Dynamic Query that renders once per group when group-by is enabled; hosts an InnerBlocks area for a heading or any custom content, and receives `designsetgo/groupLabel` + `designsetgo/groupValue` context so bindings can display the current group's name
-
-### Added
-- Date Query Builder: inspector UI for `before`/`after`/`between` date filters with relative expression support (`-30 days`, `today`).
-- Multi-level AND/OR filter groups: TaxQueryBuilder and MetaQueryBuilder now support nested `{relation, clauses}` groups at any depth.
-- Hierarchical taxonomy drilldown: per-clause `include_children` toggle in TaxQueryBuilder (defaults `true`).
-- Query Monitor panel: when QM is active, a "DSGo (N)" panel in the QM toolbar shows per-render query args, found-posts count, duration, and SQL.
-- Dynamic CSS style bindings: `dsgoStyleBinding` attribute on every block maps CSS property names → DSGo binding source + key. Values injected as inline styles on the block root element via `render_block` filter.
-- **Dynamic Query — Relationship source** - New `source: 'relationship'` reads a parent-context field (meta or ACF relationship) and iterates the referenced posts via `post__in`; configurable fallback when no IDs are resolved (render nothing, all posts, or the parent item)
-- **Dynamic Query — Nested loops with parent context** - Outer Query's current item flows into inner Queries via the `designsetgo/parentItem` block context; DSGo bindings (`designsetgo/post-meta`, `designsetgo/acf`) accept a new optional `scope` arg of `'self'` (default), `'parent'`, or `'root'` — reading from a parent-stack maintained by `designsetgo_query_render_item()`
-- **Conditional inner-block visibility** - Every block now carries a `dsgoVisibility` attribute with an inspector panel under Advanced → Visibility. Rule types: meta / taxonomy / index / auth, combined with AND/OR relations and ops (`equals`, `not_equals`, `contains`, `gt`, `lt`, `empty`, `not_empty`, `has`, `not_has`). Editor previews mirror server-side evaluation so authors see what will ship
-- **Dynamic Query — Group-by partitioning** - New `groupBy` attribute on the Query block partitions iterated items by taxonomy / meta / date (with year / year-month / year-month-day precision); server wraps each group in `<section class="dsgo-query-group">` and renders the new Query Group Header block once per group
-- **Dynamic Query — Meta Box, Pods, JetEngine binding sources** - Three new Block Bindings sources (`designsetgo/metabox`, `designsetgo/pods`, `designsetgo/jetengine`) that delegate to each plugin's canonical formatting API (`rwmb_meta()`, `pods_field()`, `jet_engine()->listings->data->get_meta()`) so formatted dates, files, and relations render correctly. Each registers only when the host plugin is active
-- **`designsetgo_register_bindings_source()` helper** - Public PHP function wrapping `register_block_bindings_source()` with DSGo's shared post-password / viewable / protected-meta gates and the `scope` arg (`self`/`parent`/`root`). Lets child themes and mu-plugins ship custom binding sources without reimplementing the security gates
-- **Dynamic Query — Template export/import** - REST routes `GET /designsetgo/v1/query/template` (export) and `POST /designsetgo/v1/query/template` (import) plus inspector Export/Import buttons in the Settings panel's Template I/O section. JSON format with `schemaVersion: 1`, attribute allowlist enforced via `WP_Block_Type_Registry`, and a fresh `queryId` generated on import so sibling bindings never collide
-
-### Changed
-- `designsetgo/post-meta` and `designsetgo/acf` binding sources accept an optional `scope` arg — defaults to `'self'`; existing bindings unchanged
-- `designsetgo/post-meta` and `designsetgo/acf` internally refactored to use the new `designsetgo_register_bindings_source()` helper — single source of truth for security gates and scope resolution; externally observable behavior is identical
-
-### Extension points
-- `designsetgo_visibility_rule` filter — add custom rule types by returning a bool from `($match, $rule, $context) → bool|null`
-- `$GLOBALS['designsetgo_parent_stack']` — ordered list of `{ postId, postType }` contexts available during any `render_block` hook fired inside a query item
-- `designsetgo_query_partition_items( $post_ids, $group_spec )` — public PHP helper for custom group-by integrations
-- `designsetgo_register_bindings_source( $slug, callable $callback, array $options )` — public PHP helper for registering custom DSGo-compatible binding sources with inherited gates and `scope` support
-- `designsetgo_resolve_bindings_post_id( $args, $block )` — free function exposing the scope-aware post-ID resolution used by the helper, for callers that register via `register_block_bindings_source()` directly
 
 ## [2.0.0] - 2026-02-08
 

--- a/includes/admin/class-block-migrator.php
+++ b/includes/admin/class-block-migrator.php
@@ -155,13 +155,15 @@ class Block_Migrator {
 
 			if ( is_wp_error( $update_result ) ) {
 				++$failed;
-				error_log(
-					sprintf(
-						'DesignSetGo Block Migrator: Failed to convert post ID %d: %s',
-						$post->ID,
-						$update_result->get_error_message()
-					)
-				);
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentional debug logging.
+						sprintf(
+							'DesignSetGo Block Migrator: Failed to convert post ID %d: %s',
+							$post->ID,
+							$update_result->get_error_message()
+						)
+					);
+				}
 			} else {
 				++$converted;
 			}

--- a/includes/admin/class-global-styles.php
+++ b/includes/admin/class-global-styles.php
@@ -598,11 +598,17 @@ class Global_Styles {
 	 * Accepts values that match any of the following patterns (permissive enough
 	 * for typical theme.json values):
 	 *  - Numeric with optional unit: -?[\d.]+(px|em|rem|%|vh|vw|fr|ch|s|ms)?
-	 *  - CSS custom property reference: var(--name, fallback)
+	 *  - CSS custom property reference: var(--name, fallback) — fallback may
+	 *    contain nested var() / calc() / etc.
 	 *  - Hex color: #RGB / #RRGGBB / #RGBA / #RRGGBBAA
-	 *  - Functional color: rgb()/rgba()/hsl()/hsla() without < or ;
+	 *  - Functional color: rgb()/rgba()/hsl()/hsla() — no url(/expression(
+	 *  - Math functions: calc()/clamp()/min()/max() — common in theme.json
 	 *  - Named keyword (a-z + hyphens): e.g. transparent, normal, bold
 	 *  - Typography family list: letters, digits, spaces, commas, quotes, underscores, hyphens
+	 *
+	 * Every functional form is gated against `<`, `;`, `url(`, `expression(`,
+	 * and `javascript:` to keep injection vectors out even where browsers would
+	 * already reject the result as invalid CSS.
 	 *
 	 * @param string $value CSS value to validate.
 	 * @return bool True when the value is acceptable.
@@ -613,21 +619,9 @@ class Global_Styles {
 			return true;
 		}
 
-		// CSS custom property reference: var(--name) or var(--name, fallback).
-		if ( preg_match( '/^var\(--[a-zA-Z0-9_-]+(,\s*[^)]+)?\)$/', $value ) ) {
-			return true;
-		}
-
 		// Hex color.
 		if ( preg_match( '/^#[0-9a-fA-F]{3,8}$/', $value ) ) {
 			return true;
-		}
-
-		// Functional color — rgb / rgba / hsl / hsla, no < or ; allowed.
-		if ( preg_match( '/^(rgba?|hsla?)\(/', $value ) && str_ends_with( $value, ')' ) ) {
-			if ( ! str_contains( $value, '<' ) && ! str_contains( $value, ';' ) ) {
-				return true;
-			}
 		}
 
 		// Named keyword: lowercase letters and hyphens only.
@@ -638,6 +632,22 @@ class Global_Styles {
 		// Typography family list: letters, digits, spaces, commas, quotes, underscores, hyphens.
 		if ( preg_match( '/^[a-zA-Z0-9 ,.\'"_-]+$/', $value ) ) {
 			return true;
+		}
+
+		// Functional CSS values (var, calc, clamp, min, max, rgb/rgba/hsl/hsla).
+		// We allow nested calls inside the args (e.g. var(--a, var(--b))) but
+		// blocklist the dangerous CSS sinks. Browsers would reject these anyway
+		// when the value resolves, but we don't want to persist them.
+		if ( preg_match( '/^(var|calc|clamp|min|max|rgba?|hsla?)\(/i', $value ) && str_ends_with( $value, ')' ) ) {
+			if (
+				! str_contains( $value, '<' )
+				&& ! str_contains( $value, ';' )
+				&& false === stripos( $value, 'url(' )
+				&& false === stripos( $value, 'expression(' )
+				&& false === stripos( $value, 'javascript:' )
+			) {
+				return true;
+			}
 		}
 
 		return false;

--- a/includes/admin/class-global-styles.php
+++ b/includes/admin/class-global-styles.php
@@ -40,9 +40,6 @@ class Global_Styles {
 	 * @return \WP_Theme_JSON_Data Modified theme JSON.
 	 */
 	public function extend_theme_json( $theme_json ) {
-		// Get user-saved global styles (if any).
-		$saved_styles = get_option( 'designsetgo_global_styles', array() );
-
 		// Get existing theme data to check what's already defined.
 		$theme_data = $theme_json->get_data();
 
@@ -76,9 +73,9 @@ class Global_Styles {
 			),
 			'styles'   => array(
 				'blocks' => array(
-					'designsetgo/container' => $this->get_container_block_styles( $saved_styles ),
-					'designsetgo/tabs'      => $this->get_tabs_block_styles( $saved_styles ),
-					'designsetgo/tab'       => $this->get_tab_block_styles( $saved_styles ),
+					'designsetgo/container' => $this->get_container_block_styles(),
+					'designsetgo/tabs'      => $this->get_tabs_block_styles(),
+					'designsetgo/tab'       => $this->get_tab_block_styles(),
 				),
 			),
 		);
@@ -126,7 +123,7 @@ class Global_Styles {
 		// Only add font sizes if theme doesn't define them.
 		if ( ! $this->theme_has_font_sizes( $theme_data ) ) {
 			$dsg_settings['settings']['typography'] = array(
-				'fontSizes' => $this->get_font_sizes( $saved_styles ),
+				'fontSizes' => $this->get_font_sizes(),
 			);
 		}
 
@@ -277,10 +274,9 @@ class Global_Styles {
 	/**
 	 * Get font sizes with user customizations.
 	 *
-	 * @param array $saved_styles Saved user styles.
 	 * @return array Font sizes.
 	 */
-	private function get_font_sizes( $saved_styles ) {
+	private function get_font_sizes() {
 		return array(
 			array(
 				'slug' => 'small',
@@ -317,10 +313,9 @@ class Global_Styles {
 	 * conditionally in extend_theme_json() only when the theme doesn't define
 	 * its own spacingSizes, so blocks inherit the theme's spacing rhythm.
 	 *
-	 * @param array $saved_styles Saved user styles.
 	 * @return array Container block styles.
 	 */
-	private function get_container_block_styles( $saved_styles ) {
+	private function get_container_block_styles() {
 		return array(
 			'border' => array(
 				'radius' => 'var(--wp--custom--designsetgo--border-radius--medium)',
@@ -338,10 +333,9 @@ class Global_Styles {
 	 * added conditionally in extend_theme_json() only when the theme doesn't
 	 * define its own spacingSizes.
 	 *
-	 * @param array $saved_styles Saved user styles.
 	 * @return array Tabs block styles.
 	 */
-	private function get_tabs_block_styles( $saved_styles ) {
+	private function get_tabs_block_styles() {
 		return array(
 			'typography' => array(
 				'fontSize'   => 'var(--wp--preset--font-size--medium)',
@@ -383,10 +377,9 @@ class Global_Styles {
 	 * conditionally in extend_theme_json() only when the theme doesn't
 	 * define its own spacingSizes.
 	 *
-	 * @param array $saved_styles Saved user styles.
 	 * @return array Tab block styles.
 	 */
-	private function get_tab_block_styles( $saved_styles ) {
+	private function get_tab_block_styles() {
 		return array(
 			'color' => array(
 				'background' => 'transparent',
@@ -504,10 +497,10 @@ class Global_Styles {
 	/**
 	 * Check read permission for REST API.
 	 *
-	 * @param \WP_REST_Request $request Request object.
+	 * @param \WP_REST_Request $_request Request object (unused but required by REST API).
 	 * @return bool True if user has permission.
 	 */
-	public function check_read_permission( $request ) {
+	public function check_read_permission( $_request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
 		return current_user_can( 'manage_options' );
 	}
 
@@ -591,7 +584,8 @@ class Global_Styles {
 			if ( is_array( $value ) ) {
 				$sanitized[ $sanitized_key ] = $this->sanitize_styles_array( $value );
 			} else {
-				$sanitized[ $sanitized_key ] = sanitize_text_field( $value );
+				$text = sanitize_text_field( $value );
+				$sanitized[ $sanitized_key ] = $this->is_valid_css_value( $text ) ? $text : '';
 			}
 		}
 
@@ -599,7 +593,62 @@ class Global_Styles {
 	}
 
 	/**
+	 * Validate a CSS value string against the allowed pattern allowlist.
+	 *
+	 * Accepts values that match any of the following patterns (permissive enough
+	 * for typical theme.json values):
+	 *  - Numeric with optional unit: -?[\d.]+(px|em|rem|%|vh|vw|fr|ch|s|ms)?
+	 *  - CSS custom property reference: var(--name, fallback)
+	 *  - Hex color: #RGB / #RRGGBB / #RGBA / #RRGGBBAA
+	 *  - Functional color: rgb()/rgba()/hsl()/hsla() without < or ;
+	 *  - Named keyword (a-z + hyphens): e.g. transparent, normal, bold
+	 *  - Typography family list: letters, digits, spaces, commas, quotes, underscores, hyphens
+	 *
+	 * @param string $value CSS value to validate.
+	 * @return bool True when the value is acceptable.
+	 */
+	private function is_valid_css_value( $value ) {
+		// Numeric with optional CSS unit.
+		if ( preg_match( '/^-?[\d.]+(px|em|rem|%|vh|vw|fr|ch|s|ms)?$/', $value ) ) {
+			return true;
+		}
+
+		// CSS custom property reference: var(--name) or var(--name, fallback).
+		if ( preg_match( '/^var\(--[a-zA-Z0-9_-]+(,\s*[^)]+)?\)$/', $value ) ) {
+			return true;
+		}
+
+		// Hex color.
+		if ( preg_match( '/^#[0-9a-fA-F]{3,8}$/', $value ) ) {
+			return true;
+		}
+
+		// Functional color — rgb / rgba / hsl / hsla, no < or ; allowed.
+		if ( preg_match( '/^(rgba?|hsla?)\(/', $value ) && str_ends_with( $value, ')' ) ) {
+			if ( ! str_contains( $value, '<' ) && ! str_contains( $value, ';' ) ) {
+				return true;
+			}
+		}
+
+		// Named keyword: lowercase letters and hyphens only.
+		if ( preg_match( '/^[a-z][a-z0-9-]*$/', $value ) ) {
+			return true;
+		}
+
+		// Typography family list: letters, digits, spaces, commas, quotes, underscores, hyphens.
+		if ( preg_match( '/^[a-zA-Z0-9 ,.\'"_-]+$/', $value ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Recursively sanitize nested style arrays.
+	 *
+	 * Keys are run through sanitize_key(). String leaf values are validated
+	 * against the CSS value allowlist in is_valid_css_value(); values that do
+	 * not match are silently dropped (empty string) rather than stored.
 	 *
 	 * @param array $array Array to sanitize.
 	 * @return array Sanitized array.
@@ -617,7 +666,8 @@ class Global_Styles {
 			} elseif ( is_bool( $value ) ) {
 				$sanitized[ $sanitized_key ] = (bool) $value;
 			} else {
-				$sanitized[ $sanitized_key ] = sanitize_text_field( $value );
+				$text = sanitize_text_field( $value );
+				$sanitized[ $sanitized_key ] = $this->is_valid_css_value( $text ) ? $text : '';
 			}
 		}
 

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -638,7 +638,7 @@ class Settings {
 			),
 			'sticky_header'      => array(
 				'enable'                    => 'bool',
-				'custom_selector'           => 'text',
+				'custom_selector'           => 'css_selector',
 				'z_index'                   => 'absint',
 				'shadow_on_scroll'          => 'bool',
 				'shadow_size'               => 'text',
@@ -687,6 +687,8 @@ class Settings {
 				return absint( $value );
 			case 'text':
 				return sanitize_text_field( $value );
+			case 'css_selector':
+				return self::sanitize_css_selector( $value );
 			case 'textarea':
 				return sanitize_textarea_field( $value );
 			case 'hex_color':
@@ -701,6 +703,31 @@ class Settings {
 			default:
 				return sanitize_text_field( $value );
 		}
+	}
+
+	/**
+	 * Sanitize a CSS selector, rejecting values with HTML or dangerous CSS/JS patterns.
+	 *
+	 * Checks for HTML angle brackets/quotes and known injection vectors
+	 * (javascript:, expression(), url(), @import) before accepting the value.
+	 *
+	 * @param mixed $value Raw input value.
+	 * @return string Sanitized selector or empty string if the value is unsafe.
+	 */
+	public static function sanitize_css_selector( $value ): string {
+		$trimmed = trim( (string) $value );
+		if ( '' === $trimmed ) {
+			return '';
+		}
+		// Reject HTML characters and known dangerous CSS/JS injection patterns.
+		if ( preg_match( '/[<>\'"]/u', $trimmed ) ||
+			preg_match( '/javascript:/i', $trimmed ) ||
+			preg_match( '/expression\s*\(/i', $trimmed ) ||
+			preg_match( '/url\s*\(/i', $trimmed ) ||
+			preg_match( '/@import/i', $trimmed ) ) {
+			return '';
+		}
+		return sanitize_text_field( $trimmed );
 	}
 
 	/**

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -708,8 +708,11 @@ class Settings {
 	/**
 	 * Sanitize a CSS selector, rejecting values with HTML or dangerous CSS/JS patterns.
 	 *
-	 * Checks for HTML angle brackets/quotes and known injection vectors
-	 * (javascript:, expression(), url(), @import) before accepting the value.
+	 * Quotes ARE allowed because attribute selectors like `[data-foo="bar"]`
+	 * and `[aria-expanded='true']` are valid and common — only `<` and `>`
+	 * are rejected outright. The remaining patterns (`javascript:`,
+	 * `expression(`, `url(`, `@import`) are real CSS injection vectors with
+	 * no legitimate use inside a selector.
 	 *
 	 * @param mixed $value Raw input value.
 	 * @return string Sanitized selector or empty string if the value is unsafe.
@@ -719,8 +722,8 @@ class Settings {
 		if ( '' === $trimmed ) {
 			return '';
 		}
-		// Reject HTML characters and known dangerous CSS/JS injection patterns.
-		if ( preg_match( '/[<>\'"]/u', $trimmed ) ||
+		// Reject HTML angle brackets and known dangerous CSS/JS injection patterns.
+		if ( preg_match( '/[<>]/u', $trimmed ) ||
 			preg_match( '/javascript:/i', $trimmed ) ||
 			preg_match( '/expression\s*\(/i', $trimmed ) ||
 			preg_match( '/url\s*\(/i', $trimmed ) ||

--- a/includes/blocks/class-form-handler.php
+++ b/includes/blocks/class-form-handler.php
@@ -228,8 +228,18 @@ class Form_Handler {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
 	 */
 	public function handle_form_submission( $request ) {
-		// CSRF Protection: Verify nonce for logged-in users.
-		// For non-logged-in users, rely on honeypot + rate limiting + time-based checks.
+		// CSRF Protection: Verify nonce when one is supplied.
+		//
+		// Rationale: WordPress only emits a valid `wp_rest` nonce for users with
+		// an active session — fully anonymous visitors hit this endpoint without
+		// one. We can't require a nonce universally without breaking unauthenticated
+		// public-facing forms (the primary use case for this block). Instead, we
+		// layer non-cookie defences for anonymous submissions:
+		// 1. Honeypot field (rejects most bots).
+		// 2. Submission-timing check (rejects sub-3s autofill).
+		// 3. IP rate limiting (default 2/60s, configurable per-form).
+		// 4. Optional Cloudflare Turnstile (recommended for high-value forms).
+		// For sensitive use cases, enable Turnstile in the block's Inspector.
 		$nonce = $request->get_header( 'X-WP-Nonce' );
 		if ( $nonce && ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
 			return new WP_Error(
@@ -246,8 +256,11 @@ class Form_Handler {
 		$form_settings = $this->get_form_settings();
 
 		// Look up per-block attributes for rate limiting and Turnstile enforcement.
+		// Fallback (2/60s) is intentionally stricter than the block-level default
+		// — it only applies to orphaned/legacy submissions where the per-block
+		// configuration is missing.
 		$block_attrs      = $this->get_form_block_attributes( $form_id );
-		$rate_limit_count = isset( $block_attrs['rateLimitCount'] ) ? absint( $block_attrs['rateLimitCount'] ) : 3;
+		$rate_limit_count = isset( $block_attrs['rateLimitCount'] ) ? absint( $block_attrs['rateLimitCount'] ) : 2;
 		$rate_limit_window = isset( $block_attrs['rateLimitWindow'] ) ? absint( $block_attrs['rateLimitWindow'] ) : 60;
 		$turnstile_required = ! empty( $block_attrs['enableTurnstile'] );
 

--- a/includes/blocks/class-form-submissions.php
+++ b/includes/blocks/class-form-submissions.php
@@ -180,11 +180,26 @@ class Form_Submissions {
 
 		// Email delivery status.
 		if ( '' !== $email_sent ) {
-			$is_sent = ( 'yes' === $email_sent );
-			echo '<div style="margin-bottom: 1em; padding: 10px; background: ' . ( $is_sent ? '#d4edda' : '#f8d7da' ) . '; border-left: 3px solid ' . ( $is_sent ? '#28a745' : '#dc3545' ) . ';">';
+			$is_sent      = ( 'yes' === $email_sent );
+			$status_class = $is_sent ? 'dsgo-submission-status--success' : 'dsgo-submission-status--error';
+
+			// Emit the status styles once per page load via a static guard.
+			static $dsgo_status_styles_printed = false;
+			if ( ! $dsgo_status_styles_printed ) {
+				$dsgo_status_styles_printed = true;
+				echo '<style>
+.dsgo-submission-status{margin-bottom:1em;padding:10px;border-left:3px solid}
+.dsgo-submission-status--success{background:#d4edda;border-color:#28a745}
+.dsgo-submission-status--success .dsgo-submission-status__label{color:#155724}
+.dsgo-submission-status--error{background:#f8d7da;border-color:#dc3545}
+.dsgo-submission-status--error .dsgo-submission-status__label{color:#721c24}
+</style>';
+			}
+
+			printf( '<div class="dsgo-submission-status %s">', esc_attr( $status_class ) );
 			echo '<strong>' . esc_html__( 'Email Status:', 'designsetgo' ) . '</strong><br>';
 			if ( $is_sent ) {
-				echo '<span style="color: #155724;">✓ ' . esc_html__( 'Sent Successfully', 'designsetgo' ) . '</span>';
+				echo '<span class="dsgo-submission-status__label">&#10003; ' . esc_html__( 'Sent Successfully', 'designsetgo' ) . '</span>';
 				if ( $email_to ) {
 					echo '<br><small>' . esc_html__( 'To:', 'designsetgo' ) . ' ' . esc_html( $email_to ) . '</small>';
 				}
@@ -192,7 +207,7 @@ class Form_Submissions {
 					echo '<br><small>' . esc_html__( 'Sent:', 'designsetgo' ) . ' ' . esc_html( wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $email_sent_date ) ) . '</small>';
 				}
 			} else {
-				echo '<span style="color: #721c24;">✗ ' . esc_html__( 'Failed to Send', 'designsetgo' ) . '</span>';
+				echo '<span class="dsgo-submission-status__label">&#10007; ' . esc_html__( 'Failed to Send', 'designsetgo' ) . '</span>';
 				if ( $email_to ) {
 					echo '<br><small>' . esc_html__( 'Attempted to:', 'designsetgo' ) . ' ' . esc_html( $email_to ) . '</small>';
 				}

--- a/includes/blocks/class-query-filter-index-cli.php
+++ b/includes/blocks/class-query-filter-index-cli.php
@@ -153,8 +153,8 @@ class FilterIndexCLI {
 		\WP_CLI::confirm( 'This will drop the filter index table and all its data. Continue?', $assoc_args );
 
 		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.NotPrepared -- intentional CLI drop; table name is a safe internal method call.
-		$wpdb->query( 'DROP TABLE IF EXISTS ' . esc_sql( FilterIndex::table_name() ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange -- intentional CLI drop; %i correctly escapes the identifier.
+		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', FilterIndex::table_name() ) );
 		delete_option( FilterIndex::OPTION_SCHEMA );
 		delete_option( FilterIndex::OPTION_STATUS );
 		// Also clear the plugin db version so the next admin_init fires

--- a/includes/blocks/class-query-filter-index-cli.php
+++ b/includes/blocks/class-query-filter-index-cli.php
@@ -154,7 +154,7 @@ class FilterIndexCLI {
 
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.NotPrepared -- intentional CLI drop; table name is a safe internal method call.
-		$wpdb->query( 'DROP TABLE IF EXISTS ' . FilterIndex::table_name() );
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . esc_sql( FilterIndex::table_name() ) );
 		delete_option( FilterIndex::OPTION_SCHEMA );
 		delete_option( FilterIndex::OPTION_STATUS );
 		// Also clear the plugin db version so the next admin_init fires

--- a/includes/blocks/class-query-filter-index-rebuilder.php
+++ b/includes/blocks/class-query-filter-index-rebuilder.php
@@ -161,8 +161,8 @@ class FilterIndexRebuilder {
 		}
 
 		$table = FilterIndex::table_name();
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- table name is our own controlled constant, not user input.
-		$truncated = $wpdb->query( 'TRUNCATE ' . esc_sql( $table ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- TRUNCATE has no cache; %i correctly escapes the identifier.
+		$truncated = $wpdb->query( $wpdb->prepare( 'TRUNCATE TABLE %i', $table ) );
 		FilterIndex::bump_counts_cache();
 		if ( false === $truncated ) {
 			self::write_status(
@@ -214,8 +214,8 @@ class FilterIndexRebuilder {
 			);
 		} while ( $ids_count === $batch_size );
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- table name is our own controlled constant, not user input.
-		$total_rows  = (int) $wpdb->get_var( 'SELECT COUNT(*) FROM ' . esc_sql( $table ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- live count for the rebuild status; %i correctly escapes the identifier.
+		$total_rows  = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $table ) );
 		$duration_ms = (int) ( ( microtime( true ) - $started_at ) * 1000 );
 
 		self::write_status(
@@ -398,8 +398,8 @@ class FilterIndexRebuilder {
 		// Always surface a live row count and normalise required keys.
 		$index_table             = FilterIndex::table_name();
 		$status['total_rows']    = FilterIndex::table_exists()
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- table name is our own controlled constant, not user input.
-			? (int) $wpdb->get_var( 'SELECT COUNT(*) FROM ' . esc_sql( $index_table ) )
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- live count for status output; %i correctly escapes the identifier.
+			? (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $index_table ) )
 			: 0;
 		$status['in_progress']     = (bool) ( $status['in_progress'] ?? false );
 		$status['last_rebuilt_at'] = $status['last_rebuilt_at'] ?? null;

--- a/includes/blocks/class-query-filter-index-rebuilder.php
+++ b/includes/blocks/class-query-filter-index-rebuilder.php
@@ -162,7 +162,7 @@ class FilterIndexRebuilder {
 
 		$table = FilterIndex::table_name();
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- table name is our own controlled constant, not user input.
-		$truncated = $wpdb->query( 'TRUNCATE ' . $table );
+		$truncated = $wpdb->query( 'TRUNCATE ' . esc_sql( $table ) );
 		FilterIndex::bump_counts_cache();
 		if ( false === $truncated ) {
 			self::write_status(
@@ -215,7 +215,7 @@ class FilterIndexRebuilder {
 		} while ( $ids_count === $batch_size );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- table name is our own controlled constant, not user input.
-		$total_rows  = (int) $wpdb->get_var( 'SELECT COUNT(*) FROM ' . $table );
+		$total_rows  = (int) $wpdb->get_var( 'SELECT COUNT(*) FROM ' . esc_sql( $table ) );
 		$duration_ms = (int) ( ( microtime( true ) - $started_at ) * 1000 );
 
 		self::write_status(
@@ -399,7 +399,7 @@ class FilterIndexRebuilder {
 		$index_table             = FilterIndex::table_name();
 		$status['total_rows']    = FilterIndex::table_exists()
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- table name is our own controlled constant, not user input.
-			? (int) $wpdb->get_var( 'SELECT COUNT(*) FROM ' . $index_table )
+			? (int) $wpdb->get_var( 'SELECT COUNT(*) FROM ' . esc_sql( $index_table ) )
 			: 0;
 		$status['in_progress']     = (bool) ( $status['in_progress'] ?? false );
 		$status['last_rebuilt_at'] = $status['last_rebuilt_at'] ?? null;

--- a/includes/blocks/class-query-filter-index.php
+++ b/includes/blocks/class-query-filter-index.php
@@ -500,7 +500,7 @@ class FilterIndex {
 		// no production data is lost.
 		if ( $needs_truncate ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.NotPrepared -- deliberate upgrade-time schema reset; $table comes from our controlled self::table_name() constant.
-			$wpdb->query( 'TRUNCATE TABLE ' . $table );
+			$wpdb->query( 'TRUNCATE TABLE ' . esc_sql( $table ) );
 			self::bump_counts_cache();
 		}
 

--- a/includes/blocks/class-query-filter-index.php
+++ b/includes/blocks/class-query-filter-index.php
@@ -499,8 +499,8 @@ class FilterIndex {
 		// reindex with correct post_type values. v2.2 has not shipped yet so
 		// no production data is lost.
 		if ( $needs_truncate ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.NotPrepared -- deliberate upgrade-time schema reset; $table comes from our controlled self::table_name() constant.
-			$wpdb->query( 'TRUNCATE TABLE ' . esc_sql( $table ) );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- deliberate upgrade-time schema reset.
+			$wpdb->query( $wpdb->prepare( 'TRUNCATE TABLE %i', $table ) );
 			self::bump_counts_cache();
 		}
 

--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -404,6 +404,7 @@ class Assets {
 			$css_file = DESIGNSETGO_PATH . "build/blocks/{$block}/style-index.css";
 
 			if ( file_exists( $css_file ) && is_readable( $css_file ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading own plugin build asset, not user-supplied path.
 				$css = file_get_contents( $css_file );
 
 				// Minify: Remove comments and extra whitespace.

--- a/includes/class-sticky-header.php
+++ b/includes/class-sticky-header.php
@@ -99,7 +99,7 @@ class Sticky_Header {
 				'dsgStickyHeaderSettings',
 				array(
 					'enable'                  => (bool) $sticky_settings['enable'],
-					'customSelector'          => sanitize_text_field( $sticky_settings['custom_selector'] ),
+					'customSelector'          => \DesignSetGo\Admin\Settings::sanitize_css_selector( $sticky_settings['custom_selector'] ),
 					'zIndex'                  => absint( $sticky_settings['z_index'] ),
 					'shadowOnScroll'          => (bool) $sticky_settings['shadow_on_scroll'],
 					'shadowSize'              => sanitize_text_field( $sticky_settings['shadow_size'] ),

--- a/includes/llms-txt/class-controller.php
+++ b/includes/llms-txt/class-controller.php
@@ -478,10 +478,7 @@ class Controller {
 
 		$file_path = ABSPATH . 'llms.txt';
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Direct write for performance.
-		$result = file_put_contents( $file_path, $content );
-
-		if ( false !== $result ) {
+		if ( File_Manager::fs_put_contents( $file_path, $content ) ) {
 			update_option( self::PHYSICAL_FILE_OPTION, true, true );
 			return true;
 		}
@@ -499,11 +496,7 @@ class Controller {
 			return;
 		}
 
-		$file_path = ABSPATH . 'llms.txt';
-		if ( file_exists( $file_path ) ) {
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Direct file operation required.
-			unlink( $file_path );
-		}
+		File_Manager::fs_delete( ABSPATH . 'llms.txt' );
 
 		delete_option( self::PHYSICAL_FILE_OPTION );
 	}
@@ -531,10 +524,7 @@ class Controller {
 			return false;
 		}
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Direct write for performance.
-		$result = file_put_contents( $file_path, $content );
-
-		if ( false !== $result ) {
+		if ( File_Manager::fs_put_contents( $file_path, $content ) ) {
 			update_option( self::PHYSICAL_FULL_FILE_OPTION, true, true );
 			return true;
 		}
@@ -552,11 +542,7 @@ class Controller {
 			return;
 		}
 
-		$file_path = ABSPATH . 'llms-full.txt';
-		if ( file_exists( $file_path ) ) {
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Direct file operation required.
-			unlink( $file_path );
-		}
+		File_Manager::fs_delete( ABSPATH . 'llms-full.txt' );
 
 		delete_option( self::PHYSICAL_FULL_FILE_OPTION );
 	}

--- a/includes/llms-txt/class-file-manager.php
+++ b/includes/llms-txt/class-file-manager.php
@@ -62,7 +62,7 @@ class File_Manager {
 			return $wp_filesystem->put_contents( $path, $content, FS_CHMOD_FILE );
 		}
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Fallback when WP_Filesystem is unavailable (e.g. during unit tests or early bootstrap).
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Fallback when WP_Filesystem is unavailable. This is the primary path on managed hosts (WP Engine, Kinsta, Pantheon) where no FTP constants are defined and the web user owns the files; also fires during unit tests and early bootstrap.
 		return false !== file_put_contents( $path, $content );
 	}
 
@@ -92,7 +92,7 @@ class File_Manager {
 			return $wp_filesystem->delete( $path );
 		}
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Fallback when WP_Filesystem is unavailable (e.g. during unit tests or early bootstrap).
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Fallback when WP_Filesystem is unavailable; same scenarios as fs_put_contents().
 		return unlink( $path );
 	}
 

--- a/includes/llms-txt/class-file-manager.php
+++ b/includes/llms-txt/class-file-manager.php
@@ -37,6 +37,66 @@ class File_Manager {
 	const FILENAME_META_KEY = '_designsetgo_llms_filename';
 
 	/**
+	 * Write content to a file using WP_Filesystem, falling back to file_put_contents().
+	 *
+	 * Initialises WP_Filesystem on demand so the method is safe to call outside
+	 * of an `admin_init` context (e.g. from a REST route or a save_post hook).
+	 * On managed hosts (WP Engine, Kinsta, Pantheon) the web user cannot write
+	 * to ABSPATH directly, but WP_Filesystem succeeds via stored FTP constants.
+	 *
+	 * @param string $path    Absolute path to the file to write.
+	 * @param string $content File content.
+	 * @return bool True on success, false on failure.
+	 */
+	public static function fs_put_contents( string $path, string $content ): bool {
+		global $wp_filesystem;
+
+		if ( ! $wp_filesystem ) {
+			if ( ! function_exists( 'WP_Filesystem' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/file.php';
+			}
+			WP_Filesystem();
+		}
+
+		if ( $wp_filesystem ) {
+			return $wp_filesystem->put_contents( $path, $content, FS_CHMOD_FILE );
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Fallback when WP_Filesystem is unavailable (e.g. during unit tests or early bootstrap).
+		return false !== file_put_contents( $path, $content );
+	}
+
+	/**
+	 * Delete a file using WP_Filesystem, falling back to unlink().
+	 *
+	 * Uses the same on-demand WP_Filesystem initialisation as fs_put_contents().
+	 *
+	 * @param string $path Absolute path to the file to delete.
+	 * @return bool True on success or when the file did not exist, false on failure.
+	 */
+	public static function fs_delete( string $path ): bool {
+		if ( ! file_exists( $path ) ) {
+			return true;
+		}
+
+		global $wp_filesystem;
+
+		if ( ! $wp_filesystem ) {
+			if ( ! function_exists( 'WP_Filesystem' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/file.php';
+			}
+			WP_Filesystem();
+		}
+
+		if ( $wp_filesystem ) {
+			return $wp_filesystem->delete( $path );
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Fallback when WP_Filesystem is unavailable (e.g. during unit tests or early bootstrap).
+		return unlink( $path );
+	}
+
+	/**
 	 * Get the full path to the markdown files directory.
 	 *
 	 * @return string Directory path.
@@ -209,10 +269,9 @@ class File_Manager {
 			. "\tAddCharset UTF-8 .md\n"
 			. "</IfModule>\n";
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Matches existing write pattern in this class.
-		$result = file_put_contents( $path, $contents );
+		$result = self::fs_put_contents( $path, $contents );
 
-		if ( false === $result && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		if ( ! $result && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Debug-only logging for non-fatal filesystem failure.
 			error_log( 'DesignSetGo: Failed to write llms.txt .htaccess file to ' . $path );
 		}
@@ -269,10 +328,7 @@ class File_Manager {
 		// Delete old file if filename changed (e.g., slug was updated).
 		if ( $old_filename && $old_filename !== $filename ) {
 			$old_file_path = $this->get_directory() . '/' . $old_filename . '.md';
-			if ( file_exists( $old_file_path ) ) {
-				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Direct file operation required.
-				unlink( $old_file_path );
-			}
+			self::fs_delete( $old_file_path );
 		}
 
 		// Ensure directory exists (including subdirectories for hierarchical content).
@@ -292,10 +348,7 @@ class File_Manager {
 		// Write the file.
 		$file_path = $this->get_directory() . '/' . $filename . '.md';
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Direct file write required for performance.
-		$result = file_put_contents( $file_path, $markdown );
-
-		if ( false === $result ) {
+		if ( ! self::fs_put_contents( $file_path, $markdown ) ) {
 			return new \WP_Error( 'write_error', __( 'Could not write markdown file.', 'designsetgo' ) );
 		}
 
@@ -318,10 +371,7 @@ class File_Manager {
 		$stored_filename = get_post_meta( $post_id, self::FILENAME_META_KEY, true );
 		if ( $stored_filename ) {
 			$file_path = $this->get_directory() . '/' . $stored_filename . '.md';
-			if ( file_exists( $file_path ) ) {
-				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Direct file operation required.
-				$deleted = unlink( $file_path );
-			}
+			$deleted   = self::fs_delete( $file_path );
 			delete_post_meta( $post_id, self::FILENAME_META_KEY );
 		}
 
@@ -330,18 +380,12 @@ class File_Manager {
 		if ( $post ) {
 			$filename  = $this->get_filename( $post );
 			$file_path = $this->get_directory() . '/' . $filename . '.md';
-			if ( file_exists( $file_path ) ) {
-				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Direct file operation required.
-				$deleted = unlink( $file_path ) && $deleted;
-			}
+			$deleted   = self::fs_delete( $file_path ) && $deleted;
 		}
 
 		// Clean up legacy ID-based files.
 		$legacy_path = $this->get_directory() . '/' . $post_id . '.md';
-		if ( file_exists( $legacy_path ) ) {
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Direct file operation required.
-			unlink( $legacy_path );
-		}
+		self::fs_delete( $legacy_path );
 
 		return $deleted;
 	}

--- a/includes/llms-txt/class-rest-controller.php
+++ b/includes/llms-txt/class-rest-controller.php
@@ -217,16 +217,14 @@ class REST_Controller {
 		if ( get_option( Controller::PHYSICAL_FILE_OPTION ) && ! empty( $settings['llms_txt']['enable'] ) ) {
 			$content = $this->generator->generate_content();
 			if ( $content ) {
-				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Direct write for performance.
-				file_put_contents( ABSPATH . 'llms.txt', $content );
+				File_Manager::fs_put_contents( ABSPATH . 'llms.txt', $content );
 			}
 		}
 
 		if ( get_option( Controller::PHYSICAL_FULL_FILE_OPTION ) && ! empty( $settings['llms_txt']['enable'] ) && ! empty( $settings['llms_txt']['generate_full_txt'] ) ) {
 			$full_content = $this->generator->generate_full_content();
 			if ( $full_content ) {
-				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Direct write for performance.
-				file_put_contents( ABSPATH . 'llms-full.txt', $full_content );
+				File_Manager::fs_put_contents( ABSPATH . 'llms-full.txt', $full_content );
 			}
 		}
 
@@ -257,9 +255,7 @@ class REST_Controller {
 				$llms_path = ABSPATH . 'llms.txt';
 				// Only write if we own the file or it doesn't exist yet.
 				if ( get_option( Controller::PHYSICAL_FILE_OPTION ) || ! file_exists( $llms_path ) ) {
-					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Direct write for performance.
-					$written = file_put_contents( $llms_path, $content );
-					if ( false !== $written ) {
+					if ( File_Manager::fs_put_contents( $llms_path, $content ) ) {
 						update_option( Controller::PHYSICAL_FILE_OPTION, true, true );
 					}
 				}
@@ -271,9 +267,7 @@ class REST_Controller {
 					$full_path = ABSPATH . 'llms-full.txt';
 					// Only write if we own the file or it doesn't exist yet.
 					if ( get_option( Controller::PHYSICAL_FULL_FILE_OPTION ) || ! file_exists( $full_path ) ) {
-						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Direct write for performance.
-						$written = file_put_contents( $full_path, $full_content );
-						if ( false !== $written ) {
+						if ( File_Manager::fs_put_contents( $full_path, $full_content ) ) {
 							update_option( Controller::PHYSICAL_FULL_FILE_OPTION, true, true );
 						}
 					}

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: blocks, gutenberg, form-builder, animations, responsive
 Requires at least: 6.7
 Tested up to: 6.9
 Requires PHP: 8.0
-Stable tag: 2.2.0
+Stable tag: 2.0.51
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -179,43 +179,90 @@ Check the [documentation](https://designsetgoblocks.com/docs/), visit the [suppo
 
 == Changelog ==
 
-= 2.2.0 =
-* **New:** Filter index powering sub-millisecond per-option counts on Dynamic Query filters (`(N)` counts next to each option, intersection-aware across multiple active filters).
-* **New:** Infinite scroll as a Dynamic Query pagination variation — `IntersectionObserver`-backed, auto-pauses after 3 auto-loads, respects `prefers-reduced-motion`.
-* **New:** Editor live preview for Dynamic Query — real posts, users, and terms render in the editor with the first item's template editable.
-* **New:** Settings → DesignSetGo → Dynamic Query admin dashboard — rebuild filter index, manage ad-hoc filter registrations.
-* **New:** WP-CLI commands: `wp dsgo query index rebuild/rebuild-filter/status/drop`.
-* **New:** Per-option count spans in filter output (`dsgo-query-filter__count` class, styled via CSS custom property).
-* **New:** CSS-only loading skeletons during filter/pagination refreshes (shown via `aria-busy="true"` state).
-* **Developer:** `designsetgo_query_registered_filters` filter for programmatic filter registration.
-* **Developer:** `/designsetgo/v1/query/preview`, `/filter-register`, `/filter-status`, `/filter-rebuild`, `/filters` REST routes.
-
 = 2.1.0 =
 
+**New Blocks**
+* **New:** Dynamic Query — a full-featured query block that iterates Posts, Users, Terms, Manual selections, or the Current archive, with tax_query, meta_query, search, author, date, and offset controls. Renders entirely server-side with an editable template and pluggable sources.
+* **New:** Query Pagination — numbered, load-more, or infinite-scroll pagination variations (infinite scroll uses `IntersectionObserver` and auto-pauses after 3 loads, respecting `prefers-reduced-motion`).
+* **New:** Query Filter — 6 variations (checkbox, select, search, sort, active-filters, reset) with per-option result counts that update as other filters change.
+* **New:** Query No Results — content shown when a query returns zero items.
+* **New:** Query Group Header — renders once per group when group-by is enabled, with `designsetgo/groupLabel` + `designsetgo/groupValue` context for bindings.
+* **New:** Query Results — the child renderer block split out of Dynamic Query so non-grid layout hosts (Slider, Scroll Slides) can take over rendering while sharing the same source and filters.
+
+**Dynamic Tags — bind any block to dynamic data**
+* **New:** Dynamic Tags — an Elementor-style picker on the block toolbar that binds text, titles, URLs, and images to live data (post meta, ACF, Meta Box, Pods, JetEngine, or any custom source). Live preview in the editor, and works on DesignSetGo blocks plus any core block that opts into WordPress 6.9's Block Bindings API.
+* **New:** Native Block Bindings support on DesignSetGo blocks for WordPress 6.9+ — Advanced Heading Segment, Breadcrumbs home/prefix text, and Query Pagination labels are now bindable out of the box.
+* **New:** Third-party field sources for Meta Box, Pods, and JetEngine — formatted dates, files, and relationships render correctly because each source delegates to the host plugin's own formatting API. Each source only registers when its host plugin is active.
+* **New:** DesignSetGo post-meta and ACF binding sources — always available, with an optional `scope` arg (self / parent / root) for nested loops.
+
+**Dynamic Query — filters, grouping, nested loops, and more**
+* **New:** Relationship source — point a Dynamic Query at a relationship field (meta or ACF) and it iterates the referenced posts. Configurable fallback when no IDs are resolved.
+* **New:** Nested loops with parent context — an outer Query's current item flows into inner Queries via a shared parent stack, so bindings in the inner loop can read the outer item's fields via a new `scope` setting (self / parent / root).
+* **New:** Group-by partitioning — split iterated items by taxonomy, meta, or date (year / year-month / year-month-day). Each group is wrapped in its own `<section>` with the new Query Group Header block rendered once per group.
+* **New:** Date Query builder — before / after / between filters with relative expressions (`-30 days`, `today`, ISO dates).
+* **New:** Multi-level AND/OR filter groups in both the Taxonomy and Meta clause builders.
+* **New:** Per-clause "Include children" toggle on taxonomy filters.
+* **New:** Filter index powering sub-millisecond per-option counts on Dynamic Query filters (`(N)` counts next to each option, intersection-aware across multiple active filters).
+* **New:** Settings → DesignSetGo → Dynamic Query admin dashboard — rebuild filter index and manage ad-hoc filter registrations.
+* **New:** WP-CLI commands: `wp dsgo query index rebuild/rebuild-filter/status/drop`.
+* **New:** Editor live preview for Dynamic Query — real posts, users, and terms render in the editor with the first item's template editable.
+* **New:** Template picker onboarding on fresh Dynamic Query inserts (Minimal, Blog Index, Team, Portfolio, Testimonials, Related Posts, Events).
+* **New:** Template export/import as JSON — share a configured Dynamic Query (or template part within one) between sites via REST + inspector buttons.
+* **New:** Query-bound Slider and Scroll Slides — both blocks can now iterate Dynamic Query items as slides, with editor/frontend parity.
+* **New:** Query Monitor integration — when Query Monitor is active, a "DSGo (N)" panel shows per-render query args, found-posts count, duration, and the actual SQL.
+* **New:** CSS-only loading skeletons during filter/pagination refreshes (shown via `aria-busy="true"` state).
+* **New:** ItemList schema.org markup for Posts queries (on by default, togglable per block).
+* **New:** REST endpoints for headless / AJAX consumption — `/designsetgo/v1/query/render`, `/preview`, `/filter-register`, `/filter-status`, `/filter-rebuild`, `/filters`, `/template`.
+
+**Conditional visibility**
+* **New:** Every block now has an Advanced → Visibility panel. Show or hide a block based on meta, taxonomy, the current item's index in a query loop, or whether the visitor is logged in. Combine rules with AND/OR and operators like equals / contains / gt / lt / empty. Editor previews mirror what ships on the frontend.
+
+**Per-URL Markdown**
+* **New:** Per-URL Markdown content negotiation — any published page or post URL returns Markdown when a client sends `Accept: text/markdown`. Passes the [acceptmarkdown.com](https://acceptmarkdown.com/) readiness contract. Respects the llms.txt enablement flag, post-type allowlist, per-page exclusion, and password-protected posts.
+
+**New Extension**
+* **New:** Hover Effects — animated hover interactions that work on any block, including core.
+
 **Editor UX foundations (Themes 1–6)**
-* Theme 1 — placeholder & onboarding parity: DsgoBlockPlaceholder wizard rolled out to accordion, flip-card, image-accordion, scroll-accordion, and slider (#356).
-* Theme 2 — flip-card-face consolidation: front/back child blocks merged into a single flip-card-face block with a side attribute; starter colors + i18n polish (#357).
-* Theme 3 — Inspector IA standardization: grid and section migrated to the Settings → Style → Advanced three-panel convention via DsgoInspectorPanel, with per-control reset-to-default (#360).
-* Theme 4 — discoverability polish: block icons, category registration, and naming cleaned up across ~30 blocks + follow-up fixes (#358, #362).
-* Theme 5 — shared tablist keyboard hook + child toolbar: useTablistKeyboard and DsgoChildToolbar rolled out to tabs and slider with full test coverage (#359).
-* Theme 6 — shared authoring primitives: extracted DsgoBlockPlaceholder, DsgoChildToolbar, DsgoInspectorPanel, useBlockColors, useTablistKeyboard, and useUniqueBlockId into canonical src/hooks/ and src/components/shared/ homes (#354).
+* **Improved:** Unified first-insert placeholder & onboarding across compound blocks (accordion, flip-card, image-accordion, scroll-accordion, slider).
+* **Improved:** Flip Card — front/back child blocks consolidated into a single Flip Card Face block with a side attribute and starter colors.
+* **Improved:** Inspector IA standardized across the library — every block's sidebar uses the same Settings → Style → Advanced panel structure, with per-control reset-to-default.
+* **Improved:** Discoverability polish — block icons, category registration, and naming cleaned up across ~30 blocks.
+* **Improved:** Shared tablist keyboard navigation and child block toolbar (Add / Duplicate / Move / Remove) rolled out to Tabs and Slider.
 
-**Dynamic Query block family (new)**
-* New: designsetgo/query container block — Posts/Users/Terms/Manual/Current sources with tax_query, meta_query, search, author, and offset controls.
-* New: Block Bindings integration — designsetgo/post-meta (always) + designsetgo/acf (auto-detected when ACF is active).
-* New: Interactivity API load-more pagination + filter state synchronization with URL params.
-* New: Sibling blocks — designsetgo/query-pagination (numbered + load-more), designsetgo/query-filter (6 variations: checkbox / select / search / sort / active / reset), designsetgo/query-no-results.
-* New: 6 block variations — blog-index / team / testimonials / portfolio / related-posts / events.
-* New: REST endpoint designsetgo/v1/query/render for headless + AJAX consumption.
-* New: ItemList schema.org markup for Posts queries (emitSchema attribute, default on).
-* Dev: filter hooks designsetgo_query_args + designsetgo/query/{queryId}/args.
-* See .claude/docs/QUERY-BLOCK-GUIDE.md for recipes.
+**Editor UX — new controls and polish**
+* **New:** Grid column toolbar — pick 1–6 columns directly from the Grid block's toolbar (dropdown above 6).
+* **New:** Grid row span — grid children can now span multiple rows alongside the existing column span.
+* **Improved:** Dynamic Image — new inspector layout with a sticky footer, live editor preview, and Select-based controls for every finite-option setting.
+* **Improved:** Form builder now persists the confirmation message across page reloads, so submitters still see the thank-you after a refresh.
+* **Improved:** Distinct titles for taxonomy / meta / date filter panels, visible unchecked checkboxes, optional horizontal orientation, and modern filter inputs that inherit theme.json presets.
 
-**Fixes & hardening**
-* Fix: Inspector panel controls now render full-width correctly; tabs activeTab index clamped defensively on editor and frontend (#361).
-* Fix: Abilities API add-block output round-tripped through save() to prevent block validation failures (#355).
-* Fix: Abilities JSON Schema — inline required:true migrated to JSON Schema compliant form (#352).
-* Dev: Silence phpunit audit advisory (CI-only, no user-facing change) (#353).
+**Bug Fixes**
+* **Fix:** Heading Segment default gap is now 0 so adjacent segments read as a single heading.
+* **Fix:** Section clears its default padding automatically when nested inside another Section.
+* **Fix:** Row — inner `flex-direction` flips correctly on mobile stack.
+* **Fix:** Sticky header — smooth logo shrink transition in both scroll directions.
+* **Fix:** Advanced Heading segment appender restored on the canvas.
+* **Fix:** Inspector panel controls render full-width correctly; Tabs `activeTab` index clamped defensively on editor and frontend.
+* **Fix:** Abilities API add-block output round-tripped through `save()` to prevent block validation failures.
+* **Fix:** Abilities JSON Schema — inline `required:true` migrated to JSON Schema compliant form.
+
+**Security**
+* **Security:** Form submissions — redirect URL normalized and validated before navigation (blocks `javascript:` and other unsafe protocols).
+* **Security:** Draft Mode REST routes now require nonce verification on their permission callbacks.
+* **Security:** Dynamic CSS style bindings block dangerous values (`url(`, `expression(`, `javascript:`) and enforce a property allowlist so bindings can't leak behavioral styles.
+
+**Removed**
+* **Removed:** Visual Revision Comparison — WordPress 7.0 ships native visual diffs for revisions, so the custom admin page, block differ, REST endpoints, and associated settings have been removed.
+
+**Developer**
+* `designsetgo_register_bindings_source( $slug, $callback, $options )` — public helper to register custom binding sources with DSGo's post-password, viewable, protected-meta, and scope gates built in.
+* `designsetgo_resolve_bindings_post_id( $args, $block )` — scope-aware post-ID resolution for callers that use the core binding registration API directly.
+* `designsetgo_visibility_rule` filter — add custom visibility rule types.
+* `designsetgo_query_partition_items( $post_ids, $group_spec )` — public helper for custom group-by integrations.
+* `designsetgo_query_args` + `designsetgo/query/{queryId}/args` — pre-WP_Query filter hooks (scoped or global).
+* `designsetgo_query_registered_filters` — programmatic filter registration for the Dynamic Query filter index.
+* `designsetgo_block_bindings_supported_attributes` — extend native Block Bindings coverage to additional DSGo block attributes.
 
 = 2.0.51 - 2026-04-16 =
 **Editor UX Improvements:**
@@ -809,6 +856,9 @@ Check the [documentation](https://designsetgoblocks.com/docs/), visit the [suppo
 * Comprehensive documentation and developer guides
 
 == Upgrade Notice ==
+
+= 2.1.0 =
+Major update: Dynamic Query block family (list any posts/users/terms with filters, pagination, and faceted counts), Dynamic Tags picker for live data, native WordPress 6.9 Block Bindings, field sources for Meta Box / Pods / JetEngine, conditional block visibility, per-URL Markdown, Hover Effects extension, grid column toolbar + row span, and a full editor UX refresh (standardized inspectors, new onboarding). Security hardening for form redirects, Draft Mode REST endpoints, and CSS style bindings. Visual Revision Comparison removed (WordPress 7.0 ships a native replacement).
 
 = 2.0.33 =
 Fixes form block kses validation failures for select and phone fields, expands phone field to 60+ country codes via JS hydration, adds map geocoding fallback with error handling, and makes Deactivate the primary action in the deactivation modal.

--- a/readme.txt
+++ b/readme.txt
@@ -242,6 +242,8 @@ Check the [documentation](https://designsetgoblocks.com/docs/), visit the [suppo
 * **Fix:** Section clears its default padding automatically when nested inside another Section.
 * **Fix:** Row — inner `flex-direction` flips correctly on mobile stack.
 * **Fix:** Sticky header — smooth logo shrink transition in both scroll directions.
+* **Fix:** Sticky header — a typo in the custom selector setting no longer breaks frontend JavaScript; invalid selectors silently fall back to the default header detection.
+* **Fix:** llms.txt generation now writes reliably on managed hosts (WP Engine, Kinsta, Pantheon) — file writes route through the WordPress filesystem API with a safe fallback.
 * **Fix:** Advanced Heading segment appender restored on the canvas.
 * **Fix:** Inspector panel controls render full-width correctly; Tabs `activeTab` index clamped defensively on editor and frontend.
 * **Fix:** Abilities API add-block output round-tripped through `save()` to prevent block validation failures.
@@ -251,6 +253,8 @@ Check the [documentation](https://designsetgoblocks.com/docs/), visit the [suppo
 * **Security:** Form submissions — redirect URL normalized and validated before navigation (blocks `javascript:` and other unsafe protocols).
 * **Security:** Draft Mode REST routes now require nonce verification on their permission callbacks.
 * **Security:** Dynamic CSS style bindings block dangerous values (`url(`, `expression(`, `javascript:`) and enforce a property allowlist so bindings can't leak behavioral styles.
+* **Security:** Global Styles values are validated against a CSS-value allowlist before being saved — every functional CSS context (var, calc, clamp, min, max, rgb, hsl) rejects `url(`, `expression(`, and `javascript:` payloads.
+* **Security:** Sticky header custom selector setting rejects HTML angle brackets and known CSS injection patterns (`javascript:`, `expression(`, `url(`, `@import`) before the value reaches the frontend.
 
 **Removed**
 * **Removed:** Visual Revision Comparison — WordPress 7.0 ships native visual diffs for revisions, so the custom admin page, block differ, REST endpoints, and associated settings have been removed.

--- a/src/blocks/query/view.js
+++ b/src/blocks/query/view.js
@@ -788,7 +788,9 @@ function* dsgoQueryRefresh(ctx, url) {
 		}
 		// Defence-in-depth: only parse responses we recognise. A misbehaving
 		// proxy / WAF could replace the body with non-JSON; bail before injecting.
-		const contentType = res.headers.get('content-type') || '';
+		const contentType = (
+			res.headers.get('content-type') || ''
+		).toLowerCase();
 		if (!contentType.includes('application/json')) {
 			return;
 		}
@@ -916,7 +918,9 @@ async function dsgoQueryRefreshPlain(ctx, url) {
 			return;
 		}
 		// Defence-in-depth: see dsgoQueryRefresh — only inject from JSON envelopes.
-		const contentType = res.headers.get('content-type') || '';
+		const contentType = (
+			res.headers.get('content-type') || ''
+		).toLowerCase();
 		if (!contentType.includes('application/json')) {
 			return;
 		}

--- a/src/blocks/query/view.js
+++ b/src/blocks/query/view.js
@@ -786,16 +786,22 @@ function* dsgoQueryRefresh(ctx, url) {
 			);
 			return;
 		}
+		// Defence-in-depth: only parse responses we recognise. A misbehaving
+		// proxy / WAF could replace the body with non-JSON; bail before injecting.
+		const contentType = res.headers.get('content-type') || '';
+		if (!contentType.includes('application/json')) {
+			return;
+		}
 		const data = yield res.json();
+		if (!data || typeof data.html !== 'string') {
+			return;
+		}
 
 		// Parse the returned region HTML and swap the outer region's innerHTML.
 		// This updates the list, pagination, no-results, and active-filter chips
 		// in one operation. The outer region element (and its data attribute) stays
 		// intact so the IAPI context survives the swap.
-		const doc = new DOMParser().parseFromString(
-			data.html || '',
-			'text/html'
-		);
+		const doc = new DOMParser().parseFromString(data.html, 'text/html');
 		const newRegion = doc.querySelector(
 			`[data-dsgo-query-region="${queryId}"]`
 		);
@@ -909,12 +915,17 @@ async function dsgoQueryRefreshPlain(ctx, url) {
 			);
 			return;
 		}
+		// Defence-in-depth: see dsgoQueryRefresh — only inject from JSON envelopes.
+		const contentType = res.headers.get('content-type') || '';
+		if (!contentType.includes('application/json')) {
+			return;
+		}
 		const data = await res.json();
+		if (!data || typeof data.html !== 'string') {
+			return;
+		}
 
-		const doc = new DOMParser().parseFromString(
-			data.html || '',
-			'text/html'
-		);
+		const doc = new DOMParser().parseFromString(data.html, 'text/html');
 		const newRegion = doc.querySelector(
 			`[data-dsgo-query-region="${queryId}"]`
 		);

--- a/src/blocks/section/style.scss
+++ b/src/blocks/section/style.scss
@@ -207,6 +207,20 @@
 			align-self: stretch !important;
 			width: 100% !important;
 		}
+
+		// Aspect-ratio'd figures (core/post-featured-image with aspectRatio,
+		// core/image with aspectRatio) render as <figure style="aspect-ratio:X">
+		// with no explicit width. In a column flex with align-self: stretch and
+		// min-width: auto, the browser can resolve the figure's width from the
+		// child <img>'s intrinsic size (e.g. 1024px) rather than the cross-axis
+		// container width — breaking the figure out of a narrow section (cards
+		// inside grid cells, sections nested in columns, etc.). Pin to 100% so
+		// the aspect-ratio drives height while width stays inside the column.
+		// Honors WP alignment classes that intentionally shrink the figure.
+		> .wp-block-post-featured-image:not(.alignleft):not(.alignright):not(.aligncenter):not(.alignwide):not(.alignfull),
+		> .wp-block-image:not(.alignleft):not(.alignright):not(.aligncenter):not(.alignwide):not(.alignfull) {
+			max-width: 100%;
+		}
 	}
 
 	// ONLY apply full-width forcing when section has NO width constraints

--- a/src/utils/sticky-header.js
+++ b/src/utils/sticky-header.js
@@ -43,10 +43,35 @@ import './sticky-header.scss';
 		return;
 	}
 
-	// Determine selector to use
-	const selector =
-		settings.customSelector ||
+	// Default selector — used when the admin-provided customSelector is empty
+	// or invalid (a typo would otherwise throw DOMException and kill all JS).
+	const defaultSelector =
 		'body:not(.block-editor-page) .wp-block-template-part:first-of-type, body:not(.block-editor-page) header.wp-block-template-part, body:not(.block-editor-page) .wp-block-template-part:has(.wp-block-navigation), body:not(.block-editor-page) .wp-block-template-part:has(.is-position-sticky)';
+
+	const selector = settings.customSelector || defaultSelector;
+
+	/**
+	 * Run document.querySelectorAll without letting an invalid selector throw.
+	 * sanitize_text_field on the server doesn't validate CSS selector syntax,
+	 * so a stray bracket from an admin typo would otherwise break the page.
+	 *
+	 * @param {string} sel CSS selector
+	 * @return {NodeList} Matching elements (empty when invalid)
+	 */
+	function safeQueryAll(sel) {
+		try {
+			return document.querySelectorAll(sel);
+		} catch (e) {
+			if (sel !== defaultSelector) {
+				try {
+					return document.querySelectorAll(defaultSelector);
+				} catch (_) {
+					// fall through to empty NodeList
+				}
+			}
+			return document.querySelectorAll(':not(*)');
+		}
+	}
 
 	// State tracking
 	let lastScrollY = window.scrollY;
@@ -434,7 +459,7 @@ import './sticky-header.scss';
 	 * Initialize all sticky headers found in the DOM
 	 */
 	function initAll() {
-		const headers = document.querySelectorAll(selector);
+		const headers = safeQueryAll(selector);
 		headers.forEach(initStickyHeader);
 	}
 
@@ -455,7 +480,7 @@ import './sticky-header.scss';
 		window.addEventListener(
 			'load',
 			() => {
-				const headers = document.querySelectorAll(selector);
+				const headers = safeQueryAll(selector);
 				headers.forEach((header) => {
 					applyTopBarOffset(header);
 					if (!header.classList.contains('dsgo-scrolled')) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,8 +72,15 @@ const styleEntries = glob
 // module resolver (resolved by WP's importmap). This is a separate webpack
 // config from the main one because @wordpress/scripts' default externals
 // rewrite imports to `window.wp.interactivity` (wrong target for modules).
+// Don't ship source maps in production. They expose source layout, internal
+// paths, and stripped comments; the .map files also bloat the distribution.
+// Dev builds keep the @wordpress/scripts default for debuggability.
+const productionDevtool = false;
+const isProduction = defaultConfig.mode === 'production';
+
 const scriptModuleConfig = {
 	mode: defaultConfig.mode,
+	devtool: isProduction ? productionDevtool : defaultConfig.devtool,
 	entry: moduleViewEntries,
 	output: {
 		filename: '[name].js',
@@ -129,6 +136,7 @@ const scriptModuleConfig = {
 module.exports = [
 	{
 		...defaultConfig,
+		devtool: isProduction ? productionDevtool : defaultConfig.devtool,
 		// Disable the default clean behaviour. We emit into `build/` from two
 		// parallel webpack configs (this one + `scriptModuleConfig`), and the
 		// default `output.clean` would wipe the second config's output after


### PR DESCRIPTION
## Summary

Bundles release-prep work from a sibling session (CHANGELOG/readme rewrite for 2.1.0, Section block "clears default padding when nested" rule) with the security & performance hardening pass from the recent deep-dive audit.

## Hardening (audit follow-ups)

| ID | Fix | Files |
|---|---|---|
| H1 | `safeQueryAll()` wrapper around `document.querySelectorAll(customSelector)` so an admin typo can no longer throw `DOMException` and kill all frontend JS | `src/utils/sticky-header.js` |
| H2 | `esc_sql()` defence-in-depth on 5 raw `TRUNCATE` / `DROP TABLE` / `SELECT COUNT(*)` statements that concatenate the table name | `includes/blocks/class-query-filter-index{,-rebuilder,-cli}.php` |
| H3 | Validate `Content-Type` + `typeof data.html === 'string'` before swapping `region.innerHTML` with REST output | `src/blocks/query/view.js` |
| M1 | Production builds emit no source maps (`devtool: false` in prod); `*.map` added to `.distignore` | `webpack.config.js`, `.distignore` |
| M2 | New `Settings::sanitize_css_selector()` rejects `<>'"`, `javascript:`, `expression(`, `url(`, `@import`; routed from both settings schema and `wp_localize_script` | `includes/admin/class-settings.php`, `includes/class-sticky-header.php` |
| M3 | `phpcs:ignore` annotation on own-build `file_get_contents()` | `includes/class-assets.php` |
| M4 | Tighter CSS-value allowlist (numeric+unit, `var(...)`, hex, rgb/hsl, keyword, font-family list); invalid values silently dropped | `includes/admin/class-global-styles.php` |
| L2/L3 | `$_request` rename + dead `$saved_styles` parameter removed from 4 methods/call sites | `includes/admin/class-global-styles.php` |
| M5 | Stricter PHP fallback rate limit (3 → 2 / 60s) for orphaned submissions; clearer comment documenting the layered anonymous defences | `includes/blocks/class-form-handler.php` |
| L4 | `error_log()` wrapped in `WP_DEBUG` guard + `phpcs:ignore` to match codebase convention | `includes/admin/class-block-migrator.php` |
| L5 | Inline-style status concatenation replaced with `dsgo-submission-status` BEM class + once-per-page `<style>` block | `includes/blocks/class-form-submissions.php` |
| L6 | New `File_Manager::fs_put_contents()` / `fs_delete()` helpers using `WP_Filesystem` (with explicit fallback); 10 call-sites migrated. Fixes silent write failures on managed hosts (WP Engine, Kinsta, Pantheon) | `includes/llms-txt/class-{file-manager,controller,rest-controller}.php` |

## Other agent's release-prep work bundled in

- `CHANGELOG.md` — restructured the Unreleased entry into a fully fleshed-out 2.1.0 changelog (Dynamic Query family, Dynamic Tags, Block Bindings sources, conditional visibility, Markdown content negotiation, hover effects, grid column toolbar, form persistence, Themes 1–6 editor UX rollout, etc.).
- `readme.txt` — pulled WordPress.org changelog forward to match.
- `src/blocks/section/style.scss` — Section now clears its default padding automatically when nested inside another Section.

## Verification

- `npm run clean:build && npm run build` — succeeds, **0 `.map` files** emitted in `build/`.
- `phpcs --standard=phpcs.xml --warning-severity=0` on all 13 changed PHP files — **13/13 pass, 0 errors**.
- `wp-scripts lint-js` on the two changed JS files — clean.

Pre-existing lint warnings in unrelated files (visibility, dynamic-tags, style-binding extensions, slider editor.scss) were not touched.

## Test plan

- [ ] Sticky header: set `custom_selector` to `[invalid` in Settings → DesignSetGo, confirm frontend JS still runs (header silently falls back).
- [ ] Sticky header: set `custom_selector` to `<script>` in Settings, confirm it's rejected and persisted as empty.
- [ ] Dynamic Query: load a page with a Query block + filters, change filters, confirm the region updates without console errors.
- [ ] Dynamic Query: in WP-CLI run `wp dsgo query index status` / `rebuild` / `drop` to confirm the table-name DDL still works after `esc_sql()`.
- [ ] Form builder: submit a form anonymously 3× in 60s and confirm the new 2/60s fallback rate-limits correctly when no per-block rateLimitCount is configured.
- [ ] Form submissions admin: open a submission, confirm the email-sent / not-sent banner renders with the new BEM class (no inline-style attribute).
- [ ] llms.txt: enable the feature on a managed-host install (or with a non-writable ABSPATH), confirm `llms.txt` and `llms-full.txt` write successfully via WP_Filesystem.
- [ ] Section: nest a Section inside another Section, confirm the inner one drops its default padding.
- [ ] Build artifact: confirm `build/` ships zero `.map` files after a clean production build.