### PR TITLE
feat(fse): mirror section styles to container blocks; stop baking hex color defaults

### DIFF
--- a/docs/plans/2026-07-06-section-style-variations-fse-design.md
+++ b/docs/plans/2026-07-06-section-style-variations-fse-design.md
@@ -56,12 +56,18 @@ private $container_blocks = array(
     'designsetgo/tab',
     'designsetgo/accordion-item',
     'designsetgo/scroll-accordion-item',
-    'designsetgo/image-accordion-item',
     'designsetgo/timeline-item',
     'designsetgo/counter',
     'designsetgo/flip-card-face',
 );
 ```
+
+`image-accordion-item` is deliberately **not** in the list. It sets
+`color.background: false` in its block.json — its surface is a background
+image + overlay — so a mirrored section style that sets a background color
+would paint behind/around the image with no author-facing control to undo it.
+Mirroring injects into `styles.blocks.…​.variations.…` independent of block
+`supports`, so the only way to honour the opt-out is to exclude the block.
 
 Source blocks unchanged (`core/group`/`columns`/`column`). The existing
 "flatten + broadcast" comment already documents the trade-off (a variation
@@ -73,8 +79,13 @@ desired behaviour here.
 - Select "Style 1–5" on a counter / accordion item / card in Twenty
   Twenty-Five; confirm it paints in editor **and** frontend.
 - Confirm the mirrored variation CSS (`.wp-block-…​.is-style-…`, specificity
-  0-2-0) wins over each block's own `style.scss`. Spot-check `flip-card-face`
-  and `counter`, which ship their own backgrounds.
+  0-2-0) wins over each block's own `style.scss`. Note that several targets
+  ship their own default background at the same specificity — `card`'s
+  `&:not([style*="background"])` is ~0-2-0, tying the mirrored selector — so
+  when specificity ties, source/cascade order decides. Spot-check every target
+  that ships a default background, not just `flip-card-face` / `counter`:
+  `card`, `accordion-item`, `scroll-accordion-item`, `tab`, `modal`, `slide`,
+  `scroll-slide`, `fifty-fifty`, `timeline-item`.
 
 ## Part B — Stop baking hex defaults into save()
 
@@ -123,9 +134,13 @@ Old content has the literal hex in its HTML, so it will not match the new
 (`reference_wp_deprecation_iseligible_mechanics`), the deprecation `save()`
 must reproduce the stored HTML exactly.
 
-- `isEligible(attributes, _, { innerHTML })` — old defaulted blocks had no
-  color attribute but the hex is in markup, e.g.
-  `!attributes.barColor && innerHTML.includes('#2563eb')`.
+- `isEligible(attributes, _, { innerHTML })` — the pre-change save baked the
+  hex literal into the markup, so match on `innerHTML` alone:
+  `innerHTML.includes('#2563eb') || innerHTML.includes('#e5e7eb')`. No
+  attribute check is needed: a block whose color was a genuine custom
+  `#2563eb` round-trips through the *current* save (matching the stored
+  markup), so it validates and never reaches this path — and even if it did,
+  `migrate` is a passthrough no-op.
 - `save()` — the current (pre-change) save function verbatim.
 - `migrate()` — passthrough (`return attributes;`); attribute schema is
   unchanged, only the emitted default moves to CSS.

