### PR TITLE
fix: resolve all WordPress.DB.DirectDatabaseQuery PCP warnings

### DIFF
--- a/includes/admin/class-block-migrator.php
+++ b/includes/admin/class-block-migrator.php
@@ -730,14 +730,14 @@ JS;
 			$prepare_values[] = $offset;
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared -- Dynamic placeholders generated from safe constants; $sql variable is built above from safe constants.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- No WP API for LIKE on post_content; admin-only migration tool, caching inappropriate for batch scans.
 		$posts = $wpdb->get_results(
 			$wpdb->prepare(
 				$sql,
 				...$prepare_values
 			)
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		if ( empty( $posts ) ) {
 			return array();
@@ -788,7 +788,7 @@ JS;
 
 		$prepare_values = array_merge( $like_values, self::POST_TYPES, $statuses );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic placeholders generated from safe constants.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- No WP API for LIKE on post_content; admin-only count, caching inappropriate for migration tool.
 		$count = (int) $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT(*) FROM {$wpdb->posts}
@@ -798,7 +798,7 @@ JS;
 				...$prepare_values
 			)
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		return $count;
 	}

--- a/includes/admin/class-block-migrator.php
+++ b/includes/admin/class-block-migrator.php
@@ -730,14 +730,15 @@ JS;
 			$prepare_values[] = $offset;
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- No WP API for LIKE on post_content; admin-only migration tool, caching inappropriate for batch scans.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared -- Dynamic placeholders and $sql variable built from safe constants above.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- No WP API for LIKE on post_content; admin-only migration tool, caching inappropriate for batch scans.
 		$posts = $wpdb->get_results(
 			$wpdb->prepare(
 				$sql,
 				...$prepare_values
 			)
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( empty( $posts ) ) {
 			return array();
@@ -788,7 +789,8 @@ JS;
 
 		$prepare_values = array_merge( $like_values, self::POST_TYPES, $statuses );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- No WP API for LIKE on post_content; admin-only count, caching inappropriate for migration tool.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic placeholders generated from safe constants.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- No WP API for LIKE on post_content; admin-only count, caching inappropriate for migration tool.
 		$count = (int) $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT(*) FROM {$wpdb->posts}
@@ -798,7 +800,7 @@ JS;
 				...$prepare_values
 			)
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		return $count;
 	}

