### PR TITLE
ci: let claude review run on fork PRs (pull_request_target)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,7 @@ name: Claude Code Review
 # inside this workflow without first re-evaluating the threat model.
 on:
   pull_request_target:
-    types: [opened, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   claude-review:
@@ -30,6 +30,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          # Don't leave the privileged base-repo GITHUB_TOKEN in .git/config
+          # while untrusted PR code is on disk.
+          persist-credentials: false
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,18 @@
 name: Claude Code Review
 
+# Uses `pull_request_target` so the workflow runs in the BASE repo context with
+# access to secrets (CLAUDE_CODE_OAUTH_TOKEN) and `id-token: write`. The default
+# `pull_request` event runs from forks WITHOUT secrets, which made every
+# external-contributor PR fail with "Unable to get ACTIONS_ID_TOKEN_REQUEST_URL".
+#
+# SECURITY: `pull_request_target` runs privileged. The action below:
+#   - Checks out the PR head SHA explicitly (untrusted code).
+#   - Only uses read-only tools (Read/Grep/Glob) plus a narrow `gh pr` allowlist.
+#   - Does NOT execute any build/test scripts from the PR.
+# Do not add steps that run code from the PR (e.g. `npm install`, `npm test`)
+# inside this workflow without first re-evaluating the threat model.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review]
 
 jobs:
@@ -14,9 +25,10 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout repository
+      - name: Checkout PR head
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Run Claude Code Review


### PR DESCRIPTION
## Summary

- Switch `.github/workflows/claude-code-review.yml` from `pull_request` to `pull_request_target` so the AI code review fires on PRs from forks/non-admins (e.g. #391, which failed because `pull_request` from forks runs without secrets and without `id-token: write`).
- Explicitly check out `github.event.pull_request.head.sha` so Claude reviews the actual proposed code rather than `main`.

## Why

PR #391 came from a fork (`ncimbaljevic-godaddy/designsetgo`). The run failed at:

> `Failed to get OIDC token: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`

That's GitHub's deliberate behavior: secrets and OIDC are stripped from `pull_request` events triggered by forks. `pull_request_target` runs in the base-repo context where `CLAUDE_CODE_OAUTH_TOKEN` and `id-token: write` are available.

## Security note

`pull_request_target` is privileged — it runs against the base branch's workflow file with secrets, then checks out untrusted PR code. The exposure here is bounded:

- The action only uses **read-only file tools** (`Read`, `Grep`, `Glob`) plus a narrow `gh pr` allowlist (`comment`, `diff`, `view`, `review`).
- No `npm install` / `npm test` / arbitrary script execution from PR content runs in this workflow.
- A header comment in the workflow warns future contributors not to add code-execution steps without revisiting the threat model.

Residual risk: a malicious PR could include prompt-injection content aimed at flipping the review verdict. That's tolerable given the bounded tool surface, and inline review comments are still subject to human review.

## Test plan

- [ ] Merge to `main`.
- [ ] Comment on #391 to re-trigger or push an empty commit there to confirm the new trigger fires with secrets present.
- [ ] Open a future fork PR; confirm `Claude Code Review` runs and posts a review.