### PR TITLE
fix: lower minimum PHP requirement from 8.0 to 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.0', '8.1', '8.2', '8.3']
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3']
 
     steps:
       - name: Checkout code
@@ -302,10 +302,10 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             # PRs: test boundary pairs (oldest + newest) for fast feedback
-            echo 'matrix={"include":[{"php":"8.0","wordpress":"6.7"},{"php":"8.3","wordpress":"latest"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"php":"7.4","wordpress":"6.7"},{"php":"8.3","wordpress":"latest"}]}' >> $GITHUB_OUTPUT
           else
             # Main push: full matrix for comprehensive coverage
-            echo 'matrix={"php":["8.0","8.1","8.2","8.3"],"wordpress":["6.7","6.8","6.9","latest"]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"php":["7.4","8.0","8.1","8.2","8.3"],"wordpress":["6.7","6.8","6.9","latest"]}' >> $GITHUB_OUTPUT
           fi
 
   wordpress-compatibility:

--- a/README.md
+++ b/README.md
@@ -738,4 +738,4 @@ Built with ❤️ for the WordPress community by developers who believe in:
 
 ---
 
-**License**: GPL-2.0-or-later | **Version**: 2.1.0 | **Requires WordPress**: 6.7+ | **Requires PHP**: 7.4+
+**License**: GPL-2.0-or-later | **Version**: 2.1.2 | **Requires WordPress**: 6.7+ | **Requires PHP**: 7.4+

--- a/README.md
+++ b/README.md
@@ -738,4 +738,4 @@ Built with ❤️ for the WordPress community by developers who believe in:
 
 ---
 