--- a/includes/admin/class-gdpr-compliance.php
+++ b/includes/admin/class-gdpr-compliance.php
@@ -540,24 +540,34 @@ We implement appropriate security measures to protect your personal data from un
 	 * @return array Statistics.
 	 */
 	public function get_statistics() {
-		global $wpdb;
-
-		$total = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = %s",
-				'dsgo_form_submission'
+		$total_query = new \WP_Query(
+			array(
+				'post_type'      => 'dsgo_form_submission',
+				'post_status'    => 'any',
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'no_found_rows'  => false,
 			)
 		);
+		$total = $total_query->found_posts;
 
 		// Get submissions older than 30 days.
-		$thirty_days_ago = gmdate( 'Y-m-d H:i:s', strtotime( '-30 days' ) );
-		$old_submissions = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = %s AND post_date < %s",
-				'dsgo_form_submission',
-				$thirty_days_ago
+		$thirty_days_ago   = gmdate( 'Y-m-d H:i:s', strtotime( '-30 days' ) );
+		$old_query = new \WP_Query(
+			array(
+				'post_type'      => 'dsgo_form_submission',
+				'post_status'    => 'any',
+				'date_query'     => array(
+					array(
+						'before' => $thirty_days_ago,
+					),
+				),
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'no_found_rows'  => false,
 			)
 		);
+		$old_submissions = $old_query->found_posts;
 
 		return array(
 			'total'           => (int) $total,

--- a/includes/admin/class-gdpr-compliance.php
+++ b/includes/admin/class-gdpr-compliance.php
@@ -17,6 +17,8 @@
 
 namespace DesignSetGo\Admin;
 
+use WP_Query;
+
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -97,7 +99,7 @@ class GDPR_Compliance {
 			'order'          => 'DESC',
 		);
 
-		$submissions = new \WP_Query( $args );
+		$submissions = new WP_Query( $args );
 
 		if ( $submissions->have_posts() ) {
 			while ( $submissions->have_posts() ) {
@@ -207,7 +209,7 @@ class GDPR_Compliance {
 			'order'          => 'DESC',
 		);
 
-		$submissions = new \WP_Query( $args );
+		$submissions = new WP_Query( $args );
 
 		if ( $submissions->have_posts() ) {
 			while ( $submissions->have_posts() ) {
@@ -540,7 +542,7 @@ We implement appropriate security measures to protect your personal data from un
 	 * @return array Statistics.
 	 */
 	public function get_statistics() {
-		$total_query = new \WP_Query(
+		$total_query = new WP_Query(
 			array(
 				'post_type'      => 'dsgo_form_submission',
 				'post_status'    => 'any',
@@ -553,7 +555,7 @@ We implement appropriate security measures to protect your personal data from un
 
 		// Get submissions older than 30 days.
 		$thirty_days_ago   = gmdate( 'Y-m-d H:i:s', strtotime( '-30 days' ) );
-		$old_query = new \WP_Query(
+		$old_query = new WP_Query(
 			array(
 				'post_type'      => 'dsgo_form_submission',
 				'post_status'    => 'any',

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -562,6 +562,7 @@ class Settings {
 
 		if ( false === $form_submissions ) {
 			// Cache miss - run the database query.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Cached via transient above; wp_count_posts() does not cover custom post types reliably.
 			$form_submissions = $wpdb->get_var(
 				$wpdb->prepare(
 					"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = %s",

--- a/includes/blocks/class-form-handler.php
+++ b/includes/blocks/class-form-handler.php
@@ -78,6 +78,7 @@
 namespace DesignSetGo\Blocks;
 
 use WP_Error;
+use WP_Query;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -903,7 +904,7 @@ class Form_Handler {
 		$batch_size = apply_filters( 'designsetgo_cleanup_batch_size', 100 );
 
 		// Find old submissions (limited batch to prevent timeout).
-		$query = new \WP_Query(
+		$query = new WP_Query(
 			array(
 				'post_type'      => 'dsgo_form_submission',
 				'post_status'    => 'any',

--- a/includes/blocks/class-form-handler.php
+++ b/includes/blocks/class-form-handler.php
@@ -896,8 +896,6 @@ class Form_Handler {
 			return;
 		}
 
-		global $wpdb;
-
 		// Calculate cutoff date.
 		$cutoff_date = gmdate( 'Y-m-d H:i:s', strtotime( "-{$retention_days} days" ) );
 
@@ -905,17 +903,22 @@ class Form_Handler {
 		$batch_size = apply_filters( 'designsetgo_cleanup_batch_size', 100 );
 
 		// Find old submissions (limited batch to prevent timeout).
-		$old_submissions = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT ID FROM {$wpdb->posts}
-				WHERE post_type = %s
-				AND post_date < %s
-				LIMIT %d",
-				'dsgo_form_submission',
-				$cutoff_date,
-				$batch_size
+		$query = new \WP_Query(
+			array(
+				'post_type'      => 'dsgo_form_submission',
+				'post_status'    => 'any',
+				'date_query'     => array(
+					array(
+						'before' => $cutoff_date,
+					),
+				),
+				'posts_per_page' => $batch_size,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
 			)
 		);
+
+		$old_submissions = $query->posts;
 
 		if ( empty( $old_submissions ) ) {
 			return;

--- a/includes/blocks/class-query-filter-index-cli.php
+++ b/includes/blocks/class-query-filter-index-cli.php
@@ -153,7 +153,7 @@ class FilterIndexCLI {
 		\WP_CLI::confirm( 'This will drop the filter index table and all its data. Continue?', $assoc_args );
 
 		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange -- intentional CLI drop; %i correctly escapes the identifier.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange -- Intentional CLI drop; no caching applicable for DDL.
 		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', FilterIndex::table_name() ) );
 		delete_option( FilterIndex::OPTION_SCHEMA );
 		delete_option( FilterIndex::OPTION_STATUS );

--- a/includes/blocks/class-query-filter-index-rebuilder.php
+++ b/includes/blocks/class-query-filter-index-rebuilder.php
@@ -297,6 +297,7 @@ class FilterIndexRebuilder {
 		$batch_size = max( self::MIN_BATCH_SIZE, (int) ( $args['batch_size'] ?? self::DEFAULT_BATCH_SIZE ) );
 
 		// Delete all rows for this key in one statement — fast regardless of row count.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table write; no WP API or caching applicable.
 		$wpdb->delete( $table, array( 'filter_key' => $key ), array( '%s' ) );
 		FilterIndex::bump_counts_cache();
 

--- a/includes/blocks/class-query-filter-index.php
+++ b/includes/blocks/class-query-filter-index.php
@@ -141,6 +141,7 @@ class FilterIndex {
 		$table = self::table_name();
 
 		// Idempotency: wipe existing rows for this object before reinsert.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table write; no WP API or caching applicable.
 		$wpdb->delete(
 			$table,
 			array(
@@ -188,7 +189,7 @@ class FilterIndex {
 		$sql = "INSERT INTO {$table} (object_id, object_type, post_type, filter_key, filter_value) VALUES "
 			. implode( ', ', $placeholders );
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- placeholders built programmatically above.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table bulk insert; placeholders built programmatically above.
 		$wpdb->query( $wpdb->prepare( $sql, $params ) );
 
 		self::bump_counts_cache();
@@ -262,6 +263,7 @@ class FilterIndex {
 			return;
 		}
 		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table write; no WP API or caching applicable.
 		$wpdb->delete(
 			self::table_name(),
 			array(
@@ -369,7 +371,7 @@ class FilterIndex {
 
 		$params = array_merge( array( $key ), $string_values, $post_type_params, $intersect_params );
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- placeholders built programmatically above.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery -- Custom table query; cached via wp_cache_get/set above. Placeholders built programmatically.
 		$rows = $wpdb->get_results( $wpdb->prepare( $sql, $params ) );
 
 		if ( is_array( $rows ) ) {

--- a/includes/llms-txt/class-rest-controller.php
+++ b/includes/llms-txt/class-rest-controller.php
@@ -199,12 +199,14 @@ class REST_Controller {
 		delete_transient( Controller::FULL_CACHE_KEY );
 
 		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Bulk transient flush by pattern; no WP API for batch option deletion.
 		$wpdb->query(
 			$wpdb->prepare(
 				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
 				'_transient_designsetgo_llms_md_%'
 			)
 		);
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Bulk transient flush by pattern; no WP API for batch option deletion.
 		$wpdb->query(
 			$wpdb->prepare(
 				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",

--- a/tests/phpunit/form-handler-test.php
+++ b/tests/phpunit/form-handler-test.php
@@ -704,4 +704,102 @@ class Test_Form_Handler extends WP_UnitTestCase {
 		// Cleanup.
 		delete_transient( $cache_key );
 	}
+
+	/**
+	 * Test cleanup deletes old submissions when retention is enabled.
+	 */
+	public function test_cleanup_deletes_old_submissions() {
+		update_option(
+			'designsetgo_settings',
+			array(
+				'forms' => array(
+					'retention_days' => 30,
+				),
+			)
+		);
+
+		// Create an old submission (older than retention period).
+		$old_post_id = wp_insert_post(
+			array(
+				'post_type'   => 'dsgo_form_submission',
+				'post_status' => 'private',
+				'post_title'  => 'Old Submission',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ),
+			)
+		);
+
+		// Create a recent submission (within retention period).
+		$new_post_id = wp_insert_post(
+			array(
+				'post_type'   => 'dsgo_form_submission',
+				'post_status' => 'private',
+				'post_title'  => 'New Submission',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-5 days' ) ),
+			)
+		);
+
+		$this->assertNotWPError( $old_post_id );
+		$this->assertNotWPError( $new_post_id );
+
+		$this->handler->cleanup_old_submissions();
+
+		// Old submission should be deleted.
+		$this->assertNull( get_post( $old_post_id ) );
+
+		// Recent submission should still exist.
+		$this->assertNotNull( get_post( $new_post_id ) );
+
+		// Cleanup.
+		wp_delete_post( $new_post_id, true );
+		delete_option( 'designsetgo_settings' );
+	}
+
+	/**
+	 * Test cleanup respects batch size filter.
+	 */
+	public function test_cleanup_respects_batch_size() {
+		update_option(
+			'designsetgo_settings',
+			array(
+				'forms' => array(
+					'retention_days' => 30,
+				),
+			)
+		);
+
+		// Create 3 old submissions.
+		$post_ids = array();
+		for ( $i = 0; $i < 3; $i++ ) {
+			$post_ids[] = wp_insert_post(
+				array(
+					'post_type'   => 'dsgo_form_submission',
+					'post_status' => 'private',
+					'post_title'  => "Old Submission {$i}",
+					'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ),
+				)
+			);
+		}
+
+		// Limit batch to 2.
+		add_filter( 'designsetgo_cleanup_batch_size', function () {
+			return 2;
+		} );
+
+		$this->handler->cleanup_old_submissions();
+
+		// Only 2 should be deleted (batch limit).
+		$remaining = 0;
+		foreach ( $post_ids as $post_id ) {
+			if ( null !== get_post( $post_id ) ) {
+				++$remaining;
+			}
+		}
+		$this->assertEquals( 1, $remaining );
+
+		// Cleanup.
+		foreach ( $post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+		delete_option( 'designsetgo_settings' );
+	}
 }

--- a/tests/phpunit/gdpr-compliance-test.php
+++ b/tests/phpunit/gdpr-compliance-test.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Tests for GDPR Compliance
+ *
+ * Tests the get_statistics method to verify correct counts
+ * of form submissions using WP_Query.
+ *
+ * @package DesignSetGo
+ */
+
+namespace DesignSetGo\Tests;
+
+use WP_UnitTestCase;
+use DesignSetGo\Admin\GDPR_Compliance;
+
+/**
+ * GDPR Compliance Test Case
+ */
+class Test_GDPR_Compliance extends WP_UnitTestCase {
+
+	/**
+	 * GDPR compliance instance.
+	 *
+	 * @var GDPR_Compliance
+	 */
+	private $gdpr;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->gdpr = new GDPR_Compliance();
+
+		register_post_type(
+			'dsgo_form_submission',
+			array(
+				'public' => false,
+			)
+		);
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+	}
+
+	/**
+	 * Test get_statistics returns zero counts when no submissions exist.
+	 */
+	public function test_get_statistics_empty() {
+		$stats = $this->gdpr->get_statistics();
+
+		$this->assertIsArray( $stats );
+		$this->assertEquals( 0, $stats['total'] );
+		$this->assertEquals( 0, $stats['old_submissions'] );
+	}
+
+	/**
+	 * Test get_statistics counts total submissions correctly.
+	 */
+	public function test_get_statistics_total_count() {
+		$post_ids = array();
+		for ( $i = 0; $i < 3; $i++ ) {
+			$post_ids[] = wp_insert_post(
+				array(
+					'post_type'   => 'dsgo_form_submission',
+					'post_status' => 'private',
+					'post_title'  => "Submission {$i}",
+					'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-5 days' ) ),
+				)
+			);
+		}
+
+		$stats = $this->gdpr->get_statistics();
+
+		$this->assertEquals( 3, $stats['total'] );
+
+		foreach ( $post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+	}
+
+	/**
+	 * Test get_statistics counts old submissions (>30 days) correctly.
+	 */
+	public function test_get_statistics_old_submissions() {
+		// Create 2 old submissions (>30 days).
+		$old_ids = array();
+		for ( $i = 0; $i < 2; $i++ ) {
+			$old_ids[] = wp_insert_post(
+				array(
+					'post_type'   => 'dsgo_form_submission',
+					'post_status' => 'private',
+					'post_title'  => "Old Submission {$i}",
+					'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ),
+				)
+			);
+		}
+
+		// Create 1 recent submission (<30 days).
+		$new_id = wp_insert_post(
+			array(
+				'post_type'   => 'dsgo_form_submission',
+				'post_status' => 'private',
+				'post_title'  => 'Recent Submission',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-5 days' ) ),
+			)
+		);
+
+		$stats = $this->gdpr->get_statistics();
+
+		$this->assertEquals( 3, $stats['total'] );
+		$this->assertEquals( 2, $stats['old_submissions'] );
+
+		foreach ( $old_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+		wp_delete_post( $new_id, true );
+	}
+
+	/**
+	 * Test get_statistics does not count other post types.
+	 */
+	public function test_get_statistics_ignores_other_post_types() {
+		// Create a regular post.
+		$page_id = wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Regular Post',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ),
+			)
+		);
+
+		// Create a form submission.
+		$sub_id = wp_insert_post(
+			array(
+				'post_type'   => 'dsgo_form_submission',
+				'post_status' => 'private',
+				'post_title'  => 'Form Submission',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-5 days' ) ),
+			)
+		);
+
+		$stats = $this->gdpr->get_statistics();
+
+		$this->assertEquals( 1, $stats['total'] );
+		$this->assertEquals( 0, $stats['old_submissions'] );
+
+		wp_delete_post( $page_id, true );
+		wp_delete_post( $sub_id, true );
+	}
+}

--- a/tests/phpunit/llms-txt-test.php
+++ b/tests/phpunit/llms-txt-test.php
@@ -276,6 +276,29 @@ class Test_LLMS_Txt extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test flush_cache endpoint clears pattern-based markdown transients.
+	 */
+	public function test_flush_cache_endpoint_clears_markdown_transients() {
+		wp_set_current_user( $this->admin_user );
+
+		// Set pattern-based transients that should be flushed.
+		set_transient( 'designsetgo_llms_md_post_1', 'cached markdown 1' );
+		set_transient( 'designsetgo_llms_md_post_2', 'cached markdown 2' );
+
+		$request  = new WP_REST_Request( 'POST', '/designsetgo/v1/llms-txt/flush-cache' );
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		// The bulk DELETE clears the DB rows; flush object cache to simulate
+		// a new request (the in-memory cache still holds stale values).
+		wp_cache_flush();
+
+		$this->assertFalse( get_transient( 'designsetgo_llms_md_post_1' ) );
+		$this->assertFalse( get_transient( 'designsetgo_llms_md_post_2' ) );
+	}
+
+	/**
 	 * Test markdown endpoint returns 404 for non-existent post.
 	 */
 	public function test_markdown_endpoint_returns_404_for_missing_post() {

--- a/uninstall.php
+++ b/uninstall.php
@@ -34,6 +34,7 @@ function designsetgo_uninstall_step( $label, $callback ) {
 designsetgo_uninstall_step(
 	'form submissions',
 	function () use ( $wpdb ) {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Uninstall bulk cleanup; no WP API for mass post deletion by type without loading each post.
 		$wpdb->query(
 			$wpdb->prepare(
 				"DELETE FROM {$wpdb->posts} WHERE post_type = %s",
@@ -48,6 +49,7 @@ designsetgo_uninstall_step(
 designsetgo_uninstall_step(
 	'post meta',
 	function () use ( $wpdb ) {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Uninstall bulk cleanup; no WP API for mass meta deletion by key pattern.
 		$wpdb->query(
 			$wpdb->prepare(
 				"DELETE FROM {$wpdb->postmeta} WHERE meta_key LIKE %s",
@@ -87,6 +89,7 @@ designsetgo_uninstall_step(
 designsetgo_uninstall_step(
 	'transients',
 	function () use ( $wpdb ) {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Uninstall bulk cleanup; no WP API for mass transient deletion by pattern.
 		$wpdb->query(
 			$wpdb->prepare(
 				"DELETE FROM {$wpdb->options}
@@ -100,6 +103,7 @@ designsetgo_uninstall_step(
 		);
 
 		// Delete transient timeout entries.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Uninstall bulk cleanup; no WP API for mass transient deletion by pattern.
 		$wpdb->query(
 			$wpdb->prepare(
 				"DELETE FROM {$wpdb->options}


### PR DESCRIPTION
## Summary

- Replace direct `$wpdb` queries with `WP_Query` in `class-form-handler.php` (cleanup) and `class-gdpr-compliance.php` (statistics)
- Add `phpcs:ignore` annotations with justification for custom table operations (filter index), content-LIKE searches (block migrator), and bulk transient flush (llms-txt) where no WP API equivalent exists
- Add tests covering the refactored cleanup logic, GDPR statistics, and transient flush behavior

## Details

**26 warnings → 0** across 8 files:

| File | Fix |
|------|-----|
| `class-form-handler.php` | `WP_Query` with `date_query` + `fields => ids` |
| `class-gdpr-compliance.php` | `WP_Query` with `found_posts` |
| `class-query-filter-index.php` | `phpcs:ignore` (custom table writes + cached read) |
| `class-query-filter-index-cli.php` | Added `NoCaching` to existing ignore |
| `class-query-filter-index-rebuilder.php` | `phpcs:ignore` (custom table write) |
| `class-block-migrator.php` | `phpcs:ignore` (no API for LIKE on post_content) |
| `class-settings.php` | `phpcs:ignore` (already cached via transient) |
| `class-rest-controller.php` | `phpcs:ignore` (bulk pattern-based DELETE) |

## Test plan

- [x] `vendor/bin/phpcs --standard=WordPress --sniffs=WordPress.DB.DirectDatabaseQuery includes/` reports 0 warnings
- [x] Full PHPCS lint passes (`npm run lint:php`)
- [x] New PHPUnit tests pass: cleanup deletion, batch size, GDPR stats, transient flush
- [x] Existing test suite unaffected (pre-existing failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)