### PR TITLE
fix: resolve WordPress.WP.AlternativeFunctions PCP warnings

### DIFF
--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -164,7 +164,7 @@ class Settings {
 			return array();
 		}
 
-		$raw_data = json_decode( file_get_contents( $json_path ), true );
+		$raw_data = wp_json_file_decode( $json_path, array( 'associative' => true ) );
 
 		if ( ! is_array( $raw_data ) ) {
 			return array();

--- a/includes/blocks/class-loader.php
+++ b/includes/blocks/class-loader.php
@@ -192,7 +192,7 @@ class Loader {
 			// In debug mode, verify the derived name matches block.json to catch
 			// directory/name mismatches during development.
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				$json_data = json_decode( file_get_contents( $block_dir . '/block.json' ), true );
+				$json_data = wp_json_file_decode( $block_dir . '/block.json', array( 'associative' => true ) );
 				$json_name = isset( $json_data['name'] ) ? $json_data['name'] : '';
 				if ( $block_name !== $json_name ) {
 					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
@@ -305,7 +305,7 @@ class Loader {
 
 			foreach ( $style_files as $style_file ) {
 				// Read and decode the JSON file.
-				$style_data = json_decode( file_get_contents( $style_file ), true );
+				$style_data = wp_json_file_decode( $style_file, array( 'associative' => true ) );
 
 				if ( ! $style_data || ! isset( $style_data['slug'] ) || ! isset( $style_data['title'] ) ) {
 					continue;

--- a/uninstall.php
+++ b/uninstall.php
@@ -63,18 +63,13 @@ designsetgo_uninstall_step(
 designsetgo_uninstall_step(
 	'options and llms.txt',
 	function () {
+		// wp_delete_file() uses @unlink() internally, safe to call without existence checks.
 		if ( get_option( 'designsetgo_llms_txt_physical' ) ) {
-			$file_path = ABSPATH . 'llms.txt';
-			if ( file_exists( $file_path ) && is_writable( $file_path ) ) {
-				wp_delete_file( $file_path );
-			}
+			wp_delete_file( ABSPATH . 'llms.txt' );
 		}
 
 		if ( get_option( 'designsetgo_llms_full_txt_physical' ) ) {
-			$full_path = ABSPATH . 'llms-full.txt';
-			if ( file_exists( $full_path ) && is_writable( $full_path ) ) {
-				wp_delete_file( $full_path );
-			}
+			wp_delete_file( ABSPATH . 'llms-full.txt' );
 		}
 
 		delete_option( 'designsetgo_global_styles' );


### PR DESCRIPTION
## Summary
- Replace `file_get_contents()` + `json_decode()` with `wp_json_file_decode()` for local JSON file reads
- Resolves all 3 `WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents` PCP warnings

## Test plan
- [x] `./vendor/bin/phpcs --standard=phpcs.xml -s` shows no AlternativeFunctions warnings
- [x] Plugin loads correctly (block registration, style registration, admin settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)