### PR TITLE
feat(editor): preview user-customized section styles on DSGo blocks

### DIFF
--- a/docs/plans/2026-07-06-section-styles-editor-preview.md
+++ b/docs/plans/2026-07-06-section-styles-editor-preview.md
@@ -1,0 +1,62 @@
+# Section styles — editor preview for user-customized variations
+
+**Date**: 2026-07-06
+**Branch**: `claude/section-styles-editor-preview`
+
+## Problem (verified)
+
+Section-style variations mirror onto DSGo container blocks correctly on the
+**frontend** and for **theme/plugin-registered** styles in the editor. But when
+an author **customizes** a section style in Global Styles (e.g. adds a border /
+radius), the DSGo block's **editor canvas preview** shows only the pre-existing
+color, not the new border.
+
+Root cause: the editor generates block-style-variation CSS **client-side**
+(`@wordpress/block-editor` `hooks/block-style-variation.js` → `toStyles`),
+reading `styles.blocks.{blockName}.variations.{slug}` from the browser-merged
+global-styles config. That merge never runs our server PHP mirror
+(`Section_Styles`), and the user's edit is keyed to `core/group` — so it never
+reaches the DSGo block in the editor. The server merged data + frontend are
+correct; only the in-editor preview lags.
+
+Core's own remedy (`__unstableBlockStyleVariationOverridesWithConfig`) is a
+locked private API — unusable by a plugin.
+
+## Approach (spike-proven, public APIs only)
+
+An **editor-only** module that:
+
+1. Reactively reads the live user global-styles config via public core-data:
+   `select('core').getEditedEntityRecord('root','globalStyles', id)` — verified
+   returns live variation edits (incl. border).
+2. Builds a CSS overlay: for each DSGo container block × each user-customized
+   section-style variation on the core containers, emits box-decoration
+   declarations (color, border, radius, spacing, shadow, font-size) scoped to
+   the **stable** `.wp-block-designsetgo-{suffix}.is-style-{slug}` class.
+   Specificity 0-2-0 cleanly beats core's `:root :where()` (0-1-0). Verified:
+   injecting such a rule makes the border render; removing it reverts.
+3. Injects/updates a single `<style>` in the editor canvas (iframe or
+   non-iframed), reactively on config change and on canvas (re)mount.
+
+Only the **user-layer delta** is emitted (theme/registry-layer variations
+already preview correctly), so this is additive and low-risk.
+
+## Files
+
+- `src/extensions/section-styles-editor-preview/generate-css.js` — pure,
+  unit-tested: `toCssValue`, `variationDeclarations`, `buildVariationCss`.
+  `TARGET_SUFFIXES` mirrors `Section_Styles::$container_blocks` (minus
+  `image-accordion-item`, which opts out of background color).
+- `src/extensions/section-styles-editor-preview/index.js` — `registerPlugin`
+  component: reactive read → `buildVariationCss` → canvas injection.
+- `src/index.js` — add the import.
+- `tests/unit/extensions/section-styles-editor-preview/generate-css.test.js`.
+
+## Verification
+
+- Unit: CSS generation for color/border(flat+split)/radius/spacing/shadow +
+  `var:preset|…` resolution.
+- Manual (editor, wp-env :9451): customize a section style's border in Global
+  Styles → confirm a DSGo section previews the border live; confirm frontend
+  unaffected; console clean.
+- `npm run build && npm run lint:js && npm run lint:css`.

--- a/docs/plans/2026-07-06-section-styles-editor-preview.md
+++ b/docs/plans/2026-07-06-section-styles-editor-preview.md
@@ -66,6 +66,14 @@ already preview correctly), so this is additive and low-risk.
   border/radius preview at all), but it means the overlay is a best-effort
   preview, not a full re-implementation of WP's theme.json → CSS pipeline.
   Extending coverage means adding to `variationDeclarations()`.
+- **Experimental core-data selector.** Reading the current global-styles
+  entity id uses `select('core').__experimentalGetCurrentGlobalStylesId()` —
+  there is no stable public equivalent. It's guarded (`typeof … === 'function'`)
+  so a rename/removal can't crash the editor, and a dev-only one-time
+  `console.warn` fires if it's ever missing. But if a future WP release drops
+  it, the overlay silently stops previewing; that guard + warning in
+  `index.js` is where to look if "border stopped previewing in the editor"
+  is ever reported after a core update.
 - **JS/PHP list parity** is enforced by `php-parity.test.js` (fails if
   `TARGET_SUFFIXES` / `SOURCE_BLOCKS` drift from the PHP `$container_blocks` /
   `$source_blocks`), rather than a runtime data pipeline — the lists change

--- a/docs/plans/2026-07-06-section-styles-editor-preview.md
+++ b/docs/plans/2026-07-06-section-styles-editor-preview.md
@@ -52,6 +52,26 @@ already preview correctly), so this is additive and low-risk.
 - `src/index.js` — add the import.
 - `tests/unit/extensions/section-styles-editor-preview/generate-css.test.js`.
 
+## Known limitations
+
+- **Partial property coverage.** The PHP mirror copies the *entire* variation
+  style object onto the DSGo blocks, so any property propagates to the
+  frontend. This editor overlay reproduces only the common box-decoration
+  subset (background / gradient / text color, border, radius, spacing, shadow,
+  font-size, line-height). If an author customizes a section style with a
+  property outside that subset (e.g. `typography.letterSpacing` /
+  `textTransform`, `elements.link`, `filter` / duotone, `dimensions.minHeight`),
+  the *editor preview* will still diverge from the saved frontend output for
+  that property. This is not a regression (the pre-overlay state was worse — no
+  border/radius preview at all), but it means the overlay is a best-effort
+  preview, not a full re-implementation of WP's theme.json → CSS pipeline.
+  Extending coverage means adding to `variationDeclarations()`.
+- **JS/PHP list parity** is enforced by `php-parity.test.js` (fails if
+  `TARGET_SUFFIXES` / `SOURCE_BLOCKS` drift from the PHP `$container_blocks` /
+  `$source_blocks`), rather than a runtime data pipeline — the lists change
+  rarely and a static list avoids coupling the editor bundle to a localized
+  global.
+
 ## Verification
 
 - Unit: CSS generation for color/border(flat+split)/radius/spacing/shadow +

