### PR TITLE
fix(scroll-accordion-item): remove editor-only left border indicator

### DIFF
--- a/src/blocks/scroll-accordion-item/editor.scss
+++ b/src/blocks/scroll-accordion-item/editor.scss
@@ -51,29 +51,6 @@
 		}
 	}
 
-	/* Editor visual indicator */
-	&::after {
-		content: '';
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 3px;
-		height: 100%;
-		background: linear-gradient(to bottom, #3858e9, #7c3aed);
-		opacity: 0.3;
-		pointer-events: none;
-		transition: opacity 0.2s ease;
-		z-index: 3; /* Above overlay */
-	}
-
-	&:hover::after {
-		opacity: 0.6;
-	}
-
-	&.is-selected::after {
-		opacity: 1;
-	}
-
 	/* Alignment support */
 	&.alignleft {
 		margin-right: auto;


### PR DESCRIPTION
## Summary
- The scroll accordion item block rendered a 3px blue→purple gradient bar down the left edge of each item **in the editor only**, via an `::after` pseudo-element in `editor.scss`. It read as a stray left border with no equivalent on the frontend.
- Removed the `&::after` visual indicator and its `:hover`/`.is-selected` opacity variants so the editor matches the rendered output. Block selection/hover feedback is already covered by the standard editor block outline.

## Test Plan
- [x] `npm run build` compiles successfully
- [x] Gradient (`#3858e9`) no longer present in any `build/*.css`
- [x] Confirmed no `::after` on `scroll-accordion-item` in `build/style-index.css` (frontend was always unaffected)
- [x] `stylelint` passes on the changed file
- [ ] In the editor, insert a Scroll Accordion → confirm items no longer show the left border/bar
- [ ] Frontend render unchanged