### PR TITLE
fix: resolve PCP DirectDB and WPQueryParams warnings

### DIFF
--- a/includes/abilities/info/class-list-extensions.php
+++ b/includes/abilities/info/class-list-extensions.php
@@ -199,7 +199,7 @@ class List_Extensions extends Abstract_Ability {
 							'blocks'      => array(
 								'description' => __( 'Which blocks this extension applies to. "all" means all blocks (with possible exclusions).', 'designsetgo' ),
 							),
-							'exclude'     => array(
+							'exclude'     => array( // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- REST schema property describing an extension's block-exclusion list, not a get_posts() query.
 								'type'        => 'array',
 								'description' => __( 'Blocks excluded from this extension', 'designsetgo' ),
 							),
@@ -322,7 +322,7 @@ class List_Extensions extends Abstract_Ability {
 				'label'       => $label,
 				'description' => $description,
 				'blocks'      => $config['blocks'],
-				'exclude'     => $config['exclude'] ?? array(),
+				'exclude'     => $config['exclude'] ?? array(), // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Passes through an extension's block-exclusion list, not a get_posts() query.
 				'attributes'  => $config['attributes'],
 			);
 		}

--- a/includes/admin/class-block-migrator.php
+++ b/includes/admin/class-block-migrator.php
@@ -789,7 +789,7 @@ JS;
 
 		$prepare_values = array_merge( $like_values, self::POST_TYPES, $statuses );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic placeholders generated from safe constants.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Dynamic placeholders generated from safe constants; the %s placeholders live inside interpolated vars ($like_sql/$type_placeholders/$status_placeholders) so the sniff cannot see them, but every value is passed through $wpdb->prepare().
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- $like_sql built from class constants with %s placeholders; all values passed through $wpdb->prepare(). No WP API for LIKE on post_content; admin-only count, caching inappropriate for migration tool.
 		$count = (int) $wpdb->get_var(
 			$wpdb->prepare(
@@ -800,7 +800,7 @@ JS;
 				...$prepare_values
 			)
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 
 		return $count;
 	}

--- a/includes/admin/class-block-migrator.php
+++ b/includes/admin/class-block-migrator.php
@@ -731,7 +731,7 @@ JS;
 		}
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared -- Dynamic placeholders and $sql variable built from safe constants above.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- No WP API for LIKE on post_content; admin-only migration tool, caching inappropriate for batch scans.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- $sql built from class constants with %s/%d placeholders; all values passed through $wpdb->prepare(). No WP API for LIKE on post_content; admin-only migration tool, caching inappropriate for batch scans.
 		$posts = $wpdb->get_results(
 			$wpdb->prepare(
 				$sql,
@@ -790,7 +790,7 @@ JS;
 		$prepare_values = array_merge( $like_values, self::POST_TYPES, $statuses );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic placeholders generated from safe constants.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- No WP API for LIKE on post_content; admin-only count, caching inappropriate for migration tool.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- $like_sql built from class constants with %s placeholders; all values passed through $wpdb->prepare(). No WP API for LIKE on post_content; admin-only count, caching inappropriate for migration tool.
 		$count = (int) $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT(*) FROM {$wpdb->posts}

--- a/includes/admin/class-draft-mode-preview.php
+++ b/includes/admin/class-draft-mode-preview.php
@@ -223,6 +223,7 @@ class Draft_Mode_Preview {
 			array(
 				'post_type'      => 'page',
 				'post_status'    => 'publish',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Bounded by posts_per_page (default 100, filterable), fetches IDs only, and the result is cached in a transient for 10 minutes; the meta lookup runs at most once per cache window.
 				'meta_key'       => Draft_Mode::META_HAS_DRAFT,
 				'posts_per_page' => $posts_per_page,
 				'fields'         => 'ids',

--- a/includes/blocks/class-query-filter-index.php
+++ b/includes/blocks/class-query-filter-index.php
@@ -189,7 +189,7 @@ class FilterIndex {
 		$sql = "INSERT INTO {$table} (object_id, object_type, post_type, filter_key, filter_value) VALUES "
 			. implode( ', ', $placeholders );
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table bulk insert; placeholders built programmatically above.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Custom table bulk insert; placeholders built programmatically above and passed through $wpdb->prepare().
 		$wpdb->query( $wpdb->prepare( $sql, $params ) );
 
 		self::bump_counts_cache();
@@ -371,7 +371,7 @@ class FilterIndex {
 
 		$params = array_merge( array( $key ), $string_values, $post_type_params, $intersect_params );
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery -- Custom table query; cached via wp_cache_get/set above. Placeholders built programmatically.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Custom table query; cached via wp_cache_get/set above. Placeholders built programmatically and passed through $wpdb->prepare().
 		$rows = $wpdb->get_results( $wpdb->prepare( $sql, $params ) );
 
 		if ( is_array( $rows ) ) {

--- a/includes/class-button-global-styles.php
+++ b/includes/class-button-global-styles.php
@@ -123,7 +123,7 @@ class Button_Global_Styles {
 		if ( wp_style_is( 'designsetgo-frontend', 'registered' ) ) {
 			wp_add_inline_style( 'designsetgo-frontend', $css );
 		} else {
-			wp_register_style( 'designsetgo-button-global-styles', false );
+			wp_register_style( 'designsetgo-button-global-styles', false, array(), DESIGNSETGO_VERSION );
 			wp_enqueue_style( 'designsetgo-button-global-styles' );
 			wp_add_inline_style( 'designsetgo-button-global-styles', $css );
 		}
@@ -158,7 +158,7 @@ class Button_Global_Styles {
 		} elseif ( wp_style_is( 'designsetgo-form-builder-style', 'enqueued' ) ) {
 			wp_add_inline_style( 'designsetgo-form-builder-style', $css );
 		} else {
-			wp_register_style( 'designsetgo-button-global-styles-editor', false );
+			wp_register_style( 'designsetgo-button-global-styles-editor', false, array(), DESIGNSETGO_VERSION );
 			wp_enqueue_style( 'designsetgo-button-global-styles-editor' );
 			wp_add_inline_style( 'designsetgo-button-global-styles-editor', $css );
 		}

--- a/includes/class-overlay-header.php
+++ b/includes/class-overlay-header.php
@@ -178,7 +178,7 @@ class Overlay_Header {
 		if ( wp_style_is( 'designsetgo-sticky-header', 'enqueued' ) ) {
 			wp_add_inline_style( 'designsetgo-sticky-header', $css );
 		} else {
-			wp_register_style( 'designsetgo-overlay-header-color', false );
+			wp_register_style( 'designsetgo-overlay-header-color', false, array(), DESIGNSETGO_VERSION );
 			wp_enqueue_style( 'designsetgo-overlay-header-color' );
 			wp_add_inline_style( 'designsetgo-overlay-header-color', $css );
 		}

--- a/includes/extension-configs/background-video.php
+++ b/includes/extension-configs/background-video.php
@@ -27,7 +27,7 @@ return array(
 		'designsetgo/image-accordion',
 		'designsetgo/image-accordion-item',
 	),
-	'exclude'    => array(),
+	'exclude'    => array(), // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Extension block-exclusion list, not a get_posts() query.
 	'attributes' => array(
 		'dsgoVideoUrl'          => array(
 			'type'    => 'string',

--- a/includes/extension-configs/block-animations.php
+++ b/includes/extension-configs/block-animations.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
 
 return array(
 	'blocks'     => 'all',
-	'exclude'    => array( 'core/freeform', 'core-embed/*' ),
+	'exclude'    => array( 'core/freeform', 'core-embed/*' ), // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Extension block-exclusion list, not a get_posts() query.
 	'attributes' => array(
 		'dsgoAnimationEnabled'  => array(
 			'type'    => 'boolean',

--- a/includes/extension-configs/clickable-group.php
+++ b/includes/extension-configs/clickable-group.php
@@ -15,7 +15,7 @@ return array(
 		'designsetgo/row',
 		'designsetgo/grid',
 	),
-	'exclude'    => array(),
+	'exclude'    => array(), // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Extension block-exclusion list, not a get_posts() query.
 	'attributes' => array(
 		'dsgoLinkUrl'    => array(
 			'type'    => 'string',

--- a/includes/extension-configs/custom-css.php
+++ b/includes/extension-configs/custom-css.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
 
 return array(
 	'blocks'     => 'all',
-	'exclude'    => array( 'core/html', 'core/code' ),
+	'exclude'    => array( 'core/html', 'core/code' ), // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Extension block-exclusion list, not a get_posts() query.
 	'attributes' => array(
 		'dsgoCustomCSS' => array(
 			'type'    => 'string',

--- a/includes/extension-configs/expanding-background.php
+++ b/includes/extension-configs/expanding-background.php
@@ -13,7 +13,7 @@ return array(
 		'core/group',
 		'designsetgo/section',
 	),
-	'exclude'    => array(),
+	'exclude'    => array(), // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Extension block-exclusion list, not a get_posts() query.
 	'attributes' => array(
 		'dsgoExpandingBgEnabled'         => array(
 			'type'    => 'boolean',

--- a/includes/extension-configs/grid-mobile-order.php
+++ b/includes/extension-configs/grid-mobile-order.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
 
 return array(
 	'blocks'     => 'all',
-	'exclude'    => array(),
+	'exclude'    => array(), // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Extension block-exclusion list, not a get_posts() query.
 	'attributes' => array(
 		'dsgoMobileOrder' => array(
 			'type'    => 'number',

--- a/includes/extension-configs/grid-span.php
+++ b/includes/extension-configs/grid-span.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
 
 return array(
 	'blocks'     => 'all',
-	'exclude'    => array(),
+	'exclude'    => array(), // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Extension block-exclusion list, not a get_posts() query.
 	'attributes' => array(
 		'dsgoColumnSpan' => array(
 			'type'    => 'number',

--- a/includes/extension-configs/max-width.php
+++ b/includes/extension-configs/max-width.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
 
 return array(
 	'blocks'     => 'all',
-	'exclude'    => array(
+	'exclude'    => array( // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Extension block-exclusion list, not a get_posts() query.
 		'core/spacer',
 		'core/separator',
 		'core/page-list',

--- a/includes/extension-configs/responsive.php
+++ b/includes/extension-configs/responsive.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
 
 return array(
 	'blocks'     => 'all',
-	'exclude'    => array(),
+	'exclude'    => array(), // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Extension block-exclusion list, not a get_posts() query.
 	'attributes' => array(
 		'dsgoHideOnDesktop' => array(
 			'type'    => 'boolean',

--- a/includes/extension-configs/reveal-container.php
+++ b/includes/extension-configs/reveal-container.php
@@ -14,7 +14,7 @@ return array(
 		'designsetgo/row',
 		'designsetgo/grid',
 	),
-	'exclude'    => array(),
+	'exclude'    => array(), // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Extension block-exclusion list, not a get_posts() query.
 	'attributes' => array(
 		'enableRevealOnHover'  => array(
 			'type'    => 'boolean',

--- a/includes/extension-configs/reveal-control.php
+++ b/includes/extension-configs/reveal-control.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
 
 return array(
 	'blocks'     => 'all',
-	'exclude'    => array(),
+	'exclude'    => array(), // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Extension block-exclusion list, not a get_posts() query.
 	'attributes' => array(
 		'dsgoRevealOnHover' => array(
 			'type'    => 'boolean',

--- a/includes/extension-configs/sticky-header-controls.php
+++ b/includes/extension-configs/sticky-header-controls.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
 
 return array(
 	'blocks'     => array( 'core/template-part' ),
-	'exclude'    => array(),
+	'exclude'    => array(), // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Extension block-exclusion list, not a get_posts() query.
 	'attributes' => array(
 		'dsgoStickyEnabled'      => array(
 			'type'    => 'boolean',

--- a/includes/extension-configs/svg-patterns.php
+++ b/includes/extension-configs/svg-patterns.php
@@ -13,7 +13,7 @@ return array(
 		'core/group',
 		'designsetgo/section',
 	),
-	'exclude'    => array(),
+	'exclude'    => array(), // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Extension block-exclusion list, not a get_posts() query.
 	'attributes' => array(
 		'dsgoSvgPatternEnabled' => array(
 			'type'    => 'boolean',

--- a/includes/extension-configs/text-reveal.php
+++ b/includes/extension-configs/text-reveal.php
@@ -13,7 +13,7 @@ return array(
 		'core/paragraph',
 		'core/heading',
 	),
-	'exclude'    => array(),
+	'exclude'    => array(), // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Extension block-exclusion list, not a get_posts() query.
 	'attributes' => array(
 		'dsgoTextRevealEnabled'    => array(
 			'type'    => 'boolean',

--- a/includes/extension-configs/vertical-parallax.php
+++ b/includes/extension-configs/vertical-parallax.php
@@ -33,7 +33,7 @@ return array(
 		'designsetgo/scroll-accordion',
 		'designsetgo/scroll-accordion-item',
 	),
-	'exclude'    => array(),
+	'exclude'    => array(), // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Extension block-exclusion list, not a get_posts() query.
 	'attributes' => array(
 		'dsgoParallaxEnabled'       => array(
 			'type'    => 'boolean',

--- a/src/blocks/product-categories-grid/render.php
+++ b/src/blocks/product-categories-grid/render.php
@@ -105,6 +105,7 @@ if ( 'manual' === $category_source ) {
 			'taxonomy'   => 'product_cat',
 			'parent'     => 0,
 			'hide_empty' => ! $show_empty,
+			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- get_terms() exclusion bounded to the default "uncategorized" product_cat term.
 			'exclude'    => $exclude_ids,
 			'orderby'    => 'menu_order',
 			'order'      => 'ASC',

--- a/src/blocks/query/render-posts.php
+++ b/src/blocks/query/render-posts.php
@@ -513,6 +513,7 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 			// If an attribute-level tax_query exists with relation=OR, wrap it so
 			// the URL-param clause ANDs against the entire OR group.
 			if ( isset( $args['tax_query'] ) && 'OR' === ( $args['tax_query']['relation'] ?? 'AND' ) ) {
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Re-wrapping an existing tax_query the user explicitly configured; same query, just AND-grouped with the URL-param clause.
 				$args['tax_query'] = array(
 					'relation' => 'AND',
 					$args['tax_query'],

--- a/src/blocks/query/render-posts.php
+++ b/src/blocks/query/render-posts.php
@@ -377,6 +377,7 @@ if ( ! function_exists( 'designsetgo_query_render_posts' ) ) :
 		if ( ! empty( $atts['excludeCurrent'] ) && is_singular() ) {
 			$current_id = get_queried_object_id();
 			if ( $current_id ) {
+				// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in -- Bounded to the single current post when "exclude current" is enabled on a singular view.
 				$args['post__not_in'] = array( $current_id );
 			}
 		}

--- a/tests/e2e/blocks-pcp-offloading.spec.js
+++ b/tests/e2e/blocks-pcp-offloading.spec.js
@@ -6,210 +6,20 @@
  * (storage fallback, local placeholder images, WP_Query migration).
  */
 
-const fs = require('fs');
-const path = require('path');
 const { test, expect } = require('@playwright/test');
 const { getEditorCanvas, createNewPost } = require('./helpers/wordpress');
+const {
+	defineArtifact,
+	saveScreenshot,
+	installVideoCapture,
+	slowScrollToBottom,
+	slowScrollEditor,
+	setPostTitle,
+	publishAndResolveUrl,
+} = require('./helpers/artifacts');
 
-// Screenshots / videos land alongside the other Playwright artifacts so they
-// are easy to find (and get uploaded by CI). They are grouped per block, then
-// per test scenario, so a block can have many scenarios without collisions:
-//
-//   screenshots/<block>/<scenario>/editor.png
-//   screenshots/<block>/<scenario>/frontend.png
-//   screenshots/<block>/<scenario>/video.webm   (only when DSGO_RECORD_VIDEO=1)
-const SCREENSHOT_DIR = path.join(
-	process.env.WP_ARTIFACTS_PATH || path.join(process.cwd(), 'artifacts'),
-	'screenshots'
-);
-
-/**
- * Tag a test with its block + scenario so screenshots and the recorded video
- * all land under screenshots/<block>/<scenario>/. Call once at the top of a
- * test; pass the returned descriptor to saveScreenshot().
- *
- * @param {import('@playwright/test').TestInfo} testInfo - Playwright test info
- * @param {string}                              block    - Block name (top folder)
- * @param {string}                              scenario - Scenario name (subfolder)
- * @return {{block: string, scenario: string}} Artifact descriptor
- */
-function defineArtifact(testInfo, block, scenario) {
-	testInfo.annotations.push({ type: 'dsgo-block', description: block });
-	testInfo.annotations.push({ type: 'dsgo-scenario', description: scenario });
-	return { block, scenario };
-}
-
-// Optional video capture. Off by default (screenshots only); set
-// DSGO_RECORD_VIDEO=1 to also record a video of each test. Videos are grouped
-// next to the screenshots, one per block: screenshots/<block>/<block>.webm.
-const RECORD_VIDEO = ['1', 'true'].includes(process.env.DSGO_RECORD_VIDEO);
-
-test.use({ video: RECORD_VIDEO ? 'on' : 'off' });
-
-// Collected during afterEach (path is known while recording) and copied into
-// place in afterAll, once every per-test context has closed and the video
-// files are finalized — avoids saveAs() deadlocking on the still-open page.
-const pendingVideos = [];
-
-test.afterEach(async ({ page }, testInfo) => {
-	if (!RECORD_VIDEO) {
-		return;
-	}
-	const video = page.video();
-	const block = testInfo.annotations.find(
-		(a) => a.type === 'dsgo-block'
-	)?.description;
-	const scenario = testInfo.annotations.find(
-		(a) => a.type === 'dsgo-scenario'
-	)?.description;
-	if (!video || !block || !scenario) {
-		return;
-	}
-	pendingVideos.push({
-		src: await video.path(),
-		dest: path.join(SCREENSHOT_DIR, block, scenario, 'video.webm'),
-	});
-});
-
-test.afterAll(async () => {
-	for (const { src, dest } of pendingVideos) {
-		try {
-			fs.mkdirSync(path.dirname(dest), { recursive: true });
-			fs.copyFileSync(src, dest);
-		} catch {
-			// Best effort — the original still exists in the test-results dir.
-		}
-	}
-});
-
-/**
- * Save a full-page screenshot under screenshots/<block>/<scenario>/.
- *
- * @param {import('@playwright/test').Page}   page     - Playwright page object
- * @param {{block: string, scenario: string}} artifact - Descriptor from defineArtifact()
- * @param {'editor'|'frontend'}               source   - Which view; names the file
- *                                                     editor.png or frontend.png.
- */
-async function saveScreenshot(page, artifact, source) {
-	const fileName = source === 'editor' ? 'editor.png' : 'frontend.png';
-	await page.screenshot({
-		path: path.join(
-			SCREENSHOT_DIR,
-			artifact.block,
-			artifact.scenario,
-			fileName
-		),
-		fullPage: true,
-	});
-}
-
-/**
- * Slowly scroll a scope from top to bottom and back to top.
- *
- * Works on either a Page (frontend window) or a Frame (the editor canvas
- * iframe) — both expose `evaluate`, and the body scrolls whatever `window`
- * belongs to that scope. Used so the full block is revealed over time in the
- * recorded video and any lazy-loaded / parallax content is triggered before
- * the screenshot. Small steps with a delay keep the motion visible.
- *
- * @param {import('@playwright/test').Page | import('@playwright/test').Frame} scope
- *                                                                                   Page or Frame to scroll.
- */
-async function slowScrollToBottom(scope) {
-	await scope.evaluate(async () => {
-		const step = 180;
-		const delayMs = 220;
-		const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-
-		window.scrollTo(0, 0);
-		await sleep(delayMs);
-
-		let last = -1;
-		// Guard against unbounded growth (infinite scroll) with a step cap.
-		for (let i = 0; i < 400; i++) {
-			const maxY =
-				document.documentElement.scrollHeight - window.innerHeight;
-			const y = Math.min(window.scrollY + step, maxY);
-			window.scrollTo(0, y);
-			await sleep(delayMs);
-			if (y >= maxY || y === last) {
-				break;
-			}
-			last = y;
-		}
-
-		await sleep(delayMs);
-		window.scrollTo(0, 0);
-	});
-}
-
-/**
- * Slowly scroll the editor canvas (which lives in the `editor-canvas` iframe)
- * so the whole block is revealed in the editor view of the recorded video.
- * Falls back to scrolling the page if the canvas iframe isn't present.
- *
- * @param {import('@playwright/test').Page} page - Playwright page object
- */
-async function slowScrollEditor(page) {
-	const frame = page.frame({ name: 'editor-canvas' });
-	await slowScrollToBottom(frame || page);
-}
-
-/**
- * Title the current post after the block under test, so test pages are
- * identifiable (instead of "(no title)") in the editor, the page list, and the
- * frontend.
- *
- * @param {import('@playwright/test').Page} page  - Playwright page object
- * @param {string}                          title - Post title (the block name)
- */
-async function setPostTitle(page, title) {
-	await page.evaluate((value) => {
-		wp.data.dispatch('core/editor').editPost({ title: value });
-	}, title);
-}
-
-/**
- * Publish the current post and return its frontend URL.
- *
- * Publishes through the editor data store rather than the publish-panel UI.
- * The UI flow is flaky under wp-env (the welcome-guide / pre-publish modal can
- * intercept the click, leaving the post an unqueryable draft). Dispatching
- * `editPost({ status: 'publish' })` + `savePost()` and then polling
- * `isCurrentPostPublished()` is deterministic.
- *
- * Returns a `?page_id=<id>` URL: a page published without a title keeps the
- * stale "auto-draft" slug in the permalink cache, so the pretty permalink can
- * 404. The query-arg form always resolves to the published content.
- *
- * @param {import('@playwright/test').Page} page - Playwright page object
- * @return {Promise<string>} Frontend URL of the published post
- */
-async function publishAndResolveUrl(page) {
-	await page.evaluate(async () => {
-		const { dispatch } = wp.data;
-		await dispatch('core/editor').editPost({ status: 'publish' });
-		await dispatch('core/editor').savePost();
-	});
-
-	// Wait until the store confirms the post is published and not mid-save.
-	await page.waitForFunction(
-		() => {
-			const editor = wp.data.select('core/editor');
-			return editor.isCurrentPostPublished() && !editor.isSavingPost();
-		},
-		undefined,
-		{ timeout: 30000 }
-	);
-
-	const id = await page.evaluate(() =>
-		wp.data.select('core/editor').getCurrentPostId()
-	);
-	if (!id) {
-		throw new Error('Could not determine published post ID');
-	}
-	return `/?page_id=${id}`;
-}
+// Record a video per test when DSGO_RECORD_VIDEO=1 (screenshots only by default).
+installVideoCapture(test);
 
 // ---------------------------------------------------------------------------
 // Modal block — editor insertion + frontend rendering
@@ -218,7 +28,12 @@ test.describe('Modal block — editor and frontend', () => {
 	test('modal block inserts without validation error and renders on frontend', async ({
 		page,
 	}, testInfo) => {
-		const artifact = defineArtifact(testInfo, 'modal', 'insert-and-render');
+		const artifact = defineArtifact(
+			testInfo,
+			'blocks',
+			'modal',
+			'insert-and-render'
+		);
 		const consoleErrors = [];
 		page.on('pageerror', (err) => consoleErrors.push(err.message));
 
@@ -348,7 +163,8 @@ test.describe('Pattern placeholder images — inserter and frontend', () => {
 		// Pattern found and inserted — tag artifacts now (past the skip guard).
 		const artifact = defineArtifact(
 			testInfo,
-			'hero-split',
+			'patterns',
+			'hero/hero-split',
 			'placeholder-images'
 		);
 
@@ -426,6 +242,7 @@ test.describe('Form builder — editor and frontend', () => {
 	}, testInfo) => {
 		const artifact = defineArtifact(
 			testInfo,
+			'blocks',
 			'form-builder',
 			'insert-and-render'
 		);

--- a/tests/e2e/helpers/artifacts.js
+++ b/tests/e2e/helpers/artifacts.js
@@ -1,0 +1,243 @@
+/**
+ * Shared artifact + publish helpers for DesignSetGo e2e tests.
+ *
+ * Screenshots / videos land alongside the other Playwright artifacts so they
+ * are easy to find (and get uploaded by CI). Every artifact is filed under a
+ * uniform three-level path — a top-level group ("blocks" or "patterns"), the
+ * item under test (a block name or pattern slug), then the scenario (the
+ * specific test) — so one item can have many scenarios without collisions:
+ *
+ *   screenshots/<group>/<item>/<scenario>/editor.png
+ *   screenshots/<group>/<item>/<scenario>/frontend.png
+ *   screenshots/<group>/<item>/<scenario>/video.webm   (only when DSGO_RECORD_VIDEO=1)
+ *
+ * e.g. screenshots/blocks/modal/insert-and-render/editor.png
+ *      screenshots/patterns/hero/hero-parallax/insert-publish-render/frontend.png
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SCREENSHOT_DIR = path.join(
+	process.env.WP_ARTIFACTS_PATH || path.join(process.cwd(), 'artifacts'),
+	'screenshots'
+);
+
+// Optional video capture. Off by default (screenshots only); set
+// DSGO_RECORD_VIDEO=1 to also record a video of each test.
+const RECORD_VIDEO = ['1', 'true'].includes(process.env.DSGO_RECORD_VIDEO);
+
+/**
+ * Tag a test with its group + item + scenario so screenshots and the recorded
+ * video all land under screenshots/<group>/<item>/<scenario>/. Call once at the
+ * top of a test; pass the returned descriptor to saveScreenshot().
+ *
+ * @param {import('@playwright/test').TestInfo} testInfo - Playwright test info
+ * @param {string}                              group    - Top-level bucket ("blocks" | "patterns")
+ * @param {string}                              item     - Item under test (block name / pattern slug)
+ * @param {string}                              scenario - Scenario name (the specific test)
+ * @return {{group: string, item: string, scenario: string}} Artifact descriptor
+ */
+function defineArtifact(testInfo, group, item, scenario) {
+	testInfo.annotations.push({ type: 'dsgo-group', description: group });
+	testInfo.annotations.push({ type: 'dsgo-item', description: item });
+	testInfo.annotations.push({ type: 'dsgo-scenario', description: scenario });
+	return { group, item, scenario };
+}
+
+/**
+ * Save a full-page screenshot under screenshots/<group>/<item>/<scenario>/.
+ *
+ * @param {import('@playwright/test').Page}                 page     - Playwright page object
+ * @param {{group: string, item: string, scenario: string}} artifact - Descriptor from defineArtifact()
+ * @param {'editor'|'frontend'}                             source   - Which view; names the file
+ *                                                                   editor.png or frontend.png.
+ */
+async function saveScreenshot(page, artifact, source) {
+	const fileName = source === 'editor' ? 'editor.png' : 'frontend.png';
+	await page.screenshot({
+		path: path.join(
+			SCREENSHOT_DIR,
+			artifact.group,
+			artifact.item,
+			artifact.scenario,
+			fileName
+		),
+		fullPage: true,
+	});
+}
+
+/**
+ * Register video-capture hooks on a test object. No-op unless
+ * DSGO_RECORD_VIDEO=1. Each video lands at
+ * screenshots/<group>/<item>/<scenario>/video.webm, copied in afterAll once
+ * every per-test context has closed and the files are finalized (avoids
+ * saveAs() deadlocking on the still-open page).
+ *
+ * Call once at module scope in a spec file:
+ *   installVideoCapture(test);
+ *
+ * @param {import('@playwright/test').TestType} test - Playwright test object
+ */
+function installVideoCapture(test) {
+	if (!RECORD_VIDEO) {
+		test.use({ video: 'off' });
+		return;
+	}
+
+	test.use({ video: 'on' });
+
+	const pendingVideos = [];
+
+	test.afterEach(async ({ page }, testInfo) => {
+		const video = page.video();
+		const find = (type) =>
+			testInfo.annotations.find((a) => a.type === type)?.description;
+		const group = find('dsgo-group');
+		const item = find('dsgo-item');
+		const scenario = find('dsgo-scenario');
+		if (!video || !group || !item || !scenario) {
+			return;
+		}
+		pendingVideos.push({
+			src: await video.path(),
+			dest: path.join(
+				SCREENSHOT_DIR,
+				group,
+				item,
+				scenario,
+				'video.webm'
+			),
+		});
+	});
+
+	test.afterAll(async () => {
+		for (const { src, dest } of pendingVideos) {
+			try {
+				fs.mkdirSync(path.dirname(dest), { recursive: true });
+				fs.copyFileSync(src, dest);
+			} catch {
+				// Best effort — the original still exists in the test-results dir.
+			}
+		}
+	});
+}
+
+/**
+ * Slowly scroll a scope from top to bottom and back to top.
+ *
+ * Works on either a Page (frontend window) or a Frame (the editor canvas
+ * iframe) — both expose `evaluate`, and the body scrolls whatever `window`
+ * belongs to that scope. Used so the full block is revealed over time in the
+ * recorded video and any lazy-loaded / parallax content is triggered before
+ * the screenshot. Small steps with a delay keep the motion visible.
+ *
+ * @param {import('@playwright/test').Page | import('@playwright/test').Frame} scope
+ *                                                                                   Page or Frame to scroll.
+ */
+async function slowScrollToBottom(scope) {
+	await scope.evaluate(async () => {
+		const step = 180;
+		const delayMs = 220;
+		const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+		window.scrollTo(0, 0);
+		await sleep(delayMs);
+
+		let last = -1;
+		// Guard against unbounded growth (infinite scroll) with a step cap.
+		for (let i = 0; i < 400; i++) {
+			const maxY =
+				document.documentElement.scrollHeight - window.innerHeight;
+			const y = Math.min(window.scrollY + step, maxY);
+			window.scrollTo(0, y);
+			await sleep(delayMs);
+			if (y >= maxY || y === last) {
+				break;
+			}
+			last = y;
+		}
+
+		await sleep(delayMs);
+		window.scrollTo(0, 0);
+	});
+}
+
+/**
+ * Slowly scroll the editor canvas (which lives in the `editor-canvas` iframe)
+ * so the whole block is revealed in the editor view of the recorded video.
+ * Falls back to scrolling the page if the canvas iframe isn't present.
+ *
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ */
+async function slowScrollEditor(page) {
+	const frame = page.frame({ name: 'editor-canvas' });
+	await slowScrollToBottom(frame || page);
+}
+
+/**
+ * Title the current post, so test pages are identifiable (instead of
+ * "(no title)") in the editor, the page list, and the frontend.
+ *
+ * @param {import('@playwright/test').Page} page  - Playwright page object
+ * @param {string}                          title - Post title
+ */
+async function setPostTitle(page, title) {
+	await page.evaluate((value) => {
+		wp.data.dispatch('core/editor').editPost({ title: value });
+	}, title);
+}
+
+/**
+ * Publish the current post and return its frontend URL.
+ *
+ * Publishes through the editor data store rather than the publish-panel UI.
+ * The UI flow is flaky under wp-env (the welcome-guide / pre-publish modal can
+ * intercept the click, leaving the post an unqueryable draft). Dispatching
+ * `editPost({ status: 'publish' })` + `savePost()` and then polling
+ * `isCurrentPostPublished()` is deterministic.
+ *
+ * Returns a `?page_id=<id>` URL: a page published without a title keeps the
+ * stale "auto-draft" slug in the permalink cache, so the pretty permalink can
+ * 404. The query-arg form always resolves to the published content.
+ *
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @return {Promise<string>} Frontend URL of the published post
+ */
+async function publishAndResolveUrl(page) {
+	await page.evaluate(async () => {
+		const { dispatch } = wp.data;
+		await dispatch('core/editor').editPost({ status: 'publish' });
+		await dispatch('core/editor').savePost();
+	});
+
+	// Wait until the store confirms the post is published and not mid-save.
+	await page.waitForFunction(
+		() => {
+			const editor = wp.data.select('core/editor');
+			return editor.isCurrentPostPublished() && !editor.isSavingPost();
+		},
+		undefined,
+		{ timeout: 30000 }
+	);
+
+	const id = await page.evaluate(() =>
+		wp.data.select('core/editor').getCurrentPostId()
+	);
+	if (!id) {
+		throw new Error('Could not determine published post ID');
+	}
+	return `/?page_id=${id}`;
+}
+
+module.exports = {
+	SCREENSHOT_DIR,
+	RECORD_VIDEO,
+	defineArtifact,
+	saveScreenshot,
+	installVideoCapture,
+	slowScrollToBottom,
+	slowScrollEditor,
+	setPostTitle,
+	publishAndResolveUrl,
+};

--- a/tests/e2e/helpers/wordpress.js
+++ b/tests/e2e/helpers/wordpress.js
@@ -296,10 +296,80 @@ async function blockHasClass(page, blockType, className, index = 0) {
 	return false;
 }
 
+/**
+ * Insert a registered block pattern by its slug, programmatically.
+ *
+ * Reads the pattern's resolved `content` straight from the data store, parses
+ * it into blocks, and inserts them. This avoids the inserter-UI search (which
+ * is flaky: the Patterns tab label and the results list vary across WP
+ * versions) and guarantees we exercise the exact content the loader
+ * registered — including the placeholder-token replacement done in PHP.
+ *
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @param {string}                          slug - Pattern slug, e.g. 'designsetgo/hero/hero-split'
+ * @return {Promise<{found: boolean, hadToken: boolean, blockCount: number}>}
+ *         Insertion result: whether the pattern was registered, whether its
+ *         registered content still contained a raw placeholder token, and how
+ *         many top-level blocks were inserted.
+ */
+async function insertPatternBySlug(page, slug) {
+	const result = await page.evaluate((patternSlug) => {
+		const patterns =
+			wp.data.select('core').getBlockPatterns?.() ||
+			wp.data.select('core/block-editor').getSettings()
+				.__experimentalBlockPatterns ||
+			[];
+		const pattern = patterns.find((p) => p.name === patternSlug);
+		if (!pattern) {
+			return { found: false, hadToken: false, blockCount: 0 };
+		}
+
+		const hadToken = pattern.content.includes('{{dsgo:placeholder-');
+		const blocks = wp.blocks.parse(pattern.content);
+		wp.data.dispatch('core/block-editor').insertBlocks(blocks);
+
+		return { found: true, hadToken, blockCount: blocks.length };
+	}, slug);
+
+	if (!result.found) {
+		throw new Error(`Pattern "${slug}" is not registered`);
+	}
+
+	return result;
+}
+
+/**
+ * Walk the editor's block tree and return the names of every block whose
+ * `isValid` is false (i.e. its markup no longer matches its save() output, so
+ * the editor would show an "Attempt Recovery" warning).
+ *
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @return {Promise<string[]>} Unique block names that failed validation.
+ */
+async function getInvalidBlockNames(page) {
+	return page.evaluate(() => {
+		const bad = [];
+		const walk = (blocks) => {
+			for (const b of blocks) {
+				if (b.isValid === false) {
+					bad.push(b.name);
+				}
+				if (b.innerBlocks) {
+					walk(b.innerBlocks);
+				}
+			}
+		};
+		walk(wp.data.select('core/block-editor').getBlocks());
+		return Array.from(new Set(bad));
+	});
+}
+
 module.exports = {
 	getEditorCanvas,
 	createNewPost,
 	insertBlock,
+	insertPatternBySlug,
+	getInvalidBlockNames,
 	openBlockSettings,
 	savePost,
 	publishPost,

--- a/tests/e2e/patterns-happy-path.spec.js
+++ b/tests/e2e/patterns-happy-path.spec.js
@@ -1,0 +1,238 @@
+/**
+ * E2E happy-path tests for patterns changed on the PCP security branch.
+ *
+ * Every pattern in `patterns/` was rewritten on this branch to replace
+ * third-party asset references with local placeholders:
+ *   - image patterns swap remote Unsplash `<img src>` for `{{dsgo:placeholder-*}}`
+ *     tokens, resolved to bundled plugin assets at registration time;
+ *   - link patterns (e.g. CTA social rows) swap external example URLs for `#`.
+ *   - parallax image figures additionally gained the `rotate-*` data-attributes
+ *     so their saved markup matches the current image-parallax save() output.
+ *
+ * Testing all 76 changed patterns end-to-end would be a very long suite, so this
+ * covers one representative pattern per category through the full happy path:
+ * insert → review the editor → publish → review the frontend. The assertions
+ * target exactly what this branch changed — placeholder resolution and the
+ * image/parallax block markup — and deliberately ignore unrelated, pre-existing
+ * block-validation debt in the slider/accordion/cover/form blocks (tracked
+ * separately) so this suite stays green on changes it does not own.
+ */
+
+const { test, expect } = require('@playwright/test');
+const {
+	getEditorCanvas,
+	createNewPost,
+	insertPatternBySlug,
+	getInvalidBlockNames,
+} = require('./helpers/wordpress');
+const {
+	defineArtifact,
+	saveScreenshot,
+	installVideoCapture,
+	slowScrollToBottom,
+	slowScrollEditor,
+	setPostTitle,
+	publishAndResolveUrl,
+} = require('./helpers/artifacts');
+
+// Record a video per test when DSGO_RECORD_VIDEO=1 (screenshots only by default).
+installVideoCapture(test);
+
+// Local placeholder assets all live under this path; every resolved token
+// points here, so a single substring match validates editor + frontend images.
+const ASSET_PATH = 'designsetgo/assets/images/patterns/';
+const TOKEN_PREFIX = '{{dsgo:placeholder-';
+
+// Blocks whose saved markup carries the swapped image references. The token
+// swap and the parallax-attribute fix must not invalidate these; unrelated
+// blocks (slider/accordion/cover/form) may carry pre-existing validation debt
+// that is out of scope for this branch, so they are intentionally not asserted.
+const IMAGE_BLOCKS = ['core/image', 'core/gallery'];
+
+/**
+ * One representative pattern per category. `slug` is the registered pattern
+ * name (designsetgo/<category>/<file>). Flags drive the optional assertions:
+ *   - hasImages:    expect ≥1 local placeholder image in editor + frontend
+ *   - hasParallax:  expect a parallax figure carrying the new rotate attribute
+ *   - forbidden:    substrings that must NOT survive the placeholder rewrite
+ */
+const PATTERNS = [
+	{
+		slug: 'designsetgo/content/content-split-image',
+		title: 'Pattern: Content Split Image',
+		hasImages: true,
+	},
+	{
+		slug: 'designsetgo/cta/cta-work-together',
+		title: 'Pattern: CTA Work Together',
+		hasImages: false,
+		// External example links were replaced with "#" anchors.
+		forbidden: [
+			'https://linkedin.com',
+			'https://x.com',
+			'https://dribbble.com',
+			'https://instagram.com',
+		],
+	},
+	{
+		slug: 'designsetgo/faq/faq-split-image',
+		title: 'Pattern: FAQ Split Image',
+		hasImages: true,
+	},
+	{
+		slug: 'designsetgo/gallery/gallery-parallax-grid',
+		title: 'Pattern: Gallery Parallax Grid',
+		hasImages: true,
+		hasParallax: true,
+	},
+	{
+		slug: 'designsetgo/hero/hero-parallax',
+		title: 'Pattern: Hero Parallax',
+		hasImages: true,
+		hasParallax: true,
+	},
+	{
+		slug: 'designsetgo/homepage/homepage-portfolio',
+		title: 'Pattern: Homepage Portfolio',
+		hasImages: true,
+	},
+	{
+		slug: 'designsetgo/modal/modal-video-cta',
+		title: 'Pattern: Modal Video CTA',
+		hasImages: true,
+	},
+	{
+		slug: 'designsetgo/team/team-grid',
+		title: 'Pattern: Team Grid',
+		hasImages: true,
+	},
+	{
+		slug: 'designsetgo/testimonials/testimonials-grid',
+		title: 'Pattern: Testimonials Grid',
+		hasImages: true,
+	},
+];
+
+test.describe('Changed patterns — editor and frontend happy path', () => {
+	for (const pattern of PATTERNS) {
+		test(`${pattern.slug} inserts, publishes, and renders with local assets`, async ({
+			page,
+		}, testInfo) => {
+			// item nests under patterns/<category>/<name>/; scenario names this
+			// specific test so the same pattern can host multiple scenarios
+			// without colliding (mirrors how block artifacts are grouped).
+			const item = pattern.slug.replace('designsetgo/', '');
+			const artifact = defineArtifact(
+				testInfo,
+				'patterns',
+				item,
+				'insert-publish-render'
+			);
+
+			// Surface any JS errors thrown while the pattern renders.
+			const pageErrors = [];
+			page.on('pageerror', (err) => pageErrors.push(err.message));
+
+			// --- Insert in the editor ---------------------------------------
+			await createNewPost(page, 'page');
+			await setPostTitle(page, pattern.title);
+
+			const insertion = await insertPatternBySlug(page, pattern.slug);
+			expect(insertion.blockCount).toBeGreaterThan(0);
+			// The loader replaces tokens in PHP, so the registered content
+			// handed to the editor must already be token-free.
+			expect(insertion.hadToken).toBe(false);
+
+			await page.waitForTimeout(800);
+
+			const canvas = getEditorCanvas(page);
+			// Pattern blocks should be present in the canvas.
+			await expect(canvas.locator('body')).toBeVisible();
+
+			// No raw placeholder token should leak into the editor markup.
+			const canvasHtml = await canvas.locator('body').innerHTML();
+			expect(canvasHtml).not.toContain(TOKEN_PREFIX);
+
+			// Forbidden external references must be gone.
+			for (const needle of pattern.forbidden || []) {
+				expect(canvasHtml).not.toContain(needle);
+			}
+
+			// Regression guard: the image/parallax blocks this branch touched
+			// must still validate against their save() output (a stale figure
+			// would render the "Attempt Recovery" warning instead).
+			const invalid = await getInvalidBlockNames(page);
+			const invalidImageBlocks = invalid.filter((name) =>
+				IMAGE_BLOCKS.includes(name)
+			);
+			expect(invalidImageBlocks).toEqual([]);
+
+			if (pattern.hasImages) {
+				const editorImages = canvas.locator(
+					`img[src*="${ASSET_PATH}"]`
+				);
+				expect(await editorImages.count()).toBeGreaterThan(0);
+			}
+
+			await slowScrollEditor(page);
+			await saveScreenshot(page, artifact, 'editor');
+
+			// --- Publish and review the frontend ----------------------------
+			const frontendUrl = await publishAndResolveUrl(page);
+
+			const response = await page.goto(frontendUrl);
+			expect(response?.ok()).toBeTruthy();
+			await page.waitForLoadState('domcontentloaded');
+
+			const pageContent = await page.content();
+			// No PHP fatal and no token leak on the rendered page.
+			expect(pageContent).not.toContain(TOKEN_PREFIX);
+			expect(pageContent).not.toContain(
+				'There has been a critical error'
+			);
+			for (const needle of pattern.forbidden || []) {
+				expect(pageContent).not.toContain(needle);
+			}
+
+			if (pattern.hasParallax) {
+				// The parallax fix added rotate-* attributes to the saved figure
+				// markup; confirm the rendered frontend carries one (proves the
+				// pattern's saved markup matches the current image-parallax save()).
+				const parallaxFigure = page.locator(
+					'.dsgo-has-parallax[data-dsgo-parallax-rotate-enabled]'
+				);
+				expect(await parallaxFigure.count()).toBeGreaterThan(0);
+			}
+
+			if (pattern.hasImages) {
+				const frontendImages = page.locator(
+					`img[src*="${ASSET_PATH}"]`
+				);
+				expect(await frontendImages.count()).toBeGreaterThan(0);
+				// The first placeholder image must actually load (real asset,
+				// not a 404), proving the bundled files resolve.
+				const naturalWidth = await frontendImages
+					.first()
+					.evaluate((img) => {
+						if (img.complete) {
+							return img.naturalWidth;
+						}
+						return new Promise((resolve) => {
+							img.addEventListener('load', () =>
+								resolve(img.naturalWidth)
+							);
+							img.addEventListener('error', () => resolve(0));
+						});
+					});
+				expect(naturalWidth).toBeGreaterThan(0);
+			}
+
+			await page.waitForLoadState('networkidle').catch(() => {});
+			await slowScrollToBottom(page);
+			await saveScreenshot(page, artifact, 'frontend');
+
+			// No uncaught JS errors should have fired during render.
+			expect(pageErrors).toEqual([]);
+		});
+	}
+});

--- a/tests/phpunit/admin/block-migrator-test.php
+++ b/tests/phpunit/admin/block-migrator-test.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Tests for the Block Migrator scan/count database queries.
+ *
+ * Exercises the private $wpdb-backed methods that locate posts containing
+ * convertible DesignSetGo blocks: count_matching_posts(), scan_for_dsgo_blocks()
+ * and the recursive count_dsgo_blocks() helper.
+ *
+ * @group block-migrator
+ */
+class DesignSetGo_Block_Migrator_Test extends WP_UnitTestCase {
+
+	/**
+	 * Block markup snippet for a single convertible block of the given name.
+	 *
+	 * @param string $block_name Full block name, e.g. 'designsetgo/section'.
+	 * @return string Serialized block comment delimiters.
+	 */
+	private function block_markup( $block_name ) {
+		return "<!-- wp:{$block_name} --><!-- /wp:{$block_name} -->";
+	}
+
+	/**
+	 * Instantiate the migrator. The constructor only registers admin hooks,
+	 * which is harmless under the test harness (reset between tests).
+	 *
+	 * @return \DesignSetGo\Admin\Block_Migrator
+	 */
+	private function migrator() {
+		require_once DESIGNSETGO_PATH . 'includes/admin/class-block-migrator.php';
+		return new \DesignSetGo\Admin\Block_Migrator();
+	}
+
+	/**
+	 * Invoke a private/protected method on a fresh migrator instance.
+	 *
+	 * @param string $method Method name.
+	 * @param array  $args   Positional arguments.
+	 * @return mixed Method return value.
+	 */
+	private function invoke( $method, array $args = array() ) {
+		$ref = new ReflectionMethod( \DesignSetGo\Admin\Block_Migrator::class, $method );
+		$ref->setAccessible( true );
+		return $ref->invokeArgs( $this->migrator(), $args );
+	}
+
+	public function test_count_matching_posts_is_zero_without_convertible_blocks() {
+		self::factory()->post->create_many(
+			3,
+			array(
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:paragraph --><p>Plain</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		$this->assertSame( 0, $this->invoke( 'count_matching_posts' ) );
+	}
+
+	public function test_count_matching_posts_counts_only_posts_with_convertible_blocks() {
+		self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => $this->block_markup( 'designsetgo/section' ),
+			)
+		);
+		self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => $this->block_markup( 'designsetgo/grid' ),
+			)
+		);
+		// Non-convertible post should be ignored.
+		self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:paragraph --><p>Plain</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		$this->assertSame( 2, $this->invoke( 'count_matching_posts' ) );
+	}
+
+	public function test_scan_returns_post_id_and_block_count() {
+		$matching = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => $this->block_markup( 'designsetgo/section' ) . $this->block_markup( 'designsetgo/row' ),
+			)
+		);
+		self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:paragraph --><p>Plain</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		$results = $this->invoke( 'scan_for_dsgo_blocks' );
+
+		$this->assertCount( 1, $results, 'Only the post containing convertible blocks should be returned.' );
+		$this->assertSame( $matching, $results[0]['post_id'] );
+		$this->assertSame( 2, $results[0]['count'], 'Both the section and row blocks should be counted.' );
+	}
+
+	public function test_scan_respects_limit_and_offset() {
+		for ( $i = 0; $i < 3; $i++ ) {
+			self::factory()->post->create(
+				array(
+					'post_status'  => 'publish',
+					'post_content' => $this->block_markup( 'designsetgo/section' ),
+				)
+			);
+		}
+
+		$first_batch  = $this->invoke( 'scan_for_dsgo_blocks', array( 2, 0 ) );
+		$second_batch = $this->invoke( 'scan_for_dsgo_blocks', array( 2, 2 ) );
+
+		$this->assertCount( 2, $first_batch, 'First batch should honour LIMIT 2.' );
+		$this->assertCount( 1, $second_batch, 'Second batch should return the remaining post via OFFSET.' );
+
+		// Batches must not overlap (ORDER BY ID ASC guarantees disjoint ranges).
+		$first_ids  = wp_list_pluck( $first_batch, 'post_id' );
+		$second_ids = wp_list_pluck( $second_batch, 'post_id' );
+		$this->assertEmpty( array_intersect( $first_ids, $second_ids ) );
+	}
+
+	public function test_count_dsgo_blocks_counts_nested_blocks_recursively() {
+		$blocks = array(
+			array(
+				'blockName'   => 'designsetgo/section',
+				'innerBlocks' => array(
+					array( 'blockName' => 'core/paragraph', 'innerBlocks' => array() ),
+					array(
+						'blockName'   => 'designsetgo/row',
+						'innerBlocks' => array(
+							array( 'blockName' => 'designsetgo/icon-button', 'innerBlocks' => array() ),
+						),
+					),
+				),
+			),
+			array( 'blockName' => 'core/heading', 'innerBlocks' => array() ),
+		);
+
+		// section + row + icon-button = 3 convertible blocks; core blocks ignored.
+		$this->assertSame( 3, $this->invoke( 'count_dsgo_blocks', array( $blocks ) ) );
+	}
+}

--- a/tests/phpunit/blocks/product-categories-grid/render-test.php
+++ b/tests/phpunit/blocks/product-categories-grid/render-test.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Tests for the product-categories-grid block server render.
+ *
+ * WooCommerce is not installed in the test environment, so we stub the
+ * `wc_get_product()` guard and register the `product_cat` taxonomy ourselves.
+ * The render template otherwise relies only on core term APIs, which lets us
+ * exercise the get_terms() exclusion path and the manual/all source modes.
+ *
+ * @group product-categories-grid
+ */
+
+if ( ! function_exists( 'wc_get_product' ) ) {
+	/**
+	 * Minimal stub so the render template passes its WooCommerce guard.
+	 *
+	 * @param mixed $the_product Ignored.
+	 * @return false
+	 */
+	function wc_get_product( $the_product = false ) {
+		return false;
+	}
+}
+
+/**
+ * @group product-categories-grid
+ */
+class DesignSetGo_Product_Categories_Grid_Render_Test extends WP_UnitTestCase {
+
+	public function set_up() {
+		parent::set_up();
+
+		register_taxonomy(
+			'product_cat',
+			array( 'product' ),
+			array(
+				'hierarchical' => true,
+				'public'       => true,
+				'rewrite'      => false,
+			)
+		);
+	}
+
+	public function tear_down() {
+		unregister_taxonomy( 'product_cat' );
+		delete_option( 'default_product_cat' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a product_cat term and return its ID.
+	 *
+	 * @param string $name Term name.
+	 * @param string $slug Term slug.
+	 * @return int Term ID.
+	 */
+	private function make_category( $name, $slug ) {
+		$term = wp_insert_term( $name, 'product_cat', array( 'slug' => $slug ) );
+		$this->assertNotWPError( $term );
+		return (int) $term['term_id'];
+	}
+
+	/**
+	 * Include the built render template with the given attributes and capture output.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Rendered HTML ('' when the template bails).
+	 */
+	private function render( array $attributes ) {
+		$path = DESIGNSETGO_PATH . 'build/blocks/product-categories-grid/render.php';
+		$this->assertFileExists( $path, 'Run `npm run build` before PHPUnit — render templates are served from build/.' );
+
+		$content = '';
+		$block   = null;
+
+		// get_block_wrapper_attributes() reads the active block from
+		// WP_Block_Supports; prime it so the call works outside a full render.
+		$previous_block = WP_Block_Supports::$block_to_render;
+		WP_Block_Supports::$block_to_render = array(
+			'blockName' => 'designsetgo/product-categories-grid',
+			'attrs'     => array(),
+		);
+
+		ob_start();
+		$returned = include $path;
+		$html     = ob_get_clean();
+
+		WP_Block_Supports::$block_to_render = $previous_block;
+
+		// The template echoes markup (include returns 1) on success and
+		// `return ''` on a bail.
+		return is_string( $returned ) ? $returned : $html;
+	}
+
+	public function test_all_mode_excludes_uncategorized_default_category() {
+		$apparel       = $this->make_category( 'Apparel', 'apparel' );
+		$shoes         = $this->make_category( 'Shoes', 'shoes' );
+		$uncategorized = $this->make_category( 'Uncategorized', 'uncategorized' );
+		update_option( 'default_product_cat', $uncategorized );
+
+		$html = $this->render(
+			array(
+				'categorySource' => 'all',
+				'showEmpty'      => true,
+			)
+		);
+
+		$this->assertStringContainsString( 'Apparel', $html );
+		$this->assertStringContainsString( 'Shoes', $html );
+		$this->assertStringNotContainsString( 'Uncategorized', $html );
+		$this->assertSame( 2, substr_count( $html, '<a href=' ), 'One card per visible category.' );
+	}
+
+	public function test_all_mode_honours_exclude_categories_attribute() {
+		$apparel = $this->make_category( 'Apparel', 'apparel' );
+		$shoes   = $this->make_category( 'Shoes', 'shoes' );
+
+		$html = $this->render(
+			array(
+				'categorySource'    => 'all',
+				'showEmpty'         => true,
+				'excludeCategories' => array( $shoes ),
+			)
+		);
+
+		$this->assertStringContainsString( 'Apparel', $html );
+		$this->assertStringNotContainsString( 'Shoes', $html );
+		$this->assertSame( 1, substr_count( $html, '<a href=' ) );
+	}
+
+	public function test_manual_mode_renders_selected_categories_in_order() {
+		$apparel = $this->make_category( 'Apparel', 'apparel' );
+		$shoes   = $this->make_category( 'Shoes', 'shoes' );
+
+		$html = $this->render(
+			array(
+				'categorySource'     => 'manual',
+				'selectedCategories' => array(
+					array( 'id' => $shoes ),
+					array( 'id' => $apparel ),
+				),
+			)
+		);
+
+		$this->assertStringContainsString( 'Apparel', $html );
+		$this->assertStringContainsString( 'Shoes', $html );
+		$this->assertLessThan(
+			strpos( $html, 'Apparel' ),
+			strpos( $html, 'Shoes' ),
+			'Manual mode preserves the user-defined order (orderby=include).'
+		);
+	}
+
+	public function test_manual_mode_with_no_valid_selection_renders_nothing() {
+		$this->make_category( 'Apparel', 'apparel' );
+
+		$html = $this->render(
+			array(
+				'categorySource'     => 'manual',
+				'selectedCategories' => array(),
+			)
+		);
+
+		$this->assertSame( '', $html );
+	}
+
+	public function test_renders_nothing_when_no_categories_exist() {
+		$html = $this->render(
+			array(
+				'categorySource' => 'all',
+				'showEmpty'      => true,
+			)
+		);
+
+		$this->assertSame( '', $html );
+	}
+}

--- a/tests/phpunit/llms-txt-test.php
+++ b/tests/phpunit/llms-txt-test.php
@@ -21,9 +21,31 @@ use DesignSetGo\Markdown\Converter;
 use DesignSetGo\Admin\Settings;
 
 /**
+ * Shared helpers for the llms.txt test cases in this file.
+ */
+trait Enables_LLMS_Feature {
+	/**
+	 * Helper: enable the llms.txt feature in settings.
+	 */
+	private function enable_llms_feature(): void {
+		update_option(
+			'designsetgo_settings',
+			array(
+				'llms_txt' => array(
+					'enable' => true,
+				),
+			)
+		);
+		Settings::invalidate_cache();
+	}
+}
+
+/**
  * llms.txt Feature Test Case
  */
 class Test_LLMS_Txt extends WP_UnitTestCase {
+	use Enables_LLMS_Feature;
+
 	/**
 	 * Controller instance.
 	 *
@@ -110,21 +132,6 @@ class Test_LLMS_Txt extends WP_UnitTestCase {
 			unlink( $htaccess );
 		}
 		return $dir;
-	}
-
-	/**
-	 * Helper: enable the llms.txt feature in settings.
-	 */
-	private function enable_llms_feature(): void {
-		update_option(
-			'designsetgo_settings',
-			array(
-				'llms_txt' => array(
-					'enable' => true,
-				),
-			)
-		);
-		Settings::invalidate_cache();
 	}
 
 	/**
@@ -924,6 +931,8 @@ class Test_LLMS_Txt extends WP_UnitTestCase {
  * Markdown Converter Test Case
  */
 class Test_Markdown_Converter extends WP_UnitTestCase {
+	use Enables_LLMS_Feature;
+
 	/**
 	 * Converter instance.
 	 *


### PR DESCRIPTION
## Summary

Resolves the remaining Plugin Check (PCP) warnings in two categories, and backfills the missing PHPUnit coverage for the touched code.

### `PluginCheck.Security.DirectDB.UnescapedDBParameter` (4 sites)
All four `$wpdb` sites already use `$wpdb->prepare()` with programmatically-built `%s`/`%d`/`%i` placeholders — these are false positives. Extended the existing `phpcs:ignore` comments to include the PCP-specific code:
- `includes/admin/class-block-migrator.php` (scan + count queries)
- `includes/blocks/class-query-filter-index.php` (bulk insert + count)

### `WordPressVIPMinimum.Performance.WPQueryParams` (19 sites)
- **17 false positives** — the sniff matches the array *key* `exclude`, which here is an extension block-exclusion list (15 `extension-configs/*.php`) or the abilities REST schema (2 sites in `class-list-extensions.php`), not a query.
- **2 genuine but bounded** cases documented inline: `post__not_in` for the current singular post (`query/render-posts.php`) and `get_terms` `exclude` of the default "uncategorized" product category (`product-categories-grid/render.php`).

All fixes use documented inline `phpcs:ignore … -- <reason>`, matching the existing convention in this codebase (and the only suppression PCP honors). The `exclude` config key was intentionally **not** renamed, since it's part of the documented extension contract and the abilities REST schema.

### Additional PCP warnings — DB + enqueue (4 sites)
A follow-up sweep cleared the remaining flagged sites:
- `class-block-migrator.php` — `WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare`: false positive — the `%s` placeholders live inside interpolated vars (`$like_sql`/`$type_placeholders`/`$status_placeholders`) so the sniff can't see them, but all values pass through `$wpdb->prepare()`. Extended the existing `phpcs:disable/enable` pair.
- `class-draft-mode-preview.php` — `WordPress.DB.SlowDBQuery.slow_db_query_meta_key`: ignored with justification — bounded by `posts_per_page`, fetches IDs only, and transient-cached for 10 minutes.
- `src/blocks/query/render-posts.php` — `WordPress.DB.SlowDBQuery.slow_db_query_tax_query`: ignored on the OR-group re-wrap (same user-configured query, just AND-grouped); matches the existing ignores at lines 398/521. Fixed in **source**, not `build/`.
- `class-overlay-header.php` + `class-button-global-styles.php` — `WordPress.WP.EnqueuedResourceParameters.MissingVersion` (3 inline-only `wp_register_style` handles): genuine fix — passes `DESIGNSETGO_VERSION`. Resolves all MissingVersion sites plugin-wide.

## Tests

### PHPUnit
Added coverage for the two touched files that previously had none:
- `tests/phpunit/admin/block-migrator-test.php` — `count_matching_posts`, `scan_for_dsgo_blocks` (incl. LIMIT/OFFSET batching), recursive `count_dsgo_blocks` (5 tests)
- `tests/phpunit/blocks/product-categories-grid/render-test.php` — the `get_terms()` exclude path: uncategorized-default exclusion, `excludeCategories` attr, manual-mode ordering, empty cases (5 tests)

### E2E (Playwright)
Added happy-path e2e coverage for the blocks and patterns changed on this branch — insert → review editor → publish → review frontend:
- `tests/e2e/patterns-happy-path.spec.js` — data-driven over **one representative pattern per category** (content, cta, faq, gallery + parallax, hero + parallax, homepage, modal, team, testimonials). Asserts placeholder tokens resolve to local plugin assets (editor + frontend), images actually load, parallax `rotate-*` markup is present, no external example URLs survive, and the image/parallax blocks this branch touched validate. Pre-existing slider/accordion/cover/form validation debt is intentionally out of scope.
- `tests/e2e/helpers/insertPatternBySlug` + `getInvalidBlockNames` — programmatic pattern insertion (avoids flaky inserter-UI search) and block-validity inspection.
- `tests/e2e/helpers/artifacts.js` — extracted shared screenshot/publish/video helpers; both block and pattern artifacts now file under a uniform `screenshots/<group>/<item>/<scenario>/` layout.
- `tests/e2e/blocks-pcp-offloading.spec.js` — refactored to the shared helpers (modal, Hero Split pattern, form builder).

## Verification
- Plugin Check: all target codes now report **0**; no new warnings introduced (every other code count unchanged).
- `npm run build` regenerated `build/` from `src/`; confirmed annotations propagated.
- PHPUnit: full suite **770 tests, 3806 assertions, 0 failures** (6 intentional skips). Also fixed a pre-existing broken helper in `Test_Markdown_Converter` (shared `enable_llms_feature` extracted to a trait) that was fatally erroring 7 llms-txt tests on the branch.
- E2E: full chromium suite **22 passed, 0 failed** (with video).
- `php -l` clean on all changed PHP files.
- Pre-commit hooks (`php -l` + e2e block suite) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


