### PR TITLE
fix(modal): fall back to in-memory state when storage is blocked

### DIFF
--- a/includes/blocks/dynamic-tags/class-dynamic-tags-registry.php
+++ b/includes/blocks/dynamic-tags/class-dynamic-tags-registry.php
@@ -55,9 +55,12 @@ class Registry {
 			if ( did_action( 'after_setup_theme' ) ) {
 				self::$instance->register_default_groups();
 			} else {
-				add_action( 'after_setup_theme', function () {
-					Registry::instance()->register_default_groups();
-				} );
+				add_action(
+					'after_setup_theme',
+					function () {
+						Registry::instance()->register_default_groups();
+					}
+				);
 			}
 		}
 		return self::$instance;

--- a/src/blocks/modal/view.js
+++ b/src/blocks/modal/view.js
@@ -604,6 +604,8 @@
 				}
 			}
 
+			// Not in the real cookie store; check the in-memory fallback in
+			// case setCookie was blocked earlier this page session.
 			return memoryStore.cookie.has(name)
 				? memoryStore.cookie.get(name)
 				: undefined;

--- a/src/blocks/modal/view.js
+++ b/src/blocks/modal/view.js
@@ -39,12 +39,17 @@
 	function safeStorageGet(type, key) {
 		try {
 			const storage = type === 'session' ? sessionStorage : localStorage;
-			const value = storage.getItem(key);
-			if (value !== null) {
-				return value;
-			}
+			return storage.getItem(key);
 		} catch (e) {
-			// Storage access blocked — fall through to memory.
+			// Storage access blocked — use memory fallback.
+			if (DEBUG_MODE) {
+				// eslint-disable-next-line no-console
+				console.warn(
+					'[DSGModal] Storage read blocked, using in-memory fallback',
+					type,
+					e
+				);
+			}
 		}
 		return memoryStore[type].has(key) ? memoryStore[type].get(key) : null;
 	}
@@ -67,6 +72,14 @@
 			return;
 		} catch (e) {
 			// Storage access blocked — use memory fallback.
+			if (DEBUG_MODE) {
+				// eslint-disable-next-line no-console
+				console.warn(
+					'[DSGModal] Storage write blocked, using in-memory fallback',
+					type,
+					e
+				);
+			}
 		}
 		memoryStore[type].set(key, value);
 	}
@@ -565,6 +578,13 @@
 			} catch (e) {
 				// document.cookie access blocked (sandboxed iframe, strict
 				// privacy mode). Fall back to in-memory store.
+				if (DEBUG_MODE) {
+					// eslint-disable-next-line no-console
+					console.warn(
+						'[DSGModal] Cookie read blocked, using in-memory fallback',
+						e
+					);
+				}
 				return memoryStore.cookie.has(name)
 					? memoryStore.cookie.get(name)
 					: undefined;
@@ -616,6 +636,13 @@
 			} catch (e) {
 				// document.cookie write blocked — keep value in memory so
 				// frequency tracking still works for the current page session.
+				if (DEBUG_MODE) {
+					// eslint-disable-next-line no-console
+					console.warn(
+						'[DSGModal] Cookie write blocked, using in-memory fallback',
+						e
+					);
+				}
 				memoryStore.cookie.set(name, value);
 			}
 		}

--- a/src/blocks/modal/view.js
+++ b/src/blocks/modal/view.js
@@ -19,6 +19,38 @@
 			window.dsgoModalDebug) ||
 		window.location.search.includes('dsgo_debug=1');
 
+	// In-memory fallback when browser storage is blocked (sandboxed iframes,
+	// incognito mode with third-party cookies disabled, strict privacy modes).
+	const memoryStore = {
+		session: new Map(),
+		local: new Map(),
+		cookie: new Map(),
+	};
+
+	function safeStorageGet(type, key) {
+		try {
+			const storage = type === 'session' ? sessionStorage : localStorage;
+			const value = storage.getItem(key);
+			if (value !== null) {
+				return value;
+			}
+		} catch (e) {
+			// Storage access blocked — fall through to memory.
+		}
+		return memoryStore[type].has(key) ? memoryStore[type].get(key) : null;
+	}
+
+	function safeStorageSet(type, key, value) {
+		try {
+			const storage = type === 'session' ? sessionStorage : localStorage;
+			storage.setItem(key, value);
+			return;
+		} catch (e) {
+			// Storage access blocked — use memory fallback.
+		}
+		memoryStore[type].set(key, value);
+	}
+
 	/**
 	 * Modal Manager Class
 	 *
@@ -450,7 +482,7 @@
 
 			// Check session storage for session frequency
 			if (frequency === 'session') {
-				if (sessionStorage.getItem(storageKey)) {
+				if (safeStorageGet('session', storageKey)) {
 					return false;
 				}
 			}
@@ -458,7 +490,7 @@
 			// Check localStorage/cookie for once frequency
 			if (frequency === 'once') {
 				// Try localStorage first
-				if (localStorage.getItem(storageKey)) {
+				if (safeStorageGet('local', storageKey)) {
 					return false;
 				}
 
@@ -484,12 +516,12 @@
 			const storageKey = `dsgo_modal_${this.modalId}_shown`;
 
 			if (frequency === 'session') {
-				sessionStorage.setItem(storageKey, 'true');
+				safeStorageSet('session', storageKey, 'true');
 			}
 
 			if (frequency === 'once') {
 				// Save to localStorage
-				localStorage.setItem(storageKey, 'true');
+				safeStorageSet('local', storageKey, 'true');
 
 				// Also save to cookie as fallback
 				this.setCookie(
@@ -507,8 +539,19 @@
 		 * @param name
 		 */
 		getCookie(name) {
+			let rawCookie = '';
+			try {
+				rawCookie = document.cookie;
+			} catch (e) {
+				// document.cookie access blocked (sandboxed iframe, strict
+				// privacy mode). Fall back to in-memory store.
+				return memoryStore.cookie.has(name)
+					? memoryStore.cookie.get(name)
+					: undefined;
+			}
+
 			// Use safer string splitting instead of complex regex
-			const cookieString = `; ${document.cookie}`;
+			const cookieString = `; ${rawCookie}`;
 			const parts = cookieString.split(`; ${name}=`);
 
 			if (parts.length === 2) {
@@ -521,7 +564,9 @@
 				}
 			}
 
