### PR TITLE
feat(abilities): add get/update-global-css

### DIFF
--- a/includes/abilities/settings/class-get-global-css.php
+++ b/includes/abilities/settings/class-get-global-css.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Get Global CSS Ability.
+ *
+ * Reads the site's "Additional CSS" stored on the active stylesheet's
+ * custom_css post — the same store the WordPress Customizer writes to.
+ * Pair with designsetgo/update-global-css to read-modify-write safely.
+ *
+ * @package DesignSetGo
+ * @subpackage Abilities
+ * @since 2.2.0
+ */
+
+namespace DesignSetGo\Abilities\Settings;
+
+use DesignSetGo\Abilities\Abstract_Ability;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Get Global CSS ability class.
+ */
+class Get_Global_CSS extends Abstract_Ability {
+
+	/**
+	 * Get ability name.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'designsetgo/get-global-css';
+	}
+
+	/**
+	 * Get ability configuration.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_config(): array {
+		return array(
+			'label'               => __( 'Get Global CSS', 'designsetgo' ),
+			'description'         => __( 'Returns the site\'s Additional CSS for the active theme — the same value managed by the WordPress Customizer\'s Additional CSS panel. Returns an empty string when none has been saved.', 'designsetgo' ),
+			'category'            => 'settings',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => new \stdClass(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => $this->get_output_schema(),
+			'permission_callback' => array( $this, 'check_permission_callback' ),
+			'show_in_rest'        => true,
+			'keywords'            => array( 'css', 'styles', 'customizer', 'additional css', 'global', 'theme' ),
+			'annotations'         => array(
+				'readonly'     => true,
+				'idempotent'   => true,
+				'instructions' => 'Call this before update-global-css when you want to append to or modify the existing Additional CSS rather than replace it. The value is scoped to the currently active theme.',
+			),
+		);
+	}
+
+	/**
+	 * Get output schema.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_output_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'success'    => array(
+					'type'        => 'boolean',
+					'description' => __( 'Whether the read succeeded.', 'designsetgo' ),
+				),
+				'css'        => array(
+					'type'        => 'string',
+					'description' => __( 'The current Additional CSS for the active theme.', 'designsetgo' ),
+				),
+				'stylesheet' => array(
+					'type'        => 'string',
+					'description' => __( 'The stylesheet (theme directory) the CSS is scoped to.', 'designsetgo' ),
+				),
+				'post_id'    => array(
+					'type'        => array( 'integer', 'null' ),
+					'description' => __( 'ID of the underlying custom_css post, or null if no CSS has been saved yet.', 'designsetgo' ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission callback.
+	 *
+	 * Mirrors the capability the Customizer's Additional CSS panel uses
+	 * (edit_css → maps to unfiltered_html on single-site, super-admin on
+	 * multisite). Reading is gated on the same cap as writing so this
+	 * ability never exposes CSS to roles that couldn't edit it anyway.
+	 *
+	 * @return bool
+	 */
+	public function check_permission_callback(): bool {
+		return $this->check_permission( 'edit_css' );
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string, mixed> $input Ignored — no inputs.
+	 * @return array<string, mixed>
+	 */
+	public function execute( array $input ): array {
+		$stylesheet = get_stylesheet();
+		$post       = wp_get_custom_css_post( $stylesheet );
+
+		return $this->success(
+			array(
+				'css'        => wp_get_custom_css( $stylesheet ),
+				'stylesheet' => $stylesheet,
+				'post_id'    => $post ? (int) $post->ID : null,
+			)
+		);
+	}
+}

--- a/includes/abilities/settings/class-update-global-css.php
+++ b/includes/abilities/settings/class-update-global-css.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Update Global CSS Ability.
+ *
+ * Writes the site's "Additional CSS" by wrapping wp_update_custom_css_post(),
+ * the same store the WordPress Customizer's Additional CSS panel uses.
+ * Theme-scoped automatically (one custom_css post per stylesheet), and
+ * runs through the WordPress core sanitization pipeline.
+ *
+ * @package DesignSetGo
+ * @subpackage Abilities
+ * @since 2.2.0
+ */
+
+namespace DesignSetGo\Abilities\Settings;
+
+use DesignSetGo\Abilities\Abstract_Ability;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Update Global CSS ability class.
+ */
+class Update_Global_CSS extends Abstract_Ability {
+
+	/**
+	 * Get ability name.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'designsetgo/update-global-css';
+	}
+
+	/**
+	 * Get ability configuration.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_config(): array {
+		return array(
+			'label'               => __( 'Update Global CSS', 'designsetgo' ),
+			'description'         => __( 'Replaces the site\'s Additional CSS for the active theme. Equivalent to saving the WordPress Customizer\'s Additional CSS panel — value is stored on the theme\'s custom_css post and applied site-wide. The submitted CSS REPLACES the existing value entirely; call get-global-css first if you need to append.', 'designsetgo' ),
+			'category'            => 'settings',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'css' ),
+				'additionalProperties' => false,
+				'properties'           => array(
+					'css' => array(
+						'type'        => 'string',
+						'description' => __( 'The complete CSS to save. Pass an empty string to clear.', 'designsetgo' ),
+					),
+				),
+			),
+			'output_schema'       => $this->get_output_schema(),
+			'permission_callback' => array( $this, 'check_permission_callback' ),
+			'show_in_rest'        => true,
+			'keywords'            => array( 'css', 'styles', 'customizer', 'additional css', 'global', 'theme' ),
+			'annotations'         => array(
+				'idempotent'   => true,
+				'instructions' => 'Submitting { "css": "..." } REPLACES the entire Additional CSS for the active theme — there is no merge. To append, call get-global-css first, concatenate, then submit. To clear, submit { "css": "" }. Sanitization is applied by WordPress core.',
+			),
+		);
+	}
+
+	/**
+	 * Get output schema.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_output_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'success'    => array(
+					'type'        => 'boolean',
+					'description' => __( 'Whether the update was applied.', 'designsetgo' ),
+				),
+				'css'        => array(
+					'type'        => 'string',
+					'description' => __( 'The CSS value as stored after sanitization.', 'designsetgo' ),
+				),
+				'stylesheet' => array(
+					'type'        => 'string',
+					'description' => __( 'The stylesheet (theme directory) the CSS was saved to.', 'designsetgo' ),
+				),
+				'post_id'    => array(
+					'type'        => 'integer',
+					'description' => __( 'ID of the custom_css post that stores the value.', 'designsetgo' ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission callback.
+	 *
+	 * Mirrors the capability the Customizer's Additional CSS panel uses
+	 * (edit_css → maps to unfiltered_html on single-site, super-admin on
+	 * multisite). Stricter than manage_options on purpose: arbitrary CSS
+	 * is a higher-trust action than toggling plugin settings.
+	 *
+	 * @return bool
+	 */
+	public function check_permission_callback(): bool {
+		return $this->check_permission( 'edit_css' );
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string, mixed> $input { css: string }.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public function execute( array $input ) {
+		$css        = isset( $input['css'] ) && is_string( $input['css'] ) ? $input['css'] : '';
+		$stylesheet = get_stylesheet();
+
+		$post = wp_update_custom_css_post(
+			$css,
+			array( 'stylesheet' => $stylesheet )
+		);
+
+		if ( is_wp_error( $post ) ) {
+			return $this->error(
+				'custom_css_update_failed',
+				$post->get_error_message(),
+				array( 'wp_error_code' => $post->get_error_code() )
+			);
+		}
+
+		return $this->success(
+			array(
+				'css'        => wp_get_custom_css( $stylesheet ),
+				'stylesheet' => $stylesheet,
+				'post_id'    => (int) $post->ID,
+			)
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `designsetgo/update-global-css` (schema `{ css: string }`) wrapping `wp_update_custom_css_post()` — same store the Customizer's Additional CSS panel uses, theme-scoped via `get_stylesheet()`, sanitization delegated to WP core.
- Adds `designsetgo/get-global-css` companion so agents can read the current value before a replace (the Customizer's CSS isn't otherwise exposed via REST/Abilities, which would block any safe append/modify flow).
- Both gated on `edit_css` to match the capability the Customizer's Additional CSS panel itself enforces — stricter than `manage_options` on purpose, since arbitrary CSS is a higher-trust action than toggling plugin settings.

Auto-discovery in `Abilities_Registry::load_abilities_from_namespace()` already scans `includes/abilities/settings/`, and the file-to-class converter handles the `Css → CSS` acronym, so no registry changes were needed.

`update-global-css` REPLACES the entire value (no merge) — documented in both the description and `instructions` annotation so the agent knows to call `get-global-css` first if it wants to append.

## Test plan

- [ ] As an admin, call `designsetgo/get-global-css` → returns `{ success: true, css: "", stylesheet: "<active-theme>", post_id: null }` on a fresh site
- [ ] Call `designsetgo/update-global-css` with `{ "css": "body { background: #f0f }" }` → returns `success: true`, `post_id` populated; visit any frontend page and confirm the rule is applied
- [ ] Call `designsetgo/get-global-css` again → returns the CSS just saved
- [ ] Open Customizer → Additional CSS and confirm the value matches what the ability wrote (proves we're hitting the same store)
- [ ] Edit the CSS via the Customizer, save, then call `get-global-css` → returns the Customizer's edit (proves the read path stays in sync)
- [ ] Submit `{ "css": "" }` to clear → frontend rule disappears, `post_id` still returned
- [ ] As a subscriber (no `edit_css`), both abilities reject with the standard permission error
- [ ] Submit invalid input (e.g. `{ "css": 123 }`) → schema validation rejects before execute runs
- [ ] Switch active theme → `stylesheet` in the response updates and the previous theme's CSS is no longer returned (confirms theme scoping)