### PR TITLE
feat(scroll-marquee): add object-fit control to Scrolling Gallery

### DIFF
--- a/src/blocks/scroll-marquee/block.json
+++ b/src/blocks/scroll-marquee/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "designsetgo/scroll-marquee",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"title": "Scrolling Gallery",
 	"category": "designsetgo",
 	"description": "Display rows of images that scroll horizontally in alternating directions based on page scroll. For best performance, use optimized images (WebP format recommended) and limit to 20 images or less.",
@@ -77,6 +77,11 @@
 		"imageWidth": {
 			"type": "string",
 			"default": "300px"
+		},
+		"objectFit": {
+			"type": "string",
+			"default": "cover",
+			"enum": [ "cover", "contain", "fill", "scale-down" ]
 		},
 		"gap": {
 			"type": "string",

--- a/src/blocks/scroll-marquee/deprecated.js
+++ b/src/blocks/scroll-marquee/deprecated.js
@@ -76,6 +76,15 @@ const v2 = {
 		// Only claim blocks whose rows are already serialized in the
 		// comment (this format). Ancient v1 blocks parse to empty rows
 		// here and must fall through to the v1 query-source deprecation.
+		//
+		// Known benign gap: a v2 block whose rows were all emptied of
+		// images is indistinguishable from a v1 block at the attribute
+		// level (both parse to image-less rows), so it also falls
+		// through to v1. v1.migrate is fully defensive and yields valid
+		// data, so the output is identical either way. We intentionally
+		// gate on row data rather than `rows` presence — `rows` has a
+		// default and is never undefined, so a presence check would
+		// wrongly claim ancient v1 blocks and discard their images.
 		return (
 			Array.isArray(attributes.rows) &&
 			attributes.rows.some(
@@ -207,21 +216,7 @@ const v1 = {
 			default: '8px',
 		},
 	},
-	supports: {
-		anchor: true,
-		align: false,
-		html: false,
-		spacing: {
-			margin: false,
-			padding: false,
-			blockGap: true,
-		},
-		color: {
-			background: true,
-			text: true,
-			gradients: true,
-		},
-	},
+	supports: sharedSupports,
 	migrate(attributes) {
 		// scrollSpeed comes back as a string from the HTML attribute source,
 		// convert to number for the new format.

--- a/src/blocks/scroll-marquee/deprecated.js
+++ b/src/blocks/scroll-marquee/deprecated.js
@@ -1,6 +1,11 @@
 /**
  * Scroll Marquee Block - Deprecations
  *
+ * v2: Save before the objectFit control. The frontend CSS hard-coded
+ * `object-fit: cover`, so the saved markup never emitted the
+ * `--dsgo-marquee-object-fit` custom property. Current saves always
+ * emit it, so older blocks need this deprecation to migrate silently.
+ *
  * v1: Original save without items schema on the rows attribute.
  * The rows data was not serialized to the block comment because WP
  * could not properly diff the nested array without an items schema.
@@ -12,6 +17,132 @@
  */
 
 import { useBlockProps } from '@wordpress/block-editor';
+
+const sharedSupports = {
+	anchor: true,
+	align: false,
+	html: false,
+	spacing: {
+		margin: false,
+		padding: false,
+		blockGap: true,
+	},
+	color: {
+		background: true,
+		text: true,
+		gradients: true,
+	},
+};
+
+const v2 = {
+	attributes: {
+		rows: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					images: {
+						type: 'array',
+						items: {
+							type: 'object',
+							properties: {
+								id: { type: 'number' },
+								url: { type: 'string' },
+								alt: { type: 'string' },
+							},
+						},
+					},
+					direction: { type: 'string' },
+				},
+			},
+			default: [{ images: [], direction: 'left' }],
+		},
+		scrollSpeed: { type: 'number', default: 0.5 },
+		imageHeight: { type: 'string', default: '200px' },
+		imageWidth: { type: 'string', default: '300px' },
+		gap: { type: 'string', default: '20px' },
+		rowGap: { type: 'string', default: '20px' },
+		borderRadius: { type: 'string', default: '8px' },
+	},
+	supports: sharedSupports,
+	isEligible(attributes, innerBlocks, { innerHTML }) {
+		// Old (pre-objectFit) saves never emitted this custom property.
+		const hasObjectFitVar =
+			typeof innerHTML === 'string' &&
+			innerHTML.includes('--dsgo-marquee-object-fit');
+		if (hasObjectFitVar) {
+			return false;
+		}
+		// Only claim blocks whose rows are already serialized in the
+		// comment (this format). Ancient v1 blocks parse to empty rows
+		// here and must fall through to the v1 query-source deprecation.
+		return (
+			Array.isArray(attributes.rows) &&
+			attributes.rows.some(
+				(row) => Array.isArray(row.images) && row.images.length > 0
+			)
+		);
+	},
+	migrate(attributes) {
+		// objectFit's block.json default ('cover') is filled in
+		// automatically; the prior hard-coded CSS matched that value.
+		return attributes;
+	},
+	save({ attributes }) {
+		const {
+			rows,
+			scrollSpeed,
+			imageHeight,
+			imageWidth,
+			gap,
+			rowGap,
+			borderRadius,
+		} = attributes;
+
+		const blockProps = useBlockProps.save({
+			className: 'dsgo-scroll-marquee',
+			'data-scroll-speed': scrollSpeed,
+			style: {
+				'--dsgo-marquee-gap': gap,
+				'--dsgo-marquee-row-gap': rowGap,
+				'--dsgo-marquee-image-height': imageHeight,
+				'--dsgo-marquee-image-width': imageWidth,
+				'--dsgo-marquee-border-radius': borderRadius,
+			},
+		});
+
+		return (
+			<div {...blockProps}>
+				{rows.map((row, rowIndex) => (
+					<div
+						key={rowIndex}
+						className="dsgo-scroll-marquee__row"
+						data-direction={row.direction}
+					>
+						<div className="dsgo-scroll-marquee__track">
+							{[...Array(6)].map((_, repeatIndex) => (
+								<div
+									key={repeatIndex}
+									className="dsgo-scroll-marquee__track-segment"
+								>
+									{row.images.map((image, imageIndex) => (
+										<img
+											key={`${repeatIndex}-${imageIndex}`}
+											src={image.url}
+											alt={image.alt || ''}
+											className="dsgo-scroll-marquee__image"
+											loading="lazy"
+										/>
+									))}
+								</div>
+							))}
+						</div>
+					</div>
+				))}
+			</div>
+		);
+	},
+};
 
 const v1 = {
 	attributes: {
@@ -176,4 +307,4 @@ const v1 = {
 	},
 };
 
-export default [v1];
+export default [v2, v1];

--- a/src/blocks/scroll-marquee/edit.js
+++ b/src/blocks/scroll-marquee/edit.js
@@ -7,6 +7,7 @@ import {
 } from '@wordpress/block-editor';
 import {
 	RangeControl,
+	SelectControl,
 	Button,
 	Notice,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- no stable export in @wordpress/components
@@ -27,6 +28,7 @@ export default function ScrollMarqueeEdit({
 		scrollSpeed,
 		imageHeight,
 		imageWidth,
+		objectFit,
 		gap,
 		rowGap,
 		borderRadius,
@@ -35,6 +37,7 @@ export default function ScrollMarqueeEdit({
 	const imageInlineStyle = {
 		height: imageHeight,
 		width: imageWidth,
+		objectFit,
 		borderRadius,
 	};
 
@@ -52,6 +55,7 @@ export default function ScrollMarqueeEdit({
 			'--dsgo-marquee-row-gap': rowGap,
 			'--dsgo-marquee-image-height': imageHeight,
 			'--dsgo-marquee-image-width': imageWidth,
+			'--dsgo-marquee-object-fit': objectFit,
 			'--dsgo-marquee-border-radius': borderRadius,
 		},
 	});
@@ -109,6 +113,7 @@ export default function ScrollMarqueeEdit({
 							scrollSpeed: 0.5,
 							imageHeight: '200px',
 							imageWidth: '300px',
+							objectFit: 'cover',
 							gap: '20px',
 							rowGap: '20px',
 							borderRadius: '8px',
@@ -192,6 +197,45 @@ export default function ScrollMarqueeEdit({
 							onChange={(value) =>
 								setAttributes({ imageWidth: value })
 							}
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+					</DsgoInspectorPanel.Item>
+
+					<DsgoInspectorPanel.Item
+						label={__('Image Fit', 'designsetgo')}
+						hasValue={() => objectFit !== 'cover'}
+						onDeselect={() => setAttributes({ objectFit: 'cover' })}
+						isShownByDefault
+					>
+						<SelectControl
+							label={__('Image Fit', 'designsetgo')}
+							value={objectFit}
+							options={[
+								{
+									label: __('Cover', 'designsetgo'),
+									value: 'cover',
+								},
+								{
+									label: __('Contain', 'designsetgo'),
+									value: 'contain',
+								},
+								{
+									label: __('Fill', 'designsetgo'),
+									value: 'fill',
+								},
+								{
+									label: __('Scale down', 'designsetgo'),
+									value: 'scale-down',
+								},
+							]}
+							onChange={(value) =>
+								setAttributes({ objectFit: value })
+							}
+							help={__(
+								'How each image fills its box. Cover crops to fill; Contain fits the whole image and may letterbox.',
+								'designsetgo'
+							)}
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 						/>

--- a/src/blocks/scroll-marquee/save.js
+++ b/src/blocks/scroll-marquee/save.js
@@ -6,6 +6,7 @@ export default function ScrollMarqueeSave({ attributes }) {
 		scrollSpeed,
 		imageHeight,
 		imageWidth,
+		objectFit,
 		gap,
 		rowGap,
 		borderRadius,
@@ -19,6 +20,7 @@ export default function ScrollMarqueeSave({ attributes }) {
 			'--dsgo-marquee-row-gap': rowGap,
 			'--dsgo-marquee-image-height': imageHeight,
 			'--dsgo-marquee-image-width': imageWidth,
+			'--dsgo-marquee-object-fit': objectFit,
 			'--dsgo-marquee-border-radius': borderRadius,
 		},
 	});

--- a/src/blocks/scroll-marquee/style.scss
+++ b/src/blocks/scroll-marquee/style.scss
@@ -8,6 +8,7 @@
 	--dsgo-marquee-row-gap: 20px;
 	--dsgo-marquee-image-height: 200px;
 	--dsgo-marquee-image-width: 300px;
+	--dsgo-marquee-object-fit: cover;
 	--dsgo-marquee-border-radius: 8px;
 
 	// Respect parent container width like other blocks
@@ -55,7 +56,7 @@
 	&__image {
 		height: var(--dsgo-marquee-image-height);
 		width: var(--dsgo-marquee-image-width);
-		object-fit: cover;
+		object-fit: var(--dsgo-marquee-object-fit, cover);
 		border-radius: var(--dsgo-marquee-border-radius);
 		flex-shrink: 0; // Prevent images from shrinking
 		display: block;


### PR DESCRIPTION
## Summary

Adds an **Image Fit** control to the Scrolling Gallery block (`designsetgo/scroll-marquee`). Previously the block hard-coded `object-fit: cover` in CSS; authors can now choose **Cover / Contain / Fill / Scale-down**, applied block-wide via a new `--dsgo-marquee-object-fit` custom property.

## Changes

- **block.json** — new `objectFit` attribute (`enum`, default `cover`); version bumped to `1.1.0`.
- **style.scss** — `object-fit: cover` → `object-fit: var(--dsgo-marquee-object-fit, cover)`.
- **save.js / edit.js** — emit the custom property; new `SelectControl` in the Settings panel with live editor preview and a `resetAll` entry.
- **deprecated.js** — new `v2` deprecation so existing galleries migrate silently.

## Backward compatibility

The new `v2` deprecation reproduces the pre-`objectFit` save (no custom property). Its `isEligible` claims a saved block only when the markup lacks `--dsgo-marquee-object-fit` **and** its rows are already serialized — so genuinely old `v1`-format blocks (rows pulled via `source: "query"`) still fall through to `v1` rather than being clobbered. `migrate` is a passthrough; the `objectFit` default of `cover` matches the previously hard-coded CSS, so existing galleries render identically.

## Verification

- `npm run build` ✅
- `npm run lint:js` ✅ · `npm run lint:css` (scroll-marquee) ✅
- Confirmed `object-fit:var(--dsgo-marquee-object-fit,cover)` in both the frontend (`style-index.css`) and editor (`index.css`) bundles.
- Pre-commit e2e suite passed (7/7).

## Not covered

- No live-editor runtime check of the auto-migration / new dropdown yet.
- No `core/gallery` ↔ block transform (out of scope — enhancement is in-place).
