### PR TITLE
feat(pill): render server-side (dynamic) so it serializes without baked classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to the DesignSetGo plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - Unreleased
+
+### Changed
+- **Pill renders dynamically** — The Pill block is now server-rendered, completing the icon/divider/map/form conversion shipped in 2.4.0. A fresh pill serializes to a single self-closing block comment with no baked-in `aligncenter` / `has-small-font-size` classes, so pills stay portable across patterns and AI-assisted (Abilities API) authoring and always reflect the current theme. Existing pills migrate silently via a new deprecation; the default centered alignment is now CSS-driven and unchanged. (#439)
+- **Existing pills inherit their context font size** — The old `fontSize: "small"` default is no longer baked into saved markup, so published pills that relied on the default small size now render at their surrounding text size. Set an explicit font size on any pill that should keep the smaller look; alignment is unaffected. (#439)
+
+## [2.4.0] - 2026-07-06
+
+### New Features
+- **Icon block: fill / outline + theme default size** — The Icon block gained a Fill / Outline style toggle and inherits a theme-defined default size, so icons match your design out of the box. (#438)
+- **Icon Button inherits core Button style variations** — Fill, Outline, and any variations the theme registers.
+- **Scrolling Gallery: native border controls** — Width, style, color, and radius replace the old single border-radius field.
+
+### Changed
+- **Icon, Divider, Map, and form field blocks render dynamically** — They always reflect the current theme and store cleaner markup; existing blocks migrate automatically.
+- **Form Builder fields inherit theme spacing and sizing.**
+- **Map markers can inherit their color from the theme.**
+
+### Bug Fixes
+- **Icon List frontend parity** — Items show their fill / outline and stroke on the frontend, matching the editor.
+- **SVG Patterns / Form Builder color baking** — No longer bake default colors into saved markup, so they inherit the theme's colors.
+- **Abilities API quote / backslash handling** — Content with quotes or backslashes saved through AI-assisted edits is no longer altered.
+- **Scrolling Gallery legacy migration** — Blocks saved by older versions or patterns (image rows stored in the markup rather than the block comment) keep migrating silently instead of showing "Attempt Recovery."
+
 ## [2.3.0] - 2026-07-01
 
 ### New Features

--- a/readme.txt
+++ b/readme.txt
@@ -94,6 +94,11 @@ Yes to both. All blocks work in the Site Editor, templates, and template parts. 
 
 == Changelog ==
 
+= 2.5.0 - Unreleased =
+
+* **Improved:** The Pill block now renders dynamically — saved pills no longer bake in a fixed size or alignment, so they stay portable across patterns and AI-assisted edits and always reflect your theme.
+* **Note:** Existing pills migrate automatically. Because font size is no longer baked into the saved markup, pills that used the previous default (small) now render at their surrounding text size; set an explicit font size on any pill where you want the smaller look. Default centering is unchanged.
+
 = 2.4.0 - 2026-07-06 =
 
 * **New:** The Icon block has a Fill / Outline style toggle and inherits a theme-defined default size, so icons match your design out of the box.

--- a/src/blocks/pill/block.json
+++ b/src/blocks/pill/block.json
@@ -15,17 +15,9 @@
 	"textdomain": "designsetgo",
 	"icon": "tag",
 	"attributes": {
-		"align": {
-			"type": "string",
-			"default": "center"
-		},
 		"content": {
 			"type": "string",
 			"default": ""
-		},
-		"fontSize": {
-			"type": "string",
-			"default": "small"
 		}
 	},
 	"supports": {
@@ -92,5 +84,6 @@
 	},
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
-	"style": "file:./index.css"
+	"style": "file:./index.css",
+	"render": "file:./render.php"
 }

--- a/src/blocks/pill/deprecated.js
+++ b/src/blocks/pill/deprecated.js
@@ -1,5 +1,180 @@
 import { useBlockProps, RichText } from '@wordpress/block-editor';
 
+// Shared style-transfer used by the static save() reproductions below: the
+// visible pill is the inner span, so colour/background/border inline styles that
+// useBlockProps.save() puts on the wrapper are moved onto `.dsgo-pill__content`.
+// Clone so we never mutate the object returned by useBlockProps.save().
+function splitPillStyles(blockProps) {
+	const wrapperStyle = { ...(blockProps.style || {}) };
+	const innerStyle = {};
+
+	if (wrapperStyle.backgroundColor) {
+		innerStyle.backgroundColor = wrapperStyle.backgroundColor;
+		delete wrapperStyle.backgroundColor;
+	}
+	if (wrapperStyle.background) {
+		innerStyle.background = wrapperStyle.background;
+		delete wrapperStyle.background;
+	}
+	if (wrapperStyle.color) {
+		innerStyle.color = wrapperStyle.color;
+		delete wrapperStyle.color;
+	}
+	if (wrapperStyle.borderColor) {
+		innerStyle.borderColor = wrapperStyle.borderColor;
+		delete wrapperStyle.borderColor;
+	}
+	if (wrapperStyle.borderWidth) {
+		innerStyle.borderWidth = wrapperStyle.borderWidth;
+		delete wrapperStyle.borderWidth;
+	}
+	if (wrapperStyle.borderStyle) {
+		innerStyle.borderStyle = wrapperStyle.borderStyle;
+		delete wrapperStyle.borderStyle;
+	}
+	if (wrapperStyle.borderRadius) {
+		innerStyle.borderRadius = wrapperStyle.borderRadius;
+		delete wrapperStyle.borderRadius;
+	}
+
+	return { wrapperStyle, innerStyle };
+}
+
+// Supports for the static reproductions — mirrors the block.json supports that
+// were in place while the pill was still a static block.
+const staticSupports = {
+	html: false,
+	inserter: true,
+	align: ['left', 'center', 'right'],
+	alignWide: false,
+	spacing: {
+		padding: true,
+		margin: ['top', 'bottom'],
+		__experimentalDefaultControls: {
+			padding: true,
+		},
+		__experimentalSelector: '.dsgo-pill__content',
+	},
+	color: {
+		background: true,
+		text: true,
+		gradients: true,
+		__experimentalDefaultControls: {
+			background: true,
+			text: true,
+		},
+		__experimentalSelector: '.dsgo-pill__content',
+	},
+	typography: {
+		fontSize: true,
+		lineHeight: true,
+		textAlign: true,
+		__experimentalDefaultControls: {
+			fontSize: true,
+		},
+		__experimentalSelector: '.dsgo-pill__content',
+		__experimentalFontFamily: true,
+		__experimentalFontWeight: true,
+		__experimentalFontStyle: true,
+		__experimentalTextTransform: true,
+		__experimentalTextDecoration: true,
+		__experimentalLetterSpacing: true,
+		__experimentalWritingMode: true,
+	},
+	__experimentalBorder: {
+		color: true,
+		radius: true,
+		style: true,
+		width: true,
+		__experimentalDefaultControls: {
+			radius: true,
+		},
+		__experimentalSelector: '.dsgo-pill__content',
+	},
+};
+
+// vStatic: the last STATIC version, in use immediately before the Pill block
+// became server-rendered (dynamic). Its save() baked `aligncenter` (from the old
+// `align` default of "center") and `has-small-font-size` (from the old `fontSize`
+// default of "small") into every wrapper. The dynamic block's save() now returns
+// null, so any stored static markup would trip the editor's "Attempt Recovery"
+// warning. This deprecation reproduces that markup and migrates existing content
+// silently; migrate() drops the old center/small defaults so migrated pills are
+// as clean as freshly inserted ones (see migrate() below).
+//
+// apiVersion: 2 (as with v1) disables the second getSaveContent.extraProps pass
+// that would otherwise re-add the colour/border inline styles to the wrapper div
+// that save() moves to the inner span.
+const vStatic = {
+	apiVersion: 2,
+	attributes: {
+		content: {
+			type: 'string',
+			default: '',
+		},
+		align: {
+			type: 'string',
+			default: 'center',
+		},
+		fontSize: {
+			type: 'string',
+			default: 'small',
+		},
+		style: {
+			type: 'object',
+		},
+	},
+	supports: staticSupports,
+	isEligible(attributes, innerBlocks, { innerHTML }) {
+		// Static pills always carried an alignment class (the "center" default was
+		// baked by useBlockProps.save()). Match a dsgo-pill wrapper that has one —
+		// the pre-align legacy (no alignment class) is handled by v1 below.
+		const html = innerHTML || '';
+		return (
+			/class="[^"]*\bdsgo-pill\b/.test(html) &&
+			(html.includes('aligncenter') ||
+				html.includes('alignleft') ||
+				html.includes('alignright'))
+		);
+	},
+	save({ attributes }) {
+		const { content } = attributes;
+
+		const blockProps = useBlockProps.save({
+			className: 'dsgo-pill',
+		});
+
+		const { wrapperStyle, innerStyle } = splitPillStyles(blockProps);
+		blockProps.style = wrapperStyle;
+
+		return (
+			<div {...blockProps}>
+				<RichText.Content
+					tagName="span"
+					className="dsgo-pill__content"
+					value={content}
+					style={innerStyle}
+				/>
+			</div>
+		);
+	},
+	migrate(attributes) {
+		// Drop the old baked defaults so migrated pills stay as clean as freshly
+		// inserted ones: `align: "center"` still centres via CSS (the class-based
+		// default) and `fontSize: "small"` becomes inherited text. Explicit,
+		// non-default choices (e.g. alignright, fontSize:large) are preserved.
+		const { align, fontSize, ...rest } = attributes;
+		const migrated = { ...rest };
+		if (align && 'center' !== align) {
+			migrated.align = align;
+		}
+		if (fontSize && 'small' !== fontSize) {
+			migrated.fontSize = fontSize;
+		}
+		return migrated;
+	},
+};
+
 // v1: the pill block had no `align` attribute in the attributes schema, so
 // `useBlockProps.save()` never injected `aligncenter` even when the block
 // support's alignment defaulted to "center". After commit 9f743ef6 the
@@ -163,4 +338,4 @@ const v1 = {
 	},
 };
 
