### PR TITLE
feat(llms-txt): extension filter for sibling-plugin sections

### DIFF
--- a/includes/llms-txt/class-generator.php
+++ b/includes/llms-txt/class-generator.php
@@ -121,6 +121,32 @@ class Generator {
 			$lines[] = '';
 		}
 
+		/**
+		 * Filter the extra markdown sections appended to /llms.txt
+		 * after the post-type listings.
+		 *
+		 * Each entry is a fully-formed markdown string (typically
+		 * starting with `## Section title`). Sibling plugins
+		 * (e.g. DesignSetGo Apps registering its bridge developer
+		 * reference) hook this filter to advertise additional
+		 * AI-readable surfaces on the site.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param string[] $sections Pre-formatted markdown sections.
+		 * @param string   $variant  Always 'summary' for llms.txt.
+		 */
+		$extra_sections = apply_filters( 'designsetgo_llms_txt_extra_sections', array(), 'summary' );
+		if ( is_array( $extra_sections ) ) {
+			foreach ( $extra_sections as $section ) {
+				if ( ! is_string( $section ) || $section === '' ) {
+					continue;
+				}
+				$lines[] = rtrim( $section );
+				$lines[] = '';
+			}
+		}
+
 		return implode( "\n", $lines );
 	}
 
@@ -192,6 +218,34 @@ class Generator {
 				}
 
 				$lines[] = $markdown;
+				$lines[] = '';
+				$lines[] = '---';
+				$lines[] = '';
+			}
+		}
+
+		/**
+		 * Filter the extra markdown sections appended to /llms-full.txt
+		 * after the post-content concatenation.
+		 *
+		 * Same shape as `designsetgo_llms_txt_extra_sections` fired
+		 * for /llms.txt, but invoked with the `'full'` variant.
+		 * Sibling plugins typically register a longer/inlined version
+		 * of their reference here so that AI tools fetching
+		 * /llms-full.txt get the complete brief.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param string[] $sections Pre-formatted markdown sections.
+		 * @param string   $variant  Always 'full' for llms-full.txt.
+		 */
+		$extra_sections = apply_filters( 'designsetgo_llms_txt_extra_sections', array(), 'full' );
+		if ( is_array( $extra_sections ) ) {
+			foreach ( $extra_sections as $section ) {
+				if ( ! is_string( $section ) || $section === '' ) {
+					continue;
+				}
+				$lines[] = rtrim( $section );
 				$lines[] = '';
 				$lines[] = '---';
 				$lines[] = '';


### PR DESCRIPTION
## Summary
- Adds `designsetgo_llms_txt_extra_sections` filter, fired in both `Generator::generate_content()` (variant `'summary'` → `/llms.txt`) and `Generator::generate_full_content()` (variant `'full'` → `/llms-full.txt`).
- Callbacks return an array of pre-formatted markdown strings; non-string / empty entries are skipped.
- No behavior change when no callbacks are registered (filter returns an empty array by default).

## Why
DesignSetGo Apps (sibling plugin) wants to advertise its bridge developer reference inside the host site's `/llms.txt` so AI tools fetching the site context pick up that this site speaks DSGo Apps and can be a deploy target. Rather than each sibling plugin shipping its own `/llms.txt` route, Blocks becomes the single AI-content index point and exposes a filter for other plugins to plug into.

## What this enables
With the filter in place, the DSGo Apps plugin can register one short section pointing at the Apps developer docs (in `/llms.txt`) and one long inlined bridge-API brief (in `/llms-full.txt`) — both fed from the same source as the in-admin "Build with Claude" copy-paste panel.

## Test plan
- [ ] PHP lint passes (verified locally on PHP 8.4).
- [ ] On a site with Blocks-only installed, `/llms.txt` and `/llms-full.txt` output is unchanged.
- [ ] On a site with Blocks + DSGo Apps installed (Apps PR pending), the DSGo Apps section appears at the tail of `/llms.txt` (short) and `/llms-full.txt` (long, with a trailing `---` separator).
- [ ] Existing `tests/phpunit/llms-txt-test.php` still passes.