--- a/src/extensions/section-styles-editor-preview/generate-css.js
+++ b/src/extensions/section-styles-editor-preview/generate-css.js
@@ -54,6 +54,25 @@ function kebabCase(segment) {
 }
 
 /**
+ * Whether a variation slug is safe to splice into a CSS selector.
+ *
+ * Style *values* are guarded by `toCssValue()`, but the slug is interpolated
+ * directly into `.wp-block-designsetgo-{suffix}.is-style-{slug}{…}`. Since the
+ * slug comes from the *unsanitized* edited Global Styles record (its keys are
+ * `Object.keys(styles.blocks.{block}.variations)`), a crafted key containing
+ * `{`/`}` could otherwise close the rule and inject sibling CSS into the canvas.
+ * We allow-list the `sanitize_title()` character set: a real block-style
+ * variation only ever produces an `is-style-` class from a sanitized name, so a
+ * slug outside this set can never match a rendered block and is safely dropped.
+ *
+ * @param {string} slug Variation slug.
+ * @return {boolean} True when the slug is a safe CSS-class token.
+ */
+function isSafeSlug(slug) {
+	return typeof slug === 'string' && /^[a-zA-Z0-9_-]+$/.test(slug);
+}
+
+/**
  * Whether a style value is present (allows `0` / empty string, excludes
  * null/undefined).
  *
@@ -259,6 +278,11 @@ export function buildVariationCss(blocksConfig) {
 			return;
 		}
 		Object.keys(variations).forEach((slug) => {
+			// Drop slugs that aren't a safe CSS-class token before they can
+			// reach the selector (mirrors the value guard in `toCssValue`).
+			if (!isSafeSlug(slug)) {
+				return;
+			}
 			if (!(slug in merged)) {
 				merged[slug] = variations[slug];
 			}

--- a/src/extensions/section-styles-editor-preview/generate-css.js
+++ b/src/extensions/section-styles-editor-preview/generate-css.js
@@ -1,0 +1,271 @@
+/**
+ * Section Styles — Editor Preview: CSS generation
+ *
+ * Pure helpers that turn a global-styles block-variation config into an editor
+ * CSS overlay for the DesignSetGo container blocks. Kept free of any
+ * `@wordpress/*` imports so it can be unit-tested in isolation.
+ *
+ * Context: WordPress mirrors theme/plugin section styles onto DSGo blocks
+ * server-side (see `DesignSetGo\Section_Styles`), but the editor generates
+ * block-style-variation CSS client-side and never runs that mirror for the
+ * user (Global Styles) layer. This overlay reproduces the user-layer variation
+ * styles on the DSGo blocks so the editor preview matches the saved output.
+ *
+ * @package
+ */
+
+/**
+ * Core container blocks whose section-style variations we mirror. Matches the
+ * `$source_blocks` list in class-section-styles.php.
+ */
+export const SOURCE_BLOCKS = ['core/group', 'core/columns', 'core/column'];
+
+/**
+ * DesignSetGo container block suffixes (the part after `designsetgo/`) that
+ * receive mirrored section styles. Mirrors `Section_Styles::$container_blocks`
+ * — deliberately excludes `image-accordion-item` (opts out of background
+ * color). Keep in sync with class-section-styles.php.
+ */
+export const TARGET_SUFFIXES = [
+	'section',
+	'row',
+	'grid',
+	'card',
+	'fifty-fifty',
+	'modal',
+	'slide',
+	'scroll-slide',
+	'tab',
+	'accordion-item',
+	'scroll-accordion-item',
+	'timeline-item',
+	'counter',
+	'flip-card-face',
+];
+
+/**
+ * Convert a camelCase segment to kebab-case for CSS custom property names.
+ *
+ * @param {string} segment Path segment (e.g. `fontSize`).
+ * @return {string} Kebab-cased segment (e.g. `font-size`).
+ */
+function kebabCase(segment) {
+	return segment.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+/**
+ * Whether a style value is present (allows `0` / empty string, excludes
+ * null/undefined).
+ *
+ * @param {*} value Value to test.
+ * @return {boolean} True when set.
+ */
+function isSet(value) {
+	return value !== undefined && value !== null;
+}
+
+/**
+ * Resolve a theme.json style value to a CSS value, expanding preset/custom
+ * references (`var:preset|color|accent-2` → `var(--wp--preset--color--accent-2)`).
+ *
+ * @param {*} value Raw style value.
+ * @return {*} CSS-ready value.
+ */
+export function toCssValue(value) {
+	if (typeof value !== 'string') {
+		return value;
+	}
+
+	const match = value.match(/^var:(preset|custom)\|(.+)$/);
+	if (!match) {
+		return value;
+	}
+
+	const kind = match[1];
+	const path = match[2].split('|').map(kebabCase).join('--');
+	return `var(--wp--${kind}--${path})`;
+}
+
+/**
+ * Build border declarations, supporting both the flat shape
+ * (`{ color, width, style, radius }`) and the split-sides shape
+ * (`{ top: { color, width, style }, … }`), plus per-corner radius.
+ *
+ * @param {Object} border Border style object.
+ * @return {string[]} CSS declarations.
+ */
+function borderDeclarations(border) {
+	const out = [];
+	if (!border || typeof border !== 'object') {
+		return out;
+	}
+
+	const sides = ['top', 'right', 'bottom', 'left'];
+	const hasSides = sides.some((side) => border[side]);
+
+	if (hasSides) {
+		sides.forEach((side) => {
+			const edge = border[side];
+			if (!edge || typeof edge !== 'object') {
+				return;
+			}
+			if (edge.color) {
+				out.push(`border-${side}-color:${toCssValue(edge.color)}`);
+			}
+			if (edge.width) {
+				out.push(`border-${side}-width:${edge.width}`);
+			}
+			if (edge.style) {
+				out.push(`border-${side}-style:${edge.style}`);
+			}
+		});
+	} else {
+		if (border.color) {
+			out.push(`border-color:${toCssValue(border.color)}`);
+		}
+		if (border.width) {
+			out.push(`border-width:${border.width}`);
+		}
+		if (border.style) {
+			out.push(`border-style:${border.style}`);
+		}
+	}
+
+	// Radius can coexist with either shape.
+	if (isSet(border.radius)) {
+		if (typeof border.radius === 'object') {
+			const corners = {
+				topLeft: 'top-left',
+				topRight: 'top-right',
+				bottomLeft: 'bottom-left',
+				bottomRight: 'bottom-right',
+			};
+			Object.keys(corners).forEach((key) => {
+				if (border.radius[key]) {
+					out.push(
+						`border-${corners[key]}-radius:${border.radius[key]}`
+					);
+				}
+			});
+		} else {
+			out.push(`border-radius:${border.radius}`);
+		}
+	}
+
+	return out;
+}
+
+/**
+ * Build spacing (padding/margin) declarations from a spacing style object.
+ *
+ * @param {Object} spacing Spacing style object.
+ * @return {string[]} CSS declarations.
+ */
+function spacingDeclarations(spacing) {
+	const out = [];
+	if (!spacing || typeof spacing !== 'object') {
+		return out;
+	}
+
+	['padding', 'margin'].forEach((prop) => {
+		const box = spacing[prop];
+		if (!box || typeof box !== 'object') {
+			return;
+		}
+		['top', 'right', 'bottom', 'left'].forEach((side) => {
+			if (isSet(box[side])) {
+				out.push(`${prop}-${side}:${toCssValue(box[side])}`);
+			}
+		});
+	});
+
+	return out;
+}
+
+/**
+ * Turn a single variation's style object into a CSS declaration string.
+ *
+ * @param {Object} variation Variation style object (theme.json shape).
+ * @return {string} `prop:value;prop:value` (no braces); empty when nothing set.
+ */
+export function variationDeclarations(variation) {
+	if (!variation || typeof variation !== 'object') {
+		return '';
+	}
+
+	const out = [];
+	const color = variation.color || {};
+
+	if (color.background) {
+		out.push(`background-color:${toCssValue(color.background)}`);
+	}
+	if (color.gradient) {
+		out.push(`background:${toCssValue(color.gradient)}`);
+	}
+	if (color.text) {
+		out.push(`color:${toCssValue(color.text)}`);
+	}
+
+	out.push(...borderDeclarations(variation.border));
+	out.push(...spacingDeclarations(variation.spacing));
+
+	if (variation.shadow) {
+		out.push(`box-shadow:${toCssValue(variation.shadow)}`);
+	}
+
+	const typography = variation.typography || {};
+	if (typography.fontSize) {
+		out.push(`font-size:${toCssValue(typography.fontSize)}`);
+	}
+	if (isSet(typography.lineHeight)) {
+		out.push(`line-height:${typography.lineHeight}`);
+	}
+
+	return out.join(';');
+}
+
+/**
+ * Build the full editor overlay stylesheet from a global-styles `styles.blocks`
+ * config. Collects every variation registered on the core container blocks
+ * (first source wins on slug collision) and emits one rule per DSGo target ×
+ * variation, scoped to the stable `is-style-{slug}` class.
+ *
+ * @param {Object} blocksConfig `styles.blocks` object from global styles.
+ * @return {string} CSS stylesheet (may be empty).
+ */
+export function buildVariationCss(blocksConfig) {
+	if (!blocksConfig || typeof blocksConfig !== 'object') {
+		return '';
+	}
+
+	// Flatten variations across the source containers; first source wins.
+	const merged = {};
+	SOURCE_BLOCKS.forEach((source) => {
+		const variations = blocksConfig[source]?.variations;
+		if (!variations) {
+			return;
+		}
+		Object.keys(variations).forEach((slug) => {
+			if (!(slug in merged)) {
+				merged[slug] = variations[slug];
+			}
+		});
+	});
+
+	const slugs = Object.keys(merged);
+	if (!slugs.length) {
+		return '';
+	}
+
+	let css = '';
+	TARGET_SUFFIXES.forEach((suffix) => {
+		slugs.forEach((slug) => {
+			const declarations = variationDeclarations(merged[slug]);
+			if (declarations) {
+				css += `.wp-block-designsetgo-${suffix}.is-style-${slug}{${declarations}}\n`;
+			}
+		});
+	});
+
+	return css;
+}

--- a/src/extensions/section-styles-editor-preview/generate-css.js
+++ b/src/extensions/section-styles-editor-preview/generate-css.js
@@ -69,11 +69,14 @@ function isSet(value) {
  * references (`var:preset|color|accent-2` → `var(--wp--preset--color--accent-2)`).
  *
  * Also strips characters that could terminate a declaration or rule (`{`, `}`,
- * `;`). Values come straight from the *unsanitized* edited Global Styles record
- * and are written via `textContent`, so this is the only guard against a
- * crafted value escaping its rule and injecting sibling CSS into the canvas.
- * Legitimate CSS values (colors, lengths, `var()`, gradients, `calc()`) never
- * contain these characters, so stripping is a no-op for real data.
+ * `;`) and the backslash (`\`) that CSS would otherwise decode into those same
+ * characters via hex escapes (e.g. `\7b` → `{`), which would slip past a
+ * literal-character strip. Values come straight from the *unsanitized* edited
+ * Global Styles record and are written via `textContent`, so this is the only
+ * guard against a crafted value escaping its rule and injecting sibling CSS
+ * into the canvas. Legitimate CSS values (colors, lengths, `var()`, gradients,
+ * `calc()`) never contain these characters, so stripping is a no-op for real
+ * data.
  *
  * @param {*} value Raw style value.
  * @return {*} CSS-ready value.
@@ -91,7 +94,7 @@ export function toCssValue(value) {
 				.join('--')})`
 		: value;
 
-	return resolved.replace(/[{};]/g, '');
+	return resolved.replace(/[{};\\]/g, '');
 }
 
 /**
@@ -228,7 +231,7 @@ export function variationDeclarations(variation) {
 		out.push(`font-size:${toCssValue(typography.fontSize)}`);
 	}
 	if (isSet(typography.lineHeight)) {
-		out.push(`line-height:${typography.lineHeight}`);
+		out.push(`line-height:${toCssValue(typography.lineHeight)}`);
 	}
 
 	return out.join(';');

--- a/src/extensions/section-styles-editor-preview/generate-css.js
+++ b/src/extensions/section-styles-editor-preview/generate-css.js
@@ -68,6 +68,13 @@ function isSet(value) {
  * Resolve a theme.json style value to a CSS value, expanding preset/custom
  * references (`var:preset|color|accent-2` → `var(--wp--preset--color--accent-2)`).
  *
+ * Also strips characters that could terminate a declaration or rule (`{`, `}`,
+ * `;`). Values come straight from the *unsanitized* edited Global Styles record
+ * and are written via `textContent`, so this is the only guard against a
+ * crafted value escaping its rule and injecting sibling CSS into the canvas.
+ * Legitimate CSS values (colors, lengths, `var()`, gradients, `calc()`) never
+ * contain these characters, so stripping is a no-op for real data.
+ *
  * @param {*} value Raw style value.
  * @return {*} CSS-ready value.
  */
@@ -77,13 +84,14 @@ export function toCssValue(value) {
 	}
 
 	const match = value.match(/^var:(preset|custom)\|(.+)$/);
-	if (!match) {
-		return value;
-	}
+	const resolved = match
+		? `var(--wp--${match[1]}--${match[2]
+				.split('|')
+				.map(kebabCase)
+				.join('--')})`
+		: value;
 
-	const kind = match[1];
-	const path = match[2].split('|').map(kebabCase).join('--');
-	return `var(--wp--${kind}--${path})`;
+	return resolved.replace(/[{};]/g, '');
 }
 
 /**
@@ -113,10 +121,10 @@ function borderDeclarations(border) {
 				out.push(`border-${side}-color:${toCssValue(edge.color)}`);
 			}
 			if (isSet(edge.width)) {
-				out.push(`border-${side}-width:${edge.width}`);
+				out.push(`border-${side}-width:${toCssValue(edge.width)}`);
 			}
 			if (isSet(edge.style)) {
-				out.push(`border-${side}-style:${edge.style}`);
+				out.push(`border-${side}-style:${toCssValue(edge.style)}`);
 			}
 		});
 	} else {
@@ -124,10 +132,10 @@ function borderDeclarations(border) {
 			out.push(`border-color:${toCssValue(border.color)}`);
 		}
 		if (isSet(border.width)) {
-			out.push(`border-width:${border.width}`);
+			out.push(`border-width:${toCssValue(border.width)}`);
 		}
 		if (isSet(border.style)) {
-			out.push(`border-style:${border.style}`);
+			out.push(`border-style:${toCssValue(border.style)}`);
 		}
 	}
 
@@ -143,12 +151,14 @@ function borderDeclarations(border) {
 			Object.keys(corners).forEach((key) => {
 				if (isSet(border.radius[key])) {
 					out.push(
-						`border-${corners[key]}-radius:${border.radius[key]}`
+						`border-${corners[key]}-radius:${toCssValue(
+							border.radius[key]
+						)}`
 					);
 				}
 			});
 		} else {
-			out.push(`border-radius:${border.radius}`);
+			out.push(`border-radius:${toCssValue(border.radius)}`);
 		}
 	}
 
@@ -196,25 +206,25 @@ export function variationDeclarations(variation) {
 	const out = [];
 	const color = variation.color || {};
 
-	if (color.background) {
+	if (isSet(color.background)) {
 		out.push(`background-color:${toCssValue(color.background)}`);
 	}
-	if (color.gradient) {
+	if (isSet(color.gradient)) {
 		out.push(`background:${toCssValue(color.gradient)}`);
 	}
-	if (color.text) {
+	if (isSet(color.text)) {
 		out.push(`color:${toCssValue(color.text)}`);
 	}
 
 	out.push(...borderDeclarations(variation.border));
 	out.push(...spacingDeclarations(variation.spacing));
 
-	if (variation.shadow) {
+	if (isSet(variation.shadow)) {
 		out.push(`box-shadow:${toCssValue(variation.shadow)}`);
 	}
 
 	const typography = variation.typography || {};
-	if (typography.fontSize) {
+	if (isSet(typography.fontSize)) {
 		out.push(`font-size:${toCssValue(typography.fontSize)}`);
 	}
 	if (isSet(typography.lineHeight)) {

--- a/src/extensions/section-styles-editor-preview/generate-css.js
+++ b/src/extensions/section-styles-editor-preview/generate-css.js
@@ -109,24 +109,24 @@ function borderDeclarations(border) {
 			if (!edge || typeof edge !== 'object') {
 				return;
 			}
-			if (edge.color) {
+			if (isSet(edge.color)) {
 				out.push(`border-${side}-color:${toCssValue(edge.color)}`);
 			}
-			if (edge.width) {
+			if (isSet(edge.width)) {
 				out.push(`border-${side}-width:${edge.width}`);
 			}
-			if (edge.style) {
+			if (isSet(edge.style)) {
 				out.push(`border-${side}-style:${edge.style}`);
 			}
 		});
 	} else {
-		if (border.color) {
+		if (isSet(border.color)) {
 			out.push(`border-color:${toCssValue(border.color)}`);
 		}
-		if (border.width) {
+		if (isSet(border.width)) {
 			out.push(`border-width:${border.width}`);
 		}
-		if (border.style) {
+		if (isSet(border.style)) {
 			out.push(`border-style:${border.style}`);
 		}
 	}
@@ -259,7 +259,18 @@ export function buildVariationCss(blocksConfig) {
 
 	let css = '';
 	TARGET_SUFFIXES.forEach((suffix) => {
+		const ownVariations =
+			blocksConfig[`designsetgo/${suffix}`]?.variations || {};
 		slugs.forEach((slug) => {
+			// Parity with Section_Styles::mirror_variation_styles(): never
+			// clobber a variation the DSGo block defines for itself. The editor
+			// already previews that one natively (it lives under the block's own
+			// name), and the server mirror skips broadcasting onto it — so
+			// emitting the core-container version here would reintroduce the
+			// preview/frontend divergence this overlay exists to prevent.
+			if (slug in ownVariations) {
+				return;
+			}
 			const declarations = variationDeclarations(merged[slug]);
 			if (declarations) {
 				css += `.wp-block-designsetgo-${suffix}.is-style-${slug}{${declarations}}\n`;

--- a/src/extensions/section-styles-editor-preview/generate-css.js
+++ b/src/extensions/section-styles-editor-preview/generate-css.js
@@ -141,7 +141,7 @@ function borderDeclarations(border) {
 				bottomRight: 'bottom-right',
 			};
 			Object.keys(corners).forEach((key) => {
-				if (border.radius[key]) {
+				if (isSet(border.radius[key])) {
 					out.push(
 						`border-${corners[key]}-radius:${border.radius[key]}`
 					);

--- a/src/extensions/section-styles-editor-preview/index.js
+++ b/src/extensions/section-styles-editor-preview/index.js
@@ -128,28 +128,26 @@ function SectionStylePreview() {
 	}, [css, scheduleInject]);
 
 	// Re-assert the overlay when the canvas iframe (re)mounts — switching
-	// devices, entering/leaving fullscreen, etc. recreate the canvas document.
-	// Only react to added <iframe> nodes so we skip the editor's constant
-	// content mutations.
+	// devices, entering/leaving fullscreen, etc. recreate the canvas document
+	// and drop the overlay. Rather than inspect every mutation (the editor
+	// churns the DOM constantly while typing), we debounce: after mutations
+	// settle we re-inject once. `injectStyles` is idempotent, so this is a
+	// no-op unless the canvas was actually replaced.
 	useEffect(() => {
-		const addsIframe = (mutations) =>
-			mutations.some((mutation) =>
-				Array.from(mutation.addedNodes).some(
-					(node) =>
-						node.nodeType === 1 &&
-						(node.nodeName === 'IFRAME' ||
-							(node.querySelector &&
-								node.querySelector('iframe')))
-				)
-			);
-
-		const observer = new window.MutationObserver((mutations) => {
-			if (addsIframe(mutations)) {
-				scheduleInject();
+		let timer = null;
+		const observer = new window.MutationObserver(() => {
+			if (timer) {
+				window.clearTimeout(timer);
 			}
+			timer = window.setTimeout(scheduleInject, 300);
 		});
 		observer.observe(document.body, { childList: true, subtree: true });
-		return () => observer.disconnect();
+		return () => {
+			if (timer) {
+				window.clearTimeout(timer);
+			}
+			observer.disconnect();
+		};
 	}, [scheduleInject]);
 
 	return null;

--- a/src/extensions/section-styles-editor-preview/index.js
+++ b/src/extensions/section-styles-editor-preview/index.js
@@ -28,6 +28,10 @@ import { buildVariationCss } from './generate-css';
 
 const STYLE_ELEMENT_ID = 'dsgo-section-style-preview';
 
+// Whether the missing-API warning has fired (dev only). See the note in
+// SectionStylePreview.
+let warnedMissingApi = false;
+
 /**
  * Collect the documents that make up the editor canvas. Handles both the
  * iframed canvas (post/site editor) and the rare non-iframed case.
@@ -49,7 +53,13 @@ function getCanvasDocuments() {
 			}
 		});
 
-	// Non-iframed fallback: the editor writing flow lives in the main document.
+	// Non-iframed fallback: the editor writing flow lives in the main document
+	// (legacy/classic path; modern editors iframe the canvas). Here the overlay
+	// goes in the top-level <head> and is scoped only by its class selector
+	// (`.wp-block-designsetgo-{suffix}.is-style-{slug}`). Those classes only
+	// appear on DSGo blocks in the editor content, so a stray match elsewhere on
+	// the admin screen is effectively impossible — an accepted tradeoff for this
+	// rare path rather than prefixing every selector with the wrapper.
 	if (!docs.length && document.querySelector('.editor-styles-wrapper')) {
 		docs.push(document);
 	}
@@ -99,8 +109,26 @@ function injectStyles(css) {
 function SectionStylePreview() {
 	const css = useSelect((select) => {
 		const core = select(coreStore);
+
+		// NOTE: `__experimentalGetCurrentGlobalStylesId` is an experimental
+		// core-data selector — there is no stable public equivalent for the
+		// current global-styles entity id. If a future WP release renames or
+		// removes it, this overlay quietly stops working; surface that in dev
+		// so it isn't a silent "border stopped previewing" mystery. See the
+		// Known limitations section of the plan doc.
 		const getId = core.__experimentalGetCurrentGlobalStylesId;
-		const id = typeof getId === 'function' ? getId() : null;
+		if (typeof getId !== 'function') {
+			if (!warnedMissingApi && process.env.NODE_ENV !== 'production') {
+				warnedMissingApi = true;
+				// eslint-disable-next-line no-console
+				console.warn(
+					'DesignSetGo: core-data selector __experimentalGetCurrentGlobalStylesId is unavailable; section-style editor preview is disabled.'
+				);
+			}
+			return '';
+		}
+
+		const id = getId();
 		if (!id) {
 			return '';
 		}
@@ -136,24 +164,49 @@ function SectionStylePreview() {
 	// debounce coalesces bursts and `injectStyles` is idempotent, so a
 	// settle-triggered re-inject is a no-op unless the canvas was replaced.
 	useEffect(() => {
-		const root =
-			document.querySelector(
-				'.editor-visual-editor, .edit-post-visual-editor, .edit-site-visual-editor, .interface-interface-skeleton__content'
-			) || document.body;
+		let observer = null;
+		let debounce = null;
+		let retry = null;
+		let attempts = 0;
 
-		let timer = null;
-		const observer = new window.MutationObserver(() => {
-			if (timer) {
-				window.clearTimeout(timer);
+		const attach = () => {
+			const root = document.querySelector(
+				'.editor-visual-editor, .edit-post-visual-editor, .edit-site-visual-editor, .interface-interface-skeleton__content'
+			);
+
+			// If the editor shell hasn't rendered its wrapper yet (this plugin
+			// component can mount first), retry briefly rather than permanently
+			// falling back to document.body — which would reintroduce the broad
+			// observation this scoping avoids. Use body only as a last resort.
+			if (!root && attempts < 10) {
+				attempts += 1;
+				retry = window.setTimeout(attach, 300);
+				return;
 			}
-			timer = window.setTimeout(scheduleInject, 300);
-		});
-		observer.observe(root, { childList: true, subtree: true });
+
+			observer = new window.MutationObserver(() => {
+				if (debounce) {
+					window.clearTimeout(debounce);
+				}
+				debounce = window.setTimeout(scheduleInject, 300);
+			});
+			observer.observe(root || document.body, {
+				childList: true,
+				subtree: true,
+			});
+		};
+		attach();
+
 		return () => {
-			if (timer) {
-				window.clearTimeout(timer);
+			if (retry) {
+				window.clearTimeout(retry);
 			}
-			observer.disconnect();
+			if (debounce) {
+				window.clearTimeout(debounce);
+			}
+			if (observer) {
+				observer.disconnect();
+			}
 		};
 	}, [scheduleInject]);
 

--- a/src/extensions/section-styles-editor-preview/index.js
+++ b/src/extensions/section-styles-editor-preview/index.js
@@ -129,11 +129,18 @@ function SectionStylePreview() {
 
 	// Re-assert the overlay when the canvas iframe (re)mounts — switching
 	// devices, entering/leaving fullscreen, etc. recreate the canvas document
-	// and drop the overlay. Rather than inspect every mutation (the editor
-	// churns the DOM constantly while typing), we debounce: after mutations
-	// settle we re-inject once. `injectStyles` is idempotent, so this is a
-	// no-op unless the canvas was actually replaced.
+	// and drop the overlay. Observe the visual-editor wrapper rather than
+	// `document.body`: the wrapper only mutates when the iframe itself is
+	// swapped (typing/selection churn happens inside the iframe's own
+	// document, which this observer does not see), so it fires rarely. The
+	// debounce coalesces bursts and `injectStyles` is idempotent, so a
+	// settle-triggered re-inject is a no-op unless the canvas was replaced.
 	useEffect(() => {
+		const root =
+			document.querySelector(
+				'.editor-visual-editor, .edit-post-visual-editor, .edit-site-visual-editor, .interface-interface-skeleton__content'
+			) || document.body;
+
 		let timer = null;
 		const observer = new window.MutationObserver(() => {
 			if (timer) {
@@ -141,7 +148,7 @@ function SectionStylePreview() {
 			}
 			timer = window.setTimeout(scheduleInject, 300);
 		});
-		observer.observe(document.body, { childList: true, subtree: true });
+		observer.observe(root, { childList: true, subtree: true });
 		return () => {
 			if (timer) {
 				window.clearTimeout(timer);
@@ -153,6 +160,6 @@ function SectionStylePreview() {
 	return null;
 }
 
-registerPlugin('designsetgo-section-style-preview', {
+registerPlugin('dsgo-section-style-preview', {
 	render: SectionStylePreview,
 });

--- a/src/extensions/section-styles-editor-preview/index.js
+++ b/src/extensions/section-styles-editor-preview/index.js
@@ -22,7 +22,7 @@
 import { registerPlugin } from '@wordpress/plugins';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useMemo, useRef } from '@wordpress/element';
 
 import { buildVariationCss } from './generate-css';
 
@@ -107,7 +107,14 @@ function injectStyles(css) {
  * @return {null} No visible output.
  */
 function SectionStylePreview() {
-	const css = useSelect((select) => {
+	// Subscribe only to the global-styles `styles.blocks` config. `useSelect`
+	// re-runs this on every core-data store update, but `getEditedEntityRecord`
+	// is memoized (returns a stable reference until the record actually
+	// changes), so the returned value is reference-stable across unrelated
+	// editor churn. The expensive `buildVariationCss` is deferred to the
+	// `useMemo` below, keyed on that reference, so it only recomputes on real
+	// Global Styles edits — not on every keystroke elsewhere in the editor.
+	const blocksConfig = useSelect((select) => {
 		const core = select(coreStore);
 
 		// NOTE: `__experimentalGetCurrentGlobalStylesId` is an experimental
@@ -125,17 +132,19 @@ function SectionStylePreview() {
 					'DesignSetGo: core-data selector __experimentalGetCurrentGlobalStylesId is unavailable; section-style editor preview is disabled.'
 				);
 			}
-			return '';
+			return undefined;
 		}
 
 		const id = getId();
 		if (!id) {
-			return '';
+			return undefined;
 		}
 
 		const record = core.getEditedEntityRecord('root', 'globalStyles', id);
-		return buildVariationCss(record?.styles?.blocks);
+		return record?.styles?.blocks;
 	}, []);
+
+	const css = useMemo(() => buildVariationCss(blocksConfig), [blocksConfig]);
 
 	// Keep the latest CSS available to deferred/observer callbacks without
 	// re-subscribing, and so stale retries always write the current value.

--- a/src/extensions/section-styles-editor-preview/index.js
+++ b/src/extensions/section-styles-editor-preview/index.js
@@ -1,0 +1,160 @@
+/**
+ * Section Styles — Editor Preview
+ *
+ * Makes user-customized (Global Styles) section-style variations preview on the
+ * DesignSetGo container blocks in the editor canvas.
+ *
+ * WordPress mirrors theme/plugin section styles onto DSGo blocks server-side
+ * (`DesignSetGo\Section_Styles`), which covers the frontend and the editor's
+ * base config. But the editor generates block-style-variation CSS client-side
+ * from the browser-merged global-styles config, which never runs that mirror
+ * for the user layer — so a border/radius an author adds to a section style in
+ * Global Styles is missing from the DSGo block's editor preview (the saved
+ * frontend output is correct). Core's own fix for this is a locked private API.
+ *
+ * This module reproduces the user-layer variation styles as a low-cost CSS
+ * overlay, scoped to the stable `is-style-{slug}` class, injected into the
+ * editor canvas and updated reactively.
+ *
+ * @package
+ */
+
+import { registerPlugin } from '@wordpress/plugins';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useEffect, useRef } from '@wordpress/element';
+
+import { buildVariationCss } from './generate-css';
+
+const STYLE_ELEMENT_ID = 'dsgo-section-style-preview';
+
+/**
+ * Collect the documents that make up the editor canvas. Handles both the
+ * iframed canvas (post/site editor) and the rare non-iframed case.
+ *
+ * @return {Document[]} Canvas documents to inject into.
+ */
+function getCanvasDocuments() {
+	const docs = [];
+
+	document
+		.querySelectorAll('iframe[name="editor-canvas"]')
+		.forEach((iframe) => {
+			try {
+				if (iframe.contentDocument) {
+					docs.push(iframe.contentDocument);
+				}
+			} catch (e) {
+				// Cross-origin (never happens for the local canvas) — ignore.
+			}
+		});
+
+	// Non-iframed fallback: the editor writing flow lives in the main document.
+	if (!docs.length && document.querySelector('.editor-styles-wrapper')) {
+		docs.push(document);
+	}
+
+	return docs;
+}
+
+/**
+ * Inject or update the overlay `<style>` in each canvas document.
+ *
+ * @param {string} css Stylesheet text.
+ */
+function injectStyles(css) {
+	getCanvasDocuments().forEach((doc) => {
+		const head = doc.head || doc.documentElement;
+		if (!head) {
+			return;
+		}
+
+		let element = doc.getElementById(STYLE_ELEMENT_ID);
+
+		if (!css) {
+			if (element) {
+				element.textContent = '';
+			}
+			return;
+		}
+
+		if (!element) {
+			element = doc.createElement('style');
+			element.id = STYLE_ELEMENT_ID;
+			head.appendChild(element);
+		}
+
+		if (element.textContent !== css) {
+			element.textContent = css;
+		}
+	});
+}
+
+/**
+ * Editor component: reads the live user global-styles config and keeps the
+ * canvas overlay in sync. Renders nothing.
+ *
+ * @return {null} No visible output.
+ */
+function SectionStylePreview() {
+	const css = useSelect((select) => {
+		const core = select(coreStore);
+		const getId = core.__experimentalGetCurrentGlobalStylesId;
+		const id = typeof getId === 'function' ? getId() : null;
+		if (!id) {
+			return '';
+		}
+
+		const record = core.getEditedEntityRecord('root', 'globalStyles', id);
+		return buildVariationCss(record?.styles?.blocks);
+	}, []);
+
+	// Keep the latest CSS available to deferred/observer callbacks without
+	// re-subscribing, and so stale retries always write the current value.
+	const cssRef = useRef(css);
+	cssRef.current = css;
+
+	// Inject now plus a couple of short retries — a freshly (re)mounted canvas
+	// iframe may not have its document ready on the first attempt.
+	const scheduleInject = useRef(() => {
+		injectStyles(cssRef.current);
+		window.setTimeout(() => injectStyles(cssRef.current), 150);
+		window.setTimeout(() => injectStyles(cssRef.current), 600);
+	}).current;
+
+	// Re-inject whenever the computed CSS changes.
+	useEffect(() => {
+		scheduleInject();
+	}, [css, scheduleInject]);
+
+	// Re-assert the overlay when the canvas iframe (re)mounts — switching
+	// devices, entering/leaving fullscreen, etc. recreate the canvas document.
+	// Only react to added <iframe> nodes so we skip the editor's constant
+	// content mutations.
+	useEffect(() => {
+		const addsIframe = (mutations) =>
+			mutations.some((mutation) =>
+				Array.from(mutation.addedNodes).some(
+					(node) =>
+						node.nodeType === 1 &&
+						(node.nodeName === 'IFRAME' ||
+							(node.querySelector &&
+								node.querySelector('iframe')))
+				)
+			);
+
+		const observer = new window.MutationObserver((mutations) => {
+			if (addsIframe(mutations)) {
+				scheduleInject();
+			}
+		});
+		observer.observe(document.body, { childList: true, subtree: true });
+		return () => observer.disconnect();
+	}, [scheduleInject]);
+
+	return null;
+}
+
+registerPlugin('designsetgo-section-style-preview', {
+	render: SectionStylePreview,
+});

--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,10 @@ import './extensions/style-binding';
 // Dynamic Tags - Elementor-style per-attribute dynamic bindings on core blocks
 import './extensions/dynamic-tags';
 
+// Section Styles Editor Preview - previews user-customized section-style
+// variations (border/radius/etc.) on DSGo container blocks in the editor canvas
+import './extensions/section-styles-editor-preview';
+
 // ===== RICH TEXT FORMATS =====
 // Text Style - adds inline text styling (color, gradient, size) to selected text
 import './formats/text-style';

--- a/tests/e2e/section-styles-editor-preview.spec.js
+++ b/tests/e2e/section-styles-editor-preview.spec.js
@@ -1,0 +1,200 @@
+/**
+ * E2E: Section Styles — Editor Preview overlay
+ *
+ * Regression coverage for the editor-only overlay that mirrors a
+ * *user-customized* (Global Styles) section-style variation onto DSGo
+ * container blocks in the editor canvas.
+ *
+ * This specifically exercises the USER layer, which is the gap the overlay
+ * fixes: WordPress does not natively apply a Global-Styles customization of a
+ * core-container section style to DSGo blocks in the editor, so a border/radius
+ * appearing on the DSGo section in the canvas proves the overlay ran. (Theme /
+ * plugin-registered variation *styles* preview natively and would pass without
+ * the overlay, so they wouldn't test anything — only the user-layer border is
+ * the overlay's responsibility.)
+ *
+ * Self-contained: a mu-plugin registers a throwaway section style (so it isn't
+ * stripped by theme.json sanitization and is mirrored onto DSGo blocks), and a
+ * user-layer border is set on it. Both are removed in teardown.
+ *
+ * @package
+ */
+
+const { test, expect } = require('@playwright/test');
+const { cli, shellArg, deletePostIds } = require('./helpers/wp-cli');
+const { getEditorCanvas } = require('./helpers/wordpress');
+
+// Throwaway slug + a distinctive border only ever set here, so the assertion
+// can't accidentally match a theme default.
+const SLUG = 'dsgoe2e';
+const BORDER = {
+	color: '#123456', // -> rgb(18, 52, 86)
+	colorRgb: 'rgb(18, 52, 86)',
+	width: '7px',
+	style: 'solid',
+	radius: '13px',
+};
+const MU_FILE = 'dsgo-e2e-section-style.php';
+
+// This test mutates shared server state (a mu-plugin + the user Global Styles
+// entity), so it must run on a single project to avoid cross-worker races. The
+// overlay under test is browser-agnostic editor JS, so one browser suffices.
+const PRIMARY_PROJECT = 'chromium';
+
+// mu-plugin registering the section style with `style_data`, so it survives
+// theme.json sanitization and Section_Styles mirrors it onto the DSGo blocks
+// (name-only registrations are not mirrored). The border itself comes from the
+// user (Global Styles) layer, set separately.
+const MU_PLUGIN = `<?php
+add_action( 'init', function () {
+	register_block_style( 'core/group', array(
+		'name'       => '${SLUG}',
+		'label'      => 'DSGo E2E Section Style',
+		'style_data' => array( 'color' => array( 'background' => '#eeeeee' ) ),
+	) );
+}, 5 );
+`;
+
+function evalPhp(php) {
+	cli(`wp eval ${shellArg(php)}`);
+}
+
+function writeMuPlugin() {
+	const b64 = Buffer.from(MU_PLUGIN).toString('base64');
+	evalPhp(
+		`if ( ! is_dir( WPMU_PLUGIN_DIR ) ) { wp_mkdir_p( WPMU_PLUGIN_DIR ); } ` +
+			`file_put_contents( WPMU_PLUGIN_DIR . "/${MU_FILE}", base64_decode( "${b64}" ) ); echo "ok";`
+	);
+}
+
+function removeMuPlugin() {
+	evalPhp(
+		`$f = WPMU_PLUGIN_DIR . "/${MU_FILE}"; if ( file_exists( $f ) ) { unlink( $f ); } echo "ok";`
+	);
+}
+
+function setUserGlobalStylesBorder() {
+	evalPhp(
+		`$id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
+		$gs = json_decode( get_post( $id )->post_content, true );
+		if ( ! is_array( $gs ) ) { $gs = array( "version" => 3, "isGlobalStylesUserThemeJSON" => true ); }
+		$gs["styles"]["blocks"]["core/group"]["variations"]["${SLUG}"]["border"] = array(
+			"color" => "${BORDER.color}", "width" => "${BORDER.width}",
+			"style" => "${BORDER.style}", "radius" => "${BORDER.radius}"
+		);
+		wp_update_post( array( "ID" => $id, "post_content" => wp_slash( wp_json_encode( $gs ) ) ) );
+		echo "ok";`
+	);
+}
+
+function clearUserGlobalStyles() {
+	evalPhp(
+		`$id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
+		$gs = json_decode( get_post( $id )->post_content, true );
+		if ( is_array( $gs ) ) {
+			unset( $gs["styles"]["blocks"]["core/group"]["variations"]["${SLUG}"] );
+			wp_update_post( array( "ID" => $id, "post_content" => wp_slash( wp_json_encode( $gs ) ) ) );
+		}
+		echo "ok";`
+	);
+}
+
+test.describe('Section styles — editor preview overlay', () => {
+	let pageId;
+
+	// Skip on every non-primary project before any browser launches or fixtures
+	// are set up (a plain `test.skip()` inside the test body runs too late — the
+	// page/browser is already created).
+	test.beforeEach(({}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== PRIMARY_PROJECT,
+			'editor overlay logic is browser-agnostic; runs once on chromium'
+		);
+	});
+
+	test.beforeAll(({}, testInfo) => {
+		if (testInfo.project.name !== PRIMARY_PROJECT) {
+			return;
+		}
+		writeMuPlugin();
+		setUserGlobalStylesBorder();
+
+		const markup = [
+			`<!-- wp:designsetgo/section {"className":"is-style-${SLUG}"} -->`,
+			`<div class="wp-block-designsetgo-section dsgo-stack is-style-${SLUG}"><div class="dsgo-stack__inner"><!-- wp:paragraph --><p>Section style preview E2E</p><!-- /wp:paragraph --></div></div>`,
+			`<!-- /wp:designsetgo/section -->`,
+		].join('\n');
+
+		const out = cli(
+			'wp post create --post_type=page --post_status=publish --porcelain ' +
+				`--post_title=${shellArg('DSGo Section Style Preview E2E')} ` +
+				`--post_content=${shellArg(markup)}`
+		);
+		pageId = (out.match(/\d+/) || [])[0];
+		expect(pageId, 'created page id').toBeTruthy();
+	});
+
+	test.afterAll(({}, testInfo) => {
+		if (testInfo.project.name !== PRIMARY_PROJECT) {
+			return;
+		}
+		if (pageId) {
+			deletePostIds([pageId]);
+		}
+		clearUserGlobalStyles();
+		removeMuPlugin();
+	});
+
+	test('previews a user-customized section-style border/radius on a DSGo section', async ({
+		page,
+	}) => {
+		await page.goto(`/wp-admin/post.php?post=${pageId}&action=edit`);
+
+		await page
+			.locator('iframe[name="editor-canvas"]')
+			.waitFor({ timeout: 30000 });
+
+		// Dismiss the welcome guide if it appears.
+		try {
+			await page
+				.locator('.components-modal__header button[aria-label="Close"]')
+				.first()
+				.click({ timeout: 2000 });
+		} catch {
+			// No modal.
+		}
+
+		const canvas = getEditorCanvas(page);
+		const section = canvas.locator('.wp-block-designsetgo-section').first();
+		await section.waitFor({ state: 'attached', timeout: 15000 });
+
+		// Core does NOT apply a user-layer variation to DSGo blocks in the
+		// editor, so this border only appears because the overlay ran. Poll to
+		// absorb the reactive inject timing.
+		await expect
+			.poll(
+				async () =>
+					section.evaluate((el) => {
+						const cs = window.getComputedStyle(el);
+						return {
+							width: cs.borderTopWidth,
+							style: cs.borderTopStyle,
+							color: cs.borderTopColor,
+							radius: cs.borderTopLeftRadius,
+						};
+					}),
+				{ timeout: 15000 }
+			)
+			.toEqual({
+				width: BORDER.width,
+				style: BORDER.style,
+				color: BORDER.colorRgb,
+				radius: BORDER.radius,
+			});
+
+		// The overlay <style> element is what supplies it.
+		await expect(
+			canvas.locator('style#dsgo-section-style-preview')
+		).toHaveCount(1);
+	});
+});

