### PR TITLE
feat(section): support gradient overlays

### DIFF
--- a/src/blocks/section/block.json
+++ b/src/blocks/section/block.json
@@ -140,6 +140,10 @@
 			"type": "string",
 			"default": ""
 		},
+		"overlayGradient": {
+			"type": "string",
+			"default": ""
+		},
 		"shapeDividerTop": {
 			"type": "string",
 			"default": ""
@@ -217,6 +221,7 @@
 			"hoverIconBackgroundColor": "Icon background color on hover (passed to child blocks via context)",
 			"hoverButtonBackgroundColor": "Button background color on hover (passed to child blocks via context)",
 			"overlayColor": "Semi-transparent overlay color for background images",
+			"overlayGradient": "Semi-transparent overlay gradient for background images (takes precedence over overlayColor when set)",
 			"shapeDividerTop": "Shape divider style for the top edge (wave, tilt, curve, etc.)",
 			"shapeDividerTopColor": "Color of the top shape divider",
 			"shapeDividerTopHeight": "Height of the top shape divider in pixels",

--- a/src/blocks/section/edit.js
+++ b/src/blocks/section/edit.js
@@ -65,6 +65,7 @@ export default function SectionEdit({ attributes, setAttributes, clientId }) {
 		hoverIconBackgroundColor,
 		hoverButtonBackgroundColor,
 		overlayColor,
+		overlayGradient,
 		layout,
 		// Shape divider attributes
 		shapeDividerTop,
@@ -137,10 +138,6 @@ export default function SectionEdit({ attributes, setAttributes, clientId }) {
 			setAttributes,
 			entries: [
 				{
-					label: __('Overlay Color', 'designsetgo'),
-					attribute: 'overlayColor',
-				},
-				{
 					label: __('Hover Background Color', 'designsetgo'),
 					attribute: 'hoverBackgroundColor',
 				},
@@ -150,6 +147,24 @@ export default function SectionEdit({ attributes, setAttributes, clientId }) {
 				},
 			],
 		});
+
+	// Overlay supports both solid color and gradient. Built inline (rather than
+	// via useBlockColors) so we can pass both colorValue/gradientValue to the
+	// dropdown and let users toggle between solid and gradient.
+	const overlaySetting = {
+		label: __('Overlay', 'designsetgo'),
+		colorValue: decodeColorValue(overlayColor, colorGradientSettings),
+		gradientValue: overlayGradient,
+		onColorChange: (color) =>
+			setAttributes({
+				overlayColor:
+					encodeColorValue(color, colorGradientSettings) || '',
+			}),
+		onGradientChange: (gradient) =>
+			setAttributes({ overlayGradient: gradient || '' }),
+		enableAlpha: true,
+		clearable: true,
+	};
 
 	// Setup custom units for width control
 	const units = useCustomUnits({
@@ -255,10 +270,11 @@ export default function SectionEdit({ attributes, setAttributes, clientId }) {
 	}, []);
 
 	// Build className (must match save.js)
+	const hasOverlay = !!(overlayColor || overlayGradient);
 	const blockClassName = [
 		'dsgo-stack',
 		!constrainWidth && 'dsgo-no-width-constraint',
-		overlayColor && 'dsgo-stack--has-overlay',
+		hasOverlay && 'dsgo-stack--has-overlay',
 		(shapeDividerTop || shapeDividerBottom) &&
 			'dsgo-stack--has-shape-divider',
 	]
@@ -291,6 +307,14 @@ export default function SectionEdit({ attributes, setAttributes, clientId }) {
 			}),
 			...(overlayColor && {
 				'--dsgo-overlay-color': convertColorToCSSVar(overlayColor),
+			}),
+			...(overlayGradient && {
+				'--dsgo-overlay-gradient': convertPresetToCSSVar(
+					overlayGradient,
+					'gradient'
+				),
+			}),
+			...(hasOverlay && {
 				'--dsgo-overlay-opacity': '0.8',
 			}),
 		},
