### PR TITLE
fix: harden Medium security findings S1–S6

### DIFF
--- a/includes/admin/class-draft-mode.php
+++ b/includes/admin/class-draft-mode.php
@@ -365,8 +365,9 @@ class Draft_Mode {
 
 			foreach ( $values as $value ) {
 				$unserialized = maybe_unserialize( $value );
-				// Reject PHP objects to prevent object injection.
-				if ( is_object( $unserialized ) ) {
+				// Reject PHP objects (including objects nested inside arrays)
+				// to prevent object injection.
+				if ( self::contains_object( $unserialized ) ) {
 					continue;
 				}
 				add_post_meta( $target_id, $key, $unserialized );
@@ -421,8 +422,9 @@ class Draft_Mode {
 
 			foreach ( $values as $value ) {
 				$unserialized = maybe_unserialize( $value );
-				// Reject PHP objects to prevent object injection.
-				if ( is_object( $unserialized ) ) {
+				// Reject PHP objects (including objects nested inside arrays)
+				// to prevent object injection.
+				if ( self::contains_object( $unserialized ) ) {
 					continue;
 				}
 				add_post_meta( $original_id, $key, $unserialized );
@@ -461,5 +463,31 @@ class Draft_Mode {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Recursively determine whether a value is, or contains, a PHP object.
+	 *
+	 * A plain is_object() check misses objects nested inside arrays (e.g. a
+	 * serialized payload like `a:1:{i:0;O:8:"stdClass":0:{}}`), which would
+	 * still trigger object injection when stored and later unserialized.
+	 *
+	 * @param mixed $value Value to inspect (already passed through maybe_unserialize()).
+	 * @return bool True if the value is an object or any nested array element is.
+	 */
+	private static function contains_object( $value ) {
+		if ( is_object( $value ) ) {
+			return true;
+		}
+
+		if ( is_array( $value ) ) {
+			foreach ( $value as $item ) {
+				if ( self::contains_object( $item ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 }

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -23,6 +23,16 @@ class Settings {
 	const OPTION_NAME = 'designsetgo_settings';
 
 	/**
+	 * Placeholder returned in place of a stored write-only secret on read.
+	 *
+	 * The REST GET endpoint redacts write-only secrets to this value so they
+	 * never reach the browser. The write path treats an incoming value equal
+	 * to this placeholder as "unchanged" and preserves the stored secret. A
+	 * real secret will never equal this string.
+	 */
+	const REDACTED_PLACEHOLDER = '••••••••';
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -464,10 +474,54 @@ class Settings {
 	/**
 	 * Get settings endpoint
 	 *
+	 * Write-only secrets (e.g. the Turnstile secret key) are redacted to a
+	 * placeholder so they never reach the browser. get_settings() itself keeps
+	 * returning the real values for server-side consumers (e.g. Turnstile
+	 * verification).
+	 *
 	 * @return \WP_REST_Response
 	 */
 	public function get_settings_endpoint() {
-		return rest_ensure_response( self::get_settings() );
+		return rest_ensure_response( self::redact_secrets( self::get_settings() ) );
+	}
+
+	/**
+	 * Map of write-only secret fields, keyed by settings group.
+	 *
+	 * Single source of truth shared by the read-redaction (redact_secrets) and
+	 * the write-strip in sanitize_settings(). Add a field here to have it
+	 * redacted on read and preserved-on-placeholder on write.
+	 *
+	 * @return array<string, string[]> Group => list of secret field keys.
+	 */
+	private static function write_only_secret_keys(): array {
+		return array(
+			'integrations' => array( 'turnstile_secret_key' ),
+		);
+	}
+
+	/**
+	 * Return a copy of $settings with write-only secrets replaced by the
+	 * redaction placeholder.
+	 *
+	 * Only non-empty string secrets are redacted; an empty value stays empty so
+	 * the UI renders an empty field when no secret has been saved.
+	 *
+	 * @param array $settings Full settings array.
+	 * @return array Settings with secrets redacted.
+	 */
+	private static function redact_secrets( array $settings ): array {
+		foreach ( self::write_only_secret_keys() as $group => $fields ) {
+			foreach ( $fields as $field ) {
+				if ( isset( $settings[ $group ][ $field ] )
+					&& is_string( $settings[ $group ][ $field ] )
+					&& '' !== $settings[ $group ][ $field ] ) {
+					$settings[ $group ][ $field ] = self::REDACTED_PLACEHOLDER;
+				}
+			}
+		}
+
+		return $settings;
 	}
 
 	/**
@@ -793,6 +847,18 @@ class Settings {
 					$sanitizer,
 					$default
 				);
+			}
+
+			// Drop write-only secrets the client echoed back unchanged (i.e. the
+			// redaction placeholder served by get_settings_endpoint()). Leaving
+			// them out lets array_replace_recursive() in update_settings()
+			// preserve the stored secret instead of overwriting it with bullets.
+			$secret_fields = self::write_only_secret_keys()[ $key ] ?? array();
+			foreach ( $secret_fields as $secret_field ) {
+				if ( isset( $settings[ $key ][ $secret_field ] )
+					&& self::REDACTED_PLACEHOLDER === $settings[ $key ][ $secret_field ] ) {
+					unset( $group_values[ $secret_field ] );
+				}
 			}
 
 			// Skip groups where no fields were actually submitted. Persisting

--- a/includes/blocks/forms/class-form-handler.php
+++ b/includes/blocks/forms/class-form-handler.php
@@ -315,8 +315,9 @@ class Form_Handler {
 		}
 
 		// Sanitize and validate all fields.
-		$form_field_types = $this->get_form_field_types( $form_id );
-		$sanitized_fields = array();
+		$form_field_types  = $this->get_form_field_types( $form_id );
+		$field_constraints = $this->get_form_field_value_constraints( $form_id );
+		$sanitized_fields  = array();
 		foreach ( $fields as $field ) {
 			if ( ! isset( $field['name'] ) || ! isset( $field['value'] ) ) {
 				continue;
@@ -329,8 +330,14 @@ class Form_Handler {
 				? $form_field_types[ $field_name ]
 				: $submitted_field_type;
 
+			// Server-defined allowed values for constrained field types (only
+			// present for select/checkbox/hidden fields resolved from the block).
+			$allowed_values = isset( $field_constraints[ $field_name ] )
+				? $field_constraints[ $field_name ]
+				: null;
+
 			// Type-specific validation.
-			$validation_result = $this->validate_field( $field_value, $field_type );
+			$validation_result = $this->validate_field( $field_value, $field_type, $allowed_values );
 			if ( is_wp_error( $validation_result ) ) {
 				// Security monitoring hook for validation failures.
 				do_action( 'designsetgo_form_validation_failed', $form_id, $field_name, $field_type, $validation_result->get_error_code(), $this->security->get_client_ip() );
@@ -521,15 +528,34 @@ class Form_Handler {
 	/**
 	 * Validate field based on type.
 	 *
-	 * @param mixed  $value Field value.
-	 * @param string $type Field type.
+	 * @param mixed      $value   Field value.
+	 * @param string     $type    Field type.
+	 * @param array|null $allowed Optional list of server-defined allowed values
+	 *                            (for select/checkbox/hidden). When provided, the
+	 *                            submitted value(s) must be members of this list.
 	 * @return true|WP_Error True if valid, WP_Error if invalid.
 	 */
-	private function validate_field( $value, $type ) {
+	private function validate_field( $value, $type, $allowed = null ) {
 		// Skip validation for empty values (optional fields).
 		// Required fields are validated by HTML5 on the frontend.
 		if ( empty( $value ) && '0' !== $value ) {
 			return true;
+		}
+
+		// Enforce server-defined allowed values for constrained field types
+		// (select options, checkbox value, hidden constant). This prevents a
+		// client from submitting arbitrary values or forging hidden fields —
+		// the field type itself is already resolved server-side.
+		if ( is_array( $allowed ) ) {
+			$submitted = is_array( $value ) ? $value : array( $value );
+			foreach ( $submitted as $single ) {
+				if ( ! in_array( (string) $single, $allowed, true ) ) {
+					return new WP_Error(
+						'value_not_allowed',
+						__( 'Submitted value is not an allowed option.', 'designsetgo' )
+					);
+				}
+			}
 		}
 
 		switch ( $type ) {
@@ -1112,6 +1138,147 @@ class Form_Handler {
 	}
 
 	/**
+	 * Look up server-defined allowed values for constrained fields by form ID.
+	 *
+	 * Parallels get_form_field_types() but returns, per field name, the list of
+	 * values the server will accept. Only select/checkbox/hidden fields are
+	 * constrained; all other field types are omitted (unconstrained). Used to
+	 * reject forged option values and hidden-field constants from the client.
+	 *
+	 * @param string $form_id Form identifier to look up.
+	 * @return array<string, string[]> Allowed values keyed by field name.
+	 */
+	private function get_form_field_value_constraints( $form_id ) {
+		$cache_key = 'dsgo_form_field_constraints_' . md5( $form_id );
+		$cached    = get_transient( $cache_key );
+
+		if ( false !== $cached && is_array( $cached ) ) {
+			return $cached;
+		}
+
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Cached via transient above.
+		$posts = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT ID, post_content FROM {$wpdb->posts}
+				WHERE post_content LIKE %s
+				AND post_content LIKE %s
+				AND post_status IN ('publish', 'private')
+				LIMIT 5",
+				'%' . $wpdb->esc_like( 'designsetgo/form-builder' ) . '%',
+				'%' . $wpdb->esc_like( '"formId":"' . $form_id . '"' ) . '%'
+			)
+		);
+
+		if ( empty( $posts ) ) {
+			return array();
+		}
+
+		foreach ( $posts as $post ) {
+			$blocks      = parse_blocks( $post->post_content );
+			$constraints = $this->find_form_field_constraints( $blocks, $form_id );
+
+			if ( ! empty( $constraints ) ) {
+				set_transient( $cache_key, $constraints, HOUR_IN_SECONDS );
+				return $constraints;
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Recursively search parsed blocks for a form-builder block and extract
+	 * allowed values for constrained fields.
+	 *
+	 * @param array  $blocks  Parsed blocks array.
+	 * @param string $form_id Form identifier to match.
+	 * @return array<string, string[]> Allowed values keyed by field name.
+	 */
+	private function find_form_field_constraints( $blocks, $form_id ) {
+		foreach ( $blocks as $block ) {
+			if (
+				'designsetgo/form-builder' === $block['blockName'] &&
+				isset( $block['attrs']['formId'] ) &&
+				$block['attrs']['formId'] === $form_id
+			) {
+				return $this->extract_field_value_constraints_from_blocks(
+					isset( $block['innerBlocks'] ) ? $block['innerBlocks'] : array()
+				);
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$result = $this->find_form_field_constraints( $block['innerBlocks'], $form_id );
+				if ( ! empty( $result ) ) {
+					return $result;
+				}
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Extract allowed values for constrained fields from a form's inner blocks.
+	 *
+	 * - select: the `value` of each entry in the `options` attribute.
+	 * - checkbox: the single `value` attribute (default "1").
+	 * - hidden: the server-defined `value` attribute (a constant).
+	 *
+	 * Fields without a constraint are not added to the map.
+	 *
+	 * @param array $blocks Parsed inner blocks.
+	 * @return array<string, string[]> Allowed values keyed by field name.
+	 */
+	private function extract_field_value_constraints_from_blocks( $blocks ) {
+		$constraints = array();
+
+		foreach ( $blocks as $block ) {
+			$block_name = isset( $block['blockName'] ) ? $block['blockName'] : '';
+			$field_name = isset( $block['attrs']['fieldName'] ) ? sanitize_text_field( $block['attrs']['fieldName'] ) : '';
+			$attrs      = isset( $block['attrs'] ) ? $block['attrs'] : array();
+
+			if ( $field_name ) {
+				switch ( $block_name ) {
+					case 'designsetgo/form-select-field':
+						if ( isset( $attrs['options'] ) && is_array( $attrs['options'] ) ) {
+							$values = array();
+							foreach ( $attrs['options'] as $option ) {
+								if ( isset( $option['value'] ) ) {
+									$values[] = (string) $option['value'];
+								}
+							}
+							$constraints[ $field_name ] = $values;
+						}
+						break;
+
+					case 'designsetgo/form-checkbox-field':
+						$constraints[ $field_name ] = array(
+							isset( $attrs['value'] ) ? (string) $attrs['value'] : '1',
+						);
+						break;
+
+					case 'designsetgo/form-hidden-field':
+						$constraints[ $field_name ] = array(
+							isset( $attrs['value'] ) ? (string) $attrs['value'] : '',
+						);
+						break;
+				}
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$constraints = array_merge(
+					$constraints,
+					$this->extract_field_value_constraints_from_blocks( $block['innerBlocks'] )
+				);
+			}
+		}
+
+		return $constraints;
+	}
+
+	/**
 	 * Recursively search parsed blocks for a form-builder block and extract field types.
 	 *
 	 * @param array  $blocks  Parsed blocks array.
@@ -1246,6 +1413,7 @@ class Form_Handler {
 			) {
 				delete_transient( 'dsgo_form_attrs_v2_' . md5( $block['attrs']['formId'] ) );
 				delete_transient( 'dsgo_form_field_types_' . md5( $block['attrs']['formId'] ) );
+				delete_transient( 'dsgo_form_field_constraints_' . md5( $block['attrs']['formId'] ) );
 			}
 
 			if ( ! empty( $block['innerBlocks'] ) ) {

--- a/includes/blocks/query/class-query-template-controller.php
+++ b/includes/blocks/query/class-query-template-controller.php
@@ -115,6 +115,11 @@ class Template_Controller {
 	 * @return true|\WP_Error
 	 */
 	public static function permission_export( \WP_REST_Request $request ) {
+		$nonce_check = self::verify_nonce( $request );
+		if ( is_wp_error( $nonce_check ) ) {
+			return $nonce_check;
+		}
+
 		$post_id = (int) $request['post_id'];
 
 		if ( ! $post_id || ! get_post( $post_id ) ) {
@@ -142,14 +147,43 @@ class Template_Controller {
 	 * Import is a generator (produces new markup), not a post mutator, so
 	 * `edit_posts` is sufficient — no specific post_id to gate against.
 	 *
+	 * @param \WP_REST_Request $request Incoming REST request.
 	 * @return true|\WP_Error
 	 */
-	public static function permission_import() {
+	public static function permission_import( \WP_REST_Request $request ) {
+		$nonce_check = self::verify_nonce( $request );
+		if ( is_wp_error( $nonce_check ) ) {
+			return $nonce_check;
+		}
+
 		if ( ! current_user_can( 'edit_posts' ) ) {
 			return new \WP_Error(
 				'dsgo_template_forbidden',
 				__( 'You do not have permission to import templates.', 'designsetgo' ),
 				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Verifies the REST nonce header to block CSRF against these routes.
+	 *
+	 * Mirrors the project-wide pattern in
+	 * DesignSetGo\Blocks\Query\Controller::check_permission(). Editor callers
+	 * use @wordpress/api-fetch, which sends the X-WP-Nonce header.
+	 *
+	 * @param \WP_REST_Request $request Incoming REST request.
+	 * @return true|\WP_Error
+	 */
+	private static function verify_nonce( \WP_REST_Request $request ) {
+		$nonce = $request->get_header( 'X-WP-Nonce' );
+		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
+			return new \WP_Error(
+				'dsgo_template_forbidden',
+				__( 'Invalid nonce.', 'designsetgo' ),
+				array( 'status' => 401 )
 			);
 		}
 

--- a/includes/dynamic-tags/class-dynamic-tags-sources-user.php
+++ b/includes/dynamic-tags/class-dynamic-tags-sources-user.php
@@ -72,7 +72,12 @@ class UserSources {
 				if ( 0 === (int) $user->ID ) {
 					return null;
 				}
-				$url = (string) $user->user_url;
+				// The profile URL is user-editable (contributors can set their
+				// own). Core's renderer escapes it, but this value also flows
+				// raw to the /dynamic-tags/preview REST JSON — enforce an
+				// http/https allowlist so a `javascript:` URL can never reach a
+				// consumer that assigns it to el.href.
+				$url = esc_url_raw( (string) $user->user_url, array( 'http', 'https' ) );
 				return '' === $url ? null : $url;
 			}
 		);

--- a/includes/features/class-custom-css-renderer.php
+++ b/includes/features/class-custom-css-renderer.php
@@ -213,6 +213,12 @@ class Custom_CSS_Renderer {
 		 */
 		$output_css = apply_filters( 'designsetgo/custom_css_output', $output_css, $this->custom_css );
 
+		// The output filter runs after per-block sanitization and its result is
+		// echoed raw below. A compromised or careless callback could reintroduce
+		// `</style><script>…` here, so re-run the highest-severity strips on the
+		// final string before it reaches the page.
+		$output_css = $this->strip_dangerous_css( $output_css );
+
 		// Only output if we have CSS after filtering.
 		if ( ! empty( $output_css ) ) {
 			echo "\n<!-- DesignSetGo Custom CSS -->\n";
@@ -337,6 +343,23 @@ class Custom_CSS_Renderer {
 		// highest-severity strips on the filtered output so no amount of
 		// filter misuse can smuggle script tags or javascript: protocols
 		// back in.
+		$css = $this->strip_dangerous_css( $css );
+
+		return $css;
+	}
+
+	/**
+	 * Re-run the highest-severity sanitization strips on a CSS string.
+	 *
+	 * Used both as the final defense pass inside sanitize_css() (after the
+	 * `custom_css_sanitize` filter) and on the complete output after the
+	 * `custom_css_output` filter, so no filter callback can smuggle script
+	 * tags or dangerous protocols back into the echoed `<style>` block.
+	 *
+	 * @param string $css CSS string to harden.
+	 * @return string CSS with script tags, HTML, dangerous protocols, expression() and event handlers removed.
+	 */
+	private function strip_dangerous_css( $css ) {
 		$css = preg_replace( '/<script\b[^>]*>(.*?)<\/script>/is', '', $css );
 		$css = preg_replace( '/<[^>]+>/i', '', $css );
 		$css = preg_replace( '/javascript:/i', '', $css );

--- a/includes/llms-txt/class-rest-controller.php
+++ b/includes/llms-txt/class-rest-controller.php
@@ -91,9 +91,7 @@ class REST_Controller {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'flush_cache' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
-				},
+				'permission_callback' => array( $this, 'check_admin_permission' ),
 			)
 		);
 
@@ -103,9 +101,7 @@ class REST_Controller {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'generate_files' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
-				},
+				'permission_callback' => array( $this, 'check_admin_permission' ),
 			)
 		);
 
@@ -147,9 +143,7 @@ class REST_Controller {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'resolve_conflict' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
-				},
+				'permission_callback' => array( $this, 'check_admin_permission' ),
 			)
 		);
 
@@ -159,11 +153,50 @@ class REST_Controller {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'dismiss_conflict' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
-				},
+				'permission_callback' => array( $this, 'check_admin_permission' ),
 			)
 		);
+	}
+
+	/**
+	 * Permission check for mutating admin routes: requires a valid REST nonce
+	 * and the manage_options capability.
+	 *
+	 * Mirrors the project-wide pattern in
+	 * DesignSetGo\Blocks\Query\Controller::check_manage_options_permission().
+	 * Without the nonce check these POST routes (which write files / options)
+	 * are reachable via CSRF against a logged-in admin.
+	 *
+	 * @param \WP_REST_Request $request The REST request.
+	 * @return true|\WP_Error
+	 */
+	public function check_admin_permission( \WP_REST_Request $request ) {
+		if ( ! is_user_logged_in() ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You must be logged in.', 'designsetgo' ),
+				array( 'status' => 401 )
+			);
+		}
+
+		$nonce = $request->get_header( 'X-WP-Nonce' );
+		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'Invalid nonce.', 'designsetgo' ),
+				array( 'status' => 401 )
+			);
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'Insufficient permissions.', 'designsetgo' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/integration/blocks/query/QueryTemplateControllerTest.php
+++ b/tests/integration/blocks/query/QueryTemplateControllerTest.php
@@ -40,6 +40,7 @@ class QueryTemplateControllerTest extends WP_UnitTestCase {
 		);
 
 		$request = new WP_REST_Request( 'GET', '/designsetgo/v1/query/template' );
+		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$request->set_query_params( array( 'post_id' => $post_id, 'query_id' => 'abc' ) );
 		$response = rest_do_request( $request );
 
@@ -61,6 +62,7 @@ class QueryTemplateControllerTest extends WP_UnitTestCase {
 		$post_id = self::factory()->post->create( array( 'post_content' => '' ) );
 
 		$request = new WP_REST_Request( 'GET', '/designsetgo/v1/query/template' );
+		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$request->set_query_params( array( 'post_id' => $post_id, 'query_id' => 'missing' ) );
 		$response = rest_do_request( $request );
 
@@ -77,6 +79,7 @@ class QueryTemplateControllerTest extends WP_UnitTestCase {
 		);
 
 		$request = new WP_REST_Request( 'GET', '/designsetgo/v1/query/template' );
+		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$request->set_query_params( array( 'post_id' => $post_id, 'query_id' => 'abc' ) );
 		$response = rest_do_request( $request );
 
@@ -95,6 +98,7 @@ class QueryTemplateControllerTest extends WP_UnitTestCase {
 		$post_id = self::factory()->post->create( array( 'post_content' => $content ) );
 
 		$request = new WP_REST_Request( 'GET', '/designsetgo/v1/query/template' );
+		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$request->set_query_params( array( 'post_id' => $post_id, 'query_id' => 'nested' ) );
 		$response = rest_do_request( $request );
 
@@ -113,6 +117,7 @@ class QueryTemplateControllerTest extends WP_UnitTestCase {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 
 		$request = new WP_REST_Request( 'POST', '/designsetgo/v1/query/template' );
+		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$request->set_body_params(
 			array(
 				'schemaVersion' => 2,
@@ -133,6 +138,7 @@ class QueryTemplateControllerTest extends WP_UnitTestCase {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 
 		$request = new WP_REST_Request( 'POST', '/designsetgo/v1/query/template' );
+		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$request->set_body_params(
 			array(
 				'schemaVersion' => 1,
@@ -153,6 +159,7 @@ class QueryTemplateControllerTest extends WP_UnitTestCase {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 
 		$request = new WP_REST_Request( 'POST', '/designsetgo/v1/query/template' );
+		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$request->set_body_params(
 			array(
 				'schemaVersion' => 1,
@@ -178,6 +185,7 @@ class QueryTemplateControllerTest extends WP_UnitTestCase {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 
 		$request = new WP_REST_Request( 'POST', '/designsetgo/v1/query/template' );
+		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$request->set_body_params(
 			array(
 				'schemaVersion' => 1,
@@ -203,6 +211,7 @@ class QueryTemplateControllerTest extends WP_UnitTestCase {
 	public function test_import_escapes_block_comment_terminator_in_attrs() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 		$request = new WP_REST_Request( 'POST', '/designsetgo/v1/query/template' );
+		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$request->set_body_params(
 			array(
 				'schemaVersion' => 1,
@@ -233,6 +242,7 @@ class QueryTemplateControllerTest extends WP_UnitTestCase {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 
 		$request = new WP_REST_Request( 'POST', '/designsetgo/v1/query/template' );
+		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$request->set_body_params(
 			array(
 				'schemaVersion' => 1,
@@ -260,6 +270,7 @@ class QueryTemplateControllerTest extends WP_UnitTestCase {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 
 		$request = new WP_REST_Request( 'POST', '/designsetgo/v1/query/template' );
+		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$request->set_body_params(
 			array(
 				'schemaVersion' => 1,

--- a/tests/phpunit/custom-css-renderer-test.php
+++ b/tests/phpunit/custom-css-renderer-test.php
@@ -214,6 +214,36 @@ class Test_Custom_CSS_Renderer extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a malicious custom_css_output filter cannot inject markup.
+	 *
+	 * The filter runs after per-block sanitization, so its result is re-stripped
+	 * before being echoed inside the <style> block.
+	 */
+	public function test_custom_css_output_filter_result_is_resanitized() {
+		$block = array(
+			'blockName' => 'designsetgo/test',
+			'attrs'     => array( 'dsgoCustomCSS' => 'selector { color: red; }' ),
+		);
+		$this->renderer->collect_custom_css( '<div>Test</div>', $block );
+
+		$inject = static function () {
+			return '</style><script>alert(1)</script>selector{color:blue}javascript:foo';
+		};
+		add_filter( 'designsetgo/custom_css_output', $inject );
+
+		ob_start();
+		$this->renderer->render_custom_css();
+		$output = ob_get_clean();
+
+		remove_filter( 'designsetgo/custom_css_output', $inject );
+
+		// The injected script tag and protocol must be stripped from the output.
+		$this->assertStringNotContainsString( '<script>', $output );
+		$this->assertStringNotContainsString( '</script>', $output );
+		$this->assertStringNotContainsString( 'javascript:', $output );
+	}
+
+	/**
 	 * Test render_custom_css deduplicates identical CSS
 	 */
 	public function test_render_custom_css_deduplication() {

--- a/tests/phpunit/draft-mode-test.php
+++ b/tests/phpunit/draft-mode-test.php
@@ -132,6 +132,33 @@ class Test_Draft_Mode extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that object-injection payloads are not copied to the draft.
+	 *
+	 * A serialized PHP object nested inside an array must be rejected by the
+	 * recursive guard, while plain scalar/array meta still copies.
+	 */
+	public function test_create_draft_skips_meta_containing_nested_objects() {
+		// Object nested inside an array (the case a flat is_object() check misses).
+		update_post_meta( $this->page_id, 'nested_object_meta', array( 'payload' => new \stdClass() ) );
+		// Top-level object.
+		update_post_meta( $this->page_id, 'object_meta', new \stdClass() );
+		// Safe scalar/array meta that must survive.
+		update_post_meta( $this->page_id, 'safe_meta', 'keep-me' );
+		update_post_meta( $this->page_id, 'safe_array_meta', array( 'a', 'b' ) );
+
+		$draft_id = $this->draft_mode->create_draft( $this->page_id );
+		$this->assertIsInt( $draft_id );
+
+		// Object-bearing meta is not copied.
+		$this->assertSame( '', get_post_meta( $draft_id, 'nested_object_meta', true ) );
+		$this->assertSame( '', get_post_meta( $draft_id, 'object_meta', true ) );
+
+		// Safe meta is copied.
+		$this->assertSame( 'keep-me', get_post_meta( $draft_id, 'safe_meta', true ) );
+		$this->assertSame( array( 'a', 'b' ), get_post_meta( $draft_id, 'safe_array_meta', true ) );
+	}
+
+	/**
 	 * Test creating draft fails for invalid post ID.
 	 */
 	public function test_create_draft_invalid_post() {

--- a/tests/phpunit/form-handler-test.php
+++ b/tests/phpunit/form-handler-test.php
@@ -682,6 +682,128 @@ class Test_Form_Handler extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test validate_field enforces a server-defined allowed-value list.
+	 *
+	 * Covers the select/checkbox/hidden enforcement: a value outside the list
+	 * is rejected with 'value_not_allowed'; a member passes; empty short-circuits.
+	 */
+	public function test_validate_field_enforces_allowed_values() {
+		$allowed = array( 'option-1', 'option-2' );
+
+		// A member of the list passes.
+		$this->assertTrue(
+			$this->call_private_method( 'validate_field', array( 'option-1', 'select', $allowed ) )
+		);
+
+		// A value outside the list is rejected.
+		$result = $this->call_private_method( 'validate_field', array( 'forged', 'select', $allowed ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'value_not_allowed', $result->get_error_code() );
+
+		// A forged hidden-field constant is rejected.
+		$hidden = $this->call_private_method( 'validate_field', array( 'tampered', 'hidden', array( 'real-constant' ) ) );
+		$this->assertInstanceOf( WP_Error::class, $hidden );
+		$this->assertEquals( 'value_not_allowed', $hidden->get_error_code() );
+
+		// Empty values still short-circuit (optional fields), even with a list.
+		$this->assertTrue(
+			$this->call_private_method( 'validate_field', array( '', 'select', $allowed ) )
+		);
+
+		// With no list (null), any value passes the membership gate.
+		$this->assertTrue(
+			$this->call_private_method( 'validate_field', array( 'anything', 'text', null ) )
+		);
+	}
+
+	/**
+	 * Test get_form_field_value_constraints extracts allowed values per field.
+	 */
+	public function test_get_form_field_value_constraints_extracts_allowed_values() {
+		$form_id = 'constraints1';
+		$content = '<!-- wp:designsetgo/form-builder {"formId":"' . $form_id . '"} --><div class="wp-block-designsetgo-form-builder">'
+				. '<!-- wp:designsetgo/form-select-field {"fieldName":"pick","options":[{"label":"A","value":"a"},{"label":"B","value":"b"}]} /-->'
+				. '<!-- wp:designsetgo/form-checkbox-field {"fieldName":"consent","value":"yes"} /-->'
+				. '<!-- wp:designsetgo/form-hidden-field {"fieldName":"campaign","value":"spring"} /-->'
+				. '<!-- wp:designsetgo/form-text-field {"fieldName":"name"} /-->'
+				. '</div><!-- /wp:designsetgo/form-builder -->';
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_title'   => 'Constraints Form',
+				'post_content' => $content,
+			)
+		);
+
+		$this->assertNotWPError( $post_id );
+		delete_transient( 'dsgo_form_field_constraints_' . md5( $form_id ) );
+
+		$constraints = $this->call_private_method( 'get_form_field_value_constraints', array( $form_id ) );
+
+		$this->assertEquals(
+			array(
+				'pick'     => array( 'a', 'b' ),
+				'consent'  => array( 'yes' ),
+				'campaign' => array( 'spring' ),
+			),
+			$constraints
+		);
+		// Unconstrained text field is absent from the map.
+		$this->assertArrayNotHasKey( 'name', $constraints );
+
+		wp_delete_post( $post_id, true );
+		delete_transient( 'dsgo_form_field_constraints_' . md5( $form_id ) );
+	}
+
+	/**
+	 * Test a forged select value is rejected end-to-end via the submit endpoint.
+	 */
+	public function test_forged_select_value_is_rejected() {
+		$form_id = 'forgedselect1';
+		$content = '<!-- wp:designsetgo/form-builder {"formId":"' . $form_id . '"} --><div class="wp-block-designsetgo-form-builder">'
+				. '<!-- wp:designsetgo/form-select-field {"fieldName":"pick","options":[{"label":"A","value":"a"},{"label":"B","value":"b"}]} /-->'
+				. '</div><!-- /wp:designsetgo/form-builder -->';
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_title'   => 'Forged Select Form',
+				'post_content' => $content,
+			)
+		);
+
+		$this->assertNotWPError( $post_id );
+		delete_transient( 'dsgo_form_field_types_' . md5( $form_id ) );
+		delete_transient( 'dsgo_form_field_constraints_' . md5( $form_id ) );
+
+		$request = new WP_REST_Request( 'POST', '/designsetgo/v1/form/submit' );
+		$request->set_body_params(
+			array(
+				'formId' => $form_id,
+				'fields' => array(
+					array(
+						'name'  => 'pick',
+						'value' => 'c', // Not in the option list.
+						'type'  => 'select',
+					),
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'validation_error', $response->get_data()['code'] );
+
+		wp_delete_post( $post_id, true );
+		delete_transient( 'dsgo_form_field_types_' . md5( $form_id ) );
+		delete_transient( 'dsgo_form_field_constraints_' . md5( $form_id ) );
+	}
+
+	/**
 	 * Test get_form_block_attributes uses transient cache.
 	 */
 	public function test_form_block_attributes_are_cached() {

--- a/tests/phpunit/llms-txt-test.php
+++ b/tests/phpunit/llms-txt-test.php
@@ -276,6 +276,7 @@ class Test_LLMS_Txt extends WP_UnitTestCase {
 		set_transient( Controller::CACHE_KEY, 'test content' );
 
 		$request  = new WP_REST_Request( 'POST', '/designsetgo/v1/llms-txt/flush-cache' );
+		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$response = rest_do_request( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -293,6 +294,7 @@ class Test_LLMS_Txt extends WP_UnitTestCase {
 		set_transient( 'designsetgo_llms_md_post_2', 'cached markdown 2' );
 
 		$request  = new WP_REST_Request( 'POST', '/designsetgo/v1/llms-txt/flush-cache' );
+		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$response = rest_do_request( $request );
 
 		$this->assertEquals( 200, $response->get_status() );

--- a/tests/phpunit/security-fixes-test.php
+++ b/tests/phpunit/security-fixes-test.php
@@ -253,6 +253,98 @@ class Test_Security_Fixes extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the settings GET endpoint redacts the write-only Turnstile secret.
+	 *
+	 * The secret must never reach the browser, but get_settings() must keep
+	 * returning the real value for server-side consumers.
+	 */
+	public function test_settings_get_endpoint_redacts_turnstile_secret() {
+		wp_set_current_user( $this->admin_user );
+
+		\DesignSetGo\Admin\Settings::invalidate_cache();
+		update_option(
+			\DesignSetGo\Admin\Settings::OPTION_NAME,
+			array( 'integrations' => array( 'turnstile_secret_key' => 'real-secret-0x123' ) )
+		);
+		\DesignSetGo\Admin\Settings::invalidate_cache();
+
+		$settings = new \DesignSetGo\Admin\Settings();
+		$data     = $settings->get_settings_endpoint()->get_data();
+
+		// The REST response redacts the secret.
+		$this->assertSame(
+			\DesignSetGo\Admin\Settings::REDACTED_PLACEHOLDER,
+			$data['integrations']['turnstile_secret_key']
+		);
+		// The underlying value is intact for server-side consumers.
+		$this->assertSame(
+			'real-secret-0x123',
+			\DesignSetGo\Admin\Settings::get_settings()['integrations']['turnstile_secret_key']
+		);
+
+		delete_option( \DesignSetGo\Admin\Settings::OPTION_NAME );
+		\DesignSetGo\Admin\Settings::invalidate_cache();
+	}
+
+	/**
+	 * Test that an empty secret is not redacted (UI shows an empty field).
+	 */
+	public function test_settings_get_endpoint_leaves_empty_secret_empty() {
+		wp_set_current_user( $this->admin_user );
+
+		\DesignSetGo\Admin\Settings::invalidate_cache();
+		update_option(
+			\DesignSetGo\Admin\Settings::OPTION_NAME,
+			array( 'integrations' => array( 'turnstile_secret_key' => '' ) )
+		);
+		\DesignSetGo\Admin\Settings::invalidate_cache();
+
+		$settings = new \DesignSetGo\Admin\Settings();
+		$data     = $settings->get_settings_endpoint()->get_data();
+
+		$this->assertSame( '', $data['integrations']['turnstile_secret_key'] );
+
+		delete_option( \DesignSetGo\Admin\Settings::OPTION_NAME );
+		\DesignSetGo\Admin\Settings::invalidate_cache();
+	}
+
+	/**
+	 * Test the secret round-trip: the placeholder preserves the stored secret,
+	 * a real new value replaces it.
+	 */
+	public function test_settings_update_round_trips_redacted_secret() {
+		wp_set_current_user( $this->admin_user );
+
+		\DesignSetGo\Admin\Settings::invalidate_cache();
+		update_option(
+			\DesignSetGo\Admin\Settings::OPTION_NAME,
+			array( 'integrations' => array( 'turnstile_secret_key' => 'stored-secret' ) )
+		);
+		\DesignSetGo\Admin\Settings::invalidate_cache();
+
+		// Submitting the redaction placeholder preserves the stored secret.
+		\DesignSetGo\Admin\Settings::update_settings(
+			array( 'integrations' => array( 'turnstile_secret_key' => \DesignSetGo\Admin\Settings::REDACTED_PLACEHOLDER ) )
+		);
+		$this->assertSame(
+			'stored-secret',
+			\DesignSetGo\Admin\Settings::get_settings()['integrations']['turnstile_secret_key']
+		);
+
+		// Submitting a real new value replaces it.
+		\DesignSetGo\Admin\Settings::update_settings(
+			array( 'integrations' => array( 'turnstile_secret_key' => 'new-secret' ) )
+		);
+		$this->assertSame(
+			'new-secret',
+			\DesignSetGo\Admin\Settings::get_settings()['integrations']['turnstile_secret_key']
+		);
+
+		delete_option( \DesignSetGo\Admin\Settings::OPTION_NAME );
+		\DesignSetGo\Admin\Settings::invalidate_cache();
+	}
+
+	/**
 	 * Test permission check ordering in Global Styles REST API
 	 *
 	 * Verifies that capability checks happen before nonce verification.


### PR DESCRIPTION
## Summary

Addresses all six **Medium** findings from a security audit of the plugin (no Critical/High exploitable vulnerabilities were found). All fixes are server-side PHP hardening — no block attribute schema or HTML changes, so **no block deprecations are required**.

| # | Finding | Fix |
|---|---------|-----|
| **S1** | Turnstile secret key leaked via REST GET `/settings` | Redact `integrations.turnstile_secret_key` to a placeholder on read; strip the placeholder on write so the stored secret is preserved (`write_only_secret_keys()` map) |
| **S2** | Mutating REST routes lacked nonce verification | Verify `X-WP-Nonce` on the 4 llms-txt POST routes (`check_admin_permission()`) and query template export/import (`verify_nonce()`) |
| **S3** | `user_url` returned without scheme validation | `current-user-url` dynamic-tags source now passes through `esc_url_raw(…, ['http','https'])` |
| **S4** | `custom_css_output` filter result echoed without re-sanitization | Extracted `strip_dangerous_css()` and re-run it on the filter result before echo |
| **S5** | select/checkbox/hidden fields lacked server-side allowed-value enforcement | New `get_form_field_value_constraints()` + `$allowed` param on `validate_field()` enforce membership/constants from the server-parsed block |
| **S6** | Incomplete object-injection guard in Draft Mode | Recursive `contains_object()` replaces flat `is_object()` in both meta-copy paths |

All affected REST routes are called from the editor/admin via `@wordpress/api-fetch`, which auto-injects `X-WP-Nonce`, so the nonce checks don't break the UI.

The two **Low** finding clusters (S7–S11) are intentionally out of scope for this PR.

## Test plan

- `composer lint` (phpcs over `includes/`) — clean
- `vendor/bin/phpstan analyse --memory-limit=1G` — no errors
- Full PHPUnit suite via wp-env — **804 passing**, 0 failures (6 pre-existing env skips)
- Added regression tests for S1 (redaction round-trip), S4 (output-filter re-sanitization), S5 (allowed-value enforcement), S6 (nested-object guard); updated query-template / llms-txt tests to send a valid nonce

🤖 Generated with [Claude Code](https://claude.com/claude-code)