### PR TITLE
release: 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the DesignSetGo plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-04-27
+
+### Bug Fixes
+- **Eliminate `_load_textdomain_just_in_time` notices on WordPress 6.7+** — Defer Dynamic Tags default group registration to `after_setup_theme`, and defer Abilities API category/ability registration to `init` when those hooks fire before translations are loaded. The previous code path called `__()` before WordPress had finished loading translations, which surfaced as PHP notices on 6.7 and grew louder on 6.9. (#391, thanks @ncimbaljevic-godaddy)
+
 ## [2.1.0] - 2026-04-24
 
 ### New Blocks

--- a/designsetgo.php
+++ b/designsetgo.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DesignSetGo
  * Plugin URI:        https://designsetgoblocks.com
  * Description:       Professional Gutenberg block library with 52 blocks and 16 powerful extensions - complete Form Builder, container system, interactive elements, maps, modals, breadcrumbs, timelines, scroll effects, and animations. Built with WordPress standards for guaranteed editor/frontend parity.
- * Version:           2.1.0
+ * Version:           2.1.1
  * Requires at least: 6.7
  * Requires PHP:      8.0
  * Author:            DesignSetGo

--- a/docs/guides/DEPLOYING-TO-WORDPRESS-ORG.md
+++ b/docs/guides/DEPLOYING-TO-WORDPRESS-ORG.md
@@ -187,11 +187,11 @@ After the release commit lands on `main`:
 ```bash
 git checkout main
 git pull
-git tag 2.2.0           # NO leading "v"
-git push origin 2.2.0
+git tag v2.2.0
+git push origin v2.2.0
 ```
 
-> **The tag name IS the WP.org SVN tag.** Use the bare version (`2.2.0`), not `v2.2.0`. Mismatched tags must be re-cut — SVN tags cannot be silently re-pointed.
+> **Tag convention:** this repo uses `v`-prefixed tags (`v2.1.0`, `v2.0.51`, …). [`10up/action-wordpress-plugin-deploy`](https://github.com/10up/action-wordpress-plugin-deploy) strips the leading `v` before pushing to SVN, so WordPress.org still gets `2.2.0` as the SVN tag and that's what `Stable tag` in `readme.txt` must match. SVN tags cannot be silently re-pointed; if you mis-tag, cut a new patch version rather than trying to overwrite.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "designsetgo",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Professional Gutenberg block library with 46 blocks and 14 extensions - complete Form Builder, container system, interactive elements, scroll effects, and animations. Built with WordPress standards.",
   "author": "DesignSetGo",
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: blocks, gutenberg, form-builder, query-loop, animations
 Requires at least: 6.7
 Tested up to: 6.9
 Requires PHP: 8.0
-Stable tag: 2.1.0
+Stable tag: 2.1.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,10 @@ Yes to both. All blocks work in the Site Editor, templates, and template parts. 
 10. Mobile responsive preview in the editor
 
 == Changelog ==
+
+= 2.1.1 - 2026-04-27 =
+
+* **Fix:** Eliminates `_load_textdomain_just_in_time` PHP notices on WordPress 6.7+. Dynamic Tags default group registration now defers to `after_setup_theme`, and Abilities API registrations defer to `init` when those hooks fire before translations are loaded. Recommended for all sites; no content or settings changes required. (Props @ncimbaljevic-godaddy)
 
 = 2.1.0 - 2026-04-24 =
 
@@ -775,6 +779,9 @@ Yes to both. All blocks work in the Site Editor, templates, and template parts. 
 * Comprehensive documentation and developer guides
 
 == Upgrade Notice ==
+
+= 2.1.1 =
+Patch fix for WordPress 6.7+: eliminates `_load_textdomain_just_in_time` PHP notices triggered by early translation function calls. Recommended for all sites.
 
 = 2.1.0 =
 Major update: Dynamic Query block family (list any posts/users/terms with filters, pagination, and faceted counts), Dynamic Tags picker for live data, native WordPress 6.9 Block Bindings, field sources for Meta Box / Pods / JetEngine, conditional block visibility, per-URL Markdown, Hover Effects extension, grid column toolbar + row span, and a full editor UX refresh (standardized inspectors, new onboarding). Security hardening for form redirects, Draft Mode REST endpoints, and CSS style bindings. Visual Revision Comparison removed (WordPress 7.0 ships a native replacement).


### PR DESCRIPTION
## Summary

Patch release. Bumps `Version` / `Stable tag` / `package.json` from `2.1.0` to `2.1.1` and adds the changelog + upgrade-notice entries.

## What's in 2.1.1

A single user-visible bug fix:

- **Eliminates `_load_textdomain_just_in_time` PHP notices on WordPress 6.7+.** Dynamic Tags default group registration now defers to `after_setup_theme`, and Abilities API registrations defer to `init` when those hooks fire before translations are loaded. The previous code path called `__()` before WordPress had finished loading translations, which surfaced as PHP notices on 6.7 and grew louder on 6.9. (#391, props @ncimbaljevic-godaddy)

Everything else merged to `main` since `v2.1.0` is docs/CI (the WordPress.org deploy guide, the fork-PR fix for the AI review workflow) and is excluded from the SVN payload via `.distignore`.

## Also in this PR

- **Deploy guide correction.** The deploy guide I added in `e190df7e` told contributors to use bare-version git tags (`2.2.0`). The repo's actual convention is `v`-prefixed (`v2.1.0`, `v2.0.51`, …) and `10up/action-wordpress-plugin-deploy` strips the `v` before pushing to SVN, so WP.org `Stable tag` stays unprefixed. Doc now matches the convention and explains the strip behavior.

## Release flow (post-merge)

1. Merge this PR.
2. From `main`: `git tag v2.1.1 && git push origin v2.1.1`.
3. The `Deploy to WordPress.org` workflow fires on the tag and pushes trunk + `tags/2.1.1/` to SVN.
4. Verify on https://wordpress.org/plugins/designsetgo/ within ~15 minutes.

## Test plan

- [x] `npm run build` clean
- [ ] CI green on this PR (lint / PHP analysis / e2e)
- [ ] After merge + tag: deploy workflow green
- [ ] WP.org listing shows 2.1.1 with the new changelog entry
- [ ] Upgrade smoke: install 2.1.0 on a WP 6.7 site → upgrade → confirm no `_load_textdomain_just_in_time` notices in `debug.log`