--- a/tests/unit/extensions/section-styles-editor-preview/generate-css.test.js
+++ b/tests/unit/extensions/section-styles-editor-preview/generate-css.test.js
@@ -48,6 +48,13 @@ describe('toCssValue', () => {
 			'var(--wp--preset--color--ab)'
 		);
 	});
+
+	it('strips backslashes so CSS hex escapes cannot re-form rule-breaking characters', () => {
+		// `\7b`/`\7d` would decode to `{`/`}` in the browser's CSS tokenizer,
+		// slipping past a literal-character strip. Removing the backslash
+		// neutralizes the escape.
+		expect(toCssValue('0\\7b color:red\\7d')).toBe('07b color:red7d');
+	});
 });
 
 describe('variationDeclarations', () => {
@@ -150,6 +157,20 @@ describe('variationDeclarations', () => {
 				'box-shadow:var(--wp--preset--shadow--natural);' +
 				'font-size:var(--wp--preset--font-size--large)'
 		);
+	});
+
+	it('routes line-height through toCssValue (preset resolution + injection strip)', () => {
+		expect(
+			variationDeclarations({
+				typography: { lineHeight: 'var:custom|lineHeight|tight' },
+			})
+		).toBe('line-height:var(--wp--custom--line-height--tight)');
+		// Injection guard applies to line-height like every other property.
+		expect(
+			variationDeclarations({
+				typography: { lineHeight: '1.5;}body{display:none' },
+			})
+		).toBe('line-height:1.5bodydisplay:none');
 	});
 });
 

