### PR TITLE
fix(max-width): respect text alignment for constrained blocks

### DIFF
--- a/src/extensions/max-width/editor.scss
+++ b/src/extensions/max-width/editor.scss
@@ -43,3 +43,43 @@
 	margin-left: auto !important;
 	margin-right: auto !important;
 }
+
+// Alignment-aware anchoring.
+// By default a max-width block is centered (margin: auto). When the block
+// carries a text alignment, anchor the constrained box to that edge instead
+// so it follows the alignment the author set (and the parent section's intent)
+// rather than always sitting in the middle.
+// Keyed on core's `has-text-align-*` classes, which are added whether the
+// alignment is stored at the top level or under style.typography.textAlign.
+// Specificity (0,2,0) intentionally beats the base `.dsgo-has-max-width`
+// (0,1,0) rules above and the per-block injected `[data-block]` styles.
+.dsgo-has-max-width.has-text-align-left {
+	margin-left: 0 !important;
+	margin-right: auto !important;
+}
+
+.dsgo-has-max-width.has-text-align-right {
+	margin-left: auto !important;
+	margin-right: 0 !important;
+}
+
+.dsgo-has-max-width.has-text-align-center {
+	margin-left: auto !important;
+	margin-right: auto !important;
+}
+
+// Top-level blocks are centered by core's editor rule
+// `.block-editor-block-list__layout.is-root-container > :where(:not(...))`,
+// which ties at (0,2,0) with the selectors above and wins on source order.
+// Bump specificity to (0,3,0) so the alignment override also wins for a
+// max-width block placed directly at the post root (keeps editor + frontend
+// consistent — the frontend has no equivalent root-container rule).
+.block-editor-block-list__layout > .dsgo-has-max-width.has-text-align-left {
+	margin-left: 0 !important;
+	margin-right: auto !important;
+}
+
+.block-editor-block-list__layout > .dsgo-has-max-width.has-text-align-right {
+	margin-left: auto !important;
+	margin-right: 0 !important;
+}

--- a/src/extensions/max-width/style.scss
+++ b/src/extensions/max-width/style.scss
@@ -32,3 +32,26 @@
 	margin-left: auto !important;
 	margin-right: auto !important;
 }
+
+// Alignment-aware anchoring.
+// A max-width block is centered by default via the inline `margin: auto` that
+// the extension writes. When the block carries a text alignment, anchor the
+// constrained box to that edge so it follows the author's alignment instead of
+// always centering. `!important` is required to beat the inline margins.
+// Keyed on core's `has-text-align-*` classes, which are present whether the
+// alignment is stored at the top level or under style.typography.textAlign, so
+// this also corrects content saved before this fix without a re-save.
+.dsgo-has-max-width.has-text-align-left {
+	margin-left: 0 !important;
+	margin-right: auto !important;
+}
+
+.dsgo-has-max-width.has-text-align-right {
+	margin-left: auto !important;
+	margin-right: 0 !important;
+}
+
+.dsgo-has-max-width.has-text-align-center {
+	margin-left: auto !important;
+	margin-right: auto !important;
+}


### PR DESCRIPTION
## Summary

A block with a **max width** (the DesignSetGo max-width extension) always centered itself via `margin:auto`, ignoring the block's text alignment. A left- or right-aligned heading with a max width stayed in the middle of its section instead of following the alignment (and the parent section's intent).

Example of the affected saved markup:

```html
<h2 class="wp-block-heading has-text-align-left dsgo-has-max-width"
    style="max-width:500px;margin-left:auto;margin-right:auto">…</h2>
```

## Root cause

- The extension writes `margin-left:auto;margin-right:auto` on every max-width block. The JS only varied margins off the legacy top-level `textAlign` attribute, missing alignment stored under `style.typography.textAlign`.
- On the **frontend** the centering comes purely from the inline `margin:auto`; in the **editor** `editor.scss` `.dsgo-has-max-width { margin:…auto !important }` overrode the per-block injected style. So the fix has to live where the cascade is actually decided.
- (`--dsgo-max-width` is never assigned anywhere, so the existing `[data-dsgo-max-width]` rules are dead no-ops.)

## Fix

CSS-only, in both `style.scss` (frontend) and `editor.scss` (editor), keyed on core's `has-text-align-*` classes (present regardless of whether alignment is stored at the top level or under `style.typography.textAlign`):

- `has-text-align-left`  → anchor left (`margin-left:0; margin-right:auto`)
- `has-text-align-right` → anchor right (`margin-left:auto; margin-right:0`)
- `has-text-align-center` → centered (unchanged default)
- A higher-specificity editor rule for top-level blocks, which core centers via the root-container layout rule.

**Why CSS over JS:** no `save()` output changes → no block-validation warnings and no deprecation needed, **and** already-saved content is corrected without a re-save.

## Verification (Chrome DevTools, wp-env)

- **Frontend** (exact reported markup): LEFT → left edge, CENTER → centered, RIGHT → right edge.
- **Editor, heading nested in a DSGo section** (the real scenario): anchors left.
- **Editor, top-level heading**: margins `0 / 330 / 660px` = left / center / right.
- `stylelint` clean; `npm run build` succeeds; pre-commit e2e suite passes.

## Behavior note

A max-width box now **follows its text alignment** (e.g. text-align-left ⇒ box hugs the left), matching the extension's original intent. The "centered box with left-aligned text" combination is no longer achievable via text alignment alone.