-export default [v1];
+export default [vStatic, v1];

--- a/src/blocks/pill/edit.js
+++ b/src/blocks/pill/edit.js
@@ -11,43 +11,20 @@ export default function PillEdit({ attributes, setAttributes }) {
 		className: 'dsgo-pill',
 	});
 
-	// Extract color/background styles from blockProps to apply to inner span
-	const wrapperStyle = blockProps.style || {};
+	// The visible pill is the inner span, so move colour / background / border
+	// inline styles off the wrapper and onto it — mirroring render.php so the
+	// editor matches the frontend. Prefix-match the camelCase style keys (rather
+	// than an exact-name list) so unlinked per-corner radius (borderTopLeftRadius)
+	// and per-side borders (borderTopColor, …) transfer too.
+	const wrapperStyle = { ...(blockProps.style || {}) };
 	const innerStyle = {};
 
-	// Transfer background color to inner span
-	if (wrapperStyle.backgroundColor) {
-		innerStyle.backgroundColor = wrapperStyle.backgroundColor;
-		delete wrapperStyle.backgroundColor;
-	}
-	if (wrapperStyle.background) {
-		innerStyle.background = wrapperStyle.background;
-		delete wrapperStyle.background;
-	}
-
-	// Transfer text color to inner span
-	if (wrapperStyle.color) {
-		innerStyle.color = wrapperStyle.color;
-		delete wrapperStyle.color;
-	}
-
-	// Transfer border styles to inner span
-	if (wrapperStyle.borderColor) {
-		innerStyle.borderColor = wrapperStyle.borderColor;
-		delete wrapperStyle.borderColor;
-	}
-	if (wrapperStyle.borderWidth) {
-		innerStyle.borderWidth = wrapperStyle.borderWidth;
-		delete wrapperStyle.borderWidth;
-	}
-	if (wrapperStyle.borderStyle) {
-		innerStyle.borderStyle = wrapperStyle.borderStyle;
-		delete wrapperStyle.borderStyle;
-	}
-	if (wrapperStyle.borderRadius) {
-		innerStyle.borderRadius = wrapperStyle.borderRadius;
-		delete wrapperStyle.borderRadius;
-	}
+	Object.keys(wrapperStyle).forEach((key) => {
+		if (/^(color|background|border)/.test(key)) {
+			innerStyle[key] = wrapperStyle[key];
+			delete wrapperStyle[key];
+		}
+	});
 
 	// Update blockProps with cleaned style
 	blockProps.style = wrapperStyle;