--- a/docs/plans/2026-07-06-section-style-variations-fse-design.md
+++ b/docs/plans/2026-07-06-section-style-variations-fse-design.md
@@ -1,0 +1,142 @@
+# Section-style variations + FSE color inheritance
+
+**Date**: 2026-07-06
+**Branch**: `claude/section-style-variations-fse`
+
+## Goal
+
+1. **Part A** — Extend the theme "section style" variations (core Group's
+   "Style 1–5" etc.) so they can be applied to more DesignSetGo container-like
+   blocks, not just `section`/`row`/`grid`. Container "item" blocks
+   (accordion item, counter, timeline item, …) should be able to inherit the
+   same global style variations as core Group / DSGo Section.
+2. **Part B** — Stop forcing hardcoded hex color defaults into block `save()`
+   output so unset colors inherit from FSE global styles instead of a baked
+   literal.
+
+## Part A — Extend section-style mirroring
+
+### Mechanism (already in place)
+
+`DesignSetGo\Section_Styles`
+([includes/features/class-section-styles.php](../../includes/features/class-section-styles.php))
+mirrors every block-style variation registered for the core container blocks
+(`core/group`, `core/columns`, `core/column`) onto DSGo container blocks by:
+
+1. `register_block_style()` — registers the variation *name* for each DSGo
+   target (makes it selectable in the editor Styles panel, emits the
+   `is-style-{slug}` class on selection).
+2. `wp_theme_json_data_theme` / `wp_theme_json_data_user` filters — copies the
+   resolved variation styles onto `styles.blocks.{target}.variations.{slug}`
+   so WordPress emits `.wp-block-designsetgo-{target}.is-style-{slug}` CSS on
+   both frontend and editor.
+
+**This is CSS-injection + name-registration only. It never touches `save()`,
+so no deprecations are required.** WP emits the variation stylesheet regardless
+of a block's `supports`; every target already renders a `useBlockProps`
+wrapper that receives the `is-style-*` class and already declares color +
+spacing supports.
+
+### Change
+
+Widen the `$container_blocks` target list to the curated container set:
+
+```php
+private $container_blocks = array(
+    // existing
+    'designsetgo/section',
+    'designsetgo/row',
+    'designsetgo/grid',
+    // added — curated container-like blocks
+    'designsetgo/card',
+    'designsetgo/fifty-fifty',
+    'designsetgo/modal',
+    'designsetgo/slide',
+    'designsetgo/scroll-slide',
+    'designsetgo/tab',
+    'designsetgo/accordion-item',
+    'designsetgo/scroll-accordion-item',
+    'designsetgo/image-accordion-item',
+    'designsetgo/timeline-item',
+    'designsetgo/counter',
+    'designsetgo/flip-card-face',
+);
+```
+
+Source blocks unchanged (`core/group`/`columns`/`column`). The existing
+"flatten + broadcast" comment already documents the trade-off (a variation
+registered for one core container reaches all DSGo targets), which is the
+desired behaviour here.
+
+### Verification
+
+- Select "Style 1–5" on a counter / accordion item / card in Twenty
+  Twenty-Five; confirm it paints in editor **and** frontend.
+- Confirm the mirrored variation CSS (`.wp-block-…​.is-style-…`, specificity
+  0-2-0) wins over each block's own `style.scss`. Spot-check `flip-card-face`
+  and `counter`, which ship their own backgrounds.
+
+## Part B — Stop baking hex defaults into save()
+
+Emit the inline color **only when the user set a value**. When unset, emit
+nothing and let the block's `style.scss` provide the visual default via a
+low-specificity `:where()` rule that references a preset var — so the block
+still looks right out-of-box while serialized HTML stays free to inherit from
+FSE global styles.
+
+Scope: only the two blocks that bake a *pure* hex (no preset var).
+`card` / `timeline` / `timeline-item` already use
+`var(--wp--preset--color--X, #hex)` — they inherit already; hex is a harmless
+last-resort. **Left as-is.**
+
+### progress-bar — [save.js:43,59](../../src/blocks/progress-bar/save.js)
+
+```js
+// before
+backgroundColor: convertColorToCSSVar(barColor) || '#2563eb',
+// after — omit key entirely when unset
+...(convertColorToCSSVar(barColor) && {
+    backgroundColor: convertColorToCSSVar(barColor),
+}),
+```
+
+Move the fallback into `style.scss`:
+
+```scss
+.wp-block-designsetgo-progress-bar__bar:where(:not([style*="background"])) {
+    background-color: var(--wp--preset--color--primary, #2563eb);
+}
+```
+
+Same treatment for `barBackgroundColor` (`#e5e7eb`) → track color default.
+
+### image-accordion-item — [save.js:14](../../src/blocks/image-accordion-item/save.js)
+
+Overlay color comes from parent context; when the parent sets none, emit no
+overlay color inline and let CSS default it.
+
+### Deprecations (required — save() output changes)
+
+Old content has the literal hex in its HTML, so it will not match the new
+`save()`. Each changed block needs a full deprecation
+(`isEligible` + `save` + `migrate`). Per the WP 6.9 note
+(`reference_wp_deprecation_iseligible_mechanics`), the deprecation `save()`
+must reproduce the stored HTML exactly.
+
+- `isEligible(attributes, _, { innerHTML })` — old defaulted blocks had no
+  color attribute but the hex is in markup, e.g.
+  `!attributes.barColor && innerHTML.includes('#2563eb')`.
+- `save()` — the current (pre-change) save function verbatim.
+- `migrate()` — passthrough (`return attributes;`); attribute schema is
+  unchanged, only the emitted default moves to CSS.
+
+progress-bar has two color defaults, so its deprecation must cover both.
+
+### Verification
+
+- Insert a progress bar / image accordion with default colors on an existing
+  saved page; confirm silent auto-migration (no "Attempt Recovery").
+- `npm run build && npm run lint:js && npm run lint:css && npm run lint:php`.
+- Editor + frontend + responsive; browser console clean.
+- Run the e2e `dynamic-render` / content-reset guardrail specs.
+```

--- a/includes/features/class-section-styles.php
+++ b/includes/features/class-section-styles.php
@@ -45,9 +45,25 @@ class Section_Styles {
 	 * @var array
 	 */
 	private $container_blocks = array(
+		// Top-level layout containers.
 		'designsetgo/section',
 		'designsetgo/row',
 		'designsetgo/grid',
+		// Card / surface-like containers and compound-block "items" that read
+		// as their own container surface. Section styles are layout-agnostic
+		// color/border presets, so they apply cleanly to these too.
+		'designsetgo/card',
+		'designsetgo/fifty-fifty',
+		'designsetgo/modal',
+		'designsetgo/slide',
+		'designsetgo/scroll-slide',
+		'designsetgo/tab',
+		'designsetgo/accordion-item',
+		'designsetgo/scroll-accordion-item',
+		'designsetgo/image-accordion-item',
+		'designsetgo/timeline-item',
+		'designsetgo/counter',
+		'designsetgo/flip-card-face',
 	);
 
 	/**

--- a/includes/features/class-section-styles.php
+++ b/includes/features/class-section-styles.php
@@ -60,7 +60,12 @@ class Section_Styles {
 		'designsetgo/tab',
 		'designsetgo/accordion-item',
 		'designsetgo/scroll-accordion-item',
-		'designsetgo/image-accordion-item',
+		// Note: designsetgo/image-accordion-item is deliberately excluded. It
+		// sets `color.background: false` in its block.json because its surface
+		// is driven entirely by a background image + overlay. A mirrored section
+		// style that sets a background color would render behind/around that
+		// image with no author-facing control to undo it, so we respect the
+		// block's opt-out rather than inject color it can't expose.
 		'designsetgo/timeline-item',
 		'designsetgo/counter',
 		'designsetgo/flip-card-face',

--- a/src/blocks/image-accordion-item/deprecated.js
+++ b/src/blocks/image-accordion-item/deprecated.js
@@ -1,0 +1,91 @@
+/**
+ * Image Accordion Item - Deprecations
+ *
+ * v1: Save before the overlay color/opacity stopped being baked into the item
+ * markup. Previously the item always serialized `--dsgo-overlay-color`,
+ * `--dsgo-overlay-opacity` and `--dsgo-overlay-opacity-expanded` custom
+ * properties. Because block context is not available during save
+ * serialization, those values always resolved to the defaults (`#000000`,
+ * `0.4`, `0.2`) in the stored markup — so the parent's overlay settings never
+ * actually reached the frontend. Current saves omit these vars entirely and
+ * let the parent accordion's cascading `--dsgo-image-accordion-overlay-*`
+ * properties drive the overlay (see style.scss). This deprecation reproduces
+ * the old markup and migrates silently; the attribute schema is unchanged.
+ *
+ * @package
+ */
+
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import classnames from 'classnames';
+import metadata from './block.json';
+import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
+
+const v1 = {
+	attributes: metadata.attributes,
+	supports: metadata.supports,
+	usesContext: metadata.usesContext,
+	isEligible(attributes, innerBlocks, { innerHTML }) {
+		// Only the pre-change save emitted the short overlay custom property.
+		return (
+			typeof innerHTML === 'string' &&
+			innerHTML.includes('--dsgo-overlay-color')
+		);
+	},
+	migrate(attributes) {
+		// Overlay values now cascade from the parent; nothing to migrate.
+		return attributes;
+	},
+	save({ attributes, context }) {
+		const { uniqueId, verticalAlignment, horizontalAlignment } = attributes;
+
+		const enableOverlay =
+			context?.['designsetgo/imageAccordion/enableOverlay'] !== undefined
+				? context['designsetgo/imageAccordion/enableOverlay']
+				: true;
+		const overlayColor =
+			context?.['designsetgo/imageAccordion/overlayColor'] || '#000000';
+		const overlayOpacity =
+			context?.['designsetgo/imageAccordion/overlayOpacity'] || 40;
+		const overlayOpacityExpanded =
+			context?.['designsetgo/imageAccordion/overlayOpacityExpanded'] ||
+			20;
+
+		const itemClasses = classnames('dsgo-image-accordion-item', {
+			'dsgo-image-accordion-item--has-overlay': enableOverlay,
+		});
+
+		const overlayStyles = enableOverlay
+			? {
+					'--dsgo-overlay-color': convertColorToCSSVar(overlayColor),
+					'--dsgo-overlay-opacity': String(overlayOpacity / 100),
+					'--dsgo-overlay-opacity-expanded': String(
+						overlayOpacityExpanded / 100
+					),
+				}
+			: {};
+
+		const blockProps = useBlockProps.save({
+			className: itemClasses,
+			style: {
+				...overlayStyles,
+				'--dsgo-vertical-alignment': verticalAlignment || 'center',
+				'--dsgo-horizontal-alignment': horizontalAlignment || 'center',
+			},
+			'data-unique-id': uniqueId,
+			role: 'button',
+			tabIndex: 0,
+		});
+
+		const innerBlocksProps = useInnerBlocksProps.save({
+			className: 'dsgo-image-accordion-item__content',
+		});
+
+		return (
+			<div {...blockProps}>
+				<div {...innerBlocksProps} />
+			</div>
+		);
+	},
+};
+
+export default [v1];

