### PR TITLE
fix: resolve all PCP PrefixAllGlobals warnings

### DIFF
--- a/includes/block-animation-attributes.php
+++ b/includes/block-animation-attributes.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param array $attributes Block attributes array.
  * @return array Array of data attributes for animations.
  */
-function dsgo_get_animation_attributes( $attributes ) {
+function designsetgo_get_animation_attributes( $attributes ) {
 	$animation_attrs   = array();
 	$animation_classes = array();
 
@@ -117,7 +117,7 @@ function dsgo_get_animation_attributes( $attributes ) {
  * @param array $attributes Block attributes array.
  * @return array Array of data attributes for links.
  */
-function dsgo_get_clickable_attributes( $attributes ) {
+function designsetgo_get_clickable_attributes( $attributes ) {
 	$link_attrs   = array();
 	$link_classes = array();
 
@@ -171,12 +171,12 @@ function dsgo_get_clickable_attributes( $attributes ) {
  * @param array  $attributes         Block attributes array.
  * @return string Modified wrapper attributes string.
  */
-function dsgo_add_animation_to_wrapper( $wrapper_attributes, $attributes ) {
+function designsetgo_add_animation_to_wrapper( $wrapper_attributes, $attributes ) {
 	// Get animation data.
-	$animation_data = dsgo_get_animation_attributes( $attributes );
+	$animation_data = designsetgo_get_animation_attributes( $attributes );
 
 	// Get clickable link data.
-	$clickable_data = dsgo_get_clickable_attributes( $attributes );
+	$clickable_data = designsetgo_get_clickable_attributes( $attributes );
 
 	// Combine all classes.
 	$all_classes = trim( $animation_data['classes'] . ' ' . $clickable_data['classes'] );

--- a/includes/class-icon-injector.php
+++ b/includes/class-icon-injector.php
@@ -98,14 +98,14 @@ class Icon_Injector {
 		wp_localize_script(
 			'designsetgo-icon-injector',
 			'dsgoIcons',
-			dsgo_get_all_icons()
+			designsetgo_get_all_icons()
 		);
 
 		// Provide alias map so frontend can resolve alternate icon names.
 		wp_localize_script(
 			'designsetgo-icon-injector',
 			'dsgoIconAliases',
-			dsgo_get_icon_aliases()
+			designsetgo_get_icon_aliases()
 		);
 	}
 

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -644,6 +644,7 @@ class Plugin {
 		if ( ! function_exists( 'wp_register_ability' ) ) {
 			if ( file_exists( DESIGNSETGO_PATH . 'vendor/wordpress/abilities-api/includes/bootstrap.php' ) ) {
 				if ( ! defined( 'WP_ABILITIES_API_DIR' ) ) {
+					// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- Constant name is fixed by the bundled wordpress/abilities-api polyfill; its bootstrap reads WP_ABILITIES_API_DIR, so it cannot be prefixed.
 					define( 'WP_ABILITIES_API_DIR', DESIGNSETGO_PATH . 'vendor/wordpress/abilities-api/' );
 				}
 				require_once DESIGNSETGO_PATH . 'vendor/wordpress/abilities-api/includes/bootstrap.php';

--- a/includes/icon-svg-library.php
+++ b/includes/icon-svg-library.php
@@ -21,15 +21,15 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param string $icon_name Icon name (e.g., 'star', 'heart', 'check').
  * @return string SVG markup or empty string if not found.
  */
-function dsgo_get_icon_svg( $icon_name ) {
-	$icons = dsgo_get_all_icons();
+function designsetgo_get_icon_svg( $icon_name ) {
+	$icons = designsetgo_get_all_icons();
 
 	if ( isset( $icons[ $icon_name ] ) ) {
 		return $icons[ $icon_name ];
 	}
 
 	// Resolve alias to canonical name.
-	$aliases = dsgo_get_icon_aliases();
+	$aliases = designsetgo_get_icon_aliases();
 	if ( isset( $aliases[ $icon_name ] ) && isset( $icons[ $aliases[ $icon_name ] ] ) ) {
 		return $icons[ $aliases[ $icon_name ] ];
 	}
@@ -42,7 +42,7 @@ function dsgo_get_icon_svg( $icon_name ) {
  *
  * @return array Associative array of icon_name => svg_markup.
  */
-function dsgo_get_all_icons() {
+function designsetgo_get_all_icons() {
 	static $icons = null;
 
 	// Cache icons in static variable for performance.
@@ -227,7 +227,7 @@ function dsgo_get_all_icons() {
  *
  * @return array Associative array of alias => canonical_name.
  */
-function dsgo_get_icon_aliases() {
+function designsetgo_get_icon_aliases() {
 	static $aliases = null;
 
 	if ( null !== $aliases ) {
@@ -255,7 +255,7 @@ function dsgo_get_icon_aliases() {
  * @param string $icon Icon slug to sanitize.
  * @return string Sanitized icon slug.
  */
-function dsgo_sanitize_icon_slug( $icon ) {
+function designsetgo_sanitize_icon_slug( $icon ) {
 	if ( empty( $icon ) || ! is_string( $icon ) ) {
 		return '';
 	}
@@ -272,7 +272,7 @@ function dsgo_sanitize_icon_slug( $icon ) {
  * @param bool   $is_open    Whether accordion item is open.
  * @return string Icon HTML markup.
  */
-function dsgo_accordion_render_icon( $icon_style, $is_open ) {
+function designsetgo_accordion_render_icon( $icon_style, $is_open ) {
 	if ( 'none' === $icon_style ) {
 		return '';
 	}

--- a/src/blocks/breadcrumbs/render.php
+++ b/src/blocks/breadcrumbs/render.php
@@ -15,63 +15,77 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// Check if we should hide breadcrumbs on homepage.
-if ( ! empty( $attributes['hideOnHome'] ) && is_front_page() ) {
-	return '';
-}
+if ( ! function_exists( 'designsetgo_render_breadcrumbs' ) ) {
+	/**
+	 * Render the Breadcrumbs block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Inner block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return void
+	 */
+	function designsetgo_render_breadcrumbs( $attributes, $content, $block ) {
+		// Check if we should hide breadcrumbs on homepage.
+		if ( ! empty( $attributes['hideOnHome'] ) && is_front_page() ) {
+			return '';
+		}
 
-// Get breadcrumb trail (function defined in includes/breadcrumbs-functions.php).
-$trail = designsetgo_get_breadcrumb_trail( $block, $attributes );
+		// Get breadcrumb trail (function defined in includes/breadcrumbs-functions.php).
+		$trail = designsetgo_get_breadcrumb_trail( $block, $attributes );
 
-// If no breadcrumbs, return empty.
-if ( empty( $trail ) ) {
-	return '';
-}
+		// If no breadcrumbs, return empty.
+		if ( empty( $trail ) ) {
+			return '';
+		}
 
-// Get separator (function defined in includes/breadcrumbs-functions.php).
-$separator = designsetgo_get_breadcrumb_separator( $attributes );
+		// Get separator (function defined in includes/breadcrumbs-functions.php).
+		$separator = designsetgo_get_breadcrumb_separator( $attributes );
 
-// Build wrapper classes.
-$classes   = array( 'dsgo-breadcrumbs' );
-$allowed   = array( 'center', 'right' );
-$justify   = isset( $attributes['contentJustification'] ) ? $attributes['contentJustification'] : 'left';
-if ( in_array( $justify, $allowed, true ) ) {
-	$classes[] = 'is-content-justification-' . $justify;
-}
+		// Build wrapper classes.
+		$classes   = array( 'dsgo-breadcrumbs' );
+		$allowed   = array( 'center', 'right' );
+		$justify   = isset( $attributes['contentJustification'] ) ? $attributes['contentJustification'] : 'left';
+		if ( in_array( $justify, $allowed, true ) ) {
+			$classes[] = 'is-content-justification-' . $justify;
+		}
 
-// Build wrapper attributes.
-$wrapper_attributes = get_block_wrapper_attributes(
-	array(
-		'class'                 => implode( ' ', $classes ),
-		'aria-label'            => __( 'Breadcrumb', 'designsetgo' ),
-		'data-dsgo-breadcrumbs' => wp_json_encode( $trail ),
-	)
-);
+		// Build wrapper attributes.
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class'                 => implode( ' ', $classes ),
+				'aria-label'            => __( 'Breadcrumb', 'designsetgo' ),
+				'data-dsgo-breadcrumbs' => wp_json_encode( $trail ),
+			)
+		);
 
-// Output directly (WordPress captures echo'd output from render callbacks).
-?>
-<nav <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-	<?php if ( ! empty( $attributes['prefixText'] ) ) : ?>
-		<span class="dsgo-breadcrumbs__prefix"><?php echo esc_html( $attributes['prefixText'] ); ?></span>
-	<?php endif; ?>
-
-	<ol class="dsgo-breadcrumbs__list">
-		<?php foreach ( $trail as $index => $item ) : ?>
-			<li class="<?php echo esc_attr( 'dsgo-breadcrumbs__item' . ( ! empty( $item['is_current'] ) ? ' dsgo-breadcrumbs__item--current' : '' ) ); ?>">
-				<?php if ( empty( $item['is_current'] ) || ! empty( $attributes['linkCurrent'] ) ) : ?>
-					<a href="<?php echo esc_url( $item['url'] ); ?>" class="dsgo-breadcrumbs__link">
-						<?php echo esc_html( $item['title'] ); ?>
-					</a>
-				<?php else : ?>
-					<span class="dsgo-breadcrumbs__text">
-						<?php echo esc_html( $item['title'] ); ?>
-					</span>
-				<?php endif; ?>
-			</li>
-
-			<?php if ( $index < count( $trail ) - 1 ) : ?>
-				<li class="dsgo-breadcrumbs__separator" aria-hidden="true"><?php echo esc_html( $separator ); ?></li>
+		// Output directly (WordPress captures echo'd output from render callbacks).
+		?>
+		<nav <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+			<?php if ( ! empty( $attributes['prefixText'] ) ) : ?>
+				<span class="dsgo-breadcrumbs__prefix"><?php echo esc_html( $attributes['prefixText'] ); ?></span>
 			<?php endif; ?>
-		<?php endforeach; ?>
-	</ol>
-</nav><?php
+
+			<ol class="dsgo-breadcrumbs__list">
+				<?php foreach ( $trail as $index => $item ) : ?>
+					<li class="<?php echo esc_attr( 'dsgo-breadcrumbs__item' . ( ! empty( $item['is_current'] ) ? ' dsgo-breadcrumbs__item--current' : '' ) ); ?>">
+						<?php if ( empty( $item['is_current'] ) || ! empty( $attributes['linkCurrent'] ) ) : ?>
+							<a href="<?php echo esc_url( $item['url'] ); ?>" class="dsgo-breadcrumbs__link">
+								<?php echo esc_html( $item['title'] ); ?>
+							</a>
+						<?php else : ?>
+							<span class="dsgo-breadcrumbs__text">
+								<?php echo esc_html( $item['title'] ); ?>
+							</span>
+						<?php endif; ?>
+					</li>
+
+					<?php if ( $index < count( $trail ) - 1 ) : ?>
+						<li class="dsgo-breadcrumbs__separator" aria-hidden="true"><?php echo esc_html( $separator ); ?></li>
+					<?php endif; ?>
+				<?php endforeach; ?>
+			</ol>
+		</nav><?php
+	}
+}
+
+designsetgo_render_breadcrumbs( $attributes, $content, $block );

--- a/src/blocks/dynamic-image/render.php
+++ b/src/blocks/dynamic-image/render.php
@@ -20,118 +20,132 @@ defined( 'ABSPATH' ) || exit;
 
 use DesignSetGo\Blocks\DynamicTags\ImageResolver;
 
-$source       = isset( $attributes['source'] ) ? (string) $attributes['source'] : '';
-$source_args  = isset( $attributes['sourceArgs'] ) && is_array( $attributes['sourceArgs'] ) ? $attributes['sourceArgs'] : array();
-$size         = isset( $attributes['size'] ) ? (string) $attributes['size'] : 'full';
-$alt_override = isset( $attributes['altOverride'] ) ? (string) $attributes['altOverride'] : '';
-$fallback_id  = isset( $attributes['fallbackId'] ) ? (int) $attributes['fallbackId'] : 0;
-$fallback_url = isset( $attributes['fallbackUrl'] ) ? (string) $attributes['fallbackUrl'] : '';
-$fallback_alt = isset( $attributes['fallbackAlt'] ) ? (string) $attributes['fallbackAlt'] : '';
-$focal        = isset( $attributes['focalPoint'] ) && is_array( $attributes['focalPoint'] ) ? $attributes['focalPoint'] : array();
-$aspect_ratio = isset( $attributes['aspectRatio'] ) ? (string) $attributes['aspectRatio'] : '';
-$object_fit   = isset( $attributes['objectFit'] ) ? (string) $attributes['objectFit'] : 'cover';
-$href         = isset( $attributes['href'] ) ? (string) $attributes['href'] : '';
-$link_target  = isset( $attributes['linkTarget'] ) ? (string) $attributes['linkTarget'] : '';
-$rel          = isset( $attributes['rel'] ) ? (string) $attributes['rel'] : '';
+if ( ! function_exists( 'designsetgo_render_dynamic_image' ) ) {
+	/**
+	 * Render the Dynamic Image block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Inner block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return void
+	 */
+	function designsetgo_render_dynamic_image( $attributes, $content, $block ) {
+		$source       = isset( $attributes['source'] ) ? (string) $attributes['source'] : '';
+		$source_args  = isset( $attributes['sourceArgs'] ) && is_array( $attributes['sourceArgs'] ) ? $attributes['sourceArgs'] : array();
+		$size         = isset( $attributes['size'] ) ? (string) $attributes['size'] : 'full';
+		$alt_override = isset( $attributes['altOverride'] ) ? (string) $attributes['altOverride'] : '';
+		$fallback_id  = isset( $attributes['fallbackId'] ) ? (int) $attributes['fallbackId'] : 0;
+		$fallback_url = isset( $attributes['fallbackUrl'] ) ? (string) $attributes['fallbackUrl'] : '';
+		$fallback_alt = isset( $attributes['fallbackAlt'] ) ? (string) $attributes['fallbackAlt'] : '';
+		$focal        = isset( $attributes['focalPoint'] ) && is_array( $attributes['focalPoint'] ) ? $attributes['focalPoint'] : array();
+		$aspect_ratio = isset( $attributes['aspectRatio'] ) ? (string) $attributes['aspectRatio'] : '';
+		$object_fit   = isset( $attributes['objectFit'] ) ? (string) $attributes['objectFit'] : 'cover';
+		$href         = isset( $attributes['href'] ) ? (string) $attributes['href'] : '';
+		$link_target  = isset( $attributes['linkTarget'] ) ? (string) $attributes['linkTarget'] : '';
+		$rel          = isset( $attributes['rel'] ) ? (string) $attributes['rel'] : '';
 
-$post_id = 0;
-if ( isset( $block->context['postId'] ) ) {
-	$post_id = (int) $block->context['postId'];
-} elseif ( get_the_ID() ) {
-	$post_id = (int) get_the_ID();
-}
+		$post_id = 0;
+		if ( isset( $block->context['postId'] ) ) {
+			$post_id = (int) $block->context['postId'];
+		} elseif ( get_the_ID() ) {
+			$post_id = (int) get_the_ID();
+		}
 
-$descriptor = null;
-if ( '' !== $source ) {
-	$descriptor = ImageResolver::resolve( $source, $source_args, $post_id, $size );
-}
+		$descriptor = null;
+		if ( '' !== $source ) {
+			$descriptor = ImageResolver::resolve( $source, $source_args, $post_id, $size );
+		}
 
-// Fallback lookup.
-if ( null === $descriptor ) {
-	if ( $fallback_id ) {
-		$descriptor = ImageResolver::descriptor_from_id( $fallback_id, $size );
-	} elseif ( '' !== $fallback_url ) {
-		$descriptor = array(
-			'id'     => 0,
-			'url'    => $fallback_url,
-			'alt'    => $fallback_alt,
-			'width'  => 0,
-			'height' => 0,
+		// Fallback lookup.
+		if ( null === $descriptor ) {
+			if ( $fallback_id ) {
+				$descriptor = ImageResolver::descriptor_from_id( $fallback_id, $size );
+			} elseif ( '' !== $fallback_url ) {
+				$descriptor = array(
+					'id'     => 0,
+					'url'    => $fallback_url,
+					'alt'    => $fallback_alt,
+					'width'  => 0,
+					'height' => 0,
+				);
+			}
+		}
+
+		if ( null === $descriptor || empty( $descriptor['url'] ) ) {
+			return '';
+		}
+
+		$alt = '' !== $alt_override ? $alt_override : (string) ( $descriptor['alt'] ?? '' );
+
+		$figure_style = array();
+		if ( '' !== $aspect_ratio ) {
+			$figure_style[] = 'aspect-ratio:' . $aspect_ratio;
+		}
+
+		$img_style = array(
+			'object-fit:' . $object_fit,
+		);
+		if ( isset( $focal['x'], $focal['y'] ) ) {
+			$img_style[] = sprintf(
+				'object-position:%s%% %s%%',
+				round( (float) $focal['x'] * 100 ),
+				round( (float) $focal['y'] * 100 )
+			);
+		}
+
+		$wrapper_attrs = get_block_wrapper_attributes(
+			array(
+				'class' => 'wp-block-designsetgo-dynamic-image',
+				'style' => implode( ';', $figure_style ),
+			)
+		);
+
+		$img_attrs = array(
+			'src'      => esc_url( $descriptor['url'] ),
+			'alt'      => esc_attr( $alt ),
+			'loading'  => 'lazy',
+			'decoding' => 'async',
+			'style'    => esc_attr( implode( ';', $img_style ) ),
+		);
+		if ( ! empty( $descriptor['width'] ) ) {
+			$img_attrs['width'] = (int) $descriptor['width'];
+		}
+		if ( ! empty( $descriptor['height'] ) ) {
+			$img_attrs['height'] = (int) $descriptor['height'];
+		}
+
+		$img_html = '<img';
+		foreach ( $img_attrs as $key => $val ) {
+			$img_html .= ' ' . $key . '="' . $val . '"';
+		}
+		$img_html .= ' />';
+
+		if ( '' !== $href ) {
+			$link_attrs = array(
+				'href' => esc_url( $href ),
+			);
+			if ( '' !== $link_target ) {
+				$link_attrs['target'] = esc_attr( $link_target );
+			}
+			if ( '' !== $rel ) {
+				$link_attrs['rel'] = esc_attr( $rel );
+			} elseif ( '_blank' === $link_target ) {
+				$link_attrs['rel'] = 'noopener noreferrer';
+			}
+			$link_open = '<a';
+			foreach ( $link_attrs as $key => $val ) {
+				$link_open .= ' ' . $key . '="' . $val . '"';
+			}
+			$link_open .= '>';
+			$img_html = $link_open . $img_html . '</a>';
+		}
+
+		printf(
+			'<figure %s>%s</figure>',
+			$wrapper_attrs, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() output is pre-escaped.
+			$img_html // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- all attribute values above are esc_* escaped.
 		);
 	}
 }
 
-if ( null === $descriptor || empty( $descriptor['url'] ) ) {
-	return '';
-}
-
-$alt = '' !== $alt_override ? $alt_override : (string) ( $descriptor['alt'] ?? '' );
-
-$figure_style = array();
-if ( '' !== $aspect_ratio ) {
-	$figure_style[] = 'aspect-ratio:' . $aspect_ratio;
-}
-
-$img_style = array(
-	'object-fit:' . $object_fit,
-);
-if ( isset( $focal['x'], $focal['y'] ) ) {
-	$img_style[] = sprintf(
-		'object-position:%s%% %s%%',
-		round( (float) $focal['x'] * 100 ),
-		round( (float) $focal['y'] * 100 )
-	);
-}
-
-$wrapper_attrs = get_block_wrapper_attributes(
-	array(
-		'class' => 'wp-block-designsetgo-dynamic-image',
-		'style' => implode( ';', $figure_style ),
-	)
-);
-
-$img_attrs = array(
-	'src'      => esc_url( $descriptor['url'] ),
-	'alt'      => esc_attr( $alt ),
-	'loading'  => 'lazy',
-	'decoding' => 'async',
-	'style'    => esc_attr( implode( ';', $img_style ) ),
-);
-if ( ! empty( $descriptor['width'] ) ) {
-	$img_attrs['width'] = (int) $descriptor['width'];
-}
-if ( ! empty( $descriptor['height'] ) ) {
-	$img_attrs['height'] = (int) $descriptor['height'];
-}
-
-$img_html = '<img';
-foreach ( $img_attrs as $key => $val ) {
-	$img_html .= ' ' . $key . '="' . $val . '"';
-}
-$img_html .= ' />';
-
-if ( '' !== $href ) {
-	$link_attrs = array(
-		'href' => esc_url( $href ),
-	);
-	if ( '' !== $link_target ) {
-		$link_attrs['target'] = esc_attr( $link_target );
-	}
-	if ( '' !== $rel ) {
-		$link_attrs['rel'] = esc_attr( $rel );
-	} elseif ( '_blank' === $link_target ) {
-		$link_attrs['rel'] = 'noopener noreferrer';
-	}
-	$link_open = '<a';
-	foreach ( $link_attrs as $key => $val ) {
-		$link_open .= ' ' . $key . '="' . $val . '"';
-	}
-	$link_open .= '>';
-	$img_html = $link_open . $img_html . '</a>';
-}
-
-printf(
-	'<figure %s>%s</figure>',
-	$wrapper_attrs, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() output is pre-escaped.
-	$img_html // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- all attribute values above are esc_* escaped.
-);
+designsetgo_render_dynamic_image( $attributes, $content, $block );

--- a/src/blocks/product-categories-grid/render.php
+++ b/src/blocks/product-categories-grid/render.php
@@ -19,199 +19,214 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// Bail if WooCommerce is not active.
-if ( ! function_exists( 'wc_get_product' ) ) {
-	return '';
-}
-
-// ---------------------------------------------------------------------------
-// Extract and validate attributes.
-// ---------------------------------------------------------------------------
-
-$category_source     = isset( $attributes['categorySource'] ) && 'manual' === $attributes['categorySource'] ? 'manual' : 'all';
-$selected_categories = isset( $attributes['selectedCategories'] ) && is_array( $attributes['selectedCategories'] ) ? $attributes['selectedCategories'] : array();
-$exclude_categories  = isset( $attributes['excludeCategories'] ) && is_array( $attributes['excludeCategories'] ) ? $attributes['excludeCategories'] : array();
-$columns             = isset( $attributes['columns'] ) ? absint( $attributes['columns'] ) : 3;
-$show_product_count  = ! isset( $attributes['showProductCount'] ) || (bool) $attributes['showProductCount'];
-$show_empty          = ! empty( $attributes['showEmpty'] );
-$image_aspect_ratio  = isset( $attributes['imageAspectRatio'] ) ? $attributes['imageAspectRatio'] : '3/4';
-$overlay_position    = isset( $attributes['overlayPosition'] ) && 'center' === $attributes['overlayPosition'] ? 'center' : 'bottom-left';
-
-// Validate columns (2–5).
-if ( $columns < 2 || $columns > 5 ) {
-	$columns = 3;
-}
-
-// Validate aspect ratio.
-$allowed_aspect_ratios = array( '1/1', '3/4', '4/3', '16/9' );
-if ( ! in_array( $image_aspect_ratio, $allowed_aspect_ratios, true ) ) {
-	$image_aspect_ratio = '3/4';
-}
-
-// ---------------------------------------------------------------------------
-// Query categories based on the selected source mode.
-// ---------------------------------------------------------------------------
-
-if ( 'manual' === $category_source ) {
-
-	// Build a list of sanitised category IDs in user-defined order.
-	$selected_ids = array();
-	$featured_map = array();
-
-	foreach ( $selected_categories as $item ) {
-		if ( ! isset( $item['id'] ) ) {
-			continue;
-		}
-		$id = absint( $item['id'] );
-		if ( ! $id ) {
-			continue;
-		}
-		$selected_ids[] = $id;
-		if ( ! empty( $item['featured'] ) ) {
-			$featured_map[ $id ] = true;
-		}
-	}
-
-	if ( empty( $selected_ids ) ) {
-		return '';
-	}
-
-	$terms = get_terms(
-		array(
-			'taxonomy'   => 'product_cat',
-			'include'    => $selected_ids,
-			'hide_empty' => false,
-			'orderby'    => 'include',
-		)
-	);
-
-} else {
-
-	// All mode: exclude empty (optionally) and the actual "Uncategorized" category.
-	$exclude_ids = array_map( 'absint', $exclude_categories );
-
-	// Only exclude the default product category if its slug is 'uncategorized'.
-	$default_cat_id = absint( get_option( 'default_product_cat', 0 ) );
-	if ( $default_cat_id ) {
-		$default_cat = get_term( $default_cat_id, 'product_cat' );
-		if ( $default_cat && ! is_wp_error( $default_cat ) && 'uncategorized' === $default_cat->slug ) {
-			$exclude_ids[] = $default_cat_id;
-		}
-	}
-	$exclude_ids = array_unique( array_filter( $exclude_ids ) );
-
-	$terms = get_terms(
-		array(
-			'taxonomy'   => 'product_cat',
-			'parent'     => 0,
-			'hide_empty' => ! $show_empty,
-			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- get_terms() exclusion bounded to the default "uncategorized" product_cat term.
-			'exclude'    => $exclude_ids,
-			'orderby'    => 'menu_order',
-			'order'      => 'ASC',
-		)
-	);
-
-	$featured_map = array();
-}
-
-// Bail silently if there are no categories to display.
-if ( is_wp_error( $terms ) || empty( $terms ) ) {
-	return '';
-}
-
-// ---------------------------------------------------------------------------
-// Build wrapper attributes.
-// ---------------------------------------------------------------------------
-
-$wrapper_attributes = get_block_wrapper_attributes(
-	array(
-		'class'       => 'dsgo-product-categories-grid dsgo-product-categories-grid--cols-' . $columns,
-		'role'        => 'navigation',
-		'aria-label'  => __( 'Product categories', 'designsetgo' ),
-		'style'       => '--dsgo-pcg-aspect-ratio: ' . esc_attr( $image_aspect_ratio ) . ';',
-	)
-);
-
-// ---------------------------------------------------------------------------
-// Placeholder SVG (2×2 grid icon) for categories without an image.
-// ---------------------------------------------------------------------------
-
-$placeholder_svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="48" height="48" aria-hidden="true" focusable="false">'
-	. '<rect x="3" y="3" width="8" height="8" rx="1" fill="currentColor" opacity="0.4"/>'
-	. '<rect x="13" y="3" width="8" height="8" rx="1" fill="currentColor" opacity="0.4"/>'
-	. '<rect x="3" y="13" width="8" height="8" rx="1" fill="currentColor" opacity="0.4"/>'
-	. '<rect x="13" y="13" width="8" height="8" rx="1" fill="currentColor" opacity="0.4"/>'
-	. '</svg>';
-
-?>
-<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() output. ?>>
-	<?php foreach ( $terms as $term ) : ?>
-		<?php
-		$term_id    = absint( $term->term_id );
-		$term_name  = $term->name;
-		$term_count = absint( $term->count );
-		$term_url   = get_term_link( $term );
-
-		if ( is_wp_error( $term_url ) ) {
-			continue;
+if ( ! function_exists( 'designsetgo_render_product_categories_grid' ) ) {
+	/**
+	 * Render the Product Categories Grid block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Inner block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return void
+	 */
+	function designsetgo_render_product_categories_grid( $attributes, $content, $block ) {
+		// Bail if WooCommerce is not active.
+		if ( ! function_exists( 'wc_get_product' ) ) {
+			return '';
 		}
 
-		// Determine if this card should span two columns (manual mode only).
-		$is_featured = isset( $featured_map[ $term_id ] );
+		// ---------------------------------------------------------------------------
+		// Extract and validate attributes.
+		// ---------------------------------------------------------------------------
 
-		// Resolve category image.
-		$thumbnail_id = absint( get_term_meta( $term_id, 'thumbnail_id', true ) );
-		$image_html   = '';
-		if ( $thumbnail_id ) {
-			$image_html = wp_get_attachment_image(
-				$thumbnail_id,
-				'medium_large',
-				false,
+		$category_source     = isset( $attributes['categorySource'] ) && 'manual' === $attributes['categorySource'] ? 'manual' : 'all';
+		$selected_categories = isset( $attributes['selectedCategories'] ) && is_array( $attributes['selectedCategories'] ) ? $attributes['selectedCategories'] : array();
+		$exclude_categories  = isset( $attributes['excludeCategories'] ) && is_array( $attributes['excludeCategories'] ) ? $attributes['excludeCategories'] : array();
+		$columns             = isset( $attributes['columns'] ) ? absint( $attributes['columns'] ) : 3;
+		$show_product_count  = ! isset( $attributes['showProductCount'] ) || (bool) $attributes['showProductCount'];
+		$show_empty          = ! empty( $attributes['showEmpty'] );
+		$image_aspect_ratio  = isset( $attributes['imageAspectRatio'] ) ? $attributes['imageAspectRatio'] : '3/4';
+		$overlay_position    = isset( $attributes['overlayPosition'] ) && 'center' === $attributes['overlayPosition'] ? 'center' : 'bottom-left';
+
+		// Validate columns (2–5).
+		if ( $columns < 2 || $columns > 5 ) {
+			$columns = 3;
+		}
+
+		// Validate aspect ratio.
+		$allowed_aspect_ratios = array( '1/1', '3/4', '4/3', '16/9' );
+		if ( ! in_array( $image_aspect_ratio, $allowed_aspect_ratios, true ) ) {
+			$image_aspect_ratio = '3/4';
+		}
+
+		// ---------------------------------------------------------------------------
+		// Query categories based on the selected source mode.
+		// ---------------------------------------------------------------------------
+
+		if ( 'manual' === $category_source ) {
+
+			// Build a list of sanitised category IDs in user-defined order.
+			$selected_ids = array();
+			$featured_map = array();
+
+			foreach ( $selected_categories as $item ) {
+				if ( ! isset( $item['id'] ) ) {
+					continue;
+				}
+				$id = absint( $item['id'] );
+				if ( ! $id ) {
+					continue;
+				}
+				$selected_ids[] = $id;
+				if ( ! empty( $item['featured'] ) ) {
+					$featured_map[ $id ] = true;
+				}
+			}
+
+			if ( empty( $selected_ids ) ) {
+				return '';
+			}
+
+			$terms = get_terms(
 				array(
-					'class'   => 'dsgo-product-categories-grid__image',
-					'alt'     => '',
-					'loading' => 'lazy',
+					'taxonomy'   => 'product_cat',
+					'include'    => $selected_ids,
+					'hide_empty' => false,
+					'orderby'    => 'include',
 				)
 			);
+
+		} else {
+
+			// All mode: exclude empty (optionally) and the actual "Uncategorized" category.
+			$exclude_ids = array_map( 'absint', $exclude_categories );
+
+			// Only exclude the default product category if its slug is 'uncategorized'.
+			$default_cat_id = absint( get_option( 'default_product_cat', 0 ) );
+			if ( $default_cat_id ) {
+				$default_cat = get_term( $default_cat_id, 'product_cat' );
+				if ( $default_cat && ! is_wp_error( $default_cat ) && 'uncategorized' === $default_cat->slug ) {
+					$exclude_ids[] = $default_cat_id;
+				}
+			}
+			$exclude_ids = array_unique( array_filter( $exclude_ids ) );
+
+			$terms = get_terms(
+				array(
+					'taxonomy'   => 'product_cat',
+					'parent'     => 0,
+					'hide_empty' => ! $show_empty,
+					// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- get_terms() exclusion bounded to the default "uncategorized" product_cat term.
+					'exclude'    => $exclude_ids,
+					'orderby'    => 'menu_order',
+					'order'      => 'ASC',
+				)
+			);
+
+			$featured_map = array();
 		}
 
-		// Build card CSS classes.
-		$card_class = 'dsgo-product-categories-grid__card';
-		if ( $is_featured ) {
-			$card_class .= ' dsgo-product-categories-grid__card--featured';
+		// Bail silently if there are no categories to display.
+		if ( is_wp_error( $terms ) || empty( $terms ) ) {
+			return '';
 		}
 
-		// Build accessible product count string.
-		/* translators: %d: number of products in a category. */
-		$count_text = sprintf( _n( '%d product', '%d products', $term_count, 'designsetgo' ), $term_count );
+		// ---------------------------------------------------------------------------
+		// Build wrapper attributes.
+		// ---------------------------------------------------------------------------
+
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class'       => 'dsgo-product-categories-grid dsgo-product-categories-grid--cols-' . $columns,
+				'role'        => 'navigation',
+				'aria-label'  => __( 'Product categories', 'designsetgo' ),
+				'style'       => '--dsgo-pcg-aspect-ratio: ' . esc_attr( $image_aspect_ratio ) . ';',
+			)
+		);
+
+		// ---------------------------------------------------------------------------
+		// Placeholder SVG (2×2 grid icon) for categories without an image.
+		// ---------------------------------------------------------------------------
+
+		$placeholder_svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="48" height="48" aria-hidden="true" focusable="false">'
+			. '<rect x="3" y="3" width="8" height="8" rx="1" fill="currentColor" opacity="0.4"/>'
+			. '<rect x="13" y="3" width="8" height="8" rx="1" fill="currentColor" opacity="0.4"/>'
+			. '<rect x="3" y="13" width="8" height="8" rx="1" fill="currentColor" opacity="0.4"/>'
+			. '<rect x="13" y="13" width="8" height="8" rx="1" fill="currentColor" opacity="0.4"/>'
+			. '</svg>';
+
 		?>
-		<a href="<?php echo esc_url( $term_url ); ?>" class="<?php echo esc_attr( $card_class ); ?>">
-			<?php if ( $image_html ) : ?>
-				<?php echo $image_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_get_attachment_image() output. ?>
-			<?php else : ?>
-				<div class="dsgo-product-categories-grid__placeholder-icon">
-					<?php echo $placeholder_svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG with no user data. ?>
-				</div>
-			<?php endif; ?>
+		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() output. ?>>
+			<?php foreach ( $terms as $term ) : ?>
+				<?php
+				$term_id    = absint( $term->term_id );
+				$term_name  = $term->name;
+				$term_count = absint( $term->count );
+				$term_url   = get_term_link( $term );
 
-			<div class="dsgo-product-categories-grid__overlay<?php echo 'center' === $overlay_position ? ' dsgo-product-categories-grid__overlay--center' : ''; ?>">
-				<h3 class="dsgo-product-categories-grid__name">
-					<?php echo esc_html( $term_name ); ?>
-				</h3>
+				if ( is_wp_error( $term_url ) ) {
+					continue;
+				}
 
-				<?php if ( $show_product_count ) : ?>
-					<span class="dsgo-product-categories-grid__count" aria-hidden="true">
-						<?php echo esc_html( $count_text ); ?>
-					</span>
-					<span class="screen-reader-text">
-						<?php
-						/* translators: 1: count text (e.g. "5 products"), 2: category name. */
-						echo esc_html( sprintf( __( '%1$s in %2$s', 'designsetgo' ), $count_text, $term_name ) );
-						?>
-					</span>
-				<?php endif; ?>
-			</div>
-		</a>
-	<?php endforeach; ?>
-</div>
+				// Determine if this card should span two columns (manual mode only).
+				$is_featured = isset( $featured_map[ $term_id ] );
+
+				// Resolve category image.
+				$thumbnail_id = absint( get_term_meta( $term_id, 'thumbnail_id', true ) );
+				$image_html   = '';
+				if ( $thumbnail_id ) {
+					$image_html = wp_get_attachment_image(
+						$thumbnail_id,
+						'medium_large',
+						false,
+						array(
+							'class'   => 'dsgo-product-categories-grid__image',
+							'alt'     => '',
+							'loading' => 'lazy',
+						)
+					);
+				}
+
+				// Build card CSS classes.
+				$card_class = 'dsgo-product-categories-grid__card';
+				if ( $is_featured ) {
+					$card_class .= ' dsgo-product-categories-grid__card--featured';
+				}
+
+				// Build accessible product count string.
+				/* translators: %d: number of products in a category. */
+				$count_text = sprintf( _n( '%d product', '%d products', $term_count, 'designsetgo' ), $term_count );
+				?>
+				<a href="<?php echo esc_url( $term_url ); ?>" class="<?php echo esc_attr( $card_class ); ?>">
+					<?php if ( $image_html ) : ?>
+						<?php echo $image_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_get_attachment_image() output. ?>
+					<?php else : ?>
+						<div class="dsgo-product-categories-grid__placeholder-icon">
+							<?php echo $placeholder_svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG with no user data. ?>
+						</div>
+					<?php endif; ?>
+
+					<div class="dsgo-product-categories-grid__overlay<?php echo 'center' === $overlay_position ? ' dsgo-product-categories-grid__overlay--center' : ''; ?>">
+						<h3 class="dsgo-product-categories-grid__name">
+							<?php echo esc_html( $term_name ); ?>
+						</h3>
+
+						<?php if ( $show_product_count ) : ?>
+							<span class="dsgo-product-categories-grid__count" aria-hidden="true">
+								<?php echo esc_html( $count_text ); ?>
+							</span>
+							<span class="screen-reader-text">
+								<?php
+								/* translators: 1: count text (e.g. "5 products"), 2: category name. */
+								echo esc_html( sprintf( __( '%1$s in %2$s', 'designsetgo' ), $count_text, $term_name ) );
+								?>
+							</span>
+						<?php endif; ?>
+					</div>
+				</a>
+			<?php endforeach; ?>
+		</div>
+		<?php
+	}
+}
+
+designsetgo_render_product_categories_grid( $attributes, $content, $block );

--- a/src/blocks/product-showcase-hero/render.php
+++ b/src/blocks/product-showcase-hero/render.php
@@ -18,198 +18,212 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// Bail if WooCommerce is not active.
-if ( ! function_exists( 'wc_get_product' ) ) {
-	return '';
-}
+if ( ! function_exists( 'designsetgo_render_product_showcase_hero' ) ) {
+	/**
+	 * Render the Product Showcase Hero block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Inner block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return void
+	 */
+	function designsetgo_render_product_showcase_hero( $attributes, $content, $block ) {
+		// Bail if WooCommerce is not active.
+		if ( ! function_exists( 'wc_get_product' ) ) {
+			return '';
+		}
 
-// Resolve product ID based on source mode.
-$product_source = isset( $attributes['productSource'] ) ? $attributes['productSource'] : 'manual';
+		// Resolve product ID based on source mode.
+		$product_source = isset( $attributes['productSource'] ) ? $attributes['productSource'] : 'manual';
 
-if ( 'current' === $product_source ) {
-	// Use the current product context (single product pages, product templates).
-	if ( isset( $GLOBALS['product'] ) && $GLOBALS['product'] instanceof WC_Product ) {
-		$product_id = $GLOBALS['product']->get_id();
-	} else {
-		$product_id = get_the_ID();
-	}
-} else {
-	$product_id = isset( $attributes['productId'] ) ? absint( $attributes['productId'] ) : 0;
-}
+		if ( 'current' === $product_source ) {
+			// Use the current product context (single product pages, product templates).
+			if ( isset( $GLOBALS['product'] ) && $GLOBALS['product'] instanceof WC_Product ) {
+				$product_id = $GLOBALS['product']->get_id();
+			} else {
+				$product_id = get_the_ID();
+			}
+		} else {
+			$product_id = isset( $attributes['productId'] ) ? absint( $attributes['productId'] ) : 0;
+		}
 
-if ( ! $product_id ) {
-	return '';
-}
+		if ( ! $product_id ) {
+			return '';
+		}
 
-// Get the product.
-$product = wc_get_product( $product_id );
-if ( ! $product || 'publish' !== get_post_status( $product_id ) ) {
-	return '';
-}
+		// Get the product.
+		$product = wc_get_product( $product_id );
+		if ( ! $product || 'publish' !== get_post_status( $product_id ) ) {
+			return '';
+		}
 
-// Respect password-protected products.
-if ( post_password_required( $product_id ) ) {
-	return get_the_password_form( $product_id );
-}
+		// Respect password-protected products.
+		if ( post_password_required( $product_id ) ) {
+			return get_the_password_form( $product_id );
+		}
 
-// Extract display settings.
-$layout                = isset( $attributes['layout'] ) && 'media-right' === $attributes['layout'] ? 'media-right' : 'media-left';
-$image_size            = isset( $attributes['imageSize'] ) ? sanitize_key( $attributes['imageSize'] ) : 'large';
-$show_price            = ! isset( $attributes['showPrice'] ) || $attributes['showPrice'];
-$show_rating           = ! isset( $attributes['showRating'] ) || $attributes['showRating'];
-$show_stock_status     = ! isset( $attributes['showStockStatus'] ) || $attributes['showStockStatus'];
-$show_sale_badge       = ! isset( $attributes['showSaleBadge'] ) || $attributes['showSaleBadge'];
-$show_short_desc       = ! empty( $attributes['showShortDescription'] );
-$show_add_to_cart      = ! isset( $attributes['showAddToCart'] ) || $attributes['showAddToCart'];
-$show_variations       = ! isset( $attributes['showVariations'] ) || $attributes['showVariations'];
-$min_height            = isset( $attributes['minHeight'] ) ? $attributes['minHeight'] : '500px';
-$focal_point           = isset( $attributes['mediaFocalPoint'] ) ? $attributes['mediaFocalPoint'] : array( 'x' => 0.5, 'y' => 0.5 );
-$allowed_alignments    = array( 'top', 'center', 'bottom' );
-$vertical_alignment    = isset( $attributes['contentVerticalAlignment'] ) && in_array( $attributes['contentVerticalAlignment'], $allowed_alignments, true )
-	? $attributes['contentVerticalAlignment']
-	: 'center';
+		// Extract display settings.
+		$layout                = isset( $attributes['layout'] ) && 'media-right' === $attributes['layout'] ? 'media-right' : 'media-left';
+		$image_size            = isset( $attributes['imageSize'] ) ? sanitize_key( $attributes['imageSize'] ) : 'large';
+		$show_price            = ! isset( $attributes['showPrice'] ) || $attributes['showPrice'];
+		$show_rating           = ! isset( $attributes['showRating'] ) || $attributes['showRating'];
+		$show_stock_status     = ! isset( $attributes['showStockStatus'] ) || $attributes['showStockStatus'];
+		$show_sale_badge       = ! isset( $attributes['showSaleBadge'] ) || $attributes['showSaleBadge'];
+		$show_short_desc       = ! empty( $attributes['showShortDescription'] );
+		$show_add_to_cart      = ! isset( $attributes['showAddToCart'] ) || $attributes['showAddToCart'];
+		$show_variations       = ! isset( $attributes['showVariations'] ) || $attributes['showVariations'];
+		$min_height            = isset( $attributes['minHeight'] ) ? $attributes['minHeight'] : '500px';
+		$focal_point           = isset( $attributes['mediaFocalPoint'] ) ? $attributes['mediaFocalPoint'] : array( 'x' => 0.5, 'y' => 0.5 );
+		$allowed_alignments    = array( 'top', 'center', 'bottom' );
+		$vertical_alignment    = isset( $attributes['contentVerticalAlignment'] ) && in_array( $attributes['contentVerticalAlignment'], $allowed_alignments, true )
+			? $attributes['contentVerticalAlignment']
+			: 'center';
 
-// Validate image size.
-$allowed_sizes = array( 'medium', 'large', 'full' );
-if ( ! in_array( $image_size, $allowed_sizes, true ) ) {
-	$image_size = 'large';
-}
+		// Validate image size.
+		$allowed_sizes = array( 'medium', 'large', 'full' );
+		if ( ! in_array( $image_size, $allowed_sizes, true ) ) {
+			$image_size = 'large';
+		}
 
-// Validate min height.
-$safe_min_height = ( $min_height && preg_match( '/^\d+(\.\d+)?(px|vh|vw|em|rem|%)$/', $min_height ) )
-	? $min_height
-	: '500px';
+		// Validate min height.
+		$safe_min_height = ( $min_height && preg_match( '/^\d+(\.\d+)?(px|vh|vw|em|rem|%)$/', $min_height ) )
+			? $min_height
+			: '500px';
 
-// Build focal point CSS.
-$focal_x = isset( $focal_point['x'] ) ? max( 0, min( 1, floatval( $focal_point['x'] ) ) ) * 100 : 50;
-$focal_y = isset( $focal_point['y'] ) ? max( 0, min( 1, floatval( $focal_point['y'] ) ) ) * 100 : 50;
-$object_position = $focal_x . '% ' . $focal_y . '%';
+		// Build focal point CSS.
+		$focal_x = isset( $focal_point['x'] ) ? max( 0, min( 1, floatval( $focal_point['x'] ) ) ) * 100 : 50;
+		$focal_y = isset( $focal_point['y'] ) ? max( 0, min( 1, floatval( $focal_point['y'] ) ) ) * 100 : 50;
+		$object_position = $focal_x . '% ' . $focal_y . '%';
 
-// Map vertical alignment.
-$align_map = array(
-	'top'    => 'flex-start',
-	'center' => 'center',
-	'bottom' => 'flex-end',
-);
-$content_justify = isset( $align_map[ $vertical_alignment ] ) ? $align_map[ $vertical_alignment ] : 'center';
+		// Map vertical alignment.
+		$align_map = array(
+			'top'    => 'flex-start',
+			'center' => 'center',
+			'bottom' => 'flex-end',
+		);
+		$content_justify = isset( $align_map[ $vertical_alignment ] ) ? $align_map[ $vertical_alignment ] : 'center';
 
-// Get product image.
-$image_id  = $product->get_image_id();
-$image_html = '';
-if ( $image_id ) {
-	$image_html = wp_get_attachment_image(
-		$image_id,
-		$image_size,
-		false,
-		array(
-			'class'         => 'dsgo-product-showcase-hero__image',
-			'style'         => 'object-position: ' . esc_attr( $object_position ) . ';',
-			'loading'       => 'eager',
-			'fetchpriority' => 'high',
-		)
-	);
-}
+		// Get product image.
+		$image_id  = $product->get_image_id();
+		$image_html = '';
+		if ( $image_id ) {
+			$image_html = wp_get_attachment_image(
+				$image_id,
+				$image_size,
+				false,
+				array(
+					'class'         => 'dsgo-product-showcase-hero__image',
+					'style'         => 'object-position: ' . esc_attr( $object_position ) . ';',
+					'loading'       => 'eager',
+					'fetchpriority' => 'high',
+				)
+			);
+		}
 
-// Build wrapper attributes.
-$wrapper_class = 'dsgo-product-showcase-hero dsgo-product-showcase-hero--' . $layout;
-$wrapper_attributes = get_block_wrapper_attributes(
-	array(
-		'class' => $wrapper_class,
-		'style' => '--dsgo-psh-min-height: ' . esc_attr( $safe_min_height ) . '; --dsgo-psh-content-justify: ' . esc_attr( $content_justify ) . ';',
-	)
-);
+		// Build wrapper attributes.
+		$wrapper_class = 'dsgo-product-showcase-hero dsgo-product-showcase-hero--' . $layout;
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class' => $wrapper_class,
+				'style' => '--dsgo-psh-min-height: ' . esc_attr( $safe_min_height ) . '; --dsgo-psh-content-justify: ' . esc_attr( $content_justify ) . ';',
+			)
+		);
 
-// Set up global product for WooCommerce template functions.
-// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-global $post;
-$original_post    = $post;
-$original_product = isset( $GLOBALS['product'] ) ? $GLOBALS['product'] : null;
-$post             = get_post( $product_id );
-// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-$GLOBALS['product'] = $product;
-setup_postdata( $post );
-?>
+		// Set up global product for WooCommerce template functions.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		global $post;
+		$original_post    = $post;
+		$original_product = isset( $GLOBALS['product'] ) ? $GLOBALS['product'] : null;
+		$post             = get_post( $product_id );
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited, WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- WooCommerce template functions require this global to be named exactly $product; swapped for loop context and restored below.
+		$GLOBALS['product'] = $product;
+		setup_postdata( $post );
+		?>
 
-<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-	<div class="dsgo-product-showcase-hero__media">
-		<?php if ( $image_html ) : ?>
-			<?php echo $image_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_get_attachment_image() output. ?>
-		<?php endif; ?>
+		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+			<div class="dsgo-product-showcase-hero__media">
+				<?php if ( $image_html ) : ?>
+					<?php echo $image_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_get_attachment_image() output. ?>
+				<?php endif; ?>
 
-		<?php if ( $show_sale_badge && $product->is_on_sale() ) : ?>
-			<span class="dsgo-product-showcase-hero__sale-badge">
-				<?php echo esc_html__( 'Sale!', 'designsetgo' ); ?>
-			</span>
-		<?php endif; ?>
-	</div>
+				<?php if ( $show_sale_badge && $product->is_on_sale() ) : ?>
+					<span class="dsgo-product-showcase-hero__sale-badge">
+						<?php echo esc_html__( 'Sale!', 'designsetgo' ); ?>
+					</span>
+				<?php endif; ?>
+			</div>
 
-	<div class="dsgo-product-showcase-hero__content">
-		<div class="dsgo-product-showcase-hero__content-inner">
-			<h2 class="dsgo-product-showcase-hero__title">
-				<?php echo esc_html( $product->get_name() ); ?>
-			</h2>
+			<div class="dsgo-product-showcase-hero__content">
+				<div class="dsgo-product-showcase-hero__content-inner">
+					<h2 class="dsgo-product-showcase-hero__title">
+						<?php echo esc_html( $product->get_name() ); ?>
+					</h2>
 
-			<?php if ( $show_price ) : ?>
-				<div class="dsgo-product-showcase-hero__price">
-					<?php echo wp_kses_post( $product->get_price_html() ); ?>
+					<?php if ( $show_price ) : ?>
+						<div class="dsgo-product-showcase-hero__price">
+							<?php echo wp_kses_post( $product->get_price_html() ); ?>
+						</div>
+					<?php endif; ?>
+
+					<?php if ( $show_rating && $product->get_average_rating() > 0 ) : ?>
+						<div class="dsgo-product-showcase-hero__rating">
+							<?php
+							echo wp_kses_post(
+								wc_get_rating_html( $product->get_average_rating(), $product->get_review_count() )
+							);
+							?>
+						</div>
+					<?php endif; ?>
+
+					<?php if ( $show_stock_status ) : ?>
+						<?php
+						$stock_class = $product->is_in_stock() ? 'instock' : 'outofstock';
+						$stock_text  = $product->is_in_stock()
+							? __( 'In stock', 'designsetgo' )
+							: __( 'Out of stock', 'designsetgo' );
+						?>
+						<div class="dsgo-product-showcase-hero__stock dsgo-product-showcase-hero__stock--<?php echo esc_attr( $stock_class ); ?>">
+							<?php echo esc_html( $stock_text ); ?>
+						</div>
+					<?php endif; ?>
+
+					<?php if ( $show_short_desc && $product->get_short_description() ) : ?>
+						<div class="dsgo-product-showcase-hero__description">
+							<?php echo wp_kses_post( $product->get_short_description() ); ?>
+						</div>
+					<?php endif; ?>
+
+					<?php if ( $show_add_to_cart ) : ?>
+						<div class="dsgo-product-showcase-hero__actions wp-block-button">
+							<?php
+							// Capture WC button output and add wp-element-button class
+							// so the button inherits theme.json button styles.
+							ob_start();
+							if ( $show_variations && $product->is_type( 'variable' ) ) {
+								woocommerce_template_single_add_to_cart();
+							} else {
+								woocommerce_template_loop_add_to_cart();
+							}
+							$add_to_cart_html = ob_get_clean();
+							echo str_replace( 'class="button', 'class="button wp-block-button__link wp-element-button', $add_to_cart_html ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- WooCommerce template output.
+							?>
+						</div>
+					<?php endif; ?>
 				</div>
-			<?php endif; ?>
-
-			<?php if ( $show_rating && $product->get_average_rating() > 0 ) : ?>
-				<div class="dsgo-product-showcase-hero__rating">
-					<?php
-					echo wp_kses_post(
-						wc_get_rating_html( $product->get_average_rating(), $product->get_review_count() )
-					);
-					?>
-				</div>
-			<?php endif; ?>
-
-			<?php if ( $show_stock_status ) : ?>
-				<?php
-				$stock_class = $product->is_in_stock() ? 'instock' : 'outofstock';
-				$stock_text  = $product->is_in_stock()
-					? __( 'In stock', 'designsetgo' )
-					: __( 'Out of stock', 'designsetgo' );
-				?>
-				<div class="dsgo-product-showcase-hero__stock dsgo-product-showcase-hero__stock--<?php echo esc_attr( $stock_class ); ?>">
-					<?php echo esc_html( $stock_text ); ?>
-				</div>
-			<?php endif; ?>
-
-			<?php if ( $show_short_desc && $product->get_short_description() ) : ?>
-				<div class="dsgo-product-showcase-hero__description">
-					<?php echo wp_kses_post( $product->get_short_description() ); ?>
-				</div>
-			<?php endif; ?>
-
-			<?php if ( $show_add_to_cart ) : ?>
-				<div class="dsgo-product-showcase-hero__actions wp-block-button">
-					<?php
-					// Capture WC button output and add wp-element-button class
-					// so the button inherits theme.json button styles.
-					ob_start();
-					if ( $show_variations && $product->is_type( 'variable' ) ) {
-						woocommerce_template_single_add_to_cart();
-					} else {
-						woocommerce_template_loop_add_to_cart();
-					}
-					$add_to_cart_html = ob_get_clean();
-					echo str_replace( 'class="button', 'class="button wp-block-button__link wp-element-button', $add_to_cart_html ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- WooCommerce template output.
-					?>
-				</div>
-			<?php endif; ?>
+			</div>
 		</div>
-	</div>
-</div>
 
-<?php
-// Restore original globals (manual restoration is safer than wp_reset_postdata()
-// because it correctly handles secondary query loops where $wp_query->post differs).
-// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-$post               = $original_post;
-// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-$GLOBALS['product'] = $original_product;
-if ( $post ) {
-	setup_postdata( $post );
+		<?php
+		// Restore original globals (manual restoration is safer than wp_reset_postdata()
+		// because it correctly handles secondary query loops where $wp_query->post differs).
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$post               = $original_post;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited, WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- restoring WooCommerce's original global $product after the loop; the name is fixed by WooCommerce.
+		$GLOBALS['product'] = $original_product;
+		if ( $post ) {
+			setup_postdata( $post );
+		}
+	}
 }
+
+designsetgo_render_product_showcase_hero( $attributes, $content, $block );

--- a/src/blocks/query-filter/render.php
+++ b/src/blocks/query-filter/render.php
@@ -259,7 +259,7 @@ if ( ! function_exists( 'designsetgo_query_filter_render_checkbox' ) ) :
 		}
 
 		// Fix 4: noscript submit so no-JS users can apply checkbox filters.
-		$dsgo_nojs_btn      = '<noscript><button type="submit" class="dsgo-query-filter__nojs-submit">' . esc_html__( 'Apply filter', 'designsetgo' ) . '</button></noscript>';
+		$designsetgo_nojs_btn      = '<noscript><button type="submit" class="dsgo-query-filter__nojs-submit">' . esc_html__( 'Apply filter', 'designsetgo' ) . '</button></noscript>';
 		$list_class_parts   = array( 'dsgo-query-filter__checkbox-list' );
 		if ( 'horizontal' === $orientation ) {
 			$list_class_parts[] = 'is-horizontal';
@@ -282,7 +282,7 @@ if ( ! function_exists( 'designsetgo_query_filter_render_checkbox' ) ) :
 				$wrapper, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				esc_html( $label ),
 				$items_html, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- per-field escaped above.
-				$dsgo_nojs_btn, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- esc_html() used inside.
+				$designsetgo_nojs_btn, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- esc_html() used inside.
 				esc_attr( $list_class )
 			);
 		} else {
@@ -290,7 +290,7 @@ if ( ! function_exists( 'designsetgo_query_filter_render_checkbox' ) ) :
 				'<form %1$s method="get" action=""><div class="%4$s">%2$s</div>%3$s</form>',
 				$wrapper, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				$items_html, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				$dsgo_nojs_btn, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- esc_html() used inside.
+				$designsetgo_nojs_btn, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- esc_html() used inside.
 				esc_attr( $list_class )
 			);
 		}
@@ -373,7 +373,7 @@ if ( ! function_exists( 'designsetgo_query_filter_render_active' ) ) :
 			);
 			$new_url = $qs_encoded ? $base . '?' . $qs_encoded : $base;
 			// Derive a human dimension label from the URL key: "filter_post_tag" → "post tag".
-			$dsgo_dimension = 'q' === $p['key']
+			$designsetgo_dimension = 'q' === $p['key']
 				? __( 'search', 'designsetgo' )
 				: str_replace( array( 'filter_', '_' ), array( '', ' ' ), $p['key'] );
 			$chips_html .= sprintf(
@@ -386,7 +386,7 @@ if ( ! function_exists( 'designsetgo_query_filter_render_active' ) ) :
 					sprintf(
 						/* translators: 1: filter dimension name (e.g. "category"), 2: filter value (e.g. "photography") */
 						__( 'Remove %1$s: %2$s', 'designsetgo' ),
-						$dsgo_dimension,
+						$designsetgo_dimension,
 						$p['value']
 					)
 				)
@@ -455,58 +455,58 @@ endif;
 // every helper above is defined by the time we invoke one.
 // ---------------------------------------------------------------------------
 
-$dsgo_query_id = isset( $block->context['designsetgo/queryId'] )
+$designsetgo_query_id = isset( $block->context['designsetgo/queryId'] )
 	? sanitize_key( (string) $block->context['designsetgo/queryId'] )
 	: '';
 
-if ( '' === $dsgo_query_id ) {
+if ( '' === $designsetgo_query_id ) {
 	return;
 }
 
-$dsgo_filter_kind        = isset( $attributes['filterKind'] ) ? sanitize_key( (string) $attributes['filterKind'] ) : 'checkbox';
-$dsgo_filter_param       = isset( $attributes['paramName'] ) ? sanitize_key( (string) $attributes['paramName'] ) : '';
-$dsgo_filter_label       = isset( $attributes['label'] ) ? (string) $attributes['label'] : '';
-$dsgo_filter_placeholder = isset( $attributes['placeholder'] ) ? (string) $attributes['placeholder'] : '';
-$dsgo_filter_taxonomy    = isset( $attributes['taxonomy'] ) ? sanitize_key( (string) $attributes['taxonomy'] ) : 'category';
-$dsgo_filter_orientation = ( isset( $attributes['orientation'] ) && 'horizontal' === $attributes['orientation'] ) ? 'horizontal' : 'vertical';
+$designsetgo_filter_kind        = isset( $attributes['filterKind'] ) ? sanitize_key( (string) $attributes['filterKind'] ) : 'checkbox';
+$designsetgo_filter_param       = isset( $attributes['paramName'] ) ? sanitize_key( (string) $attributes['paramName'] ) : '';
+$designsetgo_filter_label       = isset( $attributes['label'] ) ? (string) $attributes['label'] : '';
+$designsetgo_filter_placeholder = isset( $attributes['placeholder'] ) ? (string) $attributes['placeholder'] : '';
+$designsetgo_filter_taxonomy    = isset( $attributes['taxonomy'] ) ? sanitize_key( (string) $attributes['taxonomy'] ) : 'category';
+$designsetgo_filter_orientation = ( isset( $attributes['orientation'] ) && 'horizontal' === $attributes['orientation'] ) ? 'horizontal' : 'vertical';
 // Default `filterStyle` is `default` (classic checkboxes) to preserve the
 // look of pre-existing saved blocks that have no `filterStyle` attribute.
 // New inserts through the inserter variation opt into `underline` explicitly
 // — see the variation attributes in src/blocks/query-filter/variations.js.
-$dsgo_filter_style       = isset( $attributes['filterStyle'] ) && in_array( $attributes['filterStyle'], array( 'pill', 'underline' ), true )
+$designsetgo_filter_style       = isset( $attributes['filterStyle'] ) && in_array( $attributes['filterStyle'], array( 'pill', 'underline' ), true )
 	? $attributes['filterStyle']
 	: 'default';
 
 // Post-type scope for counts: only non-empty when the parent query targets a
 // specific post type (source === 'posts'). Users/terms sources leave it empty
 // so the count query runs unscoped (those rows carry post_type='' anyway).
-$dsgo_query_source    = isset( $block->context['designsetgo/querySource'] )
+$designsetgo_query_source    = isset( $block->context['designsetgo/querySource'] )
 	? sanitize_key( (string) $block->context['designsetgo/querySource'] )
 	: 'posts';
-$dsgo_query_post_type = '';
-if ( 'posts' === $dsgo_query_source && isset( $block->context['designsetgo/queryPostType'] ) ) {
-	$dsgo_query_post_type = sanitize_key( (string) $block->context['designsetgo/queryPostType'] );
+$designsetgo_query_post_type = '';
+if ( 'posts' === $designsetgo_query_source && isset( $block->context['designsetgo/queryPostType'] ) ) {
+	$designsetgo_query_post_type = sanitize_key( (string) $block->context['designsetgo/queryPostType'] );
 }
 
 // Whether to show (N) counts next to filter options (default: true).
-$dsgo_show_counts = ! isset( $attributes['showCounts'] ) || (bool) $attributes['showCounts'];
+$designsetgo_show_counts = ! isset( $attributes['showCounts'] ) || (bool) $attributes['showCounts'];
 
 // Extract active filters from $_GET so count queries respect the current
 // filter state. On the REST-refresh path, $_GET has been overlaid by the
 // REST controller with the incoming params, so this is always up-to-date.
-$dsgo_active_filters = array();
-foreach ( (array) $_GET as $dsgo_k => $dsgo_v ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	$dsgo_k = sanitize_key( (string) $dsgo_k );
-	if ( '' === $dsgo_k ) {
+$designsetgo_active_filters = array();
+foreach ( (array) $_GET as $designsetgo_k => $designsetgo_v ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$designsetgo_k = sanitize_key( (string) $designsetgo_k );
+	if ( '' === $designsetgo_k ) {
 		continue;
 	}
-	if ( 0 === strpos( $dsgo_k, 'filter_' ) ) {
-		if ( is_array( $dsgo_v ) ) {
-			$dsgo_active_filters[ $dsgo_k ] = array_map( 'sanitize_text_field', wp_unslash( $dsgo_v ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	if ( 0 === strpos( $designsetgo_k, 'filter_' ) ) {
+		if ( is_array( $designsetgo_v ) ) {
+			$designsetgo_active_filters[ $designsetgo_k ] = array_map( 'sanitize_text_field', wp_unslash( $designsetgo_v ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		} else {
-			$dsgo_val = sanitize_text_field( wp_unslash( (string) $dsgo_v ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			if ( '' !== $dsgo_val ) {
-				$dsgo_active_filters[ $dsgo_k ] = array( $dsgo_val );
+			$designsetgo_val = sanitize_text_field( wp_unslash( (string) $designsetgo_v ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			if ( '' !== $designsetgo_val ) {
+				$designsetgo_active_filters[ $designsetgo_k ] = array( $designsetgo_val );
 			}
 		}
 	}
@@ -514,12 +514,12 @@ foreach ( (array) $_GET as $dsgo_k => $dsgo_v ) { // phpcs:ignore WordPress.Secu
 
 // Re-key active_filters to use the bare taxonomy slug (strip "filter_" prefix)
 // because FilterIndex::count_for_options() expects filter keys, not URL param names.
-$dsgo_active_filters_by_key = array();
-foreach ( $dsgo_active_filters as $dsgo_param_key => $dsgo_param_values ) {
-	$dsgo_filter_key = 'filter_' === substr( $dsgo_param_key, 0, 7 )
-		? substr( $dsgo_param_key, 7 )
-		: $dsgo_param_key;
-	$dsgo_active_filters_by_key[ $dsgo_filter_key ] = $dsgo_param_values;
+$designsetgo_active_filters_by_key = array();
+foreach ( $designsetgo_active_filters as $designsetgo_param_key => $designsetgo_param_values ) {
+	$designsetgo_filter_key = 'filter_' === substr( $designsetgo_param_key, 0, 7 )
+		? substr( $designsetgo_param_key, 7 )
+		: $designsetgo_param_key;
+	$designsetgo_active_filters_by_key[ $designsetgo_filter_key ] = $designsetgo_param_values;
 }
 
 // Translate taxonomy slugs in active_filters_by_key to term IDs.
@@ -531,49 +531,49 @@ foreach ( $dsgo_active_filters as $dsgo_param_key => $dsgo_param_values ) {
 //
 // Meta filters store their value verbatim — no translation needed.
 if ( class_exists( '\DesignSetGo\Blocks\Query\FilterRegistry' ) ) {
-	$dsgo_registered_filters = \DesignSetGo\Blocks\Query\FilterRegistry::all();
-	foreach ( $dsgo_active_filters_by_key as $dsgo_fk => $dsgo_fv ) {
-		$dsgo_filter_config = $dsgo_registered_filters[ $dsgo_fk ] ?? null;
-		if ( ! $dsgo_filter_config || 'taxonomy' !== ( $dsgo_filter_config['type'] ?? '' ) ) {
+	$designsetgo_registered_filters = \DesignSetGo\Blocks\Query\FilterRegistry::all();
+	foreach ( $designsetgo_active_filters_by_key as $designsetgo_fk => $designsetgo_fv ) {
+		$designsetgo_filter_config = $designsetgo_registered_filters[ $designsetgo_fk ] ?? null;
+		if ( ! $designsetgo_filter_config || 'taxonomy' !== ( $designsetgo_filter_config['type'] ?? '' ) ) {
 			continue; // Meta or unknown — values are already in the correct format.
 		}
-		// Keep the loop variable distinct from $dsgo_filter_taxonomy, which holds
+		// Keep the loop variable distinct from $designsetgo_filter_taxonomy, which holds
 		// this block's own taxonomy and is needed later for the is_available()
 		// check and the render-dispatch switch.
-		$dsgo_iter_taxonomy = (string) ( $dsgo_filter_config['source'] ?? '' );
-		if ( '' === $dsgo_iter_taxonomy ) {
+		$designsetgo_iter_taxonomy = (string) ( $designsetgo_filter_config['source'] ?? '' );
+		if ( '' === $designsetgo_iter_taxonomy ) {
 			continue;
 		}
-		$dsgo_translated = array();
-		foreach ( (array) $dsgo_fv as $dsgo_slug_or_id ) {
-			$dsgo_slug_or_id = (string) $dsgo_slug_or_id;
-			if ( ctype_digit( $dsgo_slug_or_id ) ) {
+		$designsetgo_translated = array();
+		foreach ( (array) $designsetgo_fv as $designsetgo_slug_or_id ) {
+			$designsetgo_slug_or_id = (string) $designsetgo_slug_or_id;
+			if ( ctype_digit( $designsetgo_slug_or_id ) ) {
 				// Already a numeric ID — pass through as-is.
-				$dsgo_translated[] = $dsgo_slug_or_id;
+				$designsetgo_translated[] = $designsetgo_slug_or_id;
 				continue;
 			}
-			$dsgo_term = get_term_by( 'slug', $dsgo_slug_or_id, $dsgo_iter_taxonomy );
-			if ( $dsgo_term instanceof \WP_Term ) {
-				$dsgo_translated[] = (string) $dsgo_term->term_id;
+			$designsetgo_term = get_term_by( 'slug', $designsetgo_slug_or_id, $designsetgo_iter_taxonomy );
+			if ( $designsetgo_term instanceof \WP_Term ) {
+				$designsetgo_translated[] = (string) $designsetgo_term->term_id;
 			}
 		}
-		$dsgo_active_filters_by_key[ $dsgo_fk ] = $dsgo_translated;
+		$designsetgo_active_filters_by_key[ $designsetgo_fk ] = $designsetgo_translated;
 	}
-	unset( $dsgo_registered_filters, $dsgo_filter_config, $dsgo_iter_taxonomy, $dsgo_translated, $dsgo_slug_or_id, $dsgo_term );
+	unset( $designsetgo_registered_filters, $designsetgo_filter_config, $designsetgo_iter_taxonomy, $designsetgo_translated, $designsetgo_slug_or_id, $designsetgo_term );
 }
 
 // Only render counts when the filter is indexed AND showCounts is enabled.
-$dsgo_counts_enabled = $dsgo_show_counts
+$designsetgo_counts_enabled = $designsetgo_show_counts
 	&& class_exists( '\DesignSetGo\Blocks\Query\FilterIndex' )
-	&& \DesignSetGo\Blocks\Query\FilterIndex::is_available( $dsgo_filter_taxonomy );
+	&& \DesignSetGo\Blocks\Query\FilterIndex::is_available( $designsetgo_filter_taxonomy );
 
-$dsgo_filter_wrapper = get_block_wrapper_attributes(
+$designsetgo_filter_wrapper = get_block_wrapper_attributes(
 	array(
-		'class'                 => 'dsgo-query-filter dsgo-query-filter--' . esc_attr( $dsgo_filter_kind ),
+		'class'                 => 'dsgo-query-filter dsgo-query-filter--' . esc_attr( $designsetgo_filter_kind ),
 		'data-wp-interactive'   => 'designsetgo/query',
-		'data-dsgo-query-id'    => $dsgo_query_id,
-		'data-dsgo-filter-kind' => $dsgo_filter_kind,
-		'data-dsgo-param'       => $dsgo_filter_param,
+		'data-dsgo-query-id'    => $designsetgo_query_id,
+		'data-dsgo-filter-kind' => $designsetgo_filter_kind,
+		'data-dsgo-param'       => $designsetgo_filter_param,
 	)
 );
 // Seed IAPI context so `getContext()` inside setFilter / toggleFilter /
@@ -583,11 +583,11 @@ $dsgo_filter_wrapper = get_block_wrapper_attributes(
 // JSON_HEX_APOS defends the single-quoted attribute boundary against a
 // stray apostrophe in any future context value (today all four are quote-
 // free: sanitize_key / false / esc_url_raw / wp_create_nonce).
-$dsgo_filter_wrapper .= sprintf(
+$designsetgo_filter_wrapper .= sprintf(
 	" data-wp-context='%s'",
 	wp_json_encode(
 		array(
-			'queryId' => $dsgo_query_id,
+			'queryId' => $designsetgo_query_id,
 			'busy'    => false,
 			'restUrl' => esc_url_raw( rest_url( 'designsetgo/v1/query/render' ) ),
 			'nonce'   => wp_create_nonce( 'wp_rest' ),
@@ -596,25 +596,25 @@ $dsgo_filter_wrapper .= sprintf(
 	)
 );
 
-switch ( $dsgo_filter_kind ) {
+switch ( $designsetgo_filter_kind ) {
 	case 'search':
-		designsetgo_query_filter_render_search( $dsgo_filter_wrapper, $dsgo_filter_param, $dsgo_filter_label, $dsgo_filter_placeholder );
+		designsetgo_query_filter_render_search( $designsetgo_filter_wrapper, $designsetgo_filter_param, $designsetgo_filter_label, $designsetgo_filter_placeholder );
 		break;
 	case 'sort':
-		$dsgo_sort_options = isset( $attributes['sortOptions'] ) ? (array) $attributes['sortOptions'] : array();
-		designsetgo_query_filter_render_sort( $dsgo_filter_wrapper, $dsgo_filter_param, $dsgo_filter_label, $dsgo_sort_options );
+		$designsetgo_sort_options = isset( $attributes['sortOptions'] ) ? (array) $attributes['sortOptions'] : array();
+		designsetgo_query_filter_render_sort( $designsetgo_filter_wrapper, $designsetgo_filter_param, $designsetgo_filter_label, $designsetgo_sort_options );
 		break;
 	case 'select':
-		designsetgo_query_filter_render_select( $dsgo_filter_wrapper, $dsgo_filter_param, $dsgo_filter_label, $dsgo_filter_taxonomy, $dsgo_counts_enabled, $dsgo_active_filters_by_key, $dsgo_query_post_type );
+		designsetgo_query_filter_render_select( $designsetgo_filter_wrapper, $designsetgo_filter_param, $designsetgo_filter_label, $designsetgo_filter_taxonomy, $designsetgo_counts_enabled, $designsetgo_active_filters_by_key, $designsetgo_query_post_type );
 		break;
 	case 'active':
-		designsetgo_query_filter_render_active( $dsgo_filter_wrapper, $dsgo_filter_label );
+		designsetgo_query_filter_render_active( $designsetgo_filter_wrapper, $designsetgo_filter_label );
 		break;
 	case 'reset':
-		designsetgo_query_filter_render_reset( $dsgo_filter_wrapper, $dsgo_filter_label );
+		designsetgo_query_filter_render_reset( $designsetgo_filter_wrapper, $designsetgo_filter_label );
 		break;
 	case 'checkbox':
 	default:
-		designsetgo_query_filter_render_checkbox( $dsgo_filter_wrapper, $dsgo_filter_param, $dsgo_filter_label, $dsgo_filter_taxonomy, $dsgo_counts_enabled, $dsgo_active_filters_by_key, $dsgo_query_post_type, $dsgo_filter_orientation, $dsgo_filter_style );
+		designsetgo_query_filter_render_checkbox( $designsetgo_filter_wrapper, $designsetgo_filter_param, $designsetgo_filter_label, $designsetgo_filter_taxonomy, $designsetgo_counts_enabled, $designsetgo_active_filters_by_key, $designsetgo_query_post_type, $designsetgo_filter_orientation, $designsetgo_filter_style );
 		break;
 }

--- a/src/blocks/query-group-header/render.php
+++ b/src/blocks/query-group-header/render.php
@@ -16,16 +16,30 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$allowed_tags = array( 'header', 'div', 'section' );
-$tag          = isset( $attributes['tagName'] ) && in_array( $attributes['tagName'], $allowed_tags, true )
-	? $attributes['tagName']
-	: 'header';
+if ( ! function_exists( 'designsetgo_render_query_group_header' ) ) {
+	/**
+	 * Render the Query Group Header block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Inner block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return void
+	 */
+	function designsetgo_render_query_group_header( $attributes, $content, $block ) {
+		$allowed_tags = array( 'header', 'div', 'section' );
+		$tag          = isset( $attributes['tagName'] ) && in_array( $attributes['tagName'], $allowed_tags, true )
+			? $attributes['tagName']
+			: 'header';
 
-$wrapper = get_block_wrapper_attributes( array( 'class' => 'dsgo-query-group-header' ) );
+		$wrapper = get_block_wrapper_attributes( array( 'class' => 'dsgo-query-group-header' ) );
 
-printf(
-	'<%1$s %2$s>%3$s</%1$s>',
-	$tag, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- validated against allowlist above.
-	$wrapper, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	$content  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- innerBlocks HTML is WP-sanitized on save.
-);
+		printf(
+			'<%1$s %2$s>%3$s</%1$s>',
+			$tag, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- validated against allowlist above.
+			$wrapper, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			$content  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- innerBlocks HTML is WP-sanitized on save.
+		);
+	}
+}
+
+designsetgo_render_query_group_header( $attributes, $content, $block );

--- a/src/blocks/query-no-results/render.php
+++ b/src/blocks/query-no-results/render.php
@@ -16,34 +16,48 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$query_id = isset( $block->context['designsetgo/queryId'] )
-	? sanitize_key( (string) $block->context['designsetgo/queryId'] )
-	: '';
+if ( ! function_exists( 'designsetgo_render_query_no_results' ) ) {
+	/**
+	 * Render the Query No-Results block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Inner block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return void
+	 */
+	function designsetgo_render_query_no_results( $attributes, $content, $block ) {
+		$query_id = isset( $block->context['designsetgo/queryId'] )
+			? sanitize_key( (string) $block->context['designsetgo/queryId'] )
+			: '';
 
-if ( '' === $query_id ) {
-	return;
+		if ( '' === $query_id ) {
+			return;
+		}
+
+		$helpers = DESIGNSETGO_PATH . 'build/blocks/query/render-helpers.php';
+		if ( ! file_exists( $helpers ) ) {
+			return;
+		}
+		require_once $helpers;
+
+		$state = designsetgo_query_get_last_state( $query_id );
+
+		// Only render when the parent query had zero items.
+		if ( ! $state || (int) $state['totalItems'] > 0 ) {
+			return;
+		}
+
+		// $content already contains the authored innerBlocks HTML from save().
+		// Wrap with block-wrapper attrs so native supports apply.
+		$wrapper = get_block_wrapper_attributes(
+			array( 'class' => 'dsgo-query-no-results' )
+		);
+		printf(
+			'<div %1$s>%2$s</div>',
+			$wrapper, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			$content // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- innerBlocks HTML is WP-sanitized on save.
+		);
+	}
 }
 
-$helpers = DESIGNSETGO_PATH . 'build/blocks/query/render-helpers.php';
-if ( ! file_exists( $helpers ) ) {
-	return;
-}
-require_once $helpers;
-
-$state = designsetgo_query_get_last_state( $query_id );
-
-// Only render when the parent query had zero items.
-if ( ! $state || (int) $state['totalItems'] > 0 ) {
-	return;
-}
-
-// $content already contains the authored innerBlocks HTML from save().
-// Wrap with block-wrapper attrs so native supports apply.
-$wrapper = get_block_wrapper_attributes(
-	array( 'class' => 'dsgo-query-no-results' )
-);
-printf(
-	'<div %1$s>%2$s</div>',
-	$wrapper, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	$content // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- innerBlocks HTML is WP-sanitized on save.
-);
+designsetgo_render_query_no_results( $attributes, $content, $block );

--- a/src/blocks/query-pagination/render.php
+++ b/src/blocks/query-pagination/render.php
@@ -16,170 +16,184 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$query_id = isset( $block->context['designsetgo/queryId'] )
-	? sanitize_key( (string) $block->context['designsetgo/queryId'] )
-	: '';
+if ( ! function_exists( 'designsetgo_render_query_pagination' ) ) {
+	/**
+	 * Render the Query Pagination block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Inner block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return void
+	 */
+	function designsetgo_render_query_pagination( $attributes, $content, $block ) {
+		$query_id = isset( $block->context['designsetgo/queryId'] )
+			? sanitize_key( (string) $block->context['designsetgo/queryId'] )
+			: '';
 
-if ( '' === $query_id ) {
-	return;
+		if ( '' === $query_id ) {
+			return;
+		}
+
+		// Helpers must be loaded; they live in build/blocks/query/render-helpers.php.
+		$helpers = DESIGNSETGO_PATH . 'build/blocks/query/render-helpers.php';
+		if ( ! file_exists( $helpers ) ) {
+			return;
+		}
+		require_once $helpers;
+
+		$state = designsetgo_query_get_last_state( $query_id );
+
+		// Determine the effective pagination kind.
+		// paginationKind takes precedence (supports the 'infinite' variation);
+		// falls back to legacy 'mode' attribute for backwards compatibility.
+		$pagination_kind = isset( $attributes['paginationKind'] ) && 'numbered' !== $attributes['paginationKind']
+			? $attributes['paginationKind']
+			: ( isset( $attributes['mode'] ) ? $attributes['mode'] : 'numbered' );
+
+		// Horizontal alignment of the pagination control. Drives the SCSS
+		// `is-align-{left|center|right}` modifier so the numbered flex list / load-more
+		// button / infinite sentinel all honour the setting with a single class.
+		$alignment = isset( $attributes['alignment'] ) && in_array( $attributes['alignment'], array( 'center', 'right' ), true )
+			? $attributes['alignment']
+			: 'left';
+		$align_class = 'is-align-' . $alignment;
+
+		// Single-page guard applies to ALL pagination kinds, including infinite.
+		// Emit nothing for single-page results so no sentinel or button is injected.
+		if ( ! $state || (int) $state['totalPages'] < 2 ) {
+			return;
+		}
+
+		// Infinite scroll: emit the sentinel + hidden fallback button.
+		if ( 'infinite' === $pagination_kind ) {
+			$auto_pause    = isset( $attributes['autoPauseAfter'] ) ? (int) $attributes['autoPauseAfter'] : 3;
+			$sentinel_offset = isset( $attributes['sentinelOffsetPx'] ) ? (int) $attributes['sentinelOffsetPx'] : 200;
+			$btn_label     = ! empty( $attributes['buttonLabelWhenPaused'] )
+				? (string) $attributes['buttonLabelWhenPaused']
+				: __( 'Load more', 'designsetgo' );
+
+			$inf_context = wp_json_encode(
+				array(
+					'queryId'       => $query_id,
+					'autoLoadCount' => 0,
+					'page'          => 1,
+					'busy'          => false,
+					'restUrl'       => esc_url_raw( rest_url( 'designsetgo/v1/query/render' ) ),
+					'nonce'         => wp_create_nonce( 'wp_rest' ),
+				),
+				JSON_HEX_APOS
+			);
+
+			$wrapper = get_block_wrapper_attributes(
+				array(
+					'class'                    => 'dsgo-query-pagination dsgo-query-pagination--infinite ' . $align_class,
+					'data-wp-interactive'      => 'designsetgo/query',
+					'data-dsgo-query-id'       => $query_id,
+					'data-dsgo-pagination'     => 'infinite',
+					'data-dsgo-auto-pause-after' => (string) $auto_pause,
+					'data-dsgo-sentinel-offset'  => (string) $sentinel_offset,
+				)
+			);
+
+			printf(
+				'<div %1$s data-wp-context=\'%2$s\'>' .
+				'<button type="button" class="dsgo-query-pagination__loadmore wp-element-button"' .
+				' data-wp-on--click="actions.loadMore"' .
+				' data-dsgo-label-idle="%3$s"' .
+				' data-dsgo-label-loading="%4$s"' .
+				' hidden>%5$s</button>' .
+				'<div class="dsgo-query-pagination__sentinel" aria-hidden="true" data-wp-init="callbacks.initInfiniteObserver"></div>' .
+				'</div>',
+				$wrapper, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() output.
+				$inf_context, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode output inside single-quoted attr.
+				esc_attr( $btn_label ),
+				esc_attr__( 'Loading\u2026', 'designsetgo' ),
+				esc_html( $btn_label )
+			);
+			return;
+		}
+
+		$pagination_mode = $pagination_kind; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$show_prev_next  = ! isset( $attributes['showPrevNext'] ) || (bool) $attributes['showPrevNext'];
+		$label_load_more = ! empty( $attributes['labelLoadMore'] )
+			? (string) $attributes['labelLoadMore']
+			: __( 'Load more', 'designsetgo' );
+		$label_loading   = ! empty( $attributes['labelLoading'] )
+			? (string) $attributes['labelLoading']
+			: __( 'Loading…', 'designsetgo' );
+
+		if ( 'loadmore' === $pagination_mode ) {
+			// Seed the IAPI context on the pagination wrapper so `getContext()` inside
+			// actions.loadMore resolves ctx.queryId / ctx.page / ctx.busy. Without this
+			// the click handler would see an empty context and silently no-op.
+			// JSON_HEX_APOS defends the single-quoted attr boundary against a stray
+			// apostrophe in any future context value.
+			$lm_context = wp_json_encode(
+				array(
+					'queryId' => $query_id,
+					'page'    => 1,
+					'busy'    => false,
+					'restUrl' => esc_url_raw( rest_url( 'designsetgo/v1/query/render' ) ),
+					'nonce'   => wp_create_nonce( 'wp_rest' ),
+				),
+				JSON_HEX_APOS
+			);
+			$wrapper = get_block_wrapper_attributes(
+				array(
+					'class'                => 'dsgo-query-pagination dsgo-query-pagination--loadmore ' . $align_class,
+					'data-wp-interactive'  => 'designsetgo/query',
+					'data-dsgo-query-id'   => $query_id,
+					'data-dsgo-pagination' => 'loadmore',
+				)
+			);
+			printf(
+				'<div %1$s data-wp-context=\'%5$s\'><button type="button" class="dsgo-query-pagination__loadmore wp-element-button" data-wp-on--click="actions.loadMore" data-dsgo-label-idle="%3$s" data-dsgo-label-loading="%4$s">%2$s</button></div>',
+				$wrapper, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() output.
+				esc_html( $label_load_more ),
+				esc_attr( $label_load_more ),
+				esc_attr( $label_loading ),
+				$lm_context // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode output inside single-quoted attr.
+			);
+			return;
+		}
+
+		// Numbered pagination.
+		$current = max( 1, (int) get_query_var( 'paged' ) );
+		if ( 1 === $current ) {
+			// Singular-post paginator uses 'page' not 'paged'.
+			$current = max( 1, (int) get_query_var( 'page' ) );
+		}
+
+		$links = paginate_links(
+			array(
+				'total'     => (int) $state['totalPages'],
+				'current'   => $current,
+				'type'      => 'array',
+				'prev_next' => $show_prev_next,
+			)
+		);
+
+		if ( empty( $links ) || ! is_array( $links ) ) {
+			return;
+		}
+
+		$wrapper = get_block_wrapper_attributes(
+			array(
+				'class'              => 'dsgo-query-pagination dsgo-query-pagination--numbered ' . $align_class,
+				'role'               => 'navigation',
+				'aria-label'         => __( 'Query pagination', 'designsetgo' ),
+				'data-dsgo-query-id' => $query_id,
+			)
+		);
+
+		echo '<nav ' . $wrapper . '>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() output.
+		echo '<ul class="dsgo-query-pagination__list">';
+		foreach ( $links as $page_link ) {
+			// paginate_links() output is already escaped by WordPress core.
+			echo '<li class="dsgo-query-pagination__item">' . $page_link . '</li>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- paginate_links() escapes its output.
+		}
+		echo '</ul></nav>';
+	}
 }
 
-// Helpers must be loaded; they live in build/blocks/query/render-helpers.php.
-$helpers = DESIGNSETGO_PATH . 'build/blocks/query/render-helpers.php';
-if ( ! file_exists( $helpers ) ) {
-	return;
-}
-require_once $helpers;
-
-$state = designsetgo_query_get_last_state( $query_id );
-
-// Determine the effective pagination kind.
-// paginationKind takes precedence (supports the 'infinite' variation);
-// falls back to legacy 'mode' attribute for backwards compatibility.
-$pagination_kind = isset( $attributes['paginationKind'] ) && 'numbered' !== $attributes['paginationKind']
-	? $attributes['paginationKind']
-	: ( isset( $attributes['mode'] ) ? $attributes['mode'] : 'numbered' );
-
-// Horizontal alignment of the pagination control. Drives the SCSS
-// `is-align-{left|center|right}` modifier so the numbered flex list / load-more
-// button / infinite sentinel all honour the setting with a single class.
-$alignment = isset( $attributes['alignment'] ) && in_array( $attributes['alignment'], array( 'center', 'right' ), true )
-	? $attributes['alignment']
-	: 'left';
-$align_class = 'is-align-' . $alignment;
-
-// Single-page guard applies to ALL pagination kinds, including infinite.
-// Emit nothing for single-page results so no sentinel or button is injected.
-if ( ! $state || (int) $state['totalPages'] < 2 ) {
-	return;
-}
-
-// Infinite scroll: emit the sentinel + hidden fallback button.
-if ( 'infinite' === $pagination_kind ) {
-	$auto_pause    = isset( $attributes['autoPauseAfter'] ) ? (int) $attributes['autoPauseAfter'] : 3;
-	$sentinel_offset = isset( $attributes['sentinelOffsetPx'] ) ? (int) $attributes['sentinelOffsetPx'] : 200;
-	$btn_label     = ! empty( $attributes['buttonLabelWhenPaused'] )
-		? (string) $attributes['buttonLabelWhenPaused']
-		: __( 'Load more', 'designsetgo' );
-
-	$inf_context = wp_json_encode(
-		array(
-			'queryId'       => $query_id,
-			'autoLoadCount' => 0,
-			'page'          => 1,
-			'busy'          => false,
-			'restUrl'       => esc_url_raw( rest_url( 'designsetgo/v1/query/render' ) ),
-			'nonce'         => wp_create_nonce( 'wp_rest' ),
-		),
-		JSON_HEX_APOS
-	);
-
-	$wrapper = get_block_wrapper_attributes(
-		array(
-			'class'                    => 'dsgo-query-pagination dsgo-query-pagination--infinite ' . $align_class,
-			'data-wp-interactive'      => 'designsetgo/query',
-			'data-dsgo-query-id'       => $query_id,
-			'data-dsgo-pagination'     => 'infinite',
-			'data-dsgo-auto-pause-after' => (string) $auto_pause,
-			'data-dsgo-sentinel-offset'  => (string) $sentinel_offset,
-		)
-	);
-
-	printf(
-		'<div %1$s data-wp-context=\'%2$s\'>' .
-		'<button type="button" class="dsgo-query-pagination__loadmore wp-element-button"' .
-		' data-wp-on--click="actions.loadMore"' .
-		' data-dsgo-label-idle="%3$s"' .
-		' data-dsgo-label-loading="%4$s"' .
-		' hidden>%5$s</button>' .
-		'<div class="dsgo-query-pagination__sentinel" aria-hidden="true" data-wp-init="callbacks.initInfiniteObserver"></div>' .
-		'</div>',
-		$wrapper, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() output.
-		$inf_context, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode output inside single-quoted attr.
-		esc_attr( $btn_label ),
-		esc_attr__( 'Loading\u2026', 'designsetgo' ),
-		esc_html( $btn_label )
-	);
-	return;
-}
-
-$pagination_mode = $pagination_kind; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-$show_prev_next  = ! isset( $attributes['showPrevNext'] ) || (bool) $attributes['showPrevNext'];
-$label_load_more = ! empty( $attributes['labelLoadMore'] )
-	? (string) $attributes['labelLoadMore']
-	: __( 'Load more', 'designsetgo' );
-$label_loading   = ! empty( $attributes['labelLoading'] )
-	? (string) $attributes['labelLoading']
-	: __( 'Loading…', 'designsetgo' );
-
-if ( 'loadmore' === $pagination_mode ) {
-	// Seed the IAPI context on the pagination wrapper so `getContext()` inside
-	// actions.loadMore resolves ctx.queryId / ctx.page / ctx.busy. Without this
-	// the click handler would see an empty context and silently no-op.
-	// JSON_HEX_APOS defends the single-quoted attr boundary against a stray
-	// apostrophe in any future context value.
-	$lm_context = wp_json_encode(
-		array(
-			'queryId' => $query_id,
-			'page'    => 1,
-			'busy'    => false,
-			'restUrl' => esc_url_raw( rest_url( 'designsetgo/v1/query/render' ) ),
-			'nonce'   => wp_create_nonce( 'wp_rest' ),
-		),
-		JSON_HEX_APOS
-	);
-	$wrapper = get_block_wrapper_attributes(
-		array(
-			'class'                => 'dsgo-query-pagination dsgo-query-pagination--loadmore ' . $align_class,
-			'data-wp-interactive'  => 'designsetgo/query',
-			'data-dsgo-query-id'   => $query_id,
-			'data-dsgo-pagination' => 'loadmore',
-		)
-	);
-	printf(
-		'<div %1$s data-wp-context=\'%5$s\'><button type="button" class="dsgo-query-pagination__loadmore wp-element-button" data-wp-on--click="actions.loadMore" data-dsgo-label-idle="%3$s" data-dsgo-label-loading="%4$s">%2$s</button></div>',
-		$wrapper, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() output.
-		esc_html( $label_load_more ),
-		esc_attr( $label_load_more ),
-		esc_attr( $label_loading ),
-		$lm_context // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode output inside single-quoted attr.
-	);
-	return;
-}
-
-// Numbered pagination.
-$current = max( 1, (int) get_query_var( 'paged' ) );
-if ( 1 === $current ) {
-	// Singular-post paginator uses 'page' not 'paged'.
-	$current = max( 1, (int) get_query_var( 'page' ) );
-}
-
-$links = paginate_links(
-	array(
-		'total'     => (int) $state['totalPages'],
-		'current'   => $current,
-		'type'      => 'array',
-		'prev_next' => $show_prev_next,
-	)
-);
-
-if ( empty( $links ) || ! is_array( $links ) ) {
-	return;
-}
-
-$wrapper = get_block_wrapper_attributes(
-	array(
-		'class'              => 'dsgo-query-pagination dsgo-query-pagination--numbered ' . $align_class,
-		'role'               => 'navigation',
-		'aria-label'         => __( 'Query pagination', 'designsetgo' ),
-		'data-dsgo-query-id' => $query_id,
-	)
-);
-
-echo '<nav ' . $wrapper . '>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() output.
-echo '<ul class="dsgo-query-pagination__list">';
-foreach ( $links as $page_link ) {
-	// paginate_links() output is already escaped by WordPress core.
-	echo '<li class="dsgo-query-pagination__item">' . $page_link . '</li>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- paginate_links() escapes its output.
-}
-echo '</ul></nav>';
+designsetgo_render_query_pagination( $attributes, $content, $block );

--- a/src/blocks/query-results/render.php
+++ b/src/blocks/query-results/render.php
@@ -18,18 +18,32 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$query_id = isset( $block->context['designsetgo/queryId'] )
-	? sanitize_key( (string) $block->context['designsetgo/queryId'] )
-	: '';
+if ( ! function_exists( 'designsetgo_render_query_results' ) ) {
+	/**
+	 * Render the Query Results block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Inner block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return void
+	 */
+	function designsetgo_render_query_results( $attributes, $content, $block ) {
+		$query_id = isset( $block->context['designsetgo/queryId'] )
+			? sanitize_key( (string) $block->context['designsetgo/queryId'] )
+			: '';
 
-if ( '' === $query_id ) {
-	return;
+		if ( '' === $query_id ) {
+			return;
+		}
+
+		// The parent Query block's render.php pre-renders the items grid and stashes
+		// the HTML here keyed by queryId. That lets the parent run a single WP_Query
+		// and populate the state registry (for sibling pagination / no-results)
+		// before any child block renders.
+		if ( isset( $GLOBALS['designsetgo_query_results_html'][ $query_id ] ) ) {
+			echo $GLOBALS['designsetgo_query_results_html'][ $query_id ]; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered by parent query block's render.php.
+		}
+	}
 }
 
-// The parent Query block's render.php pre-renders the items grid and stashes
-// the HTML here keyed by queryId. That lets the parent run a single WP_Query
-// and populate the state registry (for sibling pagination / no-results)
-// before any child block renders.
-if ( isset( $GLOBALS['designsetgo_query_results_html'][ $query_id ] ) ) {
-	echo $GLOBALS['designsetgo_query_results_html'][ $query_id ]; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered by parent query block's render.php.
-}
+designsetgo_render_query_results( $attributes, $content, $block );

--- a/src/blocks/query/render.php
+++ b/src/blocks/query/render.php
@@ -33,21 +33,21 @@ if ( function_exists( 'wp_enqueue_script_module' ) ) {
 	wp_enqueue_script_module( 'designsetgo-query-view-script-module' );
 }
 
-$dsgo_page = max( 1, absint( get_query_var( 'paged' ) ) );
-if ( 1 === $dsgo_page ) {
-	$dsgo_page = max( 1, absint( get_query_var( 'page' ) ) );
+$designsetgo_page = max( 1, absint( get_query_var( 'paged' ) ) );
+if ( 1 === $designsetgo_page ) {
+	$designsetgo_page = max( 1, absint( get_query_var( 'page' ) ) );
 }
 
-$dsgo_query_id = isset( $attributes['queryId'] ) ? sanitize_key( (string) $attributes['queryId'] ) : '';
+$designsetgo_query_id = isset( $attributes['queryId'] ) ? sanitize_key( (string) $attributes['queryId'] ) : '';
 
-$dsgo_parsed_children = isset( $block->parsed_block['innerBlocks'] )
+$designsetgo_parsed_children = isset( $block->parsed_block['innerBlocks'] )
 	? (array) $block->parsed_block['innerBlocks']
 	: array();
 
 // Block wrapper attrs carry native-supports classes / styles / anchor id +
 // author-supplied className. We append IAPI attrs inline so the region
 // lives on a single element, giving view.js a clean swap target.
-$dsgo_wrapper_attrs = get_block_wrapper_attributes(
+$designsetgo_wrapper_attrs = get_block_wrapper_attributes(
 	array(
 		'class' => 'dsgo-query dsgo-query-region dsgo-query--source-' . sanitize_key( (string) ( $attributes['source'] ?? 'posts' ) ),
 	)
@@ -55,9 +55,9 @@ $dsgo_wrapper_attrs = get_block_wrapper_attributes(
 
 echo designsetgo_query_render_container( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- assembled from WP_Block->render() output + esc_attr()-escaped parts.
 	(array) $attributes,
-	$dsgo_parsed_children,
-	$dsgo_page,
-	$dsgo_query_id,
-	$dsgo_wrapper_attrs,
+	$designsetgo_parsed_children,
+	$designsetgo_page,
+	$designsetgo_query_id,
+	$designsetgo_wrapper_attrs,
 	(array) ( $block->context ?? array() )
 );

--- a/src/blocks/scroll-slide/render.php
+++ b/src/blocks/scroll-slide/render.php
@@ -31,44 +31,58 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( empty( $GLOBALS['designsetgo_parent_stack'] ) || ! is_array( $GLOBALS['designsetgo_parent_stack'] ) ) {
-	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
-	return;
-}
+if ( ! function_exists( 'designsetgo_render_scroll_slide' ) ) {
+	/**
+	 * Render the Scroll Slide block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Inner block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return void
+	 */
+	function designsetgo_render_scroll_slide( $attributes, $content, $block ) {
+		if ( empty( $GLOBALS['designsetgo_parent_stack'] ) || ! is_array( $GLOBALS['designsetgo_parent_stack'] ) ) {
+			echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
+			return;
+		}
 
-$top           = end( $GLOBALS['designsetgo_parent_stack'] );
-$iterated_post = is_array( $top ) && isset( $top['postId'] ) ? (int) $top['postId'] : 0;
+		$top           = end( $GLOBALS['designsetgo_parent_stack'] );
+		$iterated_post = is_array( $top ) && isset( $top['postId'] ) ? (int) $top['postId'] : 0;
 
-if ( ! $iterated_post || ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
-	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
-	return;
-}
+		if ( ! $iterated_post || ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
+			echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
+			return;
+		}
 
-$iterated_title = get_the_title( $iterated_post );
-$thumb          = get_the_post_thumbnail_url( $iterated_post, 'full' );
+		$iterated_title = get_the_title( $iterated_post );
+		$thumb          = get_the_post_thumbnail_url( $iterated_post, 'full' );
 
-$processor = new WP_HTML_Tag_Processor( $content );
-if ( ! $processor->next_tag( array( 'class_name' => 'dsgo-scroll-slide' ) ) ) {
-	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
-	return;
-}
+		$processor = new WP_HTML_Tag_Processor( $content );
+		if ( ! $processor->next_tag( array( 'class_name' => 'dsgo-scroll-slide' ) ) ) {
+			echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
+			return;
+		}
 
-if ( '' !== $iterated_title ) {
-	$processor->set_attribute( 'data-dsgo-nav-heading', $iterated_title );
-}
+		if ( '' !== $iterated_title ) {
+			$processor->set_attribute( 'data-dsgo-nav-heading', $iterated_title );
+		}
 
-if ( $thumb ) {
-	$existing_style = (string) $processor->get_attribute( 'style' );
-	// Only inject if the author hasn't already set a background image via
-	// block supports. Case-insensitive check on the property name catches
-	// `background-image` and the `background:` shorthand alike.
-	if ( false === stripos( $existing_style, 'background-image' ) && false === stripos( $existing_style, 'background:' ) ) {
-		$injected = sprintf( "background-image:url('%s');background-size:cover;background-position:center;", esc_url( $thumb ) );
-		$merged   = '' === trim( $existing_style )
-			? $injected
-			: rtrim( $existing_style, "; \t\n\r\0\x0B" ) . ';' . $injected;
-		$processor->set_attribute( 'style', $merged );
+		if ( $thumb ) {
+			$existing_style = (string) $processor->get_attribute( 'style' );
+			// Only inject if the author hasn't already set a background image via
+			// block supports. Case-insensitive check on the property name catches
+			// `background-image` and the `background:` shorthand alike.
+			if ( false === stripos( $existing_style, 'background-image' ) && false === stripos( $existing_style, 'background:' ) ) {
+				$injected = sprintf( "background-image:url('%s');background-size:cover;background-position:center;", esc_url( $thumb ) );
+				$merged   = '' === trim( $existing_style )
+					? $injected
+					: rtrim( $existing_style, "; \t\n\r\0\x0B" ) . ';' . $injected;
+				$processor->set_attribute( 'style', $merged );
+			}
+		}
+
+		echo $processor->get_updated_html(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Tag_Processor output.
 	}
 }
 
-echo $processor->get_updated_html(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Tag_Processor output.
+designsetgo_render_scroll_slide( $attributes, $content, $block );

--- a/src/blocks/scroll-slides/render.php
+++ b/src/blocks/scroll-slides/render.php
@@ -26,129 +26,143 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$query_id = '';
-if ( isset( $block->context['designsetgo/queryId'] ) ) {
-	$query_id = sanitize_key( (string) $block->context['designsetgo/queryId'] );
-}
+if ( ! function_exists( 'designsetgo_render_scroll_slides' ) ) {
+	/**
+	 * Render the Scroll Slides block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Inner block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return void
+	 */
+	function designsetgo_render_scroll_slides( $attributes, $content, $block ) {
+		$query_id = '';
+		if ( isset( $block->context['designsetgo/queryId'] ) ) {
+			$query_id = sanitize_key( (string) $block->context['designsetgo/queryId'] );
+		}
 
-// Authored mode — pass through unchanged. block.json `render` captures the
-// output buffer so we ECHO rather than return.
-if ( '' === $query_id ) {
-	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
-	return;
-}
+		// Authored mode — pass through unchanged. block.json `render` captures the
+		// output buffer so we ECHO rather than return.
+		if ( '' === $query_id ) {
+			echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
+			return;
+		}
 
-// Query mode — pull pre-rendered items from the parent container's stash.
-// Inner blocks render before their parent's render_callback fires, so we
-// can't rely on the query container having loaded the shared helpers yet.
-$helpers = DESIGNSETGO_PATH . 'build/blocks/query/render-helpers.php';
-if ( ! file_exists( $helpers ) ) {
-	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
-	return;
-}
-require_once $helpers;
+		// Query mode — pull pre-rendered items from the parent container's stash.
+		// Inner blocks render before their parent's render_callback fires, so we
+		// can't rely on the query container having loaded the shared helpers yet.
+		$helpers = DESIGNSETGO_PATH . 'build/blocks/query/render-helpers.php';
+		if ( ! file_exists( $helpers ) ) {
+			echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
+			return;
+		}
+		require_once $helpers;
 
-$items_html = '';
-if ( isset( $GLOBALS['designsetgo_query_items_html'][ $query_id ] ) ) {
-	$items_html = (string) $GLOBALS['designsetgo_query_items_html'][ $query_id ];
-}
+		$items_html = '';
+		if ( isset( $GLOBALS['designsetgo_query_items_html'][ $query_id ] ) ) {
+			$items_html = (string) $GLOBALS['designsetgo_query_items_html'][ $query_id ];
+		}
 
-$atts = wp_parse_args(
-	$attributes,
-	array(
-		'minHeight'      => '100vh',
-		'maxHeight'      => '900px',
-		'constrainWidth' => true,
-		'contentWidth'   => '',
-		'overlayColor'   => '',
-		'navColor'       => '',
-		'navActiveColor' => '',
-	)
-);
+		$atts = wp_parse_args(
+			$attributes,
+			array(
+				'minHeight'      => '100vh',
+				'maxHeight'      => '900px',
+				'constrainWidth' => true,
+				'contentWidth'   => '',
+				'overlayColor'   => '',
+				'navColor'       => '',
+				'navActiveColor' => '',
+			)
+		);
 
-// Minimal parity with save.js's convertColorToCSSVar(): convert the WP preset
-// shorthand (`var:preset|color|slug`) to a real `var(...)`, otherwise pass
-// through as-is (hex/rgb/CSS keywords already work inline).
-//
-// Both branches run the final value through designsetgo_safe_css_value() so a
-// stored color like `red; content:'x'` or a crafted slug like `slug);}` can't
-// escape the `--prop: VALUE` declaration. Preset slug segments are also
-// constrained via sanitize_html_class() so only identifier characters survive.
-$color_to_css = static function ( $value ) {
-	$value = (string) $value;
-	if ( '' === $value ) {
-		return '';
+		// Minimal parity with save.js's convertColorToCSSVar(): convert the WP preset
+		// shorthand (`var:preset|color|slug`) to a real `var(...)`, otherwise pass
+		// through as-is (hex/rgb/CSS keywords already work inline).
+		//
+		// Both branches run the final value through designsetgo_safe_css_value() so a
+		// stored color like `red; content:'x'` or a crafted slug like `slug);}` can't
+		// escape the `--prop: VALUE` declaration. Preset slug segments are also
+		// constrained via sanitize_html_class() so only identifier characters survive.
+		$color_to_css = static function ( $value ) {
+			$value = (string) $value;
+			if ( '' === $value ) {
+				return '';
+			}
+			if ( 0 === strpos( $value, 'var:preset|' ) ) {
+				$parts  = explode( '|', substr( $value, strlen( 'var:preset|' ) ) );
+				$parts  = array_filter( array_map( 'sanitize_html_class', $parts ) );
+				$result = 'var(--wp--preset--' . implode( '--', $parts ) . ')';
+				return designsetgo_safe_css_value( $result );
+			}
+			return designsetgo_safe_css_value( $value );
+		};
+
+		$classes = array( 'dsgo-scroll-slides' );
+		if ( '' !== $atts['overlayColor'] ) {
+			$classes[] = 'dsgo-scroll-slides--has-overlay';
+		}
+		if ( empty( $atts['constrainWidth'] ) ) {
+			$classes[] = 'dsgo-scroll-slides--no-width-constraint';
+		}
+		if ( '' !== $atts['navColor'] || '' !== $atts['navActiveColor'] ) {
+			$classes[] = 'dsgo-scroll-slides--has-nav-color';
+		}
+
+		$style_parts = array();
+		if ( '' !== $atts['overlayColor'] ) {
+			$style_parts[] = '--dsgo-overlay-color:' . $color_to_css( $atts['overlayColor'] );
+			$style_parts[] = '--dsgo-overlay-opacity:0.8';
+		}
+		if ( '' !== $atts['navColor'] ) {
+			$style_parts[] = '--dsgo-nav-color:' . $color_to_css( $atts['navColor'] );
+		}
+		if ( '' !== $atts['navActiveColor'] ) {
+			$style_parts[] = '--dsgo-nav-active-color:' . $color_to_css( $atts['navActiveColor'] );
+		}
+		$style_inline = implode( ';', $style_parts );
+		if ( '' !== $style_inline ) {
+			$style_inline .= ';';
+		}
+
+		$min_height = designsetgo_safe_css_value( $atts['minHeight'] );
+		if ( '' === $min_height ) {
+			$min_height = '100vh';
+		}
+		$wrapper_attrs_list = array(
+			'class'                => implode( ' ', $classes ),
+			'data-dsgo-min-height' => $min_height,
+		);
+		if ( '' !== $atts['maxHeight'] ) {
+			$max_h = designsetgo_safe_css_value( $atts['maxHeight'] );
+			if ( '' !== $max_h ) {
+				$wrapper_attrs_list['data-dsgo-max-height'] = $max_h;
+			}
+		}
+		if ( '' !== $style_inline ) {
+			$wrapper_attrs_list['style'] = $style_inline;
+		}
+
+		$wrapper_attrs = get_block_wrapper_attributes( $wrapper_attrs_list );
+
+		$inner_style = '';
+		if ( ! empty( $atts['constrainWidth'] ) ) {
+			$max_width = $atts['contentWidth'] !== ''
+				? designsetgo_safe_css_value( $atts['contentWidth'] )
+				: 'var(--wp--style--global--content-size, 1140px)';
+			if ( '' === $max_width ) {
+				$max_width = 'var(--wp--style--global--content-size, 1140px)';
+			}
+			$inner_style = ' style="max-width:' . esc_attr( $max_width ) . ';margin-left:auto;margin-right:auto"';
+		}
+
+		printf(
+			'<div %1$s><div class="dsgo-scroll-slides__inner"%2$s><div class="dsgo-scroll-slides__panels">%3$s</div></div></div>',
+			$wrapper_attrs, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped via get_block_wrapper_attributes().
+			$inner_style,   // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- assembled from esc_attr().
+			$items_html     // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- items rendered via WP_Block (WP escapes server-side).
+		);
 	}
-	if ( 0 === strpos( $value, 'var:preset|' ) ) {
-		$parts  = explode( '|', substr( $value, strlen( 'var:preset|' ) ) );
-		$parts  = array_filter( array_map( 'sanitize_html_class', $parts ) );
-		$result = 'var(--wp--preset--' . implode( '--', $parts ) . ')';
-		return designsetgo_safe_css_value( $result );
-	}
-	return designsetgo_safe_css_value( $value );
-};
-
-$classes = array( 'dsgo-scroll-slides' );
-if ( '' !== $atts['overlayColor'] ) {
-	$classes[] = 'dsgo-scroll-slides--has-overlay';
-}
-if ( empty( $atts['constrainWidth'] ) ) {
-	$classes[] = 'dsgo-scroll-slides--no-width-constraint';
-}
-if ( '' !== $atts['navColor'] || '' !== $atts['navActiveColor'] ) {
-	$classes[] = 'dsgo-scroll-slides--has-nav-color';
 }
 
-$style_parts = array();
-if ( '' !== $atts['overlayColor'] ) {
-	$style_parts[] = '--dsgo-overlay-color:' . $color_to_css( $atts['overlayColor'] );
-	$style_parts[] = '--dsgo-overlay-opacity:0.8';
-}
-if ( '' !== $atts['navColor'] ) {
-	$style_parts[] = '--dsgo-nav-color:' . $color_to_css( $atts['navColor'] );
-}
-if ( '' !== $atts['navActiveColor'] ) {
-	$style_parts[] = '--dsgo-nav-active-color:' . $color_to_css( $atts['navActiveColor'] );
-}
-$style_inline = implode( ';', $style_parts );
-if ( '' !== $style_inline ) {
-	$style_inline .= ';';
-}
-
-$min_height = designsetgo_safe_css_value( $atts['minHeight'] );
-if ( '' === $min_height ) {
-	$min_height = '100vh';
-}
-$wrapper_attrs_list = array(
-	'class'                => implode( ' ', $classes ),
-	'data-dsgo-min-height' => $min_height,
-);
-if ( '' !== $atts['maxHeight'] ) {
-	$max_h = designsetgo_safe_css_value( $atts['maxHeight'] );
-	if ( '' !== $max_h ) {
-		$wrapper_attrs_list['data-dsgo-max-height'] = $max_h;
-	}
-}
-if ( '' !== $style_inline ) {
-	$wrapper_attrs_list['style'] = $style_inline;
-}
-
-$wrapper_attrs = get_block_wrapper_attributes( $wrapper_attrs_list );
-
-$inner_style = '';
-if ( ! empty( $atts['constrainWidth'] ) ) {
-	$max_width = $atts['contentWidth'] !== ''
-		? designsetgo_safe_css_value( $atts['contentWidth'] )
-		: 'var(--wp--style--global--content-size, 1140px)';
-	if ( '' === $max_width ) {
-		$max_width = 'var(--wp--style--global--content-size, 1140px)';
-	}
-	$inner_style = ' style="max-width:' . esc_attr( $max_width ) . ';margin-left:auto;margin-right:auto"';
-}
-
-printf(
-	'<div %1$s><div class="dsgo-scroll-slides__inner"%2$s><div class="dsgo-scroll-slides__panels">%3$s</div></div></div>',
-	$wrapper_attrs, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped via get_block_wrapper_attributes().
-	$inner_style,   // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- assembled from esc_attr().
-	$items_html     // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- items rendered via WP_Block (WP escapes server-side).
-);
+designsetgo_render_scroll_slides( $attributes, $content, $block );

--- a/src/blocks/slider/render.php
+++ b/src/blocks/slider/render.php
@@ -28,202 +28,216 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$query_id = '';
-if ( isset( $block->context['designsetgo/queryId'] ) ) {
-	$query_id = sanitize_key( (string) $block->context['designsetgo/queryId'] );
+if ( ! function_exists( 'designsetgo_render_slider' ) ) {
+	/**
+	 * Render the Slider block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Inner block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return void
+	 */
+	function designsetgo_render_slider( $attributes, $content, $block ) {
+		$query_id = '';
+		if ( isset( $block->context['designsetgo/queryId'] ) ) {
+			$query_id = sanitize_key( (string) $block->context['designsetgo/queryId'] );
+		}
+
+		// Authored mode — slider behaves exactly as it did before the query integration.
+		// block.json `render` wires this file as a render_callback that captures its
+		// output buffer (require + ob_get_clean). So we ECHO rather than return.
+		if ( '' === $query_id ) {
+			echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
+			return;
+		}
+
+		// Query mode — pull pre-rendered items from the parent container's stash.
+		// Inner blocks render before their parent's render_callback fires, so we
+		// can't rely on the query container having loaded the shared helpers yet.
+		$helpers = DESIGNSETGO_PATH . 'build/blocks/query/render-helpers.php';
+		if ( ! file_exists( $helpers ) ) {
+			echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
+			return;
+		}
+		require_once $helpers;
+
+		$items_html = '';
+		if ( isset( $GLOBALS['designsetgo_query_items_html'][ $query_id ] ) ) {
+			$items_html = (string) $GLOBALS['designsetgo_query_items_html'][ $query_id ];
+		}
+
+		$atts = wp_parse_args(
+			$attributes,
+			array(
+				'slidesPerView'         => 1,
+				'slidesPerViewTablet'   => 1,
+				'slidesPerViewMobile'   => 1,
+				'height'                => '',
+				'aspectRatio'           => '16/9',
+				'useAspectRatio'        => false,
+				'gap'                   => '20px',
+				'showArrows'            => true,
+				'showDots'              => true,
+				'arrowStyle'            => 'default',
+				'arrowPosition'         => 'sides',
+				'arrowVerticalPosition' => 'center',
+				'arrowColor'            => '',
+				'arrowBackgroundColor'  => '',
+				'arrowSize'             => '24px',
+				'arrowPadding'          => '',
+				'dotStyle'              => 'default',
+				'dotPosition'           => 'inside',
+				'dotColor'              => '',
+				'effect'                => 'slide',
+				'transitionDuration'    => '0.5s',
+				'transitionEasing'      => 'ease-in-out',
+				'autoplay'              => false,
+				'autoplayInterval'      => 3000,
+				'pauseOnHover'          => true,
+				'pauseOnInteraction'    => true,
+				'loop'                  => true,
+				'draggable'             => true,
+				'swipeable'             => true,
+				'freeMode'              => false,
+				'centeredSlides'        => false,
+				'mobileBreakpoint'      => 768,
+				'tabletBreakpoint'      => 1024,
+				'activeSlide'           => 0,
+				'styleVariation'        => 'classic',
+				'ariaLabel'             => '',
+				'scrollDriven'          => false,
+				'scrollDrivenSpeed'     => 1,
+			)
+		);
+
+		// Effects that force a single slide per view (mirrors SINGLE_SLIDE_EFFECTS in save.js).
+		$single_effects = array( 'fade', 'zoom' );
+		$forces_single  = in_array( $atts['effect'], $single_effects, true );
+
+		$spv        = $forces_single ? 1 : (int) $atts['slidesPerView'];
+		$spv_tablet = $forces_single ? 1 : (int) $atts['slidesPerViewTablet'];
+		$spv_mobile = $forces_single ? 1 : (int) $atts['slidesPerViewMobile'];
+
+		// Build class list. Order matches save.js for snapshot-friendly diffs.
+		$classes = array( 'dsgo-slider' );
+		if ( ! empty( $atts['styleVariation'] ) ) {
+			$classes[] = 'dsgo-slider--' . sanitize_html_class( (string) $atts['styleVariation'] );
+		}
+		if ( ! empty( $atts['effect'] ) ) {
+			$classes[] = 'dsgo-slider--effect-' . sanitize_html_class( (string) $atts['effect'] );
+		}
+		if ( $atts['showArrows'] ) {
+			$classes[] = 'dsgo-slider--has-arrows';
+		}
+		if ( $atts['showDots'] ) {
+			$classes[] = 'dsgo-slider--has-dots';
+		}
+		if ( $atts['centeredSlides'] ) {
+			$classes[] = 'dsgo-slider--centered';
+		}
+		if ( $atts['freeMode'] ) {
+			$classes[] = 'dsgo-slider--free-mode';
+		}
+		if ( $atts['scrollDriven'] ) {
+			$classes[] = 'dsgo-slider--scroll-driven';
+		}
+
+		// CSS custom properties. Each attribute passes through designsetgo_safe_css_value()
+		// so a stored value like `20px; --dsgo-slider-slides-per-view:99` can't escape
+		// the declaration context — see render-helpers.php for the rules.
+		$style_parts = array();
+		if ( '' !== $atts['height'] ) {
+			$style_parts[] = '--dsgo-slider-height:' . designsetgo_safe_css_value( $atts['height'] );
+		}
+		$style_parts[] = '--dsgo-slider-aspect-ratio:' . designsetgo_safe_css_value( $atts['aspectRatio'] );
+		$style_parts[] = '--dsgo-slider-gap:' . designsetgo_safe_css_value( $atts['gap'] );
+		$style_parts[] = '--dsgo-slider-transition:' . designsetgo_safe_css_value( $atts['transitionDuration'] );
+		$style_parts[] = '--dsgo-slider-slides-per-view:' . (int) $spv;
+		$style_parts[] = '--dsgo-slider-slides-per-view-tablet:' . (int) $spv_tablet;
+		$style_parts[] = '--dsgo-slider-slides-per-view-mobile:' . (int) $spv_mobile;
+		if ( '' !== $atts['arrowColor'] ) {
+			$style_parts[] = '--dsgo-slider-arrow-color:' . designsetgo_safe_css_value( $atts['arrowColor'] );
+		}
+		if ( '' !== $atts['arrowBackgroundColor'] ) {
+			$style_parts[] = '--dsgo-slider-arrow-bg-color:' . designsetgo_safe_css_value( $atts['arrowBackgroundColor'] );
+		}
+		if ( '' !== $atts['dotColor'] ) {
+			$style_parts[] = '--dsgo-slider-dot-color:' . designsetgo_safe_css_value( $atts['dotColor'] );
+		}
+		if ( '' !== $atts['arrowSize'] ) {
+			$style_parts[] = '--dsgo-slider-arrow-size:' . designsetgo_safe_css_value( $atts['arrowSize'] );
+		}
+		if ( '' !== $atts['arrowPadding'] ) {
+			$style_parts[] = '--dsgo-slider-arrow-padding:' . designsetgo_safe_css_value( $atts['arrowPadding'] );
+		}
+		$style_inline = implode( ';', $style_parts ) . ';';
+
+		// Merge with get_block_wrapper_attributes() so native supports (padding, margin,
+		// color, border, etc.) flow through to query-mode output identically.
+		$wrapper_attrs = get_block_wrapper_attributes(
+			array(
+				'class'                => implode( ' ', $classes ),
+				'style'                => $style_inline,
+				'role'                 => 'region',
+				// Literal fallback mirrors save.js (which does not translate it).
+				// If save.js ever translates the default, match that change here too.
+				'aria-label'           => $atts['ariaLabel'] !== '' ? $atts['ariaLabel'] : 'Image slider',
+				'aria-roledescription' => 'slider',
+			)
+		);
+
+		// Data attributes read by view.js. Booleans serialize as the literal "true"/"false"
+		// strings — matching how React's save.js emits them via JSX attribute props.
+		$bool = static function ( $value ) {
+			return $value ? 'true' : 'false';
+		};
+
+		$data_attrs = array(
+			'data-slides-per-view'         => (string) $spv,
+			'data-slides-per-view-tablet'  => (string) $spv_tablet,
+			'data-slides-per-view-mobile'  => (string) $spv_mobile,
+			'data-use-aspect-ratio'        => $bool( $atts['useAspectRatio'] ),
+			'data-show-arrows'             => $bool( $atts['showArrows'] ),
+			'data-show-dots'               => $bool( $atts['showDots'] ),
+			'data-arrow-style'             => (string) $atts['arrowStyle'],
+			'data-arrow-position'          => (string) $atts['arrowPosition'],
+			'data-arrow-vertical-position' => (string) $atts['arrowVerticalPosition'],
+			'data-dot-style'               => (string) $atts['dotStyle'],
+			'data-dot-position'            => (string) $atts['dotPosition'],
+			'data-effect'                  => (string) $atts['effect'],
+			'data-transition-duration'     => (string) $atts['transitionDuration'],
+			'data-transition-easing'       => (string) $atts['transitionEasing'],
+			'data-autoplay'                => $bool( $atts['autoplay'] ),
+			'data-autoplay-interval'       => (string) (int) $atts['autoplayInterval'],
+			'data-pause-on-hover'          => $bool( $atts['pauseOnHover'] ),
+			'data-pause-on-interaction'    => $bool( $atts['pauseOnInteraction'] ),
+			'data-loop'                    => $bool( $atts['loop'] ),
+			'data-draggable'               => $bool( $atts['draggable'] ),
+			'data-swipeable'               => $bool( $atts['swipeable'] ),
+			'data-free-mode'               => $bool( $atts['freeMode'] ),
+			'data-centered-slides'         => $bool( $atts['centeredSlides'] ),
+			'data-mobile-breakpoint'       => (string) (int) $atts['mobileBreakpoint'],
+			'data-tablet-breakpoint'       => (string) (int) $atts['tabletBreakpoint'],
+			'data-active-slide'            => (string) (int) $atts['activeSlide'],
+		);
+
+		if ( $atts['scrollDriven'] ) {
+			$data_attrs['data-scroll-driven']       = 'true';
+			$data_attrs['data-scroll-driven-speed'] = (string) $atts['scrollDrivenSpeed'];
+		}
+
+		$data_string = '';
+		foreach ( $data_attrs as $k => $v ) {
+			$data_string .= ' ' . esc_attr( $k ) . '="' . esc_attr( $v ) . '"';
+		}
+
+		printf(
+			'<div %1$s%2$s><div class="dsgo-slider__viewport"><div class="dsgo-slider__track">%3$s</div></div></div>',
+			$wrapper_attrs, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped via get_block_wrapper_attributes().
+			$data_string,   // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- assembled from esc_attr() escaped parts.
+			$items_html     // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- items rendered via WP_Block (WP escapes server-side).
+		);
+	}
 }
 
-// Authored mode — slider behaves exactly as it did before the query integration.
-// block.json `render` wires this file as a render_callback that captures its
-// output buffer (require + ob_get_clean). So we ECHO rather than return.
-if ( '' === $query_id ) {
-	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
-	return;
-}
-
-// Query mode — pull pre-rendered items from the parent container's stash.
-// Inner blocks render before their parent's render_callback fires, so we
-// can't rely on the query container having loaded the shared helpers yet.
-$helpers = DESIGNSETGO_PATH . 'build/blocks/query/render-helpers.php';
-if ( ! file_exists( $helpers ) ) {
-	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-rendered save.js output.
-	return;
-}
-require_once $helpers;
-
-$items_html = '';
-if ( isset( $GLOBALS['designsetgo_query_items_html'][ $query_id ] ) ) {
-	$items_html = (string) $GLOBALS['designsetgo_query_items_html'][ $query_id ];
-}
-
-$atts = wp_parse_args(
-	$attributes,
-	array(
-		'slidesPerView'         => 1,
-		'slidesPerViewTablet'   => 1,
-		'slidesPerViewMobile'   => 1,
-		'height'                => '',
-		'aspectRatio'           => '16/9',
-		'useAspectRatio'        => false,
-		'gap'                   => '20px',
-		'showArrows'            => true,
-		'showDots'              => true,
-		'arrowStyle'            => 'default',
-		'arrowPosition'         => 'sides',
-		'arrowVerticalPosition' => 'center',
-		'arrowColor'            => '',
-		'arrowBackgroundColor'  => '',
-		'arrowSize'             => '24px',
-		'arrowPadding'          => '',
-		'dotStyle'              => 'default',
-		'dotPosition'           => 'inside',
-		'dotColor'              => '',
-		'effect'                => 'slide',
-		'transitionDuration'    => '0.5s',
-		'transitionEasing'      => 'ease-in-out',
-		'autoplay'              => false,
-		'autoplayInterval'      => 3000,
-		'pauseOnHover'          => true,
-		'pauseOnInteraction'    => true,
-		'loop'                  => true,
-		'draggable'             => true,
-		'swipeable'             => true,
-		'freeMode'              => false,
-		'centeredSlides'        => false,
-		'mobileBreakpoint'      => 768,
-		'tabletBreakpoint'      => 1024,
-		'activeSlide'           => 0,
-		'styleVariation'        => 'classic',
-		'ariaLabel'             => '',
-		'scrollDriven'          => false,
-		'scrollDrivenSpeed'     => 1,
-	)
-);
-
-// Effects that force a single slide per view (mirrors SINGLE_SLIDE_EFFECTS in save.js).
-$single_effects = array( 'fade', 'zoom' );
-$forces_single  = in_array( $atts['effect'], $single_effects, true );
-
-$spv        = $forces_single ? 1 : (int) $atts['slidesPerView'];
-$spv_tablet = $forces_single ? 1 : (int) $atts['slidesPerViewTablet'];
-$spv_mobile = $forces_single ? 1 : (int) $atts['slidesPerViewMobile'];
-
-// Build class list. Order matches save.js for snapshot-friendly diffs.
-$classes = array( 'dsgo-slider' );
-if ( ! empty( $atts['styleVariation'] ) ) {
-	$classes[] = 'dsgo-slider--' . sanitize_html_class( (string) $atts['styleVariation'] );
-}
-if ( ! empty( $atts['effect'] ) ) {
-	$classes[] = 'dsgo-slider--effect-' . sanitize_html_class( (string) $atts['effect'] );
-}
-if ( $atts['showArrows'] ) {
-	$classes[] = 'dsgo-slider--has-arrows';
-}
-if ( $atts['showDots'] ) {
-	$classes[] = 'dsgo-slider--has-dots';
-}
-if ( $atts['centeredSlides'] ) {
-	$classes[] = 'dsgo-slider--centered';
-}
-if ( $atts['freeMode'] ) {
-	$classes[] = 'dsgo-slider--free-mode';
-}
-if ( $atts['scrollDriven'] ) {
-	$classes[] = 'dsgo-slider--scroll-driven';
-}
-
-// CSS custom properties. Each attribute passes through designsetgo_safe_css_value()
-// so a stored value like `20px; --dsgo-slider-slides-per-view:99` can't escape
-// the declaration context — see render-helpers.php for the rules.
-$style_parts = array();
-if ( '' !== $atts['height'] ) {
-	$style_parts[] = '--dsgo-slider-height:' . designsetgo_safe_css_value( $atts['height'] );
-}
-$style_parts[] = '--dsgo-slider-aspect-ratio:' . designsetgo_safe_css_value( $atts['aspectRatio'] );
-$style_parts[] = '--dsgo-slider-gap:' . designsetgo_safe_css_value( $atts['gap'] );
-$style_parts[] = '--dsgo-slider-transition:' . designsetgo_safe_css_value( $atts['transitionDuration'] );
-$style_parts[] = '--dsgo-slider-slides-per-view:' . (int) $spv;
-$style_parts[] = '--dsgo-slider-slides-per-view-tablet:' . (int) $spv_tablet;
-$style_parts[] = '--dsgo-slider-slides-per-view-mobile:' . (int) $spv_mobile;
-if ( '' !== $atts['arrowColor'] ) {
-	$style_parts[] = '--dsgo-slider-arrow-color:' . designsetgo_safe_css_value( $atts['arrowColor'] );
-}
-if ( '' !== $atts['arrowBackgroundColor'] ) {
-	$style_parts[] = '--dsgo-slider-arrow-bg-color:' . designsetgo_safe_css_value( $atts['arrowBackgroundColor'] );
-}
-if ( '' !== $atts['dotColor'] ) {
-	$style_parts[] = '--dsgo-slider-dot-color:' . designsetgo_safe_css_value( $atts['dotColor'] );
-}
-if ( '' !== $atts['arrowSize'] ) {
-	$style_parts[] = '--dsgo-slider-arrow-size:' . designsetgo_safe_css_value( $atts['arrowSize'] );
-}
-if ( '' !== $atts['arrowPadding'] ) {
-	$style_parts[] = '--dsgo-slider-arrow-padding:' . designsetgo_safe_css_value( $atts['arrowPadding'] );
-}
-$style_inline = implode( ';', $style_parts ) . ';';
-
-// Merge with get_block_wrapper_attributes() so native supports (padding, margin,
-// color, border, etc.) flow through to query-mode output identically.
-$wrapper_attrs = get_block_wrapper_attributes(
-	array(
-		'class'                => implode( ' ', $classes ),
-		'style'                => $style_inline,
-		'role'                 => 'region',
-		// Literal fallback mirrors save.js (which does not translate it).
-		// If save.js ever translates the default, match that change here too.
-		'aria-label'           => $atts['ariaLabel'] !== '' ? $atts['ariaLabel'] : 'Image slider',
-		'aria-roledescription' => 'slider',
-	)
-);
-
-// Data attributes read by view.js. Booleans serialize as the literal "true"/"false"
-// strings — matching how React's save.js emits them via JSX attribute props.
-$bool = static function ( $value ) {
-	return $value ? 'true' : 'false';
-};
-
-$data_attrs = array(
-	'data-slides-per-view'         => (string) $spv,
-	'data-slides-per-view-tablet'  => (string) $spv_tablet,
-	'data-slides-per-view-mobile'  => (string) $spv_mobile,
-	'data-use-aspect-ratio'        => $bool( $atts['useAspectRatio'] ),
-	'data-show-arrows'             => $bool( $atts['showArrows'] ),
-	'data-show-dots'               => $bool( $atts['showDots'] ),
-	'data-arrow-style'             => (string) $atts['arrowStyle'],
-	'data-arrow-position'          => (string) $atts['arrowPosition'],
-	'data-arrow-vertical-position' => (string) $atts['arrowVerticalPosition'],
-	'data-dot-style'               => (string) $atts['dotStyle'],
-	'data-dot-position'            => (string) $atts['dotPosition'],
-	'data-effect'                  => (string) $atts['effect'],
-	'data-transition-duration'     => (string) $atts['transitionDuration'],
-	'data-transition-easing'       => (string) $atts['transitionEasing'],
-	'data-autoplay'                => $bool( $atts['autoplay'] ),
-	'data-autoplay-interval'       => (string) (int) $atts['autoplayInterval'],
-	'data-pause-on-hover'          => $bool( $atts['pauseOnHover'] ),
-	'data-pause-on-interaction'    => $bool( $atts['pauseOnInteraction'] ),
-	'data-loop'                    => $bool( $atts['loop'] ),
-	'data-draggable'               => $bool( $atts['draggable'] ),
-	'data-swipeable'               => $bool( $atts['swipeable'] ),
-	'data-free-mode'               => $bool( $atts['freeMode'] ),
-	'data-centered-slides'         => $bool( $atts['centeredSlides'] ),
-	'data-mobile-breakpoint'       => (string) (int) $atts['mobileBreakpoint'],
-	'data-tablet-breakpoint'       => (string) (int) $atts['tabletBreakpoint'],
-	'data-active-slide'            => (string) (int) $atts['activeSlide'],
-);
-
-if ( $atts['scrollDriven'] ) {
-	$data_attrs['data-scroll-driven']       = 'true';
-	$data_attrs['data-scroll-driven-speed'] = (string) $atts['scrollDrivenSpeed'];
-}
-
-$data_string = '';
-foreach ( $data_attrs as $k => $v ) {
-	$data_string .= ' ' . esc_attr( $k ) . '="' . esc_attr( $v ) . '"';
-}
-
-printf(
-	'<div %1$s%2$s><div class="dsgo-slider__viewport"><div class="dsgo-slider__track">%3$s</div></div></div>',
-	$wrapper_attrs, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped via get_block_wrapper_attributes().
-	$data_string,   // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- assembled from esc_attr() escaped parts.
-	$items_html     // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- items rendered via WP_Block (WP escapes server-side).
-);
+designsetgo_render_slider( $attributes, $content, $block );

--- a/tests/e2e/blocks-prefix-globals.spec.js
+++ b/tests/e2e/blocks-prefix-globals.spec.js
@@ -1,0 +1,212 @@
+/**
+ * E2E Tests for blocks affected by the PrefixAllGlobals refactor (PR #420).
+ *
+ * Each dynamic block's render.php body was wrapped in a prefixed
+ * designsetgo_render_*() function. These tests confirm the blocks still insert
+ * in the editor without a validation warning and render on the frontend after
+ * the refactor.
+ *
+ * Notes:
+ *  - product-showcase-hero needs WooCommerce + a product to render its body,
+ *    which is not installed in the test env, so it is editor-insertion only.
+ */
+
+const { test, expect } = require('@playwright/test');
+const { getEditorCanvas, createNewPost } = require('./helpers/wordpress');
+const {
+	defineArtifact,
+	saveScreenshot,
+	installVideoCapture,
+	slowScrollToBottom,
+	slowScrollEditor,
+	setPostTitle,
+	publishAndResolveUrl,
+} = require('./helpers/artifacts');
+
+installVideoCapture(test);
+
+/**
+ * Insert a block in a fresh page, assert it appears in the editor canvas with
+ * no validation warning, screenshot the editor, then publish and return the
+ * frontend URL.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {object} testInfo
+ * @param {object} options
+ * @param {string} options.title     Post title.
+ * @param {string} options.item      Artifact item path (e.g. 'blocks/slider').
+ * @param {Function} options.build   () => block tree, evaluated in the page.
+ * @param {string} options.blockName Block name for canvas selectors.
+ * @returns {Promise<string>} Frontend URL.
+ */
+async function insertAndPublish(page, testInfo, { title, item, build, blockName }) {
+	const artifact = defineArtifact(testInfo, 'blocks', item, 'insert-and-render');
+	await createNewPost(page, 'page');
+	await setPostTitle(page, title);
+
+	await page.evaluate(build);
+	await page.waitForTimeout(800);
+
+	const canvas = getEditorCanvas(page);
+	const block = canvas.locator(`[data-type="${blockName}"]`);
+	// Attached (not visible): some dynamic blocks render a zero-size/empty
+	// preview in the editor (e.g. dynamic-image with no resolvable image yet).
+	await expect(block.first()).toBeAttached({ timeout: 10000 });
+
+	const warnings = canvas.locator(
+		`[data-type="${blockName}"] .block-editor-warning`
+	);
+	await expect(warnings).toHaveCount(0);
+
+	await slowScrollEditor(page);
+	await saveScreenshot(page, artifact, 'editor');
+
+	const frontendUrl = await publishAndResolveUrl(page);
+	await page.goto(frontendUrl);
+	await page.waitForLoadState('domcontentloaded');
+	return { artifact, frontendUrl };
+}
+
+// ---------------------------------------------------------------------------
+test.describe('Slider block — editor and frontend', () => {
+	test('slider inserts and renders its chrome on the frontend', async ({
+		page,
+	}, testInfo) => {
+		const { artifact } = await insertAndPublish(page, testInfo, {
+			title: 'Slider',
+			item: 'slider',
+			blockName: 'designsetgo/slider',
+			build: () => {
+				const { dispatch } = wp.data;
+				const slide = wp.blocks.createBlock('designsetgo/slide', {}, [
+					wp.blocks.createBlock('core/paragraph', {
+						content: 'Slide one',
+					}),
+				]);
+				const slider = wp.blocks.createBlock('designsetgo/slider', {}, [
+					slide,
+				]);
+				dispatch('core/block-editor').insertBlocks([slider]);
+			},
+		});
+
+		const slider = page.locator('.dsgo-slider');
+		await expect(slider.first()).toBeAttached({ timeout: 10000 });
+
+		await page.waitForLoadState('networkidle').catch(() => {});
+		await slowScrollToBottom(page);
+		await saveScreenshot(page, artifact, 'frontend');
+	});
+});
+
+// ---------------------------------------------------------------------------
+test.describe('Scroll Slides block — editor and frontend', () => {
+	test('scroll-slides inserts and renders on the frontend', async ({
+		page,
+	}, testInfo) => {
+		const { artifact } = await insertAndPublish(page, testInfo, {
+			title: 'Scroll Slides',
+			item: 'scroll-slides',
+			blockName: 'designsetgo/scroll-slides',
+			build: () => {
+				const { dispatch } = wp.data;
+				const slide = wp.blocks.createBlock(
+					'designsetgo/scroll-slide',
+					{},
+					[
+						wp.blocks.createBlock('core/paragraph', {
+							content: 'Panel one',
+						}),
+					]
+				);
+				const slides = wp.blocks.createBlock(
+					'designsetgo/scroll-slides',
+					{},
+					[slide]
+				);
+				dispatch('core/block-editor').insertBlocks([slides]);
+			},
+		});
+
+		const wrapper = page.locator('.dsgo-scroll-slides');
+		await expect(wrapper.first()).toBeAttached({ timeout: 10000 });
+
+		await page.waitForLoadState('networkidle').catch(() => {});
+		await slowScrollToBottom(page);
+		await saveScreenshot(page, artifact, 'frontend');
+	});
+});
+
+// ---------------------------------------------------------------------------
+test.describe('Dynamic Image block — editor and frontend', () => {
+	test('dynamic-image renders a figure from a fallback URL', async ({
+		page,
+	}, testInfo) => {
+		const { artifact } = await insertAndPublish(page, testInfo, {
+			title: 'Dynamic Image',
+			item: 'dynamic-image',
+			blockName: 'designsetgo/dynamic-image',
+			build: () => {
+				const { dispatch } = wp.data;
+				// Same-origin core asset: avoids an external network request that
+				// would keep the frontend page from reaching networkidle.
+				const img = wp.blocks.createBlock('designsetgo/dynamic-image', {
+					fallbackUrl: '/wp-includes/images/w-logo-blue.png',
+					altText: 'Fallback image',
+				});
+				dispatch('core/block-editor').insertBlocks([img]);
+			},
+		});
+
+		const figure = page.locator('figure.wp-block-designsetgo-dynamic-image');
+		await expect(figure.first()).toBeAttached({ timeout: 10000 });
+		const img = figure.locator('img[src*="w-logo-blue.png"]');
+		expect(await img.count()).toBeGreaterThan(0);
+
+		await page.waitForLoadState('networkidle').catch(() => {});
+		await slowScrollToBottom(page);
+		await saveScreenshot(page, artifact, 'frontend');
+	});
+});
+
+// ---------------------------------------------------------------------------
+test.describe('Breadcrumbs block — editor and frontend', () => {
+	test('breadcrumbs inserts and renders nav on the frontend', async ({
+		page,
+	}, testInfo) => {
+		const consoleErrors = [];
+		page.on('pageerror', (err) => consoleErrors.push(err.message));
+
+		const { artifact } = await insertAndPublish(page, testInfo, {
+			title: 'Breadcrumbs',
+			item: 'breadcrumbs',
+			blockName: 'designsetgo/breadcrumbs',
+			build: () => {
+				const { dispatch } = wp.data;
+				const crumbs = wp.blocks.createBlock('designsetgo/breadcrumbs', {
+					showHome: true,
+					showCurrent: true,
+				});
+				dispatch('core/block-editor').insertBlocks([crumbs]);
+			},
+		});
+
+		// On a block theme the page content renders inside core/post-content,
+		// which provides postId context, so the nav should render.
+		const nav = page.locator('nav.dsgo-breadcrumbs');
+		await expect(nav.first()).toBeAttached({ timeout: 10000 });
+		expect(consoleErrors).toHaveLength(0);
+
+		await page.waitForLoadState('networkidle').catch(() => {});
+		await slowScrollToBottom(page);
+		await saveScreenshot(page, artifact, 'frontend');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// product-showcase-hero is intentionally NOT covered here: its editor preview
+// and frontend render both require WooCommerce + a real product, which is not
+// installed in the test env. The refactored guard/resolution logic
+// (designsetgo_render_product_showcase_hero) is covered by its PHPUnit render
+// test (tests/phpunit/blocks/product-showcase-hero/render-test.php). Full e2e
+// coverage belongs on a WooCommerce-enabled environment.

--- a/tests/phpunit/block-animation-attributes-test.php
+++ b/tests/phpunit/block-animation-attributes-test.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Tests for the block animation/clickable attribute helpers.
+ *
+ * Regression guard for the rename dsgo_* -> designsetgo_* in
+ * includes/block-animation-attributes.php. Confirms the renamed global
+ * functions exist and behave as before.
+ *
+ * @group animation
+ */
+
+/**
+ * @group animation
+ */
+class DesignSetGo_Block_Animation_Attributes_Test extends WP_UnitTestCase {
+
+	public function test_animation_attributes_empty_when_disabled() {
+		$result = designsetgo_get_animation_attributes( array() );
+
+		$this->assertSame( '', $result['classes'] );
+		$this->assertSame( '', $result['attrs'] );
+	}
+
+	public function test_animation_attributes_when_enabled() {
+		$result = designsetgo_get_animation_attributes(
+			array(
+				'dsgoAnimationEnabled'  => true,
+				'dsgoEntranceAnimation' => 'fade-in',
+			)
+		);
+
+		$this->assertStringContainsString( 'has-dsgo-animation', $result['classes'] );
+		$this->assertStringContainsString( 'dsgo-animation-fade-in', $result['classes'] );
+		$this->assertStringContainsString( 'data-dsgo-animation-enabled', $result['attrs'] );
+	}
+
+	public function test_clickable_attributes_empty_without_link_url() {
+		$result = designsetgo_get_clickable_attributes( array() );
+
+		$this->assertSame( '', $result['classes'] );
+		$this->assertSame( '', $result['attrs'] );
+	}
+
+	public function test_clickable_attributes_with_link_url() {
+		$result = designsetgo_get_clickable_attributes(
+			array(
+				'dsgLinkUrl'    => 'https://example.com/',
+				'dsgLinkTarget' => true,
+			)
+		);
+
+		$this->assertStringContainsString( 'dsgo-clickable', $result['classes'] );
+		$this->assertStringContainsString( 'data-link-url="https://example.com/"', $result['attrs'] );
+		$this->assertStringContainsString( 'data-link-target="_blank"', $result['attrs'] );
+	}
+
+	public function test_add_animation_to_wrapper_merges_classes() {
+		$wrapper = 'class="wp-block-designsetgo-stack"';
+
+		$result = designsetgo_add_animation_to_wrapper(
+			$wrapper,
+			array( 'dsgoAnimationEnabled' => true )
+		);
+
+		$this->assertStringContainsString( 'wp-block-designsetgo-stack', $result );
+		$this->assertStringContainsString( 'has-dsgo-animation', $result );
+	}
+}

--- a/tests/phpunit/blocks/breadcrumbs/render-test.php
+++ b/tests/phpunit/blocks/breadcrumbs/render-test.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Tests for the breadcrumbs block server render.
+ *
+ * Regression guard for the PrefixAllGlobals refactor that wrapped render.php in
+ * designsetgo_render_breadcrumbs(). The trail is built from
+ * $block->context['postId'], so we hand the render a lightweight context object
+ * pointing at a real page and assert the <nav> markup is emitted.
+ *
+ * @group breadcrumbs
+ */
+
+/**
+ * @group breadcrumbs
+ */
+class DesignSetGo_Breadcrumbs_Render_Test extends WP_UnitTestCase {
+
+	/**
+	 * Include the built render template with the given attributes/context and
+	 * capture its echoed output.
+	 *
+	 * @param array       $attributes Block attributes.
+	 * @param object|null $block      Block instance (carries context).
+	 * @return string Rendered HTML ('' when the template bails).
+	 */
+	private function render( array $attributes, $block = null ) {
+		$path = DESIGNSETGO_PATH . 'build/blocks/breadcrumbs/render.php';
+		$this->assertFileExists( $path, 'Run `npm run build` before PHPUnit — render templates are served from build/.' );
+
+		$content = '';
+
+		$previous_block                     = WP_Block_Supports::$block_to_render;
+		WP_Block_Supports::$block_to_render = array(
+			'blockName' => 'designsetgo/breadcrumbs',
+			'attrs'     => array(),
+		);
+
+		ob_start();
+		$returned = include $path;
+		$html     = ob_get_clean();
+
+		WP_Block_Supports::$block_to_render = $previous_block;
+
+		return is_string( $returned ) ? $returned : $html;
+	}
+
+	/**
+	 * Build a minimal block-context stand-in (duck-typed: render reads
+	 * $block->context['postId']).
+	 *
+	 * @param array $context Context map.
+	 * @return object
+	 */
+	private function block_with_context( array $context ) {
+		$block          = new stdClass();
+		$block->context = $context;
+		return $block;
+	}
+
+	public function test_renders_nav_with_home_and_current_for_a_page() {
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'About Our Team',
+				'post_status' => 'publish',
+			)
+		);
+
+		$html = $this->render(
+			array(
+				'showHome'    => true,
+				'showCurrent' => true,
+			),
+			$this->block_with_context( array( 'postId' => $page_id ) )
+		);
+
+		$this->assertStringContainsString( '<nav', $html );
+		$this->assertStringContainsString( 'dsgo-breadcrumbs', $html );
+		$this->assertStringContainsString( 'About Our Team', $html );
+		$this->assertStringContainsString( 'Home', $html );
+	}
+
+	public function test_renders_nothing_without_post_context() {
+		// No postId in context -> empty trail -> the template returns early.
+		$html = $this->render(
+			array(
+				'showHome'    => true,
+				'showCurrent' => true,
+			),
+			$this->block_with_context( array() )
+		);
+
+		$this->assertSame( '', $html );
+	}
+}

--- a/tests/phpunit/blocks/dynamic-image/render-test.php
+++ b/tests/phpunit/blocks/dynamic-image/render-test.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Tests for the dynamic-image block server render.
+ *
+ * Regression guard for the PrefixAllGlobals refactor that wrapped render.php in
+ * designsetgo_render_dynamic_image(). The template resolves an image source via
+ * ImageResolver and falls back to a fallbackUrl/fallbackId; we exercise the
+ * fallback-URL happy path (no attachment needed) and the no-source bail.
+ *
+ * @group dynamic-image
+ */
+
+/**
+ * @group dynamic-image
+ */
+class DesignSetGo_Dynamic_Image_Render_Test extends WP_UnitTestCase {
+
+	/**
+	 * Include the built render template with the given attributes and capture
+	 * its echoed output.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Rendered HTML ('' when the template bails).
+	 */
+	private function render( array $attributes ) {
+		$path = DESIGNSETGO_PATH . 'build/blocks/dynamic-image/render.php';
+		$this->assertFileExists( $path, 'Run `npm run build` before PHPUnit — render templates are served from build/.' );
+
+		$content = '';
+		$block   = null;
+
+		$previous_block                     = WP_Block_Supports::$block_to_render;
+		WP_Block_Supports::$block_to_render = array(
+			'blockName' => 'designsetgo/dynamic-image',
+			'attrs'     => array(),
+		);
+
+		ob_start();
+		$returned = include $path;
+		$html     = ob_get_clean();
+
+		WP_Block_Supports::$block_to_render = $previous_block;
+
+		return is_string( $returned ) ? $returned : $html;
+	}
+
+	public function test_renders_figure_from_fallback_url() {
+		$html = $this->render(
+			array(
+				'fallbackUrl' => 'https://example.com/fallback.jpg',
+				'altText'     => 'Fallback alt',
+				'aspectRatio' => '16/9',
+			)
+		);
+
+		$this->assertStringContainsString( '<figure', $html );
+		$this->assertStringContainsString( '<img', $html );
+		$this->assertStringContainsString( 'https://example.com/fallback.jpg', $html );
+	}
+
+	public function test_renders_nothing_without_source_or_fallback() {
+		$html = $this->render( array() );
+
+		$this->assertSame( '', $html );
+	}
+}

--- a/tests/phpunit/blocks/product-showcase-hero/render-test.php
+++ b/tests/phpunit/blocks/product-showcase-hero/render-test.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Tests for the product-showcase-hero block server render.
+ *
+ * WooCommerce is not installed in the test environment, so the full happy-path
+ * render (which needs a real WC_Product) cannot run here — that is covered by
+ * e2e/manual testing on a WooCommerce site. These tests stub the
+ * `wc_get_product()` guard and assert the resolution/bail logic in the
+ * refactored designsetgo_render_product_showcase_hero() returns '' cleanly
+ * (no fatal) when no valid product is available.
+ *
+ * @group product-showcase-hero
+ */
+
+if ( ! function_exists( 'wc_get_product' ) ) {
+	/**
+	 * Minimal stub so the render template passes its WooCommerce guard.
+	 *
+	 * @param mixed $the_product Ignored.
+	 * @return false
+	 */
+	function wc_get_product( $the_product = false ) {
+		return false;
+	}
+}
+
+/**
+ * @group product-showcase-hero
+ */
+class DesignSetGo_Product_Showcase_Hero_Render_Test extends WP_UnitTestCase {
+
+	/**
+	 * Include the built render template with the given attributes and capture
+	 * its echoed output.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Rendered HTML ('' when the template bails).
+	 */
+	private function render( array $attributes ) {
+		$path = DESIGNSETGO_PATH . 'build/blocks/product-showcase-hero/render.php';
+		$this->assertFileExists( $path, 'Run `npm run build` before PHPUnit — render templates are served from build/.' );
+
+		$content = '';
+		$block   = null;
+
+		$previous_block                     = WP_Block_Supports::$block_to_render;
+		WP_Block_Supports::$block_to_render = array(
+			'blockName' => 'designsetgo/product-showcase-hero',
+			'attrs'     => array(),
+		);
+
+		ob_start();
+		$returned = include $path;
+		$html     = ob_get_clean();
+
+		WP_Block_Supports::$block_to_render = $previous_block;
+
+		return is_string( $returned ) ? $returned : $html;
+	}
+
+	public function test_renders_nothing_when_no_product_id() {
+		$html = $this->render(
+			array(
+				'productSource' => 'manual',
+				'productId'     => 0,
+			)
+		);
+
+		$this->assertSame( '', $html );
+	}
+
+	public function test_renders_nothing_when_product_not_found() {
+		// wc_get_product() is stubbed to return false, so any id resolves to no
+		// product and the template bails without fatal.
+		$html = $this->render(
+			array(
+				'productSource' => 'manual',
+				'productId'     => 99999,
+			)
+		);
+
+		$this->assertSame( '', $html );
+	}
+}

--- a/tests/phpunit/blocks/scroll-slide/render-test.php
+++ b/tests/phpunit/blocks/scroll-slide/render-test.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Tests for the scroll-slide block server render.
+ *
+ * Regression guard for the PrefixAllGlobals refactor that wrapped render.php in
+ * designsetgo_render_scroll_slide(). Standalone (authored) slides pass through
+ * unchanged; inside a query iteration (an item context on
+ * $GLOBALS['designsetgo_parent_stack']) the slide is enriched with the iterated
+ * post's title via WP_HTML_Tag_Processor.
+ *
+ * @group scroll-slide
+ */
+
+/**
+ * @group scroll-slide
+ */
+class DesignSetGo_Scroll_Slide_Render_Test extends WP_UnitTestCase {
+
+	/**
+	 * Include the built render template and capture its echoed output.
+	 *
+	 * @param array       $attributes Block attributes.
+	 * @param string      $content    Pre-rendered save.js output.
+	 * @param object|null $block      Block instance.
+	 * @return string Rendered HTML.
+	 */
+	private function render( array $attributes, $content = '', $block = null ) {
+		$path = DESIGNSETGO_PATH . 'build/blocks/scroll-slide/render.php';
+		$this->assertFileExists( $path, 'Run `npm run build` before PHPUnit — render templates are served from build/.' );
+
+		$previous_block                     = WP_Block_Supports::$block_to_render;
+		WP_Block_Supports::$block_to_render = array(
+			'blockName' => 'designsetgo/scroll-slide',
+			'attrs'     => array(),
+		);
+
+		ob_start();
+		$returned = include $path;
+		$html     = ob_get_clean();
+
+		WP_Block_Supports::$block_to_render = $previous_block;
+
+		return is_string( $returned ) ? $returned : $html;
+	}
+
+	public function test_authored_mode_passes_content_through_unchanged() {
+		$content = '<div class="dsgo-scroll-slide">authored slide</div>';
+
+		// No parent stack -> authored mode.
+		unset( $GLOBALS['designsetgo_parent_stack'] );
+
+		$html = $this->render( array(), $content );
+
+		$this->assertSame( $content, $html );
+	}
+
+	public function test_query_iteration_injects_post_title_as_nav_heading() {
+		if ( ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
+			$this->markTestSkipped( 'WP_HTML_Tag_Processor not available.' );
+		}
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'Spotlight Story',
+				'post_status' => 'publish',
+			)
+		);
+
+		$content = '<div class="dsgo-scroll-slide">slide body</div>';
+
+		$GLOBALS['designsetgo_parent_stack'] = array(
+			array( 'postId' => $post_id ),
+		);
+
+		$html = $this->render( array(), $content, new stdClass() );
+
+		unset( $GLOBALS['designsetgo_parent_stack'] );
+
+		$this->assertStringContainsString( 'data-dsgo-nav-heading="Spotlight Story"', $html );
+	}
+}

--- a/tests/phpunit/blocks/scroll-slides/render-test.php
+++ b/tests/phpunit/blocks/scroll-slides/render-test.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Tests for the scroll-slides block server render.
+ *
+ * Regression guard for the PrefixAllGlobals refactor that wrapped render.php in
+ * designsetgo_render_scroll_slides(). Authored mode passes the saved markup
+ * through unchanged; query-bound mode rebuilds chrome and splices in items
+ * stashed by the parent query container (where the refactored locals live).
+ *
+ * @group scroll-slides
+ */
+
+/**
+ * @group scroll-slides
+ */
+class DesignSetGo_Scroll_Slides_Render_Test extends WP_UnitTestCase {
+
+	/**
+	 * Include the built render template and capture its echoed output.
+	 *
+	 * @param array       $attributes Block attributes.
+	 * @param string      $content    Pre-rendered save.js output.
+	 * @param object|null $block      Block instance (carries context).
+	 * @return string Rendered HTML.
+	 */
+	private function render( array $attributes, $content = '', $block = null ) {
+		$path = DESIGNSETGO_PATH . 'build/blocks/scroll-slides/render.php';
+		$this->assertFileExists( $path, 'Run `npm run build` before PHPUnit — render templates are served from build/.' );
+
+		$previous_block                     = WP_Block_Supports::$block_to_render;
+		WP_Block_Supports::$block_to_render = array(
+			'blockName' => 'designsetgo/scroll-slides',
+			'attrs'     => array(),
+		);
+
+		ob_start();
+		$returned = include $path;
+		$html     = ob_get_clean();
+
+		WP_Block_Supports::$block_to_render = $previous_block;
+
+		return is_string( $returned ) ? $returned : $html;
+	}
+
+	public function test_authored_mode_passes_content_through_unchanged() {
+		$content = '<div class="dsgo-scroll-slides">authored markup</div>';
+
+		$html = $this->render( array(), $content );
+
+		$this->assertSame( $content, $html );
+	}
+
+	public function test_query_mode_builds_chrome_and_injects_items() {
+		$query_id = 'slides42';
+
+		$block          = new stdClass();
+		$block->context = array( 'designsetgo/queryId' => $query_id );
+
+		$GLOBALS['designsetgo_query_items_html'] = array(
+			$query_id => '<div class="dsgo-scroll-slide">panel one</div>',
+		);
+
+		$html = $this->render( array(), '', $block );
+
+		unset( $GLOBALS['designsetgo_query_items_html'] );
+
+		$this->assertStringContainsString( 'dsgo-scroll-slides', $html );
+		$this->assertStringContainsString( 'panel one', $html );
+	}
+}

--- a/tests/phpunit/blocks/slider/render-test.php
+++ b/tests/phpunit/blocks/slider/render-test.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Tests for the slider block server render.
+ *
+ * Regression guard for the PrefixAllGlobals refactor that wrapped render.php in
+ * designsetgo_render_slider(). Two modes:
+ *  - authored (no query context): the saved markup passes through unchanged;
+ *  - query-bound: the template rebuilds slider chrome and splices in items
+ *    stashed by the parent query container. The query path is where the
+ *    refactored local variables live, so we assert the wrapper chrome here.
+ *    (Full query integration is also covered by query/slider-host-test.php.)
+ *
+ * @group slider
+ */
+
+/**
+ * @group slider
+ */
+class DesignSetGo_Slider_Render_Test extends WP_UnitTestCase {
+
+	/**
+	 * Include the built render template and capture its echoed output.
+	 *
+	 * @param array       $attributes Block attributes.
+	 * @param string      $content    Pre-rendered save.js output.
+	 * @param object|null $block      Block instance (carries context).
+	 * @return string Rendered HTML.
+	 */
+	private function render( array $attributes, $content = '', $block = null ) {
+		$path = DESIGNSETGO_PATH . 'build/blocks/slider/render.php';
+		$this->assertFileExists( $path, 'Run `npm run build` before PHPUnit — render templates are served from build/.' );
+
+		$previous_block                     = WP_Block_Supports::$block_to_render;
+		WP_Block_Supports::$block_to_render = array(
+			'blockName' => 'designsetgo/slider',
+			'attrs'     => array(),
+		);
+
+		ob_start();
+		$returned = include $path;
+		$html     = ob_get_clean();
+
+		WP_Block_Supports::$block_to_render = $previous_block;
+
+		return is_string( $returned ) ? $returned : $html;
+	}
+
+	public function test_authored_mode_passes_content_through_unchanged() {
+		$content = '<div class="dsgo-slider">authored slider markup</div>';
+
+		$html = $this->render( array(), $content );
+
+		$this->assertSame( $content, $html );
+	}
+
+	public function test_query_mode_builds_chrome_and_injects_items() {
+		$query_id = 'abc123';
+
+		$block          = new stdClass();
+		$block->context = array( 'designsetgo/queryId' => $query_id );
+
+		$GLOBALS['designsetgo_query_items_html'] = array(
+			$query_id => '<div class="dsgo-slide">item one</div>',
+		);
+
+		$html = $this->render(
+			array(
+				'effect'     => 'slide',
+				'showArrows' => true,
+			),
+			'',
+			$block
+		);
+
+		unset( $GLOBALS['designsetgo_query_items_html'] );
+
+		$this->assertStringContainsString( 'dsgo-slider', $html );
+		$this->assertStringContainsString( 'dsgo-slider__viewport', $html );
+		$this->assertStringContainsString( 'dsgo-slider__track', $html );
+		$this->assertStringContainsString( 'item one', $html );
+		$this->assertStringContainsString( 'data-show-arrows="true"', $html );
+	}
+}

--- a/tests/phpunit/icon-svg-library-test.php
+++ b/tests/phpunit/icon-svg-library-test.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Tests for the icon SVG library helpers.
+ *
+ * Regression guard for the rename dsgo_* -> designsetgo_* in
+ * includes/icon-svg-library.php. Confirms the renamed global functions exist
+ * and behave as before.
+ *
+ * @group icons
+ */
+
+/**
+ * @group icons
+ */
+class DesignSetGo_Icon_Svg_Library_Test extends WP_UnitTestCase {
+
+	public function test_get_all_icons_returns_keyed_svg_map() {
+		$icons = designsetgo_get_all_icons();
+
+		$this->assertIsArray( $icons );
+		$this->assertNotEmpty( $icons );
+		$this->assertArrayHasKey( 'accordion', $icons );
+		$this->assertStringContainsString( '<svg', $icons['accordion'] );
+	}
+
+	public function test_get_icon_svg_returns_markup_for_known_icon() {
+		$svg = designsetgo_get_icon_svg( 'arrow-down' );
+
+		$this->assertStringContainsString( '<svg', $svg );
+	}
+
+	public function test_get_icon_svg_returns_empty_for_unknown_icon() {
+		$this->assertSame( '', designsetgo_get_icon_svg( 'this-icon-does-not-exist' ) );
+	}
+
+	public function test_get_icon_aliases_returns_array() {
+		$this->assertIsArray( designsetgo_get_icon_aliases() );
+	}
+
+	public function test_sanitize_icon_slug_strips_unsafe_characters() {
+		$this->assertSame( 'arrow-down', designsetgo_sanitize_icon_slug( 'Arrow-Down' ) );
+		$this->assertSame( 'foobar', designsetgo_sanitize_icon_slug( 'foo Bar!' ) );
+		$this->assertSame( '', designsetgo_sanitize_icon_slug( '' ) );
+	}
+
+	public function test_accordion_render_icon_returns_span_with_svg() {
+		$html = designsetgo_accordion_render_icon( 'chevron', false );
+
+		$this->assertStringContainsString( 'dsgo-accordion-item__icon', $html );
+		$this->assertStringContainsString( '<svg', $html );
+	}
+
+	public function test_accordion_render_icon_returns_empty_for_none_style() {
+		$this->assertSame( '', designsetgo_accordion_render_icon( 'none', false ) );
+	}
+}


### PR DESCRIPTION
## Summary

Eliminates **all** `WordPress.NamingConventions.PrefixAllGlobals` Plugin Check findings. Verified with the real Plugin Check (`wp plugin check designsetgo`): **0** `NonPrefixedVariableFound` (down from a true baseline of **278** across 13 files), **0** `NonPrefixedFunctionFound`, **0** `NonPrefixedConstantFound`, and **0** ERROR lines.

## Changes

**Dynamic block render templates (13 files)**
- Wrapped 11 `render.php` bodies in `function_exists`-guarded `designsetgo_render_*()` functions so their locals are function-scoped: `slider`, `dynamic-image`, `product-showcase-hero`, `product-categories-grid`, `scroll-slides`, `scroll-slide`, `query-pagination`, `breadcrumbs`, `query-no-results`, `query-group-header`, `query-results`.
  - WordPress includes file-based renders inside a closure (`ob_start(); require; ob_get_clean();`), so the wrapped bodies keep echoing exactly as before.
  - The guard prevents redeclaration when multiple instances of a block render on one page.
- `query/render.php` and `query-filter/render.php` already prefixed their locals, but with the `dsgo` prefix that PCP rejects — renamed `$dsgo_` → `$designsetgo_` (the minimal fix matching each file's existing strategy).

**Function-prefix consistency**
- Renamed 8 `dsgo_` helper functions to `designsetgo_` (per CLAUDE.md's PHP prefix convention) plus their call sites, in `icon-svg-library.php`, `class-icon-injector.php`, `block-animation-attributes.php`.

**Justified suppressions (unavoidable third-party globals)**
- `product-showcase-hero/render.php`: `$GLOBALS['product']` swap — WooCommerce requires that exact global name.
- `class-plugin.php`: `WP_ABILITIES_API_DIR` — the name is fixed by the bundled `wordpress/abilities-api` polyfill, which reads it in its bootstrap.

## Verification
- `php -l` clean on all changed files
- `composer run-script lint` (phpcs) clean
- Full PHPUnit suite: **770 passing** (6 pre-existing environmental skips)
- Pre-commit e2e smoke tests passing
- Real Plugin Check: 0 PrefixAllGlobals findings, 0 errors

## Notes / possible follow-ups
- 4 of the renamed icon/animation helpers (`designsetgo_get_icon_svg`, `_sanitize_icon_slug`, `_accordion_render_icon`, `_add_animation_to_wrapper`) appear to have **no callers** — possible dead code worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)