### PR TITLE
feat: add WordPress Plugin Check (PCP)

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -1,0 +1,97 @@
+name: Plugin Check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: plugin-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  plugin-check:
+    name: Plugin Check (PCP)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build plugin
+        run: npm run build
+
+      - name: Start wp-env
+        run: npx @wordpress/env start
+
+      - name: Wait for WordPress
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:9451/wp-login.php > /dev/null 2>&1; then
+              echo "WordPress ready (attempt $i)"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "ERROR: WordPress did not start" >&2
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Run Plugin Check
+        id: pcp
+        run: |
+          npx @wordpress/env run cli -- wp plugin install plugin-check --activate --force
+          set +e
+          RESULTS=$(npx @wordpress/env run cli -- wp plugin check designsetgo --format=table --fields=code,type,message,file,line --exclude-directories=tests,bin,scripts,src,.github,.claude,.idea,docs,assets,.husky,node_modules --exclude-files=phpstan-constants.php,phpstan.neon,phpcs.xml.dist,composer.json,composer.lock,package.json,package-lock.json,webpack.config.js,playwright.config.js --ignore-codes=hidden_files,application_detected,unexpected_markdown_file 2>&1)
+          PCP_EXIT=$?
+          set -e
+
+          echo "${RESULTS}"
+
+          mkdir -p plugin-check-results
+          {
+            echo "## Plugin Check Results"
+            echo ""
+            if [ "${PCP_EXIT}" -eq 0 ]; then
+              echo "**Status: Passed**"
+            else
+              echo "**Status: Failed**"
+            fi
+            echo ""
+            echo "<details>"
+            echo "<summary>Full report (click to expand)</summary>"
+            echo ""
+            echo '```'
+            echo "${RESULTS}"
+            echo '```'
+            echo ""
+            echo "</details>"
+          } > plugin-check-results/report.md
+
+          exit "${PCP_EXIT}"
+
+      - name: Post results to PR
+        if: always() && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: plugin-check
+          path: plugin-check-results/report.md
+
+      - name: Stop wp-env
+        if: always()
+        run: npx @wordpress/env stop || true

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -63,14 +63,19 @@ jobs:
 
           echo "${RESULTS}"
 
+          ERROR_COUNT=0
+          if echo "${RESULTS}" | grep -q $'\tERROR\t'; then
+            ERROR_COUNT=$(echo "${RESULTS}" | grep -c $'\tERROR\t')
+          fi
+
           mkdir -p plugin-check-results
           {
             echo "## Plugin Check Results"
             echo ""
-            if [ "${PCP_EXIT}" -eq 0 ]; then
-              echo "**Status: Passed**"
+            if [ "${ERROR_COUNT}" -gt 0 ]; then
+              echo "**Status: Failed** (${ERROR_COUNT} error(s))"
             else
-              echo "**Status: Failed**"
+              echo "**Status: Passed**"
             fi
             echo ""
             echo "<details>"
@@ -83,7 +88,10 @@ jobs:
             echo "</details>"
           } > plugin-check-results/report.md
 
-          exit "${PCP_EXIT}"
+          if [ "${ERROR_COUNT}" -gt 0 ]; then
+            echo "::error::Plugin Check found ${ERROR_COUNT} error(s)"
+            exit 1
+          fi
 
       - name: Post results to PR
         if: always() && github.event_name == 'pull_request'

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "clean:cache": "rimraf node_modules/.cache",
     "clean:cache:wp-env": "rimraf .wp-env/WordPress",
     "clean:build": "rimraf build",
-    "clean:all": "npm run clean:cache && npm run clean:cache:wp-env && npm run clean:build"
+    "clean:all": "npm run clean:cache && npm run clean:cache:wp-env && npm run clean:build",
+    "plugin-check": "npx @wordpress/env run cli -- wp plugin install plugin-check --activate --force && npx @wordpress/env run cli -- wp plugin check designsetgo --format=table --fields=code,type,message,file,line --exclude-directories=tests,bin,scripts,src,.github,.claude,.idea,docs,assets,.husky,node_modules --exclude-files=phpstan-constants.php,phpstan.neon,phpcs.xml.dist,composer.json,composer.lock,package.json,package-lock.json,webpack.config.js,playwright.config.js --ignore-codes=hidden_files,application_detected,unexpected_markdown_file"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.28.5",


### PR DESCRIPTION
## Summary

- Adds `npm run plugin-check` script for local PCP runs (requires wp-env running)
- Adds `.github/workflows/plugin-check.yml` CI workflow triggered on PRs, push to main, and manual dispatch
- Posts a sticky PR comment with full PCP results on every PR run
- Excludes dev-only directories/files (aligned with `.distignore`) so only distributable code is checked
- Fails on errors to block PRs with real issues

## Test plan

- [x] Verified locally: `npm run plugin-check` runs successfully against wp-env
- [x] Confirm GitHub Action triggers on this PR
- [x] Verify sticky comment appears with results

🤖 Generated with [Claude Code](https://claude.com/claude-code)