-**License**: GPL-2.0-or-later | **Version**: 2.1.0 | **Requires WordPress**: 6.7+ | **Requires PHP**: 8.0+
+**License**: GPL-2.0-or-later | **Version**: 2.1.0 | **Requires WordPress**: 6.7+ | **Requires PHP**: 7.4+

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "wordpress-plugin",
   "license": "GPL-2.0-or-later",
   "require": {
-    "php": ">=8.0"
+    "php": ">=7.4"
   },
   "suggest": {
     "wordpress/abilities-api": "^0.4.0 - Only needed for WordPress < 6.9 (6.9+ includes Abilities API natively)"

--- a/designsetgo.php
+++ b/designsetgo.php
@@ -5,7 +5,7 @@
  * Description:       Professional Gutenberg block library with 52 blocks and 16 powerful extensions - complete Form Builder, container system, interactive elements, maps, modals, breadcrumbs, timelines, scroll effects, and animations. Built with WordPress standards for guaranteed editor/frontend parity.
  * Version:           2.1.2
  * Requires at least: 6.7
- * Requires PHP:      8.0
+ * Requires PHP:      7.4
  * Author:            DesignSetGo
  * Author URI:        https://designsetgoblocks.com/nealey
  * License:           GPL-2.0-or-later

--- a/includes/admin/class-global-styles.php
+++ b/includes/admin/class-global-styles.php
@@ -638,10 +638,10 @@ class Global_Styles {
 		// We allow nested calls inside the args (e.g. var(--a, var(--b))) but
 		// blocklist the dangerous CSS sinks. Browsers would reject these anyway
 		// when the value resolves, but we don't want to persist them.
-		if ( preg_match( '/^(var|calc|clamp|min|max|rgba?|hsla?)\(/i', $value ) && str_ends_with( $value, ')' ) ) {
+		if ( preg_match( '/^(var|calc|clamp|min|max|rgba?|hsla?)\(/i', $value ) && ')' === substr( $value, -1 ) ) {
 			if (
-				! str_contains( $value, '<' )
-				&& ! str_contains( $value, ';' )
+				false === strpos( $value, '<' )
+				&& false === strpos( $value, ';' )
 				&& false === stripos( $value, 'url(' )
 				&& false === stripos( $value, 'expression(' )
 				&& false === stripos( $value, 'javascript:' )

--- a/includes/class-style-binding.php
+++ b/includes/class-style-binding.php
@@ -97,7 +97,8 @@ class StyleBinding {
 		}
 
 		$existing = (string) ( $processor->get_attribute( 'style' ) ?? '' );
-		$sep      = ( '' !== $existing && ! str_ends_with( rtrim( $existing ), ';' ) ) ? ';' : '';
+		$trimmed  = rtrim( $existing );
+		$sep      = ( '' !== $existing && ';' !== substr( $trimmed, -1 ) ) ? ';' : '';
 		$processor->set_attribute( 'style', $existing . $sep . implode( ';', $styles ) );
 
 		return $processor->get_updated_html();

--- a/includes/class-style-binding.php
+++ b/includes/class-style-binding.php
@@ -96,9 +96,8 @@ class StyleBinding {
 			return $html;
 		}
 
-		$existing = (string) ( $processor->get_attribute( 'style' ) ?? '' );
-		$trimmed  = rtrim( $existing );
-		$sep      = ( '' !== $existing && ';' !== substr( $trimmed, -1 ) ) ? ';' : '';
+		$existing = trim( (string) ( $processor->get_attribute( 'style' ) ?? '' ) );
+		$sep      = ( '' !== $existing && ';' !== substr( $existing, -1 ) ) ? ';' : '';
 		$processor->set_attribute( 'style', $existing . $sep . implode( ';', $styles ) );
 
 		return $processor->get_updated_html();

--- a/includes/llms-txt/class-generator.php
+++ b/includes/llms-txt/class-generator.php
@@ -204,7 +204,7 @@ class Generator {
 					$real_path = realpath( $file_path );
 					$real_dir  = realpath( $this->file_manager->get_directory() );
 
-					if ( $real_path && $real_dir && str_starts_with( $real_path, $real_dir ) && file_exists( $real_path ) ) {
+					if ( $real_path && $real_dir && 0 === strpos( $real_path, $real_dir ) && file_exists( $real_path ) ) {
 						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading local static file.
 						$markdown = file_get_contents( $real_path );
 						if ( false === $markdown ) {
@@ -276,7 +276,7 @@ class Generator {
 		// Truncate to max length before escaping.
 		if ( mb_strlen( $excerpt ) > self::EXCERPT_MAX_LENGTH ) {
 			$excerpt = mb_substr( $excerpt, 0, self::EXCERPT_MAX_LENGTH - 3 );
-			if ( ! str_ends_with( $excerpt, '...' ) ) {
+			if ( '...' !== substr( $excerpt, -3 ) ) {
 				$excerpt .= '...';
 			}
 		}

--- a/includes/llms-txt/class-generator.php
+++ b/includes/llms-txt/class-generator.php
@@ -204,7 +204,7 @@ class Generator {
 					$real_path = realpath( $file_path );
 					$real_dir  = realpath( $this->file_manager->get_directory() );
 
-					if ( $real_path && $real_dir && 0 === strpos( $real_path, $real_dir ) && file_exists( $real_path ) ) {
+					if ( $real_path && $real_dir && 0 === strpos( $real_path, trailingslashit( $real_dir ) ) && file_exists( $real_path ) ) {
 						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading local static file.
 						$markdown = file_get_contents( $real_path );
 						if ( false === $markdown ) {

--- a/includes/llms-txt/class-generator.php
+++ b/includes/llms-txt/class-generator.php
@@ -204,7 +204,7 @@ class Generator {
 					$real_path = realpath( $file_path );
 					$real_dir  = realpath( $this->file_manager->get_directory() );
 
-					if ( $real_path && $real_dir && 0 === strpos( $real_path, trailingslashit( $real_dir ) ) && file_exists( $real_path ) ) {
+					if ( $real_path && $real_dir && 0 === strpos( wp_normalize_path( $real_path ), wp_normalize_path( trailingslashit( $real_dir ) ) ) && file_exists( $real_path ) ) {
 						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading local static file.
 						$markdown = file_get_contents( $real_path );
 						if ( false === $markdown ) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://designsetgoblocks.com/donate
 Tags: blocks, gutenberg, form-builder, query-loop, animations
 Requires at least: 6.7
 Tested up to: 6.9
-Requires PHP: 8.0
+Requires PHP: 7.4
 Stable tag: 2.1.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/src/blocks/query/render-relationship.php
+++ b/src/blocks/query/render-relationship.php
@@ -99,7 +99,7 @@ if ( ! function_exists( 'designsetgo_query_render_relationship' ) ) :
 			return array_values( array_filter( $ids ) );
 		}
 		if ( is_string( $value ) && '' !== $value ) {
-			if ( str_contains( $value, ',' ) ) {
+			if ( false !== strpos( $value, ',' ) ) {
 				return array_values( array_filter( array_map( 'absint', explode( ',', $value ) ) ) );
 			}
 			if ( is_numeric( $value ) ) {


### PR DESCRIPTION
## Summary
- Replace PHP 8.0 `str_contains`/`str_starts_with`/`str_ends_with` with `strpos`/`substr` equivalents — no reliance on WordPress `compat.php` polyfills
- Update `Requires PHP` declarations from 8.0 to 7.4 in plugin header, readme.txt, README.md, and composer.json
- Add PHP 7.4 to CI lint and WordPress compatibility test matrices
- Path containment check uses trailing slash to prevent sibling-directory prefix bypass
- Style binding separator logic uses `trim()` consistently

## Test plan
- [x] CI passes on the new PHP 7.4 matrix entry (lint + syntax check + PHPUnit)
- [ ] Verify plugin activates cleanly on a PHP 7.4 environment
- [ ] Spot-check style binding, global styles sanitization, and llms.txt generation still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)