### PR TITLE
fix(e2e+sec): nav-retry test helper + PR #424 review follow-ups

### DIFF
--- a/includes/admin/class-draft-mode.php
+++ b/includes/admin/class-draft-mode.php
@@ -36,6 +36,14 @@ class Draft_Mode {
 	const META_DRAFT_CREATED = '_dsgo_draft_created';
 
 	/**
+	 * Maximum nesting depth scanned by contains_object().
+	 *
+	 * Anything deeper is treated as containing an object (fail closed),
+	 * capping recursion so a maliciously deep payload cannot overflow the stack.
+	 */
+	const MAX_OBJECT_SCAN_DEPTH = 20;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -472,17 +480,27 @@ class Draft_Mode {
 	 * serialized payload like `a:1:{i:0;O:8:"stdClass":0:{}}`), which would
 	 * still trigger object injection when stored and later unserialized.
 	 *
+	 * Recursion is bounded by self::MAX_OBJECT_SCAN_DEPTH. A structure deeper
+	 * than that is treated as if it contains an object (fail closed) so the
+	 * caller skips it — both eliminating any stack-overflow risk from a
+	 * maliciously deep payload and erring on the side of rejecting it.
+	 *
 	 * @param mixed $value Value to inspect (already passed through maybe_unserialize()).
+	 * @param int   $depth Current recursion depth (internal).
 	 * @return bool True if the value is an object or any nested array element is.
 	 */
-	private static function contains_object( $value ) {
+	private static function contains_object( $value, $depth = 0 ) {
 		if ( is_object( $value ) ) {
 			return true;
 		}
 
 		if ( is_array( $value ) ) {
+			if ( $depth >= self::MAX_OBJECT_SCAN_DEPTH ) {
+				return true;
+			}
+
 			foreach ( $value as $item ) {
-				if ( self::contains_object( $item ) ) {
+				if ( self::contains_object( $item, $depth + 1 ) ) {
 					return true;
 				}
 			}

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -29,8 +29,11 @@ class Settings {
 	 * never reach the browser. The write path treats an incoming value equal
 	 * to this placeholder as "unchanged" and preserves the stored secret. A
 	 * real secret will never equal this string.
+	 *
+	 * Pure ASCII so it is byte-identical across encodings and opcode caches; a
+	 * value this distinctive will not collide with a legitimate secret.
 	 */
-	const REDACTED_PLACEHOLDER = '••••••••';
+	const REDACTED_PLACEHOLDER = '__DSGO_REDACTED__';
 
 	/**
 	 * Constructor

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -32,6 +32,13 @@ class Settings {
 	 *
 	 * Pure ASCII so it is byte-identical across encodings and opcode caches; a
 	 * value this distinctive will not collide with a legitimate secret.
+	 *
+	 * Migration note: this placeholder changed from the prior '••••••••' on
+	 * upgrade. An admin who had the settings page open at the exact moment of
+	 * deploy still holds the old placeholder in their form; submitting without
+	 * re-touching the secret field would write that literal as the new value.
+	 * The window is one page-load wide and fully recoverable (re-enter the
+	 * key). Call it out in release notes for ops teams managing secrets.
 	 */
 	const REDACTED_PLACEHOLDER = '__DSGO_REDACTED__';
 

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -34,13 +34,24 @@ class Settings {
 	 * value this distinctive will not collide with a legitimate secret.
 	 *
 	 * Migration note: this placeholder changed from the prior '••••••••' on
-	 * upgrade. An admin who had the settings page open at the exact moment of
-	 * deploy still holds the old placeholder in their form; submitting without
-	 * re-touching the secret field would write that literal as the new value.
-	 * The window is one page-load wide and fully recoverable (re-enter the
-	 * key). Call it out in release notes for ops teams managing secrets.
+	 * upgrade. A browser that still has the old settings form cached at deploy
+	 * time echoes the old placeholder back on submit. The write path accepts
+	 * LEGACY_REDACTED_PLACEHOLDER as "unchanged" too, so that stale submit
+	 * preserves the stored secret instead of overwriting it. See
+	 * is_redaction_placeholder().
 	 */
 	const REDACTED_PLACEHOLDER = '__DSGO_REDACTED__';
+
+	/**
+	 * Legacy redaction placeholder served by builds before REDACTED_PLACEHOLDER
+	 * became ASCII.
+	 *
+	 * Eight U+2022 bullets. Defined with \u escapes so the bytes are exact
+	 * regardless of how this file is saved or cached in an opcode cache. Only
+	 * ever accepted on write (treated as "unchanged"); read paths emit
+	 * REDACTED_PLACEHOLDER exclusively, so this is never sent to a browser.
+	 */
+	const LEGACY_REDACTED_PLACEHOLDER = "\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}";
 
 	/**
 	 * Constructor
@@ -511,6 +522,22 @@ class Settings {
 	}
 
 	/**
+	 * Whether an incoming secret value is a redaction placeholder meaning
+	 * "unchanged — keep the stored secret rather than persisting this value".
+	 *
+	 * Accepts both the current placeholder and the legacy one so a browser
+	 * holding a stale settings form at upgrade time cannot overwrite the real
+	 * secret with the old bullet string.
+	 *
+	 * @param mixed $value Submitted field value.
+	 * @return bool True when the value is a placeholder and must not be saved.
+	 */
+	private static function is_redaction_placeholder( $value ): bool {
+		return self::REDACTED_PLACEHOLDER === $value
+			|| self::LEGACY_REDACTED_PLACEHOLDER === $value;
+	}
+
+	/**
 	 * Return a copy of $settings with write-only secrets replaced by the
 	 * redaction placeholder.
 	 *
@@ -866,7 +893,7 @@ class Settings {
 			$secret_fields = self::write_only_secret_keys()[ $key ] ?? array();
 			foreach ( $secret_fields as $secret_field ) {
 				if ( isset( $settings[ $key ][ $secret_field ] )
-					&& self::REDACTED_PLACEHOLDER === $settings[ $key ][ $secret_field ] ) {
+					&& self::is_redaction_placeholder( $settings[ $key ][ $secret_field ] ) ) {
 					unset( $group_values[ $secret_field ] );
 				}
 			}

--- a/includes/blocks/query/class-query-template-controller.php
+++ b/includes/blocks/query/class-query-template-controller.php
@@ -111,15 +111,16 @@ class Template_Controller {
 	/**
 	 * Checks that the requesting user can edit the specified post.
 	 *
+	 * Export is an idempotent GET, so it is not a CSRF vector and intentionally
+	 * does not require an X-WP-Nonce header — the `edit_post` capability check
+	 * below is the real guard. This mirrors the read path in
+	 * DesignSetGo\Admin\Settings::check_read_permission(). The mutating import
+	 * route (POST) still verifies the nonce.
+	 *
 	 * @param \WP_REST_Request $request Incoming REST request.
 	 * @return true|\WP_Error
 	 */
 	public static function permission_export( \WP_REST_Request $request ) {
-		$nonce_check = self::verify_nonce( $request );
-		if ( is_wp_error( $nonce_check ) ) {
-			return $nonce_check;
-		}
-
 		$post_id = (int) $request['post_id'];
 
 		if ( ! $post_id || ! get_post( $post_id ) ) {
@@ -168,7 +169,7 @@ class Template_Controller {
 	}
 
 	/**
-	 * Verifies the REST nonce header to block CSRF against these routes.
+	 * Verifies the REST nonce header to block CSRF against the mutating import route.
 	 *
 	 * Mirrors the project-wide pattern in
 	 * DesignSetGo\Blocks\Query\Controller::check_permission(). Editor callers

--- a/tests/e2e/helpers/wordpress.js
+++ b/tests/e2e/helpers/wordpress.js
@@ -318,7 +318,6 @@ async function blockHasClass(page, blockType, className, index = 0) {
  * @return {Promise<*>} The evaluate result.
  */
 async function evaluateAcrossNavigation(page, fn, arg, tries = 3) {
-	let lastError;
 	for (let attempt = 1; attempt <= tries; attempt++) {
 		try {
 			return await page.evaluate(fn, arg);
@@ -327,17 +326,20 @@ async function evaluateAcrossNavigation(page, fn, arg, tries = 3) {
 				/execution context was destroyed|because of a navigation|frame (was )?detached/i.test(
 					error.message
 				);
+			// Rethrow anything that isn't the one-shot navigation race, and stop
+			// retrying once attempts are exhausted.
 			if (!isNavigationRace || attempt === tries) {
 				throw error;
 			}
-			lastError = error;
 			// Let the auto-draft navigation finish before the next attempt. A
 			// context-destroying navigation also discards anything the failed
 			// attempt dispatched into the store, so re-running is idempotent.
 			await page.waitForLoadState('domcontentloaded').catch(() => {});
 		}
 	}
-	throw lastError;
+	// Only reachable when called with tries < 1 — a misuse worth surfacing
+	// loudly rather than returning undefined.
+	throw new Error('evaluateAcrossNavigation: `tries` must be >= 1');
 }
 
 /**

--- a/tests/e2e/helpers/wordpress.js
+++ b/tests/e2e/helpers/wordpress.js
@@ -297,6 +297,50 @@ async function blockHasClass(page, blockType, className, index = 0) {
 }
 
 /**
+ * Run `fn` via page.evaluate, retrying if the editor navigates out from under
+ * it mid-flight.
+ *
+ * A freshly opened post-new.php editor creates an auto-draft a beat after the
+ * post is first dirtied, swapping the URL (post-new.php -> post.php?post=N) and
+ * tearing down the page's JS execution context. Any page.evaluate() that is
+ * awaiting when that happens rejects with "Execution context was destroyed,
+ * most likely because of a navigation." (and, less often, "frame was
+ * detached"). The navigation is one-shot, so re-running after it settles
+ * succeeds. Only that race is retried; every other error is rethrown at once.
+ *
+ * Used for two-workers/no-retries local runs, where this race surfaces; CI hides
+ * it behind retries. See tests/e2e/patterns-sweep.spec.js.
+ *
+ * @param {import('@playwright/test').Page} page  - Playwright page object
+ * @param {Function}                        fn    - In-page function to evaluate
+ * @param {*}                               arg   - Serialisable argument for fn
+ * @param {number}                          tries - Max attempts (default 3)
+ * @return {Promise<*>} The evaluate result.
+ */
+async function evaluateAcrossNavigation(page, fn, arg, tries = 3) {
+	let lastError;
+	for (let attempt = 1; attempt <= tries; attempt++) {
+		try {
+			return await page.evaluate(fn, arg);
+		} catch (error) {
+			const isNavigationRace =
+				/execution context was destroyed|because of a navigation|frame (was )?detached/i.test(
+					error.message
+				);
+			if (!isNavigationRace || attempt === tries) {
+				throw error;
+			}
+			lastError = error;
+			// Let the auto-draft navigation finish before the next attempt. A
+			// context-destroying navigation also discards anything the failed
+			// attempt dispatched into the store, so re-running is idempotent.
+			await page.waitForLoadState('domcontentloaded').catch(() => {});
+		}
+	}
+	throw lastError;
+}
+
+/**
  * Insert a registered block pattern by its slug, programmatically.
  *
  * Reads the pattern's resolved `content` straight from the data store, parses
@@ -314,36 +358,42 @@ async function blockHasClass(page, blockType, className, index = 0) {
  *         (so callers can wait for it to render in the canvas).
  */
 async function insertPatternBySlug(page, slug) {
-	const result = await page.evaluate(async (patternSlug) => {
-		// `core`.getBlockPatterns is resolver-backed (it fetches from the REST
-		// block-patterns endpoint), so the first synchronous call returns [].
-		// Await the resolver so the full registry is present before we look up
-		// the slug; fall back to the editor settings list for older WP.
-		let patterns = [];
-		if (wp.data.resolveSelect('core').getBlockPatterns) {
-			patterns = await wp.data.resolveSelect('core').getBlockPatterns();
-		}
-		if (!patterns || !patterns.length) {
-			patterns =
-				wp.data.select('core/block-editor').getSettings()
-					.__experimentalBlockPatterns || [];
-		}
-		const pattern = patterns.find((p) => p.name === patternSlug);
-		if (!pattern) {
-			return { found: false, hadToken: false, blockCount: 0 };
-		}
+	const result = await evaluateAcrossNavigation(
+		page,
+		async (patternSlug) => {
+			// `core`.getBlockPatterns is resolver-backed (it fetches from the REST
+			// block-patterns endpoint), so the first synchronous call returns [].
+			// Await the resolver so the full registry is present before we look up
+			// the slug; fall back to the editor settings list for older WP.
+			let patterns = [];
+			if (wp.data.resolveSelect('core').getBlockPatterns) {
+				patterns = await wp.data
+					.resolveSelect('core')
+					.getBlockPatterns();
+			}
+			if (!patterns || !patterns.length) {
+				patterns =
+					wp.data.select('core/block-editor').getSettings()
+						.__experimentalBlockPatterns || [];
+			}
+			const pattern = patterns.find((p) => p.name === patternSlug);
+			if (!pattern) {
+				return { found: false, hadToken: false, blockCount: 0 };
+			}
 
-		const hadToken = pattern.content.includes('{{dsgo:placeholder-');
-		const blocks = wp.blocks.parse(pattern.content);
-		wp.data.dispatch('core/block-editor').insertBlocks(blocks);
+			const hadToken = pattern.content.includes('{{dsgo:placeholder-');
+			const blocks = wp.blocks.parse(pattern.content);
+			wp.data.dispatch('core/block-editor').insertBlocks(blocks);
 
-		return {
-			found: true,
-			hadToken,
-			blockCount: blocks.length,
-			clientId: blocks[0] ? blocks[0].clientId : null,
-		};
-	}, slug);
+			return {
+				found: true,
+				hadToken,
+				blockCount: blocks.length,
+				clientId: blocks[0] ? blocks[0].clientId : null,
+			};
+		},
+		slug
+	);
 
 	if (!result.found) {
 		throw new Error(`Pattern "${slug}" is not registered`);
@@ -361,7 +411,7 @@ async function insertPatternBySlug(page, slug) {
  * @return {Promise<string[]>} Unique block names that failed validation.
  */
 async function getInvalidBlockNames(page) {
-	return page.evaluate(() => {
+	return evaluateAcrossNavigation(page, () => {
 		const bad = [];
 		const walk = (blocks) => {
 			for (const b of blocks) {
@@ -382,6 +432,7 @@ module.exports = {
 	getEditorCanvas,
 	createNewPost,
 	insertBlock,
+	evaluateAcrossNavigation,
 	insertPatternBySlug,
 	getInvalidBlockNames,
 	openBlockSettings,

--- a/tests/integration/blocks/query/QueryTemplateControllerTest.php
+++ b/tests/integration/blocks/query/QueryTemplateControllerTest.php
@@ -32,6 +32,9 @@ class QueryTemplateControllerTest extends WP_UnitTestCase {
 
 	/**
 	 * A valid export request returns 200 with the full blob.
+	 *
+	 * Export is an idempotent GET guarded by the `edit_post` capability, not a
+	 * nonce, so this deliberately omits the X-WP-Nonce header.
 	 */
 	public function test_export_returns_json_for_existing_block() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
@@ -40,7 +43,6 @@ class QueryTemplateControllerTest extends WP_UnitTestCase {
 		);
 
 		$request = new WP_REST_Request( 'GET', '/designsetgo/v1/query/template' );
-		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$request->set_query_params( array( 'post_id' => $post_id, 'query_id' => 'abc' ) );
 		$response = rest_do_request( $request );
 
@@ -62,7 +64,6 @@ class QueryTemplateControllerTest extends WP_UnitTestCase {
 		$post_id = self::factory()->post->create( array( 'post_content' => '' ) );
 
 		$request = new WP_REST_Request( 'GET', '/designsetgo/v1/query/template' );
-		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$request->set_query_params( array( 'post_id' => $post_id, 'query_id' => 'missing' ) );
 		$response = rest_do_request( $request );
 
@@ -79,7 +80,6 @@ class QueryTemplateControllerTest extends WP_UnitTestCase {
 		);
 
 		$request = new WP_REST_Request( 'GET', '/designsetgo/v1/query/template' );
-		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$request->set_query_params( array( 'post_id' => $post_id, 'query_id' => 'abc' ) );
 		$response = rest_do_request( $request );
 
@@ -98,7 +98,6 @@ class QueryTemplateControllerTest extends WP_UnitTestCase {
 		$post_id = self::factory()->post->create( array( 'post_content' => $content ) );
 
 		$request = new WP_REST_Request( 'GET', '/designsetgo/v1/query/template' );
-		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$request->set_query_params( array( 'post_id' => $post_id, 'query_id' => 'nested' ) );
 		$response = rest_do_request( $request );
 
@@ -109,6 +108,49 @@ class QueryTemplateControllerTest extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 	// Import tests
 	// -------------------------------------------------------------------------
+
+	/**
+	 * Import (a mutating POST) rejects a request with no X-WP-Nonce header,
+	 * even for a user who has the edit_posts capability. Guards the S2 CSRF fix.
+	 */
+	public function test_import_rejects_missing_nonce() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$request = new WP_REST_Request( 'POST', '/designsetgo/v1/query/template' );
+		// Intentionally omit the X-WP-Nonce header.
+		$request->set_body_params(
+			array(
+				'schemaVersion' => 1,
+				'blockName'     => 'designsetgo/query',
+				'attributes'    => array( 'perPage' => 5 ),
+				'innerBlocks'   => '',
+			)
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * Import rejects a request carrying an invalid nonce. Guards the S2 CSRF fix.
+	 */
+	public function test_import_rejects_invalid_nonce() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$request = new WP_REST_Request( 'POST', '/designsetgo/v1/query/template' );
+		$request->set_header( 'X-WP-Nonce', 'not-a-valid-nonce' );
+		$request->set_body_params(
+			array(
+				'schemaVersion' => 1,
+				'blockName'     => 'designsetgo/query',
+				'attributes'    => array( 'perPage' => 5 ),
+				'innerBlocks'   => '',
+			)
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
 
 	/**
 	 * Import returns 400 when schemaVersion is not 1.

--- a/tests/phpunit/draft-mode-test.php
+++ b/tests/phpunit/draft-mode-test.php
@@ -159,6 +159,32 @@ class Test_Draft_Mode extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that meta nested deeper than the recursion cap is rejected (fail closed).
+	 *
+	 * The object guard stops recursing at MAX_OBJECT_SCAN_DEPTH and treats
+	 * anything deeper as suspect, so a pathologically deep payload is skipped
+	 * rather than copied — and cannot overflow the stack. Normally-shallow
+	 * arrays (covered above) still copy.
+	 */
+	public function test_create_draft_skips_meta_nested_beyond_depth_cap() {
+		// Wrap a scalar in arrays well past the 20-level cap (no object present).
+		$deep = 'leaf';
+		for ( $i = 0; $i < 25; $i++ ) {
+			$deep = array( $deep );
+		}
+		update_post_meta( $this->page_id, 'too_deep_meta', $deep );
+		update_post_meta( $this->page_id, 'safe_meta', 'keep-me' );
+
+		$draft_id = $this->draft_mode->create_draft( $this->page_id );
+		$this->assertIsInt( $draft_id );
+
+		// Over-deep meta is not copied.
+		$this->assertSame( '', get_post_meta( $draft_id, 'too_deep_meta', true ) );
+		// Safe meta still copies.
+		$this->assertSame( 'keep-me', get_post_meta( $draft_id, 'safe_meta', true ) );
+	}
+
+	/**
 	 * Test creating draft fails for invalid post ID.
 	 */
 	public function test_create_draft_invalid_post() {

--- a/tests/phpunit/llms-txt-test.php
+++ b/tests/phpunit/llms-txt-test.php
@@ -267,6 +267,35 @@ class Test_LLMS_Txt extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test flush cache endpoint rejects a request with no X-WP-Nonce header,
+	 * even for an administrator. Guards the S2 CSRF fix on the llms-txt POST routes.
+	 */
+	public function test_flush_cache_endpoint_rejects_missing_nonce() {
+		wp_set_current_user( $this->admin_user );
+
+		$request = new WP_REST_Request( 'POST', '/designsetgo/v1/llms-txt/flush-cache' );
+		// Intentionally omit the X-WP-Nonce header.
+
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test flush cache endpoint rejects a request carrying an invalid nonce.
+	 */
+	public function test_flush_cache_endpoint_rejects_invalid_nonce() {
+		wp_set_current_user( $this->admin_user );
+
+		$request = new WP_REST_Request( 'POST', '/designsetgo/v1/llms-txt/flush-cache' );
+		$request->set_header( 'X-WP-Nonce', 'not-a-valid-nonce' );
+
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
 	 * Test flush cache endpoint clears cache.
 	 */
 	public function test_flush_cache_endpoint_clears_cache() {

--- a/tests/phpunit/security-fixes-test.php
+++ b/tests/phpunit/security-fixes-test.php
@@ -345,6 +345,35 @@ class Test_Security_Fixes extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A browser holding a stale settings form at upgrade time echoes the legacy
+	 * bullet placeholder back on submit; it must be treated as "unchanged" and
+	 * never overwrite the stored secret.
+	 */
+	public function test_settings_update_preserves_secret_on_legacy_placeholder() {
+		wp_set_current_user( $this->admin_user );
+
+		\DesignSetGo\Admin\Settings::invalidate_cache();
+		update_option(
+			\DesignSetGo\Admin\Settings::OPTION_NAME,
+			array( 'integrations' => array( 'turnstile_secret_key' => 'stored-secret' ) )
+		);
+		\DesignSetGo\Admin\Settings::invalidate_cache();
+
+		\DesignSetGo\Admin\Settings::update_settings(
+			array( 'integrations' => array( 'turnstile_secret_key' => \DesignSetGo\Admin\Settings::LEGACY_REDACTED_PLACEHOLDER ) )
+		);
+
+		$this->assertSame(
+			'stored-secret',
+			\DesignSetGo\Admin\Settings::get_settings()['integrations']['turnstile_secret_key'],
+			'Legacy bullet placeholder must preserve the stored secret, not overwrite it.'
+		);
+
+		delete_option( \DesignSetGo\Admin\Settings::OPTION_NAME );
+		\DesignSetGo\Admin\Settings::invalidate_cache();
+	}
+
+	/**
 	 * Test permission check ordering in Global Styles REST API
 	 *
 	 * Verifies that capability checks happen before nonce verification.


### PR DESCRIPTION
Consolidates three follow-up fixes that were stranded after their parent PRs merged. Two distinct areas — an e2e test-infra fix and two security review follow-ups — kept in one PR by request.

## Commits

### 1. `test(e2e): retry page.evaluate across editor auto-draft navigation`
Adds `evaluateAcrossNavigation()` to the e2e WordPress helpers and routes `insertPatternBySlug` and `getInvalidBlockNames` through it. A freshly opened `post-new.php` editor creates an auto-draft shortly after the post is dirtied, swapping the URL (`post-new.php` → `post.php?post=N`) and tearing down the page's JS execution context; a `page.evaluate()` awaiting at that moment rejects with *"Execution context was destroyed, most likely because of a navigation."* The wrapper retries **only** that one-shot race (rethrowing every other error) and is idempotent (the navigation also discards anything the failed attempt dispatched). Surfaced under the local config (`workers=2, retries=0`); CI hid it behind `retries=2`. Follow-up to #427.

### 2. `fix: address PR #424 review for S2 nonce hardening`
Review follow-ups for the merged #424 — S2 nonce hardening on the query template controller — plus tests (`QueryTemplateControllerTest`, `llms-txt-test`).

### 3. `fix: harden contains_object recursion + ASCII redaction placeholder`
Draft-mode `contains_object` recursion hardening and ASCII redaction placeholder in settings, plus tests (`draft-mode-test`). Also a #424 review follow-up.

Commits 2–3 were committed locally on `fix/sec-fixes` *after* #424 merged and were never pushed; consolidated here rather than left stranded.

## Verification

- PHP suite (wp-env): **809 passed**, 6 environmental skips.
- e2e `patterns-sweep` @ `workers=2 / retries=0`: **185/185**, zero navigation-race failures (was 14).
- `affected-blocks.spec.js` (exercises the wrapped `getInvalidBlockNames`): **15/15**.
- Changed JS helper is lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)