-			return undefined;
+			return memoryStore.cookie.has(name)
+				? memoryStore.cookie.get(name)
+				: undefined;
 		}
 
 		/**
@@ -546,7 +591,13 @@
 			const secure =
 				window.location.protocol === 'https:' ? ';Secure' : '';
 
-			document.cookie = `${name}=${encodedValue};expires=${expires.toUTCString()};path=/;SameSite=${sameSite}${secure}`;
+			try {
+				document.cookie = `${name}=${encodedValue};expires=${expires.toUTCString()};path=/;SameSite=${sameSite}${secure}`;
+			} catch (e) {
+				// document.cookie write blocked — keep value in memory so
+				// frequency tracking still works for the current page session.
+				memoryStore.cookie.set(name, value);
+			}
 		}
 
 		/**

--- a/src/blocks/modal/view.js
+++ b/src/blocks/modal/view.js
@@ -27,6 +27,15 @@
 		cookie: new Map(),
 	};
 
+	/**
+	 * Read a value from browser storage, falling back to the in-memory store
+	 * if the storage API throws (sandboxed iframe, strict privacy mode, etc.).
+	 *
+	 * @param {'session'|'local'} type Which Web Storage area to read from.
+	 * @param {string}            key  Storage key.
+	 * @return {string|null} Stored value, or `null` when neither storage nor
+	 * the memory fallback has the key.
+	 */
 	function safeStorageGet(type, key) {
 		try {
 			const storage = type === 'session' ? sessionStorage : localStorage;
@@ -40,6 +49,17 @@
 		return memoryStore[type].has(key) ? memoryStore[type].get(key) : null;
 	}
 
+	/**
+	 * Write a value to browser storage, falling back to the in-memory store
+	 * if the storage API throws (sandboxed iframe, strict privacy mode, etc.).
+	 *
+	 * When storage is blocked the value is kept in memory so suppression still
+	 * works for the current page lifetime; it will not persist across reloads.
+	 *
+	 * @param {'session'|'local'} type  Which Web Storage area to write to.
+	 * @param {string}            key   Storage key.
+	 * @param {string}            value Value to store.
+	 */
 	function safeStorageSet(type, key, value) {
 		try {
 			const storage = type === 'session' ? sessionStorage : localStorage;

--- a/tests/unit/modal.test.js
+++ b/tests/unit/modal.test.js
@@ -6,7 +6,7 @@
  * @package
  */
 
-/* global sessionStorage, localStorage, Document */
+/* global sessionStorage, localStorage, Document, Storage */
 
 // Import modal functionality
 import '../../src/blocks/modal/view.js';
@@ -398,6 +398,124 @@ describe('DSGModal - Core Functionality', () => {
 			instance.markAsShown();
 
 			expect(instance.checkTriggerFrequency()).toBe(false);
+		});
+	});
+
+	describe('Storage Fallback - Blocked Storage', () => {
+		// Each test uses a unique modal id so the module-scoped in-memory
+		// fallback (which persists across tests) doesn't bleed state.
+
+		test('"session" frequency tolerates sessionStorage throwing and uses memory fallback', () => {
+			const getSpy = jest
+				.spyOn(Storage.prototype, 'getItem')
+				.mockImplementation(() => {
+					throw new Error('SecurityError: storage blocked');
+				});
+			const setSpy = jest
+				.spyOn(Storage.prototype, 'setItem')
+				.mockImplementation(() => {
+					throw new Error('SecurityError: storage blocked');
+				});
+
+			try {
+				const modal = createMockModal({ id: 'blocked-session' });
+				modal.setAttribute('data-auto-trigger-frequency', 'session');
+				const instance = new window.DSGModal(modal);
+
+				expect(() => instance.checkTriggerFrequency()).not.toThrow();
+				expect(instance.checkTriggerFrequency()).toBe(true);
+
+				expect(() => instance.markAsShown()).not.toThrow();
+
+				// In-memory fallback should now suppress repeat triggers.
+				expect(instance.checkTriggerFrequency()).toBe(false);
+			} finally {
+				getSpy.mockRestore();
+				setSpy.mockRestore();
+			}
+		});
+
+		test('"once" frequency tolerates localStorage and document.cookie throwing', () => {
+			const getSpy = jest
+				.spyOn(Storage.prototype, 'getItem')
+				.mockImplementation(() => {
+					throw new Error('SecurityError: storage blocked');
+				});
+			const setSpy = jest
+				.spyOn(Storage.prototype, 'setItem')
+				.mockImplementation(() => {
+					throw new Error('SecurityError: storage blocked');
+				});
+
+			const originalDescriptor = Object.getOwnPropertyDescriptor(
+				Document.prototype,
+				'cookie'
+			);
+			Object.defineProperty(document, 'cookie', {
+				get: () => {
+					throw new Error('SecurityError: cookie blocked');
+				},
+				set: () => {
+					throw new Error('SecurityError: cookie blocked');
+				},
+				configurable: true,
+			});
+
+			try {
+				const modal = createMockModal({ id: 'blocked-once' });
+				modal.setAttribute('data-auto-trigger-frequency', 'once');
+				modal.setAttribute('data-cookie-duration', '7');
+				const instance = new window.DSGModal(modal);
+
+				expect(() => instance.checkTriggerFrequency()).not.toThrow();
+				expect(instance.checkTriggerFrequency()).toBe(true);
+
+				expect(() => instance.markAsShown()).not.toThrow();
+
+				// In-memory fallback should now suppress repeat triggers.
+				expect(instance.checkTriggerFrequency()).toBe(false);
+			} finally {
+				getSpy.mockRestore();
+				setSpy.mockRestore();
+				Object.defineProperty(
+					document,
+					'cookie',
+					originalDescriptor || { value: '', writable: true }
+				);
+			}
+		});
+
+		test('getCookie returns undefined without throwing when document.cookie read throws', () => {
+			const originalDescriptor = Object.getOwnPropertyDescriptor(
+				Document.prototype,
+				'cookie'
+			);
+			Object.defineProperty(document, 'cookie', {
+				get: () => {
+					throw new Error('SecurityError: cookie blocked');
+				},
+				set: () => {
+					throw new Error('SecurityError: cookie blocked');
+				},
+				configurable: true,
+			});
+
+			try {
+				const modal = createMockModal({ id: 'blocked-cookie-read' });
+				const instance = new window.DSGModal(modal);
+
+				let result;
+				expect(() => {
+					result = instance.getCookie('nonexistent-key');
+				}).not.toThrow();
+				expect(result).toBeUndefined();
+			} finally {
+				Object.defineProperty(
+					document,
+					'cookie',
+					originalDescriptor || { value: '', writable: true }
+				);
+			}
 		});
 	});
 


### PR DESCRIPTION
## Summary

The modal block's frequency tracking accessed `sessionStorage`, `localStorage`, and `document.cookie` directly. In sandboxed iframes, incognito sessions with third-party cookies disabled, and strict privacy modes, those reads/writes throw `SecurityError` — taking the modal script down with it.

This change wraps each access in `try`/`catch` with a module-scoped in-memory `Map` fallback, so frequency tracking still works for the current page session even when persistent storage is unavailable. This mirrors what most modern block libraries already do for incognito compatibility, and avoids needing to relax the sandbox to "fix" the symptom.

### Changes
- Added `memoryStore` (session/local/cookie Maps) at module scope in `src/blocks/modal/view.js`.
- Added `safeStorageGet`/`safeStorageSet` helpers that try the real storage first, then fall back to the in-memory map.
- Replaced direct `sessionStorage`/`localStorage` calls in `checkTriggerFrequency()` and `markAsShown()` with the safe helpers.
- Wrapped `document.cookie` read in `getCookie()` and write in `setCookie()` in `try`/`catch`, also falling through to the in-memory cookie map.

### Behavior
- **Storage available**: identical behavior to before — persistence across page loads / sessions works as designed.
- **Storage blocked**: `frequency: "session"` and `frequency: "once"` still suppress repeat opens within the current page lifetime, but won't persist across reloads (expected — there's no storage to persist to).

## Test plan
- [x] `npx wp-scripts test-unit-js tests/unit/modal.test.js` — all 30 tests pass
- [x] `npx wp-scripts lint-js src/blocks/modal/view.js` — clean
- [ ] Manual: load a modal in an incognito window with third-party cookies disabled and confirm no console errors
- [ ] Manual: load a modal inside a sandboxed iframe (e.g. WordPress Playground) and confirm `frequency: "once"` still suppresses repeats within a page session

---
_Generated by [Claude Code](https://claude.ai/code/session_016ekxnxdvaDkWUPsqGQvgox)_