--- a/src/blocks/pill/editor.scss
+++ b/src/blocks/pill/editor.scss
@@ -64,7 +64,6 @@
 	padding: 0.5em 1em;
 	background-color: var(--wp--preset--color--primary, #2563eb);
 	color: var(--wp--preset--color--base, #fff);
-	font-size: 0.875em;
 	font-weight: 500;
 	line-height: 1.5;
 	border-radius: 999px;
@@ -97,8 +96,11 @@
 	margin-left: 0 !important;
 }
 
-.dsgo-pill.aligncenter,
-[class*="wp-container"] > .dsgo-pill.aligncenter {
+// Default alignment is centered (class-based, no baked `aligncenter` attribute):
+// any pill that is not explicitly left/right aligned is centered. Explicit
+// `aligncenter` matches this too; `alignleft` / `alignright` override it.
+.dsgo-pill:not(.alignleft):not(.alignright),
+[class*="wp-container"] > .dsgo-pill:not(.alignleft):not(.alignright) {
 	float: none !important;
 	display: flex !important;
 	justify-content: center;

--- a/src/blocks/pill/render.php
+++ b/src/blocks/pill/render.php
@@ -41,64 +41,56 @@ if ( ! function_exists( 'designsetgo_render_pill' ) ) {
 
 		$text = isset( $attributes['content'] ) ? (string) $attributes['content'] : '';
 
+		// The visible pill is the inner `.dsgo-pill__content` span, so the colour,
+		// background and border inline styles are placed on the span here (the same
+		// transfer the old static save() did). Everything else the style supports
+		// produce — padding, margin, typography, dimensions — stays on the wrapper.
+		//
+		// Rather than re-parse the serialized `style="…"` string that
+		// get_block_wrapper_attributes() produces (fragile: a `;` inside any future
+		// value — a gradient, box-shadow, multi-value font-family — would split a
+		// declaration mid-value, and a change to core's serialization format would
+		// silently misroute styles), the two style strings are computed directly
+		// from the structured `style` attribute via the Style Engine. Whole style
+		// *groups* move as a unit — `color` (text/background/gradient), `background`
+		// and `border` (incl. unlinked per-corner radius / per-side colour+width) —
+		// so there is no per-property allowlist to fall out of date. Colour *classes*
+		// (has-…-color) stay on the wrapper and reach the span via style.scss.
+		$block_style = ( isset( $attributes['style'] ) && is_array( $attributes['style'] ) ) ? $attributes['style'] : array();
+		$inner_keys  = array(
+			'color'      => true,
+			'background' => true,
+			'border'     => true,
+		);
+		$inner_styles = wp_style_engine_get_styles( array_intersect_key( $block_style, $inner_keys ) );
+		$keep_styles  = wp_style_engine_get_styles( array_diff_key( $block_style, $inner_keys ) );
+		$inner_css    = isset( $inner_styles['css'] ) ? $inner_styles['css'] : '';
+		$keep_css     = isset( $keep_styles['css'] ) ? $keep_styles['css'] : '';
+
 		$wrapper = get_block_wrapper_attributes( array( 'class' => 'dsgo-pill' ) );
 
-		// The visible pill is the inner `.dsgo-pill__content` span, so the colour,
-		// background and border inline styles that get_block_wrapper_attributes()
-		// places on the wrapper are moved onto the span here (the same transfer the
-		// old static save() did). Everything else — padding, margin, typography —
-		// stays on the wrapper.
-		//
-		// A declaration moves when its property is `color` or belongs to the
-		// `background` / `border` groups (prefix match, not an exact-name list), so
-		// unlinked per-corner radius (`border-top-left-radius`) and per-side borders
-		// (`border-top-color`, …) move too — an exact-name list silently left those
-		// on the wrapper, where they never reached the visible span.
-		//
-		// This reads/rewrites the wrapper's `style` as a string, which couples to
-		// get_block_wrapper_attributes()'s output: double-quoted and `esc_attr()`-
-		// escaped (so any `"` in a value is `&quot;`, never a bare quote that would
-		// break the `[^"]*` capture) and `;`-joined. Splitting on `;` is safe for
-		// this block because none of its enabled supports (colour, gradient, border;
-		// no background-image) can produce a value containing a literal `;`. Revisit
-		// if background-image — or any other `;`-bearing value — is ever supported.
-		$inner_decls = array();
-		$keep_decls  = array();
-
-		if ( preg_match( '/style="([^"]*)"/', $wrapper, $style_match ) ) {
-			foreach ( explode( ';', $style_match[1] ) as $declaration ) {
-				$declaration = trim( $declaration );
-				if ( '' === $declaration ) {
-					continue;
-				}
-				$property = strtolower( trim( strtok( $declaration, ':' ) ) );
-				$move     = 0 === strpos( $property, 'color' )
-					|| 0 === strpos( $property, 'background' )
-					|| 0 === strpos( $property, 'border' );
-				if ( $move ) {
-					$inner_decls[] = $declaration;
-				} else {
-					$keep_decls[] = $declaration;
-				}
-			}
-
-			// Rebuild the wrapper's style attribute with only the kept declarations
-			// (values are already escaped by get_block_wrapper_attributes()).
-			$keep_style  = implode( ';', $keep_decls );
-			$replacement = '' !== $keep_style ? 'style="' . $keep_style . '"' : '';
-			$wrapper     = preg_replace( '/style="[^"]*"/', $replacement, $wrapper );
-		}
-
-		$inner_style = implode( ';', $inner_decls );
-		// Values originate from get_block_wrapper_attributes(), already escaped.
-		$inner_style_attr = '' !== $inner_style ? ' style="' . $inner_style . '"' : '';
-
-		return sprintf(
-			'<div %1$s><span class="dsgo-pill__content"%2$s>%3$s</span></div>',
-			trim( $wrapper ),
-			$inner_style_attr,
+		$html = sprintf(
+			'<div %1$s><span class="dsgo-pill__content">%2$s</span></div>',
+			$wrapper,
 			wp_kses_post( $text )
 		);
+
+		// Overwrite the wrapper's colour/border-bearing style with only the kept
+		// declarations and set the moved declarations on the span. WP_HTML_Tag_Processor
+		// handles attribute quoting/escaping, so there is no string surgery.
+		$processor = new WP_HTML_Tag_Processor( $html );
+		$processor->next_tag( 'div' );
+		if ( '' !== $keep_css ) {
+			$processor->set_attribute( 'style', $keep_css );
+		} else {
+			$processor->remove_attribute( 'style' );
+		}
+		if ( '' !== $inner_css ) {
+			$processor->next_tag( 'span' );
+			$processor->set_attribute( 'style', $inner_css );
+		}
+
+		return $processor->get_updated_html();
 	}
 }
 

--- a/src/blocks/pill/render.php
+++ b/src/blocks/pill/render.php
@@ -43,19 +43,25 @@ if ( ! function_exists( 'designsetgo_render_pill' ) ) {
 
 		$wrapper = get_block_wrapper_attributes( array( 'class' => 'dsgo-pill' ) );
 
-		// Inline declarations WordPress placed on the wrapper. Colour/background/
-		// border ones belong on the inner span (the visible pill); everything else
-		// (padding, margin, typography) stays on the wrapper — matching the old
-		// static save() which only moved colour + border.
-		$move_props  = array(
-			'color',
-			'background-color',
-			'background',
-			'border-color',
-			'border-width',
-			'border-style',
-			'border-radius',
-		);
+		// The visible pill is the inner `.dsgo-pill__content` span, so the colour,
+		// background and border inline styles that get_block_wrapper_attributes()
+		// places on the wrapper are moved onto the span here (the same transfer the
+		// old static save() did). Everything else — padding, margin, typography —
+		// stays on the wrapper.
+		//
+		// A declaration moves when its property is `color` or belongs to the
+		// `background` / `border` groups (prefix match, not an exact-name list), so
+		// unlinked per-corner radius (`border-top-left-radius`) and per-side borders
+		// (`border-top-color`, …) move too — an exact-name list silently left those
+		// on the wrapper, where they never reached the visible span.
+		//
+		// This reads/rewrites the wrapper's `style` as a string, which couples to
+		// get_block_wrapper_attributes()'s output: double-quoted and `esc_attr()`-
+		// escaped (so any `"` in a value is `&quot;`, never a bare quote that would
+		// break the `[^"]*` capture) and `;`-joined. Splitting on `;` is safe for
+		// this block because none of its enabled supports (colour, gradient, border;
+		// no background-image) can produce a value containing a literal `;`. Revisit
+		// if background-image — or any other `;`-bearing value — is ever supported.
 		$inner_decls = array();
 		$keep_decls  = array();
 
@@ -65,8 +71,11 @@ if ( ! function_exists( 'designsetgo_render_pill' ) ) {
 				if ( '' === $declaration ) {
 					continue;
 				}
-				$property = trim( strtok( $declaration, ':' ) );
-				if ( in_array( $property, $move_props, true ) ) {
+				$property = strtolower( trim( strtok( $declaration, ':' ) ) );
+				$move     = 0 === strpos( $property, 'color' )
+					|| 0 === strpos( $property, 'background' )
+					|| 0 === strpos( $property, 'border' );
+				if ( $move ) {
 					$inner_decls[] = $declaration;
 				} else {
 					$keep_decls[] = $declaration;

--- a/src/blocks/pill/render.php
+++ b/src/blocks/pill/render.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Pill Block - Server-side Rendering
+ *
+ * Dynamic render. The block serializes to a single self-closing comment (no
+ * stored HTML), so a fresh pill never bakes `aligncenter` / `has-small-font-size`
+ * into the database — those classes only appear when the author explicitly sets
+ * an alignment or font size. The default centred, inherited-text look is CSS
+ * (style.scss), not baked attributes.
+ *
+ * The visible pill is the inner `.dsgo-pill__content` span; the outer `.dsgo-pill`
+ * div is the alignment container. So the colour/background/border inline styles
+ * that `get_block_wrapper_attributes()` puts on the wrapper are moved to the inner
+ * span here — the same transfer the old static save() did in JS. Colour *classes*
+ * stay on the wrapper and are transferred to the span by CSS (style.scss).
+ *
+ * @package DesignSetGo
+ * @since 2.5.0
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block content (unused for dynamic blocks).
+ * @param WP_Block $block      Block instance.
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'designsetgo_render_pill' ) ) {
+	/**
+	 * Render the Pill block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Inner block content (unused).
+	 * @param WP_Block $block      Block instance.
+	 * @return string Pill markup.
+	 */
+	function designsetgo_render_pill( $attributes, $content, $block ) {
+		unset( $content, $block );
+
+		$text = isset( $attributes['content'] ) ? (string) $attributes['content'] : '';
+
+		$wrapper = get_block_wrapper_attributes( array( 'class' => 'dsgo-pill' ) );
+
+		// Inline declarations WordPress placed on the wrapper. Colour/background/
+		// border ones belong on the inner span (the visible pill); everything else
+		// (padding, margin, typography) stays on the wrapper — matching the old
+		// static save() which only moved colour + border.
+		$move_props  = array(
+			'color',
+			'background-color',
+			'background',
+			'border-color',
+			'border-width',
+			'border-style',
+			'border-radius',
+		);
+		$inner_decls = array();
+		$keep_decls  = array();
+
+		if ( preg_match( '/style="([^"]*)"/', $wrapper, $style_match ) ) {
+			foreach ( explode( ';', $style_match[1] ) as $declaration ) {
+				$declaration = trim( $declaration );
+				if ( '' === $declaration ) {
+					continue;
+				}
+				$property = trim( strtok( $declaration, ':' ) );
+				if ( in_array( $property, $move_props, true ) ) {
+					$inner_decls[] = $declaration;
+				} else {
+					$keep_decls[] = $declaration;
+				}
+			}
+
+			// Rebuild the wrapper's style attribute with only the kept declarations
+			// (values are already escaped by get_block_wrapper_attributes()).
+			$keep_style  = implode( ';', $keep_decls );
+			$replacement = '' !== $keep_style ? 'style="' . $keep_style . '"' : '';
+			$wrapper     = preg_replace( '/style="[^"]*"/', $replacement, $wrapper );
+		}
+
+		$inner_style = implode( ';', $inner_decls );
+		// Values originate from get_block_wrapper_attributes(), already escaped.
+		$inner_style_attr = '' !== $inner_style ? ' style="' . $inner_style . '"' : '';
+
+		return sprintf(
+			'<div %1$s><span class="dsgo-pill__content"%2$s>%3$s</span></div>',
+			trim( $wrapper ),
+			$inner_style_attr,
+			wp_kses_post( $text )
+		);
+	}
+}
+
+// Output directly (WordPress captures echo'd output from render callbacks).
+echo designsetgo_render_pill( $attributes, $content, $block ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/src/blocks/pill/save.js
+++ b/src/blocks/pill/save.js
@@ -1,64 +1,13 @@
 /**
- * Save component for Pill Block
+ * Pill Block - Save Component
+ *
+ * Dynamic block rendered server-side via render.php. No static HTML is saved to
+ * the database, so the serialized block is a single self-closing comment
+ * (`<!-- wp:designsetgo/pill {"content":"…"} /-->`) with no baked-in alignment
+ * or font-size classes. Historical static markup is handled by ./deprecated.js.
+ *
+ * @return {null} Null because this is a dynamic block.
  */
-import { useBlockProps, RichText } from '@wordpress/block-editor';
-
-export default function PillSave({ attributes }) {
-	const { content } = attributes;
-
-	const blockProps = useBlockProps.save({
-		className: 'dsgo-pill',
-	});
-
-	// Extract color/background styles from blockProps to apply to inner span
-	const wrapperStyle = blockProps.style || {};
-	const innerStyle = {};
-
-	// Transfer background color to inner span
-	if (wrapperStyle.backgroundColor) {
-		innerStyle.backgroundColor = wrapperStyle.backgroundColor;
-		delete wrapperStyle.backgroundColor;
-	}
-	if (wrapperStyle.background) {
-		innerStyle.background = wrapperStyle.background;
-		delete wrapperStyle.background;
-	}
-
-	// Transfer text color to inner span
-	if (wrapperStyle.color) {
-		innerStyle.color = wrapperStyle.color;
-		delete wrapperStyle.color;
-	}
-
-	// Transfer border styles to inner span
-	if (wrapperStyle.borderColor) {
-		innerStyle.borderColor = wrapperStyle.borderColor;
-		delete wrapperStyle.borderColor;
-	}
-	if (wrapperStyle.borderWidth) {
-		innerStyle.borderWidth = wrapperStyle.borderWidth;
-		delete wrapperStyle.borderWidth;
-	}
-	if (wrapperStyle.borderStyle) {
-		innerStyle.borderStyle = wrapperStyle.borderStyle;
-		delete wrapperStyle.borderStyle;
-	}
-	if (wrapperStyle.borderRadius) {
-		innerStyle.borderRadius = wrapperStyle.borderRadius;
-		delete wrapperStyle.borderRadius;
-	}
-
-	// Update blockProps with cleaned style
-	blockProps.style = wrapperStyle;
-
-	return (
-		<div {...blockProps}>
-			<RichText.Content
-				tagName="span"
-				className="dsgo-pill__content"
-				value={content}
-				style={innerStyle}
-			/>
-		</div>
-	);
+export default function PillSave() {
+	return null;
 }

--- a/src/blocks/pill/style.scss
+++ b/src/blocks/pill/style.scss
@@ -63,11 +63,12 @@
 	// Ensure text doesn't break awkwardly
 	white-space: nowrap;
 
-	// Default styles - always applied as base, overridden by WordPress color transfers
+	// Default styles - always applied as base, overridden by WordPress color transfers.
+	// Font size intentionally inherits from context (no forced size) so the pill is
+	// never saved with a baked `has-small-font-size` class.
 	padding: 0.5em 1em;
 	background-color: var(--wp--preset--color--primary, #2563eb);
 	color: var(--wp--preset--color--base, #fff);
-	font-size: 0.875em;
 	font-weight: 500;
 	line-height: 1.5;
 }
@@ -95,8 +96,11 @@
 	margin-left: 0 !important;
 }
 
-.dsgo-pill.aligncenter:not([class*="dsgo-hide-"]),
-[class*="wp-container"] > .dsgo-pill.aligncenter:not([class*="dsgo-hide-"]) {
+// Default alignment is centered (class-based, no baked `aligncenter` attribute):
+// any pill that is not explicitly left/right aligned is centered. Explicit
+// `aligncenter` matches this too; `alignleft` / `alignright` below override it.
+.dsgo-pill:not(.alignleft):not(.alignright):not([class*="dsgo-hide-"]),
+[class*="wp-container"] > .dsgo-pill:not(.alignleft):not(.alignright):not([class*="dsgo-hide-"]) {
 	float: none !important;
 	display: flex !important;
 	justify-content: center;

--- a/tests/e2e/blocks-dynamic-render.spec.js
+++ b/tests/e2e/blocks-dynamic-render.spec.js
@@ -42,6 +42,14 @@ const LEGACY_DIVIDER = `<!-- wp:designsetgo/divider {"dividerStyle":"icon","icon
 <div class="wp-block-designsetgo-divider dsgo-divider dsgo-divider--icon"><div class="dsgo-divider__container" style="width:100%"><div class="dsgo-divider__icon-wrapper"><span class="dsgo-divider__line dsgo-divider__line--left" style="height:2px"></span><span class="dsgo-divider__icon dsgo-lazy-icon" data-icon-name="star"></span><span class="dsgo-divider__line dsgo-divider__line--right" style="height:2px"></span></div></div></div>
 <!-- /wp:designsetgo/divider -->`;
 
+// Pre-conversion STATIC pill markup: the wrapper baked `aligncenter` (from the
+// old align default of "center") and `has-small-font-size` (from the old fontSize
+// default of "small"). The new deprecation must migrate it silently now that the
+// pill is server-rendered.
+const LEGACY_PILL = `<!-- wp:designsetgo/pill {"content":"Test"} -->
+<div class="wp-block-designsetgo-pill aligncenter dsgo-pill has-small-font-size"><span class="dsgo-pill__content">Test</span></div>
+<!-- /wp:designsetgo/pill -->`;
+
 // Authentic pre-conversion markup from the site-designer contact patterns
 // (block-patterns/patterns/contact). This is the exact shape that used to throw
 // "Block validation: Expected text ..., saw ...": the block comment carries no
@@ -289,6 +297,91 @@ test.describe('Divider block — dynamic render', () => {
 		// would also leave getInvalidBlockNames empty).
 		const { invalid, names } = await parseValidity(page, LEGACY_DIVIDER);
 		expect(names).toContain('designsetgo/divider');
+		expect(invalid).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Pill block
+// ---------------------------------------------------------------------------
+test.describe('Pill block — dynamic render', () => {
+	test('fresh insert is valid and serializes without aligncenter / has-small-font-size', async ({
+		page,
+	}, testInfo) => {
+		const artifact = defineArtifact(
+			testInfo,
+			'blocks',
+			'pill',
+			'dynamic-render'
+		);
+
+		await createNewPost(page, 'page');
+		await setPostTitle(page, 'Pill Dynamic Render');
+		await insertBlock(page, 'designsetgo/pill', { content: 'New Feature' });
+
+		const canvas = getEditorCanvas(page);
+		await expect(
+			canvas.locator('[data-type="designsetgo/pill"]').first()
+		).toBeVisible({ timeout: 10000 });
+
+		expect(await getInvalidBlockNames(page)).not.toContain(
+			'designsetgo/pill'
+		);
+		await expect(
+			canvas.locator(
+				'[data-type="designsetgo/pill"] .block-editor-warning'
+			)
+		).toHaveCount(0);
+
+		// The dynamic block serializes to a single self-closing comment — no
+		// stored HTML, so no baked alignment / font-size classes.
+		const serialized = await page.evaluate(() => {
+			const blocks = wp.data
+				.select('core/block-editor')
+				.getBlocks()
+				.filter((b) => b.name === 'designsetgo/pill');
+			return wp.blocks.serialize(blocks);
+		});
+		expect(serialized).not.toContain('aligncenter');
+		expect(serialized).not.toContain('has-small-font-size');
+		await saveScreenshot(page, artifact, 'editor');
+
+		const frontendUrl = await publishAndResolveUrl(page);
+		await page.goto(frontendUrl);
+		await page.waitForLoadState('domcontentloaded');
+
+		// The pill renders its text; the wrapper carries neither baked class.
+		await expect(
+			page.locator('.wp-block-designsetgo-pill .dsgo-pill__content').first()
+		).toHaveText('New Feature', { timeout: 10000 });
+		expect(
+			await page
+				.locator(
+					'.wp-block-designsetgo-pill.aligncenter, .wp-block-designsetgo-pill.has-small-font-size'
+				)
+				.count()
+		).toBe(0);
+
+		await page.waitForLoadState('networkidle').catch(() => {});
+		await slowScrollToBottom(page);
+		await saveScreenshot(page, artifact, 'frontend');
+	});
+
+	test('legacy static markup migrates silently (no invalid content)', async ({
+		page,
+	}) => {
+		await createNewPost(page, 'page');
+		await setPostTitle(page, 'Pill Legacy Migration');
+		await insertRawMarkup(page, LEGACY_PILL);
+
+		expect(await getInvalidBlockNames(page)).not.toContain(
+			'designsetgo/pill'
+		);
+
+		// Guard against a vacuous pass: confirm the block actually survived the
+		// parse/deprecation pipeline rather than being silently dropped.
+		const { invalid, names } = await parseValidity(page, LEGACY_PILL);
+		expect(names).toContain('designsetgo/pill');
 		expect(invalid).toEqual([]);
 	});
 });

--- a/tests/phpunit/blocks/pill/render-test.php
+++ b/tests/phpunit/blocks/pill/render-test.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Tests for the Pill block server render.
+ *
+ * The visible pill is the inner `.dsgo-pill__content` span, so colour, background
+ * and border inline styles are moved off the wrapper onto that span (padding /
+ * typography stay on the wrapper). render.php computes both style strings from the
+ * structured `style` attribute via the Style Engine, so this guards the split —
+ * in particular that unlinked PER-CORNER border-radius and per-side border styles
+ * (the case that a per-property allowlist or a `;`-split would silently miss)
+ * reach the span, not the wrapper.
+ *
+ * @group pill
+ */
+
+/**
+ * @group pill
+ */
+class DesignSetGo_Pill_Render_Test extends WP_UnitTestCase {
+
+	/**
+	 * Include the built render template with the given attributes and capture its
+	 * echoed output.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Rendered HTML.
+	 */
+	private function render( array $attributes ) {
+		$path = DESIGNSETGO_PATH . 'build/blocks/pill/render.php';
+		$this->assertFileExists( $path, 'Run `npm run build` before PHPUnit — render templates are served from build/.' );
+
+		$content = '';
+		$block   = null;
+
+		// get_block_wrapper_attributes() reads the current block's attrs from this
+		// global to build the wrapper class list.
+		$previous_block                     = WP_Block_Supports::$block_to_render;
+		WP_Block_Supports::$block_to_render = array(
+			'blockName' => 'designsetgo/pill',
+			'attrs'     => $attributes,
+		);
+
+		ob_start();
+		$returned = include $path;
+		$html     = ob_get_clean();
+
+		WP_Block_Supports::$block_to_render = $previous_block;
+
+		return is_string( $returned ) ? $returned : $html;
+	}
+
+	/**
+	 * Read the inline style of the first matching tag in a fragment.
+	 *
+	 * @param string $html     HTML fragment.
+	 * @param string $tag_name Tag to read (e.g. 'div', 'span').
+	 * @return string Style attribute value ('' when absent).
+	 */
+	private function style_of( $html, $tag_name ) {
+		$processor = new WP_HTML_Tag_Processor( $html );
+		if ( ! $processor->next_tag( $tag_name ) ) {
+			return '';
+		}
+		return (string) $processor->get_attribute( 'style' );
+	}
+
+	public function test_per_corner_radius_and_border_color_land_on_inner_span() {
+		$html = $this->render(
+			array(
+				'content' => 'Test',
+				'style'   => array(
+					'border'  => array(
+						// Unlinked per-corner radius — the exact case a per-property
+						// allowlist (border-radius only) or a `;`-split would drop.
+						'radius' => array(
+							'topLeft'     => '10px',
+							'topRight'    => '2px',
+							'bottomLeft'  => '4px',
+							'bottomRight' => '8px',
+						),
+						'color'  => '#ff0000',
+						'width'  => '2px',
+						'style'  => 'solid',
+					),
+					'color'   => array(
+						'text' => '#0000ff',
+					),
+					'spacing' => array(
+						'padding' => array(
+							'top'    => '4px',
+							'right'  => '8px',
+							'bottom' => '4px',
+							'left'   => '8px',
+						),
+					),
+				),
+			)
+		);
+
+		$wrapper_style = $this->style_of( $html, 'div' );
+		$span_style    = $this->style_of( $html, 'span' );
+
+		// Colour + every border declaration (incl. all four per-corner radii) moved
+		// to the visible span.
+		$this->assertStringContainsString( 'color:#0000ff', $span_style );
+		$this->assertStringContainsString( 'border-color:#ff0000', $span_style );
+		$this->assertStringContainsString( 'border-width:2px', $span_style );
+		$this->assertStringContainsString( 'border-top-left-radius:10px', $span_style );
+		$this->assertStringContainsString( 'border-top-right-radius:2px', $span_style );
+		$this->assertStringContainsString( 'border-bottom-left-radius:4px', $span_style );
+		$this->assertStringContainsString( 'border-bottom-right-radius:8px', $span_style );
+
+		// The wrapper keeps padding but carries no colour/border declarations — if
+		// any stayed here they would never reach the visible pill (the span).
+		$this->assertStringContainsString( 'padding', $wrapper_style );
+		$this->assertStringNotContainsString( 'border', $wrapper_style );
+		$this->assertStringNotContainsString( 'color', $wrapper_style );
+	}
+
+	public function test_plain_pill_has_no_inline_styles() {
+		$html = $this->render( array( 'content' => 'Test' ) );
+
+		$this->assertStringContainsString( 'class="dsgo-pill__content"', $html );
+		$this->assertSame( '', $this->style_of( $html, 'div' ) );
+		$this->assertSame( '', $this->style_of( $html, 'span' ) );
+	}
+}

--- a/tests/unit/pill-deprecation.test.js
+++ b/tests/unit/pill-deprecation.test.js
@@ -1,0 +1,126 @@
+/**
+ * Pill Block - static → dynamic deprecation
+ *
+ * Guards the `vStatic.migrate()` branch that PRESERVES a non-default alignment /
+ * font size while dropping the old baked `center` / `small` defaults. That branch
+ * (`if (align && 'center' !== align)` / `if (fontSize && 'small' !== fontSize)`)
+ * is the one most likely to regress silently — a fresh insert and a
+ * migrate-to-default case (covered by the e2e spec) would both still pass even if
+ * explicit choices were accidentally discarded.
+ *
+ * Two layers:
+ *  - migrate() called directly, asserting the attribute-level contract for each
+ *    branch (default dropped, explicit kept);
+ *  - the real @wordpress/blocks parser end-to-end, asserting an explicit
+ *    `alignright` / `has-large-font-size` legacy pill migrates silently (no
+ *    "Attempt Recovery") and re-serializes clean — keeping both attributes, with
+ *    no baked classes in the dynamic output.
+ *
+ * @package
+ */
+
+// @wordpress/block-editor ships its own nested copy of @wordpress/blocks.
+// useBlockProps.save() (used by the deprecation's save()) resolves block supports
+// against THAT copy's registry, so registration/parsing must go through the same
+// instance.
+const {
+	registerBlockType,
+	unregisterBlockType,
+	parse,
+	serialize,
+} = require('@wordpress/block-editor/node_modules/@wordpress/blocks');
+
+import metadata from '../../src/blocks/pill/block.json';
+import save from '../../src/blocks/pill/save';
+import deprecated from '../../src/blocks/pill/deprecated';
+
+// vStatic is the first (newest) deprecation — the last static version.
+const [vStatic] = deprecated;
+
+describe('Pill deprecation - vStatic.migrate()', () => {
+	it('drops the old baked center/small defaults', () => {
+		const migrated = vStatic.migrate({
+			content: 'Test',
+			align: 'center',
+			fontSize: 'small',
+		});
+
+		expect(migrated).not.toHaveProperty('align');
+		expect(migrated).not.toHaveProperty('fontSize');
+		expect(migrated.content).toBe('Test');
+	});
+
+	it('preserves an explicit non-default alignment and font size', () => {
+		const migrated = vStatic.migrate({
+			content: 'Test',
+			align: 'right',
+			fontSize: 'large',
+		});
+
+		expect(migrated.align).toBe('right');
+		expect(migrated.fontSize).toBe('large');
+		expect(migrated.content).toBe('Test');
+	});
+
+	it('preserves an explicit alignment even when no font size is set', () => {
+		const migrated = vStatic.migrate({
+			content: 'Test',
+			align: 'left',
+		});
+
+		expect(migrated.align).toBe('left');
+		expect(migrated).not.toHaveProperty('fontSize');
+	});
+});
+
+describe('Pill deprecation - explicit legacy markup migrates silently', () => {
+	beforeAll(() => {
+		registerBlockType(metadata.name, {
+			...metadata,
+			// The custom 'designsetgo' category isn't registered in the jest
+			// environment; category is irrelevant to parse/validation, so use a
+			// built-in one to avoid an unrelated invalid-category warning.
+			category: 'design',
+			save,
+			deprecated,
+		});
+	});
+
+	afterAll(() => {
+		unregisterBlockType(metadata.name);
+	});
+
+	// Pre-conversion STATIC markup with EXPLICIT, non-default choices: the comment
+	// carries align:right + fontSize:large (both non-default, so they were
+	// serialized), and the wrapper baked `alignright` + `has-large-font-size`.
+	const LEGACY_PILL_EXPLICIT = `<!-- wp:designsetgo/pill {"content":"Test","align":"right","fontSize":"large"} -->
+<div class="wp-block-designsetgo-pill alignright dsgo-pill has-large-font-size"><span class="dsgo-pill__content">Test</span></div>
+<!-- /wp:designsetgo/pill -->`;
+
+	it('migrates without an "Attempt Recovery" warning and keeps both attributes', () => {
+		const [block] = parse(LEGACY_PILL_EXPLICIT);
+
+		// The parser logs an info message when a deprecated version's save matches
+		// and the block is silently migrated — the behavior under test.
+		expect(console).toHaveInformed();
+
+		expect(block).toBeTruthy();
+		expect(block.name).toBe(metadata.name);
+		expect(block.isValid).toBe(true);
+		expect(block.attributes.align).toBe('right');
+		expect(block.attributes.fontSize).toBe('large');
+	});
+
+	it('re-serializes clean: attributes kept, no baked classes in dynamic output', () => {
+		const [block] = parse(LEGACY_PILL_EXPLICIT);
+
+		expect(console).toHaveInformed();
+
+		const serialized = serialize(block);
+		expect(serialized).toContain('"align":"right"');
+		expect(serialized).toContain('"fontSize":"large"');
+		// Dynamic block → self-closing comment, no stored HTML / baked classes.
+		expect(serialized).not.toContain('has-large-font-size');
+		expect(serialized).not.toContain('<div');
+	});
+});


### PR DESCRIPTION
## Summary

Converts `designsetgo/pill` from a static block to a **dynamic, server-rendered** block — the same pattern already applied to icon, divider, map, and the form fields. A fresh pill now serializes to a single self-closing comment with **no baked-in `aligncenter` / `has-small-font-size` classes**:

```
<!-- wp:designsetgo/pill {"content":"New Feature"} /-->
```

Those two classes came from the `align:{default:"center"}` and `fontSize:{default:"small"}` attribute defaults, which `useBlockProps.save()` stamped onto every wrapper — breaking hand/LLM authoring and pattern portability.

## Changes

- **block.json** — add `render`; remove the `align`/`fontSize` attribute defaults (supports stay, so the toolbar/typography panel still work).
- **render.php** (new) — reproduces the wrapper + inner-span markup and moves colour/border inline styles onto `.dsgo-pill__content` (the visible pill), matching the old static `save()` for visual parity; padding + colour classes stay on the wrapper.
- **save.js** — returns `null`.
- **deprecated.js** — new `vStatic` entry reproduces the last static markup so existing content migrates silently (no "Attempt Recovery"); its `migrate()` drops the old center/small defaults so migrated pills are as clean as fresh ones (explicit values like `alignright` / `fontSize:large` are preserved).
- **style.scss / editor.scss** — default alignment is now class-based on `.dsgo-pill` (kept centered so existing content doesn't shift); text inherits its context size.
- **e2e** — adds pill fresh-insert + legacy-migration cases to the dynamic-render spec.

## Verification (WordPress 6.9)

| Case | Result |
|---|---|
| Fresh save | `<div class="dsgo-pill wp-block-designsetgo-pill"><span class="dsgo-pill__content">Test</span></div>` — no baked classes |
| Legacy static markup → `wp.blocks.parse()` | `isValid: true` (silent migration), re-serializes clean |
| Explicit `align:right` / `fontSize:large` | preserved, rendered only when set |
| Custom colour/border | moved to inner span; padding + colour classes on wrapper (parity) |
| Published legacy pages (never re-opened) | render through render.php, dynamic ignores stored HTML |

Lint (PHP/JS/CSS) clean.

**Note:** the browser e2e spec can't run in the current local harness — every test in that file (including the already-merged icon/divider/map/form ones) times out at `createNewPost` waiting for the editor-canvas iframe, a pre-existing environment issue. The editor-side migration was verified directly via `wp.blocks.parse()`; the new spec cases will run in CI.