### PR TITLE
fix(form-builder): stabilize useSelect result to remove re-render warning

### DIFF
--- a/src/blocks/form-builder/edit.js
+++ b/src/blocks/form-builder/edit.js
@@ -26,7 +26,7 @@ import {
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import { DsgoInspectorPanel } from '../../components/shared';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import classnames from 'classnames';
 import { useUniqueBlockId } from '../../hooks';
@@ -139,23 +139,28 @@ export default function FormBuilderEdit({
 
 	// Track child count so we can show the template chooser on first insert,
 	// and build the reply-to dropdown options from the actual form fields.
-	const { hasInnerBlocks, replyToFieldOptions } = useSelect(
-		(select) => {
-			const children =
-				select('core/block-editor').getBlocks(clientId) || [];
-			const fields = children
+	//
+	// Return the store's already-memoized `getBlocks` array directly rather than
+	// a freshly-derived object/array: useSelect compares its mapSelect result by
+	// reference, so building `.filter().map()` output inside the selector makes
+	// it unstable on every call (the "useSelect returns different values" dev
+	// warning). Derive the dropdown options in a useMemo keyed on that stable
+	// array instead.
+	const childBlocks = useSelect(
+		(select) => select('core/block-editor').getBlocks(clientId),
+		[clientId]
+	);
+	const hasInnerBlocks = childBlocks.length > 0;
+	const replyToFieldOptions = useMemo(
+		() =>
+			childBlocks
 				.filter((child) => EMAILABLE_FIELD_BLOCKS.has(child.name))
 				.map((child) => ({
 					name: child.attributes?.fieldName || '',
 					label: child.attributes?.label || '',
 				}))
-				.filter((field) => !!field.name);
-			return {
-				hasInnerBlocks: children.length > 0,
-				replyToFieldOptions: fields,
-			};
-		},
-		[clientId]
+				.filter((field) => !!field.name),
+		[childBlocks]
 	);
 
 	// Keep hasFields in sync with the actual child field count so save.js can

--- a/src/blocks/form-builder/edit.js
+++ b/src/blocks/form-builder/edit.js
@@ -146,8 +146,11 @@ export default function FormBuilderEdit({
 	// it unstable on every call (the "useSelect returns different values" dev
 	// warning). Derive the dropdown options in a useMemo keyed on that stable
 	// array instead.
+	// `getBlocks` always returns an array (stable `[]` for an unknown clientId),
+	// so `|| []` short-circuits to that same reference and never reintroduces the
+	// instability — it's kept purely as a defensive guard.
 	const childBlocks = useSelect(
-		(select) => select('core/block-editor').getBlocks(clientId),
+		(select) => select('core/block-editor').getBlocks(clientId) || [],
 		[clientId]
 	);
 	const hasInnerBlocks = childBlocks.length > 0;


### PR DESCRIPTION
## Summary

While smoke-testing `release/2.2.0` I noticed a dev-mode console warning whenever a Form Builder block is in the editor:

> The `useSelect` hook returns different values when called with the same state and parameters. This can lead to unnecessary re-renders and performance issues if not fixed. … `replyToFieldOptions`

## Root cause

The inspector's reply-to dropdown built its options with `.filter().map().filter()` **inside** the `useSelect` mapSelect callback and returned a new wrapper object each call:

```js
const { hasInnerBlocks, replyToFieldOptions } = useSelect((select) => {
    const children = select('core/block-editor').getBlocks(clientId) || [];
    const fields = children.filter(...).map(...).filter(...);
    return { hasInnerBlocks: children.length > 0, replyToFieldOptions: fields };
}, [clientId]);
```

`useSelect` compares its mapSelect result by reference. Returning a freshly-derived array/object makes the result unstable on every call, which is exactly what the dev warning detects, and causes avoidable re-renders.

## Fix

Return the store's already-memoized `getBlocks` array from `useSelect` (stable for the same state), and derive `hasInnerBlocks` + `replyToFieldOptions` outside it — the options via `useMemo` keyed on that stable array. Behavior is identical; only referential stability changes.

## Verification

- Reproduced the warning on a Form Builder insert, confirmed it's **gone** after the fix (console clean apart from unrelated `pods` plugin noise).
- `npm run build` ✓, `eslint` ✓
- Pre-commit e2e (incl. form-builder insert/render) 7/7 ✓

Scoped to the one warning; no behavior or markup change.