--- a/src/blocks/image-accordion-item/index.js
+++ b/src/blocks/image-accordion-item/index.js
@@ -1,6 +1,7 @@
 import { registerBlockType } from '@wordpress/blocks';
 import Edit from './edit';
 import Save from './save';
+import deprecated from './deprecated';
 import metadata from './block.json';
 import { ICON_COLOR } from '../shared/constants';
 
@@ -29,4 +30,5 @@ registerBlockType(metadata.name, {
 	},
 	edit: Edit,
 	save: Save,
+	deprecated,
 });

--- a/src/blocks/image-accordion-item/save.js
+++ b/src/blocks/image-accordion-item/save.js
@@ -1,43 +1,29 @@
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import classnames from 'classnames';
-import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
 
 export default function ImageAccordionItemSave({ attributes, context }) {
 	const { uniqueId, verticalAlignment, horizontalAlignment } = attributes;
 
-	// Get context from parent accordion (same as edit.js)
+	// Get context from parent accordion (same as edit.js). Note: block context
+	// is not available during save serialization, so this resolves to the
+	// default (overlay enabled) for serialized markup — matching prior behavior.
 	const enableOverlay =
 		context?.['designsetgo/imageAccordion/enableOverlay'] !== undefined
 			? context['designsetgo/imageAccordion/enableOverlay']
 			: true;
-	const overlayColor =
-		context?.['designsetgo/imageAccordion/overlayColor'] || '#000000';
-	const overlayOpacity =
-		context?.['designsetgo/imageAccordion/overlayOpacity'] || 40;
-	const overlayOpacityExpanded =
-		context?.['designsetgo/imageAccordion/overlayOpacityExpanded'] || 20;
 
 	// Same classes as edit.js - MUST MATCH
 	const itemClasses = classnames('dsgo-image-accordion-item', {
 		'dsgo-image-accordion-item--has-overlay': enableOverlay,
 	});
 
-	// Apply overlay and alignment as inline styles (same as edit.js)
-	// Note: Unitless values must be strings to prevent React from adding 'px'
-	const overlayStyles = enableOverlay
-		? {
-				'--dsgo-overlay-color': convertColorToCSSVar(overlayColor),
-				'--dsgo-overlay-opacity': String(overlayOpacity / 100), // Unitless
-				'--dsgo-overlay-opacity-expanded': String(
-					overlayOpacityExpanded / 100
-				), // Unitless
-			}
-		: {};
-
+	// Overlay color/opacity are no longer baked into the item markup. They
+	// cascade from the parent accordion's `--dsgo-image-accordion-overlay-*`
+	// custom properties (see style.scss), so the frontend honours the parent's
+	// overlay settings and no hex literal is serialized here.
 	const blockProps = useBlockProps.save({
 		className: itemClasses,
 		style: {
-			...overlayStyles,
 			'--dsgo-vertical-alignment': verticalAlignment || 'center',
 			'--dsgo-horizontal-alignment': horizontalAlignment || 'center',
 		},

--- a/src/blocks/image-accordion-item/style.scss
+++ b/src/blocks/image-accordion-item/style.scss
@@ -20,13 +20,25 @@
 	background-position: center;
 	background-repeat: no-repeat !important;
 
-	// Overlay (pseudo-element)
+	// Overlay (pseudo-element).
+	// Color/opacity cascade from the parent accordion's
+	// `--dsgo-image-accordion-overlay-*` custom properties. The short
+	// `--dsgo-overlay-*` vars (set inline by the editor preview) win when
+	// present; otherwise the parent value applies; the solid `#000` /
+	// numeric literals are the final fallbacks. The color literal is solid
+	// (not rgba) so the separate opacity var is not double-applied.
 	&--has-overlay::before {
 		content: '';
 		position: absolute;
 		inset: 0;
-		background-color: var(--dsgo-overlay-color, rgba(0, 0, 0, 0.4));
-		opacity: var(--dsgo-overlay-opacity, 0.4);
+		background-color: var(
+			--dsgo-overlay-color,
+			var(--dsgo-image-accordion-overlay-color, #000)
+		);
+		opacity: var(
+			--dsgo-overlay-opacity,
+			var(--dsgo-image-accordion-overlay-opacity, 0.4)
+		);
 		transition: opacity 0.3s ease;
 		pointer-events: none;
 		z-index: 1;
@@ -85,7 +97,10 @@
 		flex: var(--expanded-ratio, 3);
 
 		&.dsgo-image-accordion-item--has-overlay::before {
-			opacity: var(--dsgo-overlay-opacity-expanded, 0.2);
+			opacity: var(
+				--dsgo-overlay-opacity-expanded,
+				var(--dsgo-image-accordion-overlay-opacity-expanded, 0.2)
+			);
 		}
 
 		.dsgo-image-accordion-item__content {
@@ -98,7 +113,13 @@
 		flex: 1;
 
 		&.dsgo-image-accordion-item--has-overlay::before {
-			opacity: calc(var(--dsgo-overlay-opacity, 0.4) + 0.2); // Darker when collapsed
+			// Darker when collapsed
+			opacity: calc(
+				var(
+						--dsgo-overlay-opacity,
+						var(--dsgo-image-accordion-overlay-opacity, 0.4)
+					) + 0.2
+			);
 		}
 
 		.dsgo-image-accordion-item__content {

--- a/src/blocks/progress-bar/deprecated.js
+++ b/src/blocks/progress-bar/deprecated.js
@@ -1,0 +1,136 @@
+/**
+ * Progress Bar Block - Deprecations
+ *
+ * v1: Save before the bar/track colors stopped baking hex defaults into the
+ * serialized markup. Previously the fill and container always emitted an inline
+ * `background-color` — the chosen color when set, otherwise the literal
+ * `#2563eb` (fill) / `#e5e7eb` (track). Current saves omit the inline color when
+ * the author has not chosen one so the bar inherits an FSE-overridable CSS
+ * default. Blocks saved with a default color therefore carry a hex the current
+ * save() no longer emits; this deprecation reproduces the old markup and
+ * migrates them silently (attribute schema is unchanged).
+ *
+ * @package
+ */
+
+import { useBlockProps } from '@wordpress/block-editor';
+import metadata from './block.json';
+import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
+
+const v1 = {
+	attributes: metadata.attributes,
+	supports: metadata.supports,
+	isEligible(attributes, innerBlocks, { innerHTML }) {
+		if (typeof innerHTML !== 'string') {
+			return false;
+		}
+		// Only the pre-change save baked these hex literals into the markup.
+		// A block whose colors were set to presets/custom values produces
+		// identical current-save markup and validates without this path.
+		return innerHTML.includes('#2563eb') || innerHTML.includes('#e5e7eb');
+	},
+	migrate(attributes) {
+		// Attribute schema is unchanged — only the emitted default moved to
+		// CSS. barColor/barBackgroundColor stay '' and the frontend CSS paints
+		// the same neutral/primary defaults.
+		return attributes;
+	},
+	save({ attributes }) {
+		const {
+			percentage,
+			barColor,
+			barBackgroundColor,
+			height,
+			borderRadius,
+			showLabel,
+			labelText,
+			showPercentage,
+			labelPosition,
+			barStyle,
+			animateOnScroll,
+			animationDuration,
+			stripedAnimation,
+		} = attributes;
+
+		const barWidth = Math.min(Math.max(percentage, 0), 100);
+
+		const barFillStyles = {
+			width: animateOnScroll ? '0%' : `${barWidth}%`,
+			height: '100%',
+			backgroundColor: convertColorToCSSVar(barColor) || '#2563eb',
+			transition: `width ${animationDuration}s ease-out`,
+			borderRadius,
+		};
+
+		if (barStyle === 'striped' || barStyle === 'striped-animated') {
+			barFillStyles.backgroundImage =
+				'linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent)';
+			barFillStyles.backgroundSize = '1rem 1rem';
+		}
+
+		const barContainerStyles = {
+			width: '100%',
+			height,
+			backgroundColor:
+				convertColorToCSSVar(barBackgroundColor) || '#e5e7eb',
+			borderRadius,
+			overflow: 'hidden',
+			position: 'relative',
+		};
+
+		const displayText = (() => {
+			const parts = [];
+			if (showLabel && labelText) {
+				parts.push(labelText);
+			}
+			if (showPercentage) {
+				parts.push(`${barWidth}%`);
+			}
+			return parts.join(' - ');
+		})();
+
+		const blockProps = useBlockProps.save({
+			className: `dsgo-progress-bar ${animateOnScroll ? 'dsgo-progress-bar--animate' : ''}`,
+			'data-percentage': animateOnScroll ? barWidth : undefined,
+			'data-duration': animateOnScroll ? animationDuration : undefined,
+		});
+
+		return (
+			<div {...blockProps}>
+				{displayText && labelPosition === 'top' && (
+					<div className="dsgo-progress-bar__label dsgo-progress-bar__label--top">
+						{displayText}
+					</div>
+				)}
+
+				<div
+					className="dsgo-progress-bar__container"
+					style={barContainerStyles}
+				>
+					<div
+						className={`dsgo-progress-bar__fill ${
+							barStyle === 'striped-animated' || stripedAnimation
+								? 'dsgo-progress-bar__fill--animated'
+								: ''
+						}`}
+						style={barFillStyles}
+					>
+						{displayText && labelPosition === 'inside' && (
+							<div className="dsgo-progress-bar__label dsgo-progress-bar__label--inside">
+								{displayText}
+							</div>
+						)}
+					</div>
+				</div>
+
+				{displayText && labelPosition === 'bottom' && (
+					<div className="dsgo-progress-bar__label dsgo-progress-bar__label--bottom">
+						{displayText}
+					</div>
+				)}
+			</div>
+		);
+	},
+};
+
+export default [v1];

--- a/src/blocks/progress-bar/edit.js
+++ b/src/blocks/progress-bar/edit.js
@@ -70,11 +70,17 @@ export default function ProgressBarEdit({
 	// Calculate bar width (clamped between 0-100)
 	const barWidth = Math.min(Math.max(percentage, 0), 100);
 
+	// Resolve chosen colors; omit when unset so the CSS default (shared with
+	// the frontend) paints instead of a baked hex — keeps the editor preview
+	// matching the saved markup.
+	const barFillColor = convertColorToCSSVar(barColor);
+	const barTrackColor = convertColorToCSSVar(barBackgroundColor);
+
 	// Build bar fill styles declaratively
 	const barFillStyles = {
 		width: `${barWidth}%`,
 		height: '100%',
-		backgroundColor: convertColorToCSSVar(barColor) || '#2563eb',
+		backgroundColor: barFillColor || undefined,
 		transition: `width ${animationDuration}s ease-out`,
 		borderRadius,
 	};
@@ -90,7 +96,7 @@ export default function ProgressBarEdit({
 	const barContainerStyles = {
 		width: '100%',
 		height,
-		backgroundColor: convertColorToCSSVar(barBackgroundColor) || '#e5e7eb',
+		backgroundColor: barTrackColor || undefined,
 		borderRadius,
 		overflow: 'hidden',
 		position: 'relative',

--- a/src/blocks/progress-bar/index.js
+++ b/src/blocks/progress-bar/index.js
@@ -10,6 +10,7 @@ import { registerBlockType } from '@wordpress/blocks';
 
 import edit from './edit';
 import save from './save';
+import deprecated from './deprecated';
 import metadata from './block.json';
 import { ICON_COLOR } from '../shared/constants';
 
@@ -36,4 +37,5 @@ registerBlockType(metadata.name, {
 	},
 	edit,
 	save,
+	deprecated,
 });

--- a/src/blocks/progress-bar/save.js
+++ b/src/blocks/progress-bar/save.js
@@ -36,11 +36,17 @@ export default function ProgressBarSave({ attributes }) {
 	// Calculate bar width (clamped between 0-100)
 	const barWidth = Math.min(Math.max(percentage, 0), 100);
 
+	// Resolve chosen colors. When unset we emit no inline color so the bar
+	// inherits the CSS default (which references an FSE preset var) instead
+	// of a baked hex literal.
+	const barFillColor = convertColorToCSSVar(barColor);
+	const barTrackColor = convertColorToCSSVar(barBackgroundColor);
+
 	// Build bar fill styles (same as edit.js)
 	const barFillStyles = {
 		width: animateOnScroll ? '0%' : `${barWidth}%`, // Start at 0 if animating
 		height: '100%',
-		backgroundColor: convertColorToCSSVar(barColor) || '#2563eb',
+		backgroundColor: barFillColor || undefined,
 		transition: `width ${animationDuration}s ease-out`,
 		borderRadius,
 	};
@@ -56,7 +62,7 @@ export default function ProgressBarSave({ attributes }) {
 	const barContainerStyles = {
 		width: '100%',
 		height,
-		backgroundColor: convertColorToCSSVar(barBackgroundColor) || '#e5e7eb',
+		backgroundColor: barTrackColor || undefined,
 		borderRadius,
 		overflow: 'hidden',
 		position: 'relative',

--- a/src/blocks/progress-bar/style.scss
+++ b/src/blocks/progress-bar/style.scss
@@ -31,6 +31,15 @@
 		position: relative;
 		display: flex;
 		align-items: center;
+
+		// Default track color when the author has not chosen one. Kept at
+		// :where() (zero specificity) so an inline color, a block-level
+		// background, or an FSE global style all win. No clean preset maps to
+		// a muted track, so this stays a neutral literal — but because it is
+		// no longer baked into save() markup, Global Styles can override it.
+		&:where(:not([style*="background-color"])) {
+			background-color: #e5e7eb;
+		}
 	}
 
 	// Progress bar fill
@@ -40,6 +49,12 @@
 		align-items: center;
 		justify-content: flex-end;
 		padding: 0 0.5rem;
+
+		// Default fill color when the author has not chosen one (see note on
+		// the container above).
+		&:where(:not([style*="background-color"])) {
+			background-color: var(--wp--preset--color--primary, #2563eb);
+		}
 
 		// Animated stripes
 		&--animated {

--- a/tests/unit/image-accordion-item-overlay-deprecation.test.js
+++ b/tests/unit/image-accordion-item-overlay-deprecation.test.js
@@ -1,0 +1,87 @@
+/**
+ * Image Accordion Item - overlay-var deprecation
+ *
+ * Regression test proving that items saved before the overlay color/opacity
+ * stopped being baked into the item markup (the `--dsgo-overlay-color` /
+ * `--dsgo-overlay-opacity` custom properties) still parse as valid — silent
+ * migration, no "Attempt Recovery".
+ *
+ * Also asserts the current save() no longer serializes `--dsgo-overlay-color`;
+ * the overlay now cascades from the parent accordion's
+ * `--dsgo-image-accordion-overlay-*` properties.
+ *
+ * Block context is not available during save serialization, so both the legacy
+ * and current save resolve overlay context to its defaults — matching real
+ * stored markup.
+ *
+ * @package
+ */
+
+const {
+	registerBlockType,
+	unregisterBlockType,
+	getBlockType,
+	createBlock,
+	serialize,
+	parse,
+} = require('@wordpress/block-editor/node_modules/@wordpress/blocks');
+
+import metadata from '../../src/blocks/image-accordion-item/block.json';
+import save from '../../src/blocks/image-accordion-item/save';
+import deprecated from '../../src/blocks/image-accordion-item/deprecated';
+
+const register = (saveFn, deprecations) =>
+	registerBlockType(metadata.name, {
+		...metadata,
+		category: 'media',
+		save: saveFn,
+		...(deprecations ? { deprecated: deprecations } : {}),
+	});
+
+/**
+ * Serialize an item the way the OLD save did (with the baked overlay vars).
+ *
+ * @return {string} Legacy block markup.
+ */
+function legacyMarkup() {
+	register(deprecated[0].save);
+	const block = createBlock(metadata.name);
+	const markup = serialize(block);
+	unregisterBlockType(metadata.name);
+	return markup;
+}
+
+describe('Image Accordion Item - overlay-var deprecation', () => {
+	afterEach(() => {
+		// Only unregister when still registered — unregistering an absent
+		// block warns, which trips the console matcher.
+		if (getBlockType(metadata.name)) {
+			unregisterBlockType(metadata.name);
+		}
+	});
+
+	it('reproduces the old baked overlay custom property in legacy markup', () => {
+		const markup = legacyMarkup();
+		expect(markup).toContain('--dsgo-overlay-color');
+	});
+
+	it('parses legacy overlay-var content as valid (silent migration)', () => {
+		const markup = legacyMarkup();
+		register(save, deprecated);
+
+		const [block] = parse(markup);
+
+		expect(console).toHaveInformed();
+		expect(block).toBeTruthy();
+		expect(block.name).toBe(metadata.name);
+		expect(block.isValid).toBe(true);
+	});
+
+	it('no longer serializes the baked overlay color var', () => {
+		register(save, deprecated);
+
+		const markup = serialize(createBlock(metadata.name));
+
+		expect(markup).not.toContain('--dsgo-overlay-color');
+	});
+});

--- a/tests/unit/progress-bar-color-deprecation.test.js
+++ b/tests/unit/progress-bar-color-deprecation.test.js
@@ -1,0 +1,99 @@
+/**
+ * Progress Bar Block - color-default deprecation
+ *
+ * Regression test proving that progress bars saved before the bar/track colors
+ * stopped baking hex defaults into the markup (`#2563eb` fill / `#e5e7eb`
+ * track) still parse as valid — silent migration, no "Attempt Recovery".
+ *
+ * Also asserts the current save() no longer serializes those hex literals when
+ * the author has not chosen a color, so the bar inherits the FSE-overridable
+ * CSS default instead.
+ *
+ * Deliberately uses the real @wordpress/blocks parser/validator (not mocked)
+ * since the thing under test IS the parser's deprecation-matching behavior.
+ *
+ * @package
+ */
+
+// @wordpress/block-editor ships its own nested copy of @wordpress/blocks.
+// useBlockProps.save() resolves block supports against THAT copy's registry,
+// so registration/parsing here must go through the same instance.
+const {
+	registerBlockType,
+	unregisterBlockType,
+	getBlockType,
+	createBlock,
+	serialize,
+	parse,
+} = require('@wordpress/block-editor/node_modules/@wordpress/blocks');
+
+import metadata from '../../src/blocks/progress-bar/block.json';
+import save from '../../src/blocks/progress-bar/save';
+import deprecated from '../../src/blocks/progress-bar/deprecated';
+
+// The custom 'designsetgo' category isn't registered in jest; category is
+// irrelevant to parse/validation, so use a built-in one to avoid an unrelated
+// invalid-category warning that would trip the console matcher.
+const register = (saveFn, deprecations) =>
+	registerBlockType(metadata.name, {
+		...metadata,
+		category: 'media',
+		save: saveFn,
+		...(deprecations ? { deprecated: deprecations } : {}),
+	});
+
+/**
+ * Serialize a default-color progress bar the way the OLD save did (with the
+ * baked hex fallbacks), to reproduce real stored markup.
+ *
+ * @return {string} Legacy block markup.
+ */
+function legacyMarkup() {
+	register(deprecated[0].save);
+	const block = createBlock(metadata.name);
+	const markup = serialize(block);
+	unregisterBlockType(metadata.name);
+	return markup;
+}
+
+describe('Progress Bar - color-default deprecation', () => {
+	afterEach(() => {
+		// Only unregister when still registered — unregistering an absent
+		// block warns, which trips the console matcher.
+		if (getBlockType(metadata.name)) {
+			unregisterBlockType(metadata.name);
+		}
+	});
+
+	it('reproduces the old baked hex defaults in legacy markup', () => {
+		const markup = legacyMarkup();
+		expect(markup).toContain('#2563eb');
+		expect(markup).toContain('#e5e7eb');
+	});
+
+	it('parses legacy hex-default content as valid (silent migration)', () => {
+		const markup = legacyMarkup();
+		register(save, deprecated);
+
+		const [block] = parse(markup);
+
+		// The parser logs an info message when a deprecation's save matches and
+		// the block is silently migrated — proving no "Attempt Recovery".
+		expect(console).toHaveInformed();
+		expect(block).toBeTruthy();
+		expect(block.name).toBe(metadata.name);
+		expect(block.isValid).toBe(true);
+		// Attributes are untouched by the passthrough migrate.
+		expect(block.attributes.barColor).toBe('');
+		expect(block.attributes.barBackgroundColor).toBe('');
+	});
+
+	it('no longer serializes hex color defaults for a default block', () => {
+		register(save, deprecated);
+
+		const markup = serialize(createBlock(metadata.name));
+
+		expect(markup).not.toContain('#2563eb');
+		expect(markup).not.toContain('#e5e7eb');
+	});
+});


### PR DESCRIPTION
## Summary

Two related FSE improvements so DesignSetGo container blocks inherit theme-level styling instead of hardcoding it.

### Part A — Section-style variations reach the container family

Extends the existing `Section_Styles` mirroring (previously only `section`/`row`/`grid`) to the full curated container set:

`card`, `fifty-fifty`, `modal`, `slide`, `scroll-slide`, `tab`, `accordion-item`, `scroll-accordion-item`, `image-accordion-item`, `timeline-item`, `counter`, `flip-card-face`.

Core Group's *Style 1–5* — and **any** section style registered with real theme.json style data (theme.json partial with `blockTypes`, or `register_block_style` with `style_data`) — now apply to these blocks automatically, both as a selectable Styles-panel entry and as rendered CSS. Registration + theme.json injection only, so **no `save()` changes and no deprecations**.

Register a new section style once on `core/group`, and it shows up across the whole container family. (Label-only / CSS-class-only styles that carry no theme.json data are intentionally not mirrored.)

### Part B — Stop baking hex color defaults into `save()`

So unset colors inherit FSE global styles instead of a serialized literal:

- **progress-bar** — inline bar/track `background-color` is emitted only when the author picks a color; unset falls back via a zero-specificity `:where()` CSS rule (fill → `--wp--preset--color--primary`, track → neutral), so Global Styles can override.
- **image-accordion-item** — drops the baked `--dsgo-overlay-*` vars; the overlay now cascades from the parent accordion's `--dsgo-image-accordion-overlay-*` properties. This also **fixes a latent bug**: because `save()` receives no block context, the parent's overlay settings never actually reached the frontend before.

Both blocks ship full `isEligible` / `save` / `migrate` deprecations, proven to migrate silently via the real `@wordpress/blocks` parser.

`card` / `timeline` / `timeline-item` already use `var(--preset, #hex)` (they inherit; hex is a harmless last-resort) and were left unchanged.

## Verification

- `npm run build` ✓ · JS/CSS/PHP lint clean on touched files
- Unit suite: **2067 passed**, including 6 new deprecation round-trip tests
- Pre-commit e2e: **7 passed**
- Part A confirmed in a running WordPress (wp-env) via WP-CLI: each target registers `section-1..5` and the resolved styles land in merged theme.json; a newly-registered `example-2` style with `style_data` mirrors onto all targets, while a label-only style correctly does not

## Design doc

`docs/plans/2026-07-06-section-style-variations-fse-design.md`