--- a/tests/unit/extensions/section-styles-editor-preview/generate-css.test.js
+++ b/tests/unit/extensions/section-styles-editor-preview/generate-css.test.js
@@ -39,6 +39,15 @@ describe('toCssValue', () => {
 		expect(toCssValue(40)).toBe(40);
 		expect(toCssValue(undefined)).toBe(undefined);
 	});
+
+	it('strips rule-breaking characters to prevent CSS injection', () => {
+		expect(toCssValue('red;}body{display:none')).toBe(
+			'redbodydisplay:none'
+		);
+		expect(toCssValue('var:preset|color|a}b')).toBe(
+			'var(--wp--preset--color--ab)'
+		);
+	});
 });
 
 describe('variationDeclarations', () => {
@@ -63,6 +72,20 @@ describe('variationDeclarations', () => {
 				color: { gradient: 'linear-gradient(#000,#fff)' },
 			})
 		).toBe('background:linear-gradient(#000,#fff)');
+	});
+
+	it('resolves preset references on border width and radius', () => {
+		expect(
+			variationDeclarations({
+				border: {
+					width: 'var:preset|spacing|40',
+					radius: 'var:custom|radius|lg',
+				},
+			})
+		).toBe(
+			'border-width:var(--wp--preset--spacing--40);' +
+				'border-radius:var(--wp--custom--radius--lg)'
+		);
 	});
 
 	it('preserves a zero border-width override (falsy-but-set)', () => {

--- a/tests/unit/extensions/section-styles-editor-preview/generate-css.test.js
+++ b/tests/unit/extensions/section-styles-editor-preview/generate-css.test.js
@@ -65,6 +65,12 @@ describe('variationDeclarations', () => {
 		).toBe('background:linear-gradient(#000,#fff)');
 	});
 
+	it('preserves a zero border-width override (falsy-but-set)', () => {
+		expect(
+			variationDeclarations({ border: { width: '0', style: 'none' } })
+		).toBe('border-width:0;border-style:none');
+	});
+
 	it('emits flat border with radius', () => {
 		expect(
 			variationDeclarations({
@@ -157,6 +163,29 @@ describe('buildVariationCss', () => {
 				'core/group': { variations: { empty: {} } },
 			})
 		).toBe('');
+	});
+
+	it('skips a target that defines its own explicit variation for the slug', () => {
+		const css = buildVariationCss({
+			'core/group': {
+				variations: {
+					'section-2': { border: { width: '5px', style: 'solid' } },
+				},
+			},
+			// The section block has its own explicit section-2 — the editor
+			// previews that natively and the server mirror protects it, so the
+			// overlay must not emit the core-container version onto it.
+			'designsetgo/section': {
+				variations: { 'section-2': { color: { text: '#000' } } },
+			},
+		});
+		expect(css).not.toContain(
+			'.wp-block-designsetgo-section.is-style-section-2{'
+		);
+		// Other targets without their own explicit variation still get it.
+		expect(css).toContain(
+			'.wp-block-designsetgo-counter.is-style-section-2{'
+		);
 	});
 
 	it('first source block wins on slug collision', () => {

--- a/tests/unit/extensions/section-styles-editor-preview/generate-css.test.js
+++ b/tests/unit/extensions/section-styles-editor-preview/generate-css.test.js
@@ -1,0 +1,176 @@
+/**
+ * Section Styles — Editor Preview: CSS generation unit tests
+ *
+ * @package
+ */
+
+import {
+	toCssValue,
+	variationDeclarations,
+	buildVariationCss,
+	TARGET_SUFFIXES,
+} from '../../../../src/extensions/section-styles-editor-preview/generate-css';
+
+describe('toCssValue', () => {
+	it('passes plain values through', () => {
+		expect(toCssValue('#ff0000')).toBe('#ff0000');
+		expect(toCssValue('3px')).toBe('3px');
+	});
+
+	it('expands preset references', () => {
+		expect(toCssValue('var:preset|color|accent-2')).toBe(
+			'var(--wp--preset--color--accent-2)'
+		);
+		expect(toCssValue('var:preset|shadow|natural')).toBe(
+			'var(--wp--preset--shadow--natural)'
+		);
+	});
+
+	it('kebab-cases multi-word preset types', () => {
+		expect(toCssValue('var:preset|font-size|large')).toBe(
+			'var(--wp--preset--font-size--large)'
+		);
+		expect(toCssValue('var:custom|myToken|innerValue')).toBe(
+			'var(--wp--custom--my-token--inner-value)'
+		);
+	});
+
+	it('ignores non-strings', () => {
+		expect(toCssValue(40)).toBe(40);
+		expect(toCssValue(undefined)).toBe(undefined);
+	});
+});
+
+describe('variationDeclarations', () => {
+	it('returns empty for nothing set', () => {
+		expect(variationDeclarations({})).toBe('');
+		expect(variationDeclarations(null)).toBe('');
+	});
+
+	it('emits color + gradient + text', () => {
+		expect(
+			variationDeclarations({
+				color: {
+					background: 'var:preset|color|accent-2',
+					text: '#fff',
+				},
+			})
+		).toBe(
+			'background-color:var(--wp--preset--color--accent-2);color:#fff'
+		);
+		expect(
+			variationDeclarations({
+				color: { gradient: 'linear-gradient(#000,#fff)' },
+			})
+		).toBe('background:linear-gradient(#000,#fff)');
+	});
+
+	it('emits flat border with radius', () => {
+		expect(
+			variationDeclarations({
+				border: {
+					color: '#008000',
+					width: '6px',
+					style: 'solid',
+					radius: '20px',
+				},
+			})
+		).toBe(
+			'border-color:#008000;border-width:6px;border-style:solid;border-radius:20px'
+		);
+	});
+
+	it('emits split-side borders and per-corner radius', () => {
+		expect(
+			variationDeclarations({
+				border: {
+					top: { color: '#111', width: '2px', style: 'solid' },
+					bottom: { width: '4px', style: 'dashed' },
+					radius: {
+						topLeft: '8px',
+						bottomRight: '12px',
+					},
+				},
+			})
+		).toBe(
+			'border-top-color:#111;border-top-width:2px;border-top-style:solid;' +
+				'border-bottom-width:4px;border-bottom-style:dashed;' +
+				'border-top-left-radius:8px;border-bottom-right-radius:12px'
+		);
+	});
+
+	it('emits spacing, shadow and typography', () => {
+		expect(
+			variationDeclarations({
+				spacing: {
+					padding: { top: '40px', bottom: 'var:preset|spacing|50' },
+				},
+				shadow: 'var:preset|shadow|natural',
+				typography: { fontSize: 'var:preset|font-size|large' },
+			})
+		).toBe(
+			'padding-top:40px;padding-bottom:var(--wp--preset--spacing--50);' +
+				'box-shadow:var(--wp--preset--shadow--natural);' +
+				'font-size:var(--wp--preset--font-size--large)'
+		);
+	});
+});
+
+describe('buildVariationCss', () => {
+	it('returns empty when no source variations exist', () => {
+		expect(buildVariationCss({})).toBe('');
+		expect(buildVariationCss({ 'core/group': {} })).toBe('');
+		expect(buildVariationCss(null)).toBe('');
+	});
+
+	it('emits one rule per target for each variation, stable is-style class', () => {
+		const css = buildVariationCss({
+			'core/group': {
+				variations: {
+					'section-2': { border: { width: '5px', style: 'solid' } },
+				},
+			},
+		});
+		// One rule per DSGo target suffix.
+		const ruleCount = (css.match(/is-style-section-2\{/g) || []).length;
+		expect(ruleCount).toBe(TARGET_SUFFIXES.length);
+		expect(css).toContain(
+			'.wp-block-designsetgo-section.is-style-section-2{border-width:5px;border-style:solid}'
+		);
+		expect(css).toContain(
+			'.wp-block-designsetgo-counter.is-style-section-2{border-width:5px;border-style:solid}'
+		);
+	});
+
+	it('excludes image-accordion-item (background opt-out)', () => {
+		const css = buildVariationCss({
+			'core/group': {
+				variations: { 'section-2': { color: { background: '#f00' } } },
+			},
+		});
+		expect(css).not.toContain('image-accordion-item');
+	});
+
+	it('skips variations with no renderable declarations', () => {
+		expect(
+			buildVariationCss({
+				'core/group': { variations: { empty: {} } },
+			})
+		).toBe('');
+	});
+
+	it('first source block wins on slug collision', () => {
+		const css = buildVariationCss({
+			'core/group': {
+				variations: { dup: { color: { text: '#111' } } },
+			},
+			'core/columns': {
+				variations: { dup: { color: { text: '#999' } } },
+			},
+		});
+		expect(css).toContain(
+			'.wp-block-designsetgo-section.is-style-dup{color:#111}'
+		);
+		expect(css).not.toContain('#999');
+	});
+});

--- a/tests/unit/extensions/section-styles-editor-preview/generate-css.test.js
+++ b/tests/unit/extensions/section-styles-editor-preview/generate-css.test.js
@@ -105,6 +105,14 @@ describe('variationDeclarations', () => {
 		);
 	});
 
+	it('preserves a numeric 0 per-corner radius (falsy-but-set)', () => {
+		expect(
+			variationDeclarations({
+				border: { radius: { topLeft: 0, bottomRight: '12px' } },
+			})
+		).toBe('border-top-left-radius:0;border-bottom-right-radius:12px');
+	});
+
 	it('emits spacing, shadow and typography', () => {
 		expect(
 			variationDeclarations({

--- a/tests/unit/extensions/section-styles-editor-preview/generate-css.test.js
+++ b/tests/unit/extensions/section-styles-editor-preview/generate-css.test.js
@@ -254,4 +254,24 @@ describe('buildVariationCss', () => {
 		);
 		expect(css).not.toContain('#999');
 	});
+
+	it('drops a variation slug that is not a safe CSS-class token', () => {
+		const css = buildVariationCss({
+			'core/group': {
+				variations: {
+					'evil}body{display:none': {
+						color: { background: '#f00' },
+					},
+					safe: { color: { text: '#111' } },
+				},
+			},
+		});
+		// The crafted slug can't reach the selector at all.
+		expect(css).not.toContain('display:none');
+		expect(css).not.toContain('evil');
+		// Legitimate sibling variation still emits.
+		expect(css).toContain(
+			'.wp-block-designsetgo-section.is-style-safe{color:#111}'
+		);
+	});
 });

--- a/tests/unit/extensions/section-styles-editor-preview/php-parity.test.js
+++ b/tests/unit/extensions/section-styles-editor-preview/php-parity.test.js
@@ -1,0 +1,77 @@
+/**
+ * Section Styles — Editor Preview: JS/PHP list parity
+ *
+ * `TARGET_SUFFIXES` / `SOURCE_BLOCKS` in generate-css.js must stay in sync with
+ * `Section_Styles::$container_blocks` / `$source_blocks` in the PHP mirror. This
+ * test parses the PHP source and fails if the two drift, so a container block
+ * added/removed/renamed on either side surfaces immediately instead of silently
+ * breaking the editor preview.
+ *
+ * @package
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import {
+	TARGET_SUFFIXES,
+	SOURCE_BLOCKS,
+} from '../../../../src/extensions/section-styles-editor-preview/generate-css';
+
+const PHP_FILE = path.join(
+	__dirname,
+	'../../../../includes/features/class-section-styles.php'
+);
+
+/**
+ * Extract the quoted block names from a `private $name = array( ... );` PHP
+ * property. Only matches quoted array entries, so commented-out mentions (e.g.
+ * the `image-accordion-item` exclusion note) are ignored.
+ *
+ * @param {string} php      PHP source.
+ * @param {string} property Property name without the `$`.
+ * @param {RegExp} pattern  Per-entry matcher with one capture group.
+ * @return {string[]} Captured values in source order.
+ */
+function extractList(php, property, pattern) {
+	const start = php.indexOf(`private $${property}`);
+	if (start === -1) {
+		throw new Error(
+			`Could not find $${property} in class-section-styles.php`
+		);
+	}
+	const end = php.indexOf(');', start);
+	const block = php.slice(start, end);
+
+	const values = [];
+	let match;
+	const global = new RegExp(pattern.source, 'g');
+	while ((match = global.exec(block)) !== null) {
+		values.push(match[1]);
+	}
+	return values;
+}
+
+describe('Section Styles editor preview — JS/PHP list parity', () => {
+	const php = fs.readFileSync(PHP_FILE, 'utf8');
+
+	it('TARGET_SUFFIXES matches PHP $container_blocks', () => {
+		const phpSuffixes = extractList(
+			php,
+			'container_blocks',
+			/'designsetgo\/([a-z-]+)'/
+		);
+		expect(phpSuffixes.length).toBeGreaterThan(0);
+		expect(TARGET_SUFFIXES).toEqual(phpSuffixes);
+	});
+
+	it('SOURCE_BLOCKS matches PHP $source_blocks', () => {
+		const phpSources = extractList(
+			php,
+			'source_blocks',
+			/'(core\/[a-z]+)'/
+		);
+		expect(phpSources.length).toBeGreaterThan(0);
+		expect(SOURCE_BLOCKS).toEqual(phpSources);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the editor-preview gap found while investigating section styles: when an author **customizes** a section style in Global Styles (e.g. adds a border or radius), the DSGo container blocks now reflect it live in the editor canvas — matching what already renders on the published frontend.

## Background

Section-style variations mirror onto DSGo container blocks server-side (`Section_Styles`), which covers the **frontend** and **theme/plugin-registered** styles in the editor. But the editor generates block-style-variation CSS **client-side** from the browser-merged global-styles config, which never runs that server mirror for the **user (Global Styles) layer**. So a border/radius added to a section style in Global Styles was missing from the DSGo block's editor preview — even though the saved frontend output was already correct.

Core's own remedy (`__unstableBlockStyleVariationOverridesWithConfig`) is a locked private API, unusable by a plugin.

## Approach

An **editor-only** module (`src/extensions/section-styles-editor-preview/`) that:

1. Reactively reads the live user global-styles config via **public** core-data APIs (`getEditedEntityRecord('root','globalStyles', id)`).
2. Builds a CSS overlay: for each DSGo container block × each user-customized section-style variation on the core containers, emits box-decoration declarations (color, border, radius, spacing, shadow, font-size) scoped to the **stable** `.wp-block-designsetgo-{suffix}.is-style-{slug}` class (specificity 0-2-0, cleanly beats core's `:root :where()` 0-1-0).
3. Injects/updates a single `<style>` in the editor canvas (iframe-aware), reactively on config change and on canvas remount.

Only the **user-layer delta** is emitted — theme/registry-layer variations already preview correctly — so it's additive and low-risk. Excludes `image-accordion-item`, matching `Section_Styles`. Editor-only (the `designsetgo-extensions` script is `is_admin()`-guarded); zero frontend impact.

## Verification

- **Unit** (14 tests): CSS generation for color / border (flat + split) / radius / spacing / shadow / typography + `var:preset|…` resolution + target-set / opt-out / slug-collision behavior.
- **Manual** (wp-env editor): customized `section-2`'s border in the user global styles → the DSGo section's editor canvas now previews the `5px solid` border + `16px` radius; a live entity edit (blue / 9px) updated the overlay reactively; console clean (only an unrelated `pods` warning); `getEditedEntityRecord` confirmed to return the user-layer delta only.
- Full unit suite: **8307 passed**. Pre-commit e2e: **7 passed**.

## Follow-up notes

- Property coverage is the common box-decoration set; full theme.json fidelity (ref resolution beyond `var:preset|…`, per-element/inner-block rules) is intentionally out of scope.
- `TARGET_SUFFIXES` mirrors `Section_Styles::$container_blocks` and is annotated to keep the two in sync.