@@ -443,6 +467,7 @@ export default function SectionEdit({ attributes, setAttributes, clientId }) {
 					panelId={clientId}
 					title={__('Hover Settings', 'designsetgo')}
 					settings={[
+						overlaySetting,
 						...hoverColorSettings,
 						// Only show icon background control if hover background is set
 						...(hoverBackgroundColor

--- a/src/blocks/section/editor.scss
+++ b/src/blocks/section/editor.scss
@@ -90,7 +90,11 @@ $inline-block-data-types: (
 			left: 0;
 			right: 0;
 			bottom: 0;
-			background-color: var(--dsgo-overlay-color) !important;
+			/* Gradient takes precedence; falls back to solid color when unset */
+			background: var(
+				--dsgo-overlay-gradient,
+				var(--dsgo-overlay-color)
+			) !important;
 			opacity: var(--dsgo-overlay-opacity, 0.8) !important;
 			pointer-events: none;
 			z-index: 1;

--- a/src/blocks/section/save.js
+++ b/src/blocks/section/save.js
@@ -8,7 +8,10 @@
  */
 
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
-import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
+import {
+	convertColorToCSSVar,
+	convertPresetToCSSVar,
+} from '../../utils/convert-preset-to-css-var';
 import ShapeDivider from './components/ShapeDivider';
 
 /**
@@ -30,6 +33,7 @@ export default function SectionSave({ attributes }) {
 		hoverIconBackgroundColor,
 		hoverButtonBackgroundColor,
 		overlayColor,
+		overlayGradient,
 		// Shape divider attributes
 		shapeDividerTop,
 		shapeDividerTopColor,
@@ -61,10 +65,11 @@ export default function SectionSave({ attributes }) {
 		(textColor ? `var(--wp--preset--color--${textColor})` : '');
 
 	// Build className with conditional no-width-constraint and overlay classes
+	const hasOverlay = !!(overlayColor || overlayGradient);
 	const className = [
 		'dsgo-stack',
 		!constrainWidth && 'dsgo-no-width-constraint',
-		overlayColor && 'dsgo-stack--has-overlay',
+		hasOverlay && 'dsgo-stack--has-overlay',
 		(shapeDividerTop || shapeDividerBottom) &&
 			'dsgo-stack--has-shape-divider',
 	]
@@ -95,6 +100,14 @@ export default function SectionSave({ attributes }) {
 			}),
 			...(overlayColor && {
 				'--dsgo-overlay-color': convertColorToCSSVar(overlayColor),
+			}),
+			...(overlayGradient && {
+				'--dsgo-overlay-gradient': convertPresetToCSSVar(
+					overlayGradient,
+					'gradient'
+				),
+			}),
+			...(hasOverlay && {
 				'--dsgo-overlay-opacity': '0.8',
 			}),
 		},

--- a/src/blocks/section/style.scss
+++ b/src/blocks/section/style.scss
@@ -64,7 +64,8 @@
 			left: 0;
 			right: 0;
 			bottom: 0;
-			background-color: var(--dsgo-overlay-color);
+			/* Gradient takes precedence; falls back to solid color when unset */
+			background: var(--dsgo-overlay-gradient, var(--dsgo-overlay-color));
 			opacity: var(--dsgo-overlay-opacity, 0.8);
 			pointer-events: none; /* Allow clicks to pass through to content */
 			z-index: 1; /* Above background image but below content */

--- a/src/utils/convert-preset-to-css-var.js
+++ b/src/utils/convert-preset-to-css-var.js
@@ -18,7 +18,7 @@ const CSS_KEYWORDS = new Set([
  * Values that start with these prefixes are already valid CSS and should pass through.
  */
 const CSS_VALUE_PREFIX =
-	/^(#|rgb|hsl|hwb|lab|lch|oklch|oklab|color\(|var\(|url\(|\d)/;
+	/^(#|rgb|hsl|hwb|lab|lch|oklch|oklab|color\(|var\(|url\(|linear-gradient\(|radial-gradient\(|conic-gradient\(|repeating-linear-gradient\(|repeating-radial-gradient\(|repeating-conic-gradient\(|\d)/;
 
 /**
  * Convert WordPress preset format to CSS variable.


### PR DESCRIPTION
## Summary

The Section block's overlay control previously accepted only a single solid color. This adds gradient support so users can pick either a solid color or a gradient for the overlay (with gradient taking precedence when both are set).

## Changes

- `block.json`: new `overlayGradient` attribute (string, default `''`).
- `edit.js` / `save.js`: read `overlayGradient`, render `dsgo-stack--has-overlay` when either color or gradient is set, and emit `--dsgo-overlay-gradient` (run through `convertPresetToCSSVar(..., 'gradient')` so preset gradients become `var(--wp--preset--gradient--{slug})`).
- The Overlay entry is now built inline (not via `useBlockColors`) so the same control surfaces both `colorValue`/`onColorChange` and `gradientValue`/`onGradientChange`, giving the standard solid/gradient toggle in `ColorGradientSettingsDropdown`.
- `style.scss` / `editor.scss`: the `&--has-overlay::before` pseudo-element now uses `background: var(--dsgo-overlay-gradient, var(--dsgo-overlay-color))` so gradient overrides color and falls back cleanly when only color is set.

## Backwards compatibility

Existing blocks that only set `overlayColor` continue to render identical save markup (no `--dsgo-overlay-gradient` is emitted), so no new deprecation entry was needed — they still validate against the current save output.

## Test plan

- [ ] Add a Section with a background image, set a solid overlay color → renders as before.
- [ ] Switch the overlay tab to Gradient and pick a preset gradient → overlay renders the gradient.
- [ ] Pick a custom gradient (custom angle / colors) → overlay renders correctly on the frontend.
- [ ] Clear the gradient with the color still set → falls back to solid color.
- [ ] Clear both → overlay class is removed and pseudo-element disappears.
- [ ] Open an existing Section block saved with only `overlayColor` → no validation error / deprecation prompt.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7z1w1TekEN9hraq7rBwAL)_