### PR TITLE
fix(form-builder): prevent accidental black border around form block

### DIFF
--- a/src/blocks/form-builder/style.scss
+++ b/src/blocks/form-builder/style.scss
@@ -15,6 +15,14 @@
 	--dsgo-form-success-color: #16a34a;
 	// Button colors intentionally not set here - uses theme defaults unless overridden
 
+	// The wrapper itself must never render a border. WordPress core ships
+	// `html :where([style*="border-color"]) { border-style: solid; }`, whose
+	// substring match catches the `--dsgo-form-border-color` custom property in
+	// this block's inline style and forces a solid border (with currentColor and
+	// a default width) around the whole form. The border color is only ever
+	// consumed by the field inputs, never the wrapper, so reset it here.
+	border-style: none;
+
 	// Prevents padding + border from exceeding container width when border-radius is applied
 	box-sizing: border-box;
 	padding: 1rem;


### PR DESCRIPTION
## Problem

Generated/edited sites show a **solid near-black border around the entire contact form** (the `.dsgo-form-builder` wrapper), even though only the input fields are meant to have a light-gray border.

### Root cause

The form-builder wrapper emits an inline CSS custom property `--dsgo-form-border-color:#d1d5db`. WordPress core (`block-library/common.css`) ships:

```css
html :where([style*="border-color"]) { border-style: solid; }
```

That attribute selector is a **substring** match — it matches the custom-property *name* `--dsgo-form-border-color` because it contains the literal text `border-color`. WordPress then forces `border-style: solid` on the wrapper. With no width/color intentionally set, the border falls back to a default width and `currentColor` (the theme's near-black text color), producing a black box around the whole form.

The `#d1d5db` value is a red herring — it's never applied to the wrapper. The property is only ever consumed by the field inputs (`form-text-field/style.scss` → `--dsgo-field-border-color` → `border: 1px solid var(...)`).

## Fix

Reset `border-style: none` on `.dsgo-form-builder` so the wrapper never renders a border. One line, and it fixes the issue everywhere the property is emitted:

- existing saved content (incl. deprecated block versions)
- fresh editor inserts (`save.js` / `edit.js`)
- pattern / AI-generated forms (`includes/abilities/class-block-inserter.php`)

…without touching any of the inline-style emit sites.

## Verification

- Reproduced live: wrapper computed border was `1.5px solid rgb(17,17,17)`; removing the trigger dropped it to `0px none` while input field borders stayed light gray.
- `npm run build` succeeds; compiled `build/blocks/form-builder/index.css` now includes `border-style:none` on `.dsgo-form-builder`.
- `wp-scripts lint-style` passes on the changed file.

## Before / After

Before: black box around the full form, gray inputs inside.
After: black box gone, gray field borders unchanged.