### PR TITLE
feat(section): emit overlay class for style-kit overlay variations

### DIFF
--- a/src/blocks/icon-button/editor.scss
+++ b/src/blocks/icon-button/editor.scss
@@ -59,9 +59,12 @@
 // CRITICAL: Check if PARENT container has the variable, not the button itself
 // CRITICAL: Use __inner wrapper to avoid triggering on outer padding areas
 // CRITICAL: Use direct child selector (>) to only affect direct children
+// See style.scss: the --has-hover-button selector adds Section style-variation
+// support alongside the inline-var (attribute) gate.
 .dsgo-flex[style*="--dsgo-parent-hover-button-bg"]:hover .dsgo-flex__inner > .dsgo-icon-button .dsgo-icon-button__wrapper,
 .dsgo-grid[style*="--dsgo-parent-hover-button-bg"]:hover .dsgo-grid__inner > .dsgo-icon-button .dsgo-icon-button__wrapper,
-.dsgo-stack[style*="--dsgo-parent-hover-button-bg"]:hover .dsgo-stack__inner > .dsgo-icon-button .dsgo-icon-button__wrapper {
+.dsgo-stack[style*="--dsgo-parent-hover-button-bg"]:hover .dsgo-stack__inner > .dsgo-icon-button .dsgo-icon-button__wrapper,
+.dsgo-stack--has-hover-button:hover .dsgo-stack__inner > .dsgo-icon-button .dsgo-icon-button__wrapper {
 	background-color: var(--dsgo-parent-hover-button-bg) !important;
 	transition: background-color 0.3s ease;
 }

--- a/src/blocks/icon-button/style.scss
+++ b/src/blocks/icon-button/style.scss
@@ -146,9 +146,14 @@
 // CRITICAL: Check if PARENT container has the variable, not the button itself
 // CRITICAL: Use __inner wrapper to avoid triggering on outer padding areas
 // CRITICAL: Use direct child selector (>) to only affect direct children
+// The `--has-hover-button` selector adds Section style-variation support
+// (is-style-hover-button-*) alongside the inline-var (attribute) gate. The class
+// is only emitted for that variation, so the !important override never clobbers
+// a button whose parent has no hover-button color set.
 .dsgo-flex[style*="--dsgo-parent-hover-button-bg"]:hover .dsgo-flex__inner > .dsgo-icon-button,
 .dsgo-grid[style*="--dsgo-parent-hover-button-bg"]:hover .dsgo-grid__inner > .dsgo-icon-button,
-.dsgo-stack[style*="--dsgo-parent-hover-button-bg"]:hover .dsgo-stack__inner > .dsgo-icon-button {
+.dsgo-stack[style*="--dsgo-parent-hover-button-bg"]:hover .dsgo-stack__inner > .dsgo-icon-button,
+.dsgo-stack--has-hover-button:hover .dsgo-stack__inner > .dsgo-icon-button {
 	background-color: var(--dsgo-parent-hover-button-bg) !important;
 	transition: background-color 0.3s ease;
 }

--- a/src/blocks/icon/editor.scss
+++ b/src/blocks/icon/editor.scss
@@ -108,9 +108,12 @@
 // CRITICAL: Use __inner wrapper to avoid triggering on outer padding areas
 // CRITICAL: Exclude icons that are inside nested containers
 // This changes the block's background color, which the wrapper inherits
+// See style.scss: the --has-hover-icon selector adds Section style-variation
+// support alongside the inline-var (attribute) gate.
 .dsgo-flex[style*="--dsgo-parent-hover-icon-bg"]:hover .dsgo-flex__inner > .dsgo-icon,
 .dsgo-grid[style*="--dsgo-parent-hover-icon-bg"]:hover .dsgo-grid__inner > .dsgo-icon,
-.dsgo-stack[style*="--dsgo-parent-hover-icon-bg"]:hover .dsgo-stack__inner > .dsgo-icon {
+.dsgo-stack[style*="--dsgo-parent-hover-icon-bg"]:hover .dsgo-stack__inner > .dsgo-icon,
+.dsgo-stack--has-hover-icon:hover .dsgo-stack__inner > .dsgo-icon {
 	background-color: var(--dsgo-parent-hover-icon-bg) !important;
 	transition: background-color 0.3s ease;
 }

--- a/src/blocks/icon/style.scss
+++ b/src/blocks/icon/style.scss
@@ -148,10 +148,17 @@
 // CRITICAL: Check if PARENT container has the variable, not the icon itself
 // CRITICAL: Use __inner wrapper to avoid triggering on outer padding areas
 // CRITICAL: Exclude icons that are inside nested containers
-// This changes the block's background color, which the wrapper inherits
+// This changes the block's background color, which the wrapper inherits.
+// The `[style*=…]` selectors activate from the parent's inline var (its
+// hoverIconBackgroundColor attribute). The `.dsgo-stack--has-hover-icon`
+// selector activates from a Section `is-style-hover-icon-*` style variation,
+// whose stylesheet supplies the var — the inline gate can't see it. The class
+// is only emitted for that variation, so the !important override never clobbers
+// an icon whose parent has no hover-icon color set.
 .dsgo-flex[style*="--dsgo-parent-hover-icon-bg"]:hover .dsgo-flex__inner > .dsgo-icon,
 .dsgo-grid[style*="--dsgo-parent-hover-icon-bg"]:hover .dsgo-grid__inner > .dsgo-icon,
-.dsgo-stack[style*="--dsgo-parent-hover-icon-bg"]:hover .dsgo-stack__inner > .dsgo-icon {
+.dsgo-stack[style*="--dsgo-parent-hover-icon-bg"]:hover .dsgo-stack__inner > .dsgo-icon,
+.dsgo-stack--has-hover-icon:hover .dsgo-stack__inner > .dsgo-icon {
 	background-color: var(--dsgo-parent-hover-icon-bg) !important;
 	transition: background-color 0.3s ease;
 }

--- a/src/blocks/section/deprecated.js
+++ b/src/blocks/section/deprecated.js
@@ -11,6 +11,8 @@ import {
 } from '../../utils/convert-preset-to-css-var';
 import { getLegacyShapeDivider } from './utils/legacy-shape-dividers';
 import { sanitizeColor } from './utils/sanitize-color';
+import { hasOverlayStyleClass } from './utils/has-overlay-style';
+import ShapeDivider from './components/ShapeDivider';
 
 // Shared supports for deprecations (must match what was in block.json when blocks were saved).
 // Without this, useBlockProps.save() in deprecated save functions won't generate
@@ -264,6 +266,195 @@ function V4ShapeDivider({
 		</div>
 	);
 }
+
+// Version 7: Overlay class from overlayColor only (before style-kit overlay
+// variations). The current save() also emits `dsgo-stack--has-overlay` when a
+// style-kit overlay variation (`is-style-overlay-*`) is present on className,
+// so the overlay color can move out of the `overlayColor` attribute and into
+// the variation's stylesheet. Sections saved with such a variation but no
+// `overlayColor` therefore lack `dsgo-stack--has-overlay` in their stored HTML
+// while the new save() adds it — an "invalid content" mismatch.
+//
+// isEligible targets exactly that signature (overlay variation on className +
+// no overlay class in the stored HTML) so those blocks migrate SILENTLY. save()
+// reproduces the pre-change output (overlay class from `overlayColor` only) so
+// it also byte-matches on WP versions that still validate the deprecation's
+// save() before migrating. migrate() is a passthrough — only the serialised
+// class differs, not the attribute values; the current save() then re-renders
+// the block with the overlay class derived from the variation.
+const v7 = {
+	supports: sharedSupports,
+	attributes: {
+		align: { type: 'string', default: 'full' },
+		tagName: { type: 'string', default: 'div' },
+		constrainWidth: { type: 'boolean', default: true },
+		contentWidth: { type: 'string', default: '' },
+		style: { type: 'object' },
+		hoverBackgroundColor: { type: 'string', default: '' },
+		hoverTextColor: { type: 'string', default: '' },
+		hoverIconBackgroundColor: { type: 'string', default: '' },
+		hoverButtonBackgroundColor: { type: 'string', default: '' },
+		overlayColor: { type: 'string', default: '' },
+		shapeDividerTop: { type: 'string', default: '' },
+		shapeDividerTopHeight: { type: 'number', default: 100 },
+		shapeDividerTopWidth: { type: 'number', default: 100 },
+		shapeDividerTopFlipX: { type: 'boolean', default: false },
+		shapeDividerTopFlipY: { type: 'boolean', default: false },
+		shapeDividerTopFront: { type: 'boolean', default: false },
+		shapeDividerTopBackgroundColor: { type: 'string', default: '' },
+		shapeDividerBottom: { type: 'string', default: '' },
+		shapeDividerBottomHeight: { type: 'number', default: 100 },
+		shapeDividerBottomWidth: { type: 'number', default: 100 },
+		shapeDividerBottomFlipX: { type: 'boolean', default: false },
+		shapeDividerBottomFlipY: { type: 'boolean', default: false },
+		shapeDividerBottomFront: { type: 'boolean', default: false },
+		shapeDividerBottomBackgroundColor: { type: 'string', default: '' },
+	},
+	/**
+	 * Silently migrate sections that carry a style-kit overlay variation
+	 * (`is-style-overlay-*`) but whose stored HTML predates the overlay class
+	 * being derived from that variation.
+	 *
+	 * @param {Object} attributes      Block attributes.
+	 * @param {Array}  innerBlocks     Inner blocks.
+	 * @param {Object} extra           Extra data.
+	 * @param {string} extra.innerHTML Stored serialised HTML.
+	 * @return {boolean} True when the pre-variation overlay signature is found.
+	 */
+	isEligible(attributes, innerBlocks, { innerHTML }) {
+		return !!(
+			hasOverlayStyleClass(attributes.className) &&
+			innerHTML &&
+			innerHTML.includes('dsgo-stack') &&
+			!innerHTML.includes('dsgo-stack--has-overlay')
+		);
+	},
+	save({ attributes }) {
+		const {
+			tagName = 'div',
+			constrainWidth,
+			contentWidth,
+			hoverBackgroundColor,
+			hoverTextColor,
+			hoverIconBackgroundColor,
+			hoverButtonBackgroundColor,
+			overlayColor,
+			shapeDividerTop,
+			shapeDividerTopBackgroundColor,
+			shapeDividerTopHeight,
+			shapeDividerTopWidth,
+			shapeDividerTopFlipX,
+			shapeDividerTopFlipY,
+			shapeDividerTopFront,
+			shapeDividerBottom,
+			shapeDividerBottomBackgroundColor,
+			shapeDividerBottomHeight,
+			shapeDividerBottomWidth,
+			shapeDividerBottomFlipX,
+			shapeDividerBottomFlipY,
+			shapeDividerBottomFront,
+		} = attributes;
+
+		const shapeDividerTopBandColor = convertColorToCSSVar(
+			shapeDividerTopBackgroundColor
+		);
+		const shapeDividerBottomBandColor = convertColorToCSSVar(
+			shapeDividerBottomBackgroundColor
+		);
+
+		// Pre-change className: overlay class from overlayColor ONLY.
+		const className = [
+			'dsgo-stack',
+			!constrainWidth && 'dsgo-no-width-constraint',
+			overlayColor && 'dsgo-stack--has-overlay',
+			(shapeDividerTop || shapeDividerBottom) &&
+				'dsgo-stack--has-shape-divider',
+		]
+			.filter(Boolean)
+			.join(' ');
+
+		const TagName = tagName || 'div';
+		const blockProps = useBlockProps.save({
+			className,
+			style: {
+				...(hoverBackgroundColor && {
+					'--dsgo-hover-bg-color':
+						convertColorToCSSVar(hoverBackgroundColor),
+				}),
+				...(hoverTextColor && {
+					'--dsgo-hover-text-color':
+						convertColorToCSSVar(hoverTextColor),
+				}),
+				...(hoverIconBackgroundColor && {
+					'--dsgo-parent-hover-icon-bg': convertColorToCSSVar(
+						hoverIconBackgroundColor
+					),
+				}),
+				...(hoverButtonBackgroundColor && {
+					'--dsgo-parent-hover-button-bg': convertColorToCSSVar(
+						hoverButtonBackgroundColor
+					),
+				}),
+				...(overlayColor && {
+					'--dsgo-overlay-color': convertColorToCSSVar(overlayColor),
+					'--dsgo-overlay-opacity': '0.8',
+				}),
+			},
+		});
+
+		const innerStyle = {};
+		if (constrainWidth) {
+			innerStyle.maxWidth =
+				contentWidth ||
+				'var(--wp--style--global--content-size, 1140px)';
+			innerStyle.marginLeft = 'auto';
+			innerStyle.marginRight = 'auto';
+		}
+
+		if (shapeDividerTop) {
+			innerStyle.paddingTop = `${shapeDividerTopHeight || 100}px`;
+		}
+		if (shapeDividerBottom) {
+			innerStyle.paddingBottom = `${shapeDividerBottomHeight || 100}px`;
+		}
+
+		const innerBlocksProps = useInnerBlocksProps.save({
+			className: 'dsgo-stack__inner',
+			style: innerStyle,
+		});
+
+		return (
+			<TagName {...blockProps}>
+				<ShapeDivider
+					shape={shapeDividerTop}
+					position="top"
+					height={shapeDividerTopHeight}
+					width={shapeDividerTopWidth}
+					flipX={shapeDividerTopFlipX}
+					flipY={shapeDividerTopFlipY}
+					front={shapeDividerTopFront}
+					bandColor={shapeDividerTopBandColor}
+				/>
+				<div {...innerBlocksProps} />
+				<ShapeDivider
+					shape={shapeDividerBottom}
+					position="bottom"
+					height={shapeDividerBottomHeight}
+					width={shapeDividerBottomWidth}
+					flipX={shapeDividerBottomFlipX}
+					flipY={shapeDividerBottomFlipY}
+					front={shapeDividerBottomFront}
+					bandColor={shapeDividerBottomBandColor}
+				/>
+			</TagName>
+		);
+	},
+	migrate(attributes) {
+		// Only the serialised overlay class differs; the current save() derives
+		// it from the style variation on className, so no attribute change.
+		return attributes;
+	},
+};
 
 // Version 6: Block animations extension before lean serialization.
 // In commit 634833e5, addAnimationSaveProps was changed to only output data
@@ -1349,4 +1540,4 @@ const v1 = {
 };
 
 // Export deprecations in reverse chronological order (newest first)
-export default [v6, v5, v4, v3, v2, v1];
+export default [v7, v6, v5, v4, v3, v2, v1];

--- a/src/blocks/section/deprecated.js
+++ b/src/blocks/section/deprecated.js
@@ -289,7 +289,23 @@ const v7 = {
 		tagName: { type: 'string', default: 'div' },
 		constrainWidth: { type: 'boolean', default: true },
 		contentWidth: { type: 'string', default: '' },
-		style: { type: 'object' },
+		// Mirror block.json's `style` default. Without it, migration parses
+		// `style` as undefined and v7.save() omits the default spacing padding,
+		// so it no longer byte-matches stored markup (which carries the padding)
+		// and the deprecation never fires. Must stay in sync with block.json.
+		style: {
+			type: 'object',
+			default: {
+				spacing: {
+					padding: {
+						top: 'var:preset|spacing|50',
+						bottom: 'var:preset|spacing|50',
+						left: 'var:preset|spacing|30',
+						right: 'var:preset|spacing|30',
+					},
+				},
+			},
+		},
 		hoverBackgroundColor: { type: 'string', default: '' },
 		hoverTextColor: { type: 'string', default: '' },
 		hoverIconBackgroundColor: { type: 'string', default: '' },

--- a/src/blocks/section/deprecated.js
+++ b/src/blocks/section/deprecated.js
@@ -11,7 +11,10 @@ import {
 } from '../../utils/convert-preset-to-css-var';
 import { getLegacyShapeDivider } from './utils/legacy-shape-dividers';
 import { sanitizeColor } from './utils/sanitize-color';
-import { hasOverlayStyleClass } from './utils/has-overlay-style';
+import {
+	hasOverlayStyleClass,
+	hoverVariationClasses,
+} from './utils/has-overlay-style';
 import ShapeDivider from './components/ShapeDivider';
 
 // Shared supports for deprecations (must match what was in block.json when blocks were saved).
@@ -267,6 +270,222 @@ function V4ShapeDivider({
 	);
 }
 
+// Version 8: Pre-hover-variation-classes output. The current save() also
+// emits `dsgo-stack--has-hover-text` / `-icon` / `-button` when a style-kit
+// hover variation (`is-style-hover-{text,icon,button}-*`) is present on
+// className, so the corresponding `!important` hover override can activate
+// from a variation's stylesheet instead of only the inline-style gate.
+// Sections saved with such a variation but no matching `dsgo-stack--has-hover-*`
+// class in their stored HTML therefore mismatch the current save() — an
+// "invalid content" mismatch, the same failure mode v7 fixes for the overlay
+// class.
+//
+// isEligible targets that signature (a hover-variation family present on
+// className whose activation class is missing from the stored HTML) so those
+// blocks migrate SILENTLY. save() reproduces the pre-hover-variation-classes
+// output — i.e. v7's *current* (non-deprecated) behavior at the time hover
+// classes were added, which already includes the overlay-variation class
+// derivation from v7/60c99058, just without the hover activation classes —
+// so it also byte-matches on WP versions that still validate the
+// deprecation's save() before migrating. migrate() is a passthrough — only
+// the serialised class differs, not the attribute values; the current save()
+// then re-derives the hover classes from the variation.
+const v8 = {
+	supports: sharedSupports,
+	attributes: {
+		align: { type: 'string', default: 'full' },
+		tagName: { type: 'string', default: 'div' },
+		constrainWidth: { type: 'boolean', default: true },
+		contentWidth: { type: 'string', default: '' },
+		// Mirror block.json's `style` default (see v7's identical note).
+		style: {
+			type: 'object',
+			default: {
+				spacing: {
+					padding: {
+						top: 'var:preset|spacing|50',
+						bottom: 'var:preset|spacing|50',
+						left: 'var:preset|spacing|30',
+						right: 'var:preset|spacing|30',
+					},
+				},
+			},
+		},
+		hoverBackgroundColor: { type: 'string', default: '' },
+		hoverTextColor: { type: 'string', default: '' },
+		hoverIconBackgroundColor: { type: 'string', default: '' },
+		hoverButtonBackgroundColor: { type: 'string', default: '' },
+		overlayColor: { type: 'string', default: '' },
+		shapeDividerTop: { type: 'string', default: '' },
+		shapeDividerTopColor: { type: 'string', default: '' },
+		shapeDividerTopHeight: { type: 'number', default: 100 },
+		shapeDividerTopWidth: { type: 'number', default: 100 },
+		shapeDividerTopFlipX: { type: 'boolean', default: false },
+		shapeDividerTopFlipY: { type: 'boolean', default: false },
+		shapeDividerTopFront: { type: 'boolean', default: false },
+		shapeDividerTopBackgroundColor: { type: 'string', default: '' },
+		shapeDividerBottom: { type: 'string', default: '' },
+		shapeDividerBottomColor: { type: 'string', default: '' },
+		shapeDividerBottomHeight: { type: 'number', default: 100 },
+		shapeDividerBottomWidth: { type: 'number', default: 100 },
+		shapeDividerBottomFlipX: { type: 'boolean', default: false },
+		shapeDividerBottomFlipY: { type: 'boolean', default: false },
+		shapeDividerBottomFront: { type: 'boolean', default: false },
+		shapeDividerBottomBackgroundColor: { type: 'string', default: '' },
+	},
+	/**
+	 * Silently migrate sections that carry a style-kit hover variation
+	 * (`is-style-hover-{text,icon,button}-*`) but whose stored HTML predates
+	 * the matching `dsgo-stack--has-hover-*` activation class being derived
+	 * from that variation.
+	 *
+	 * @param {Object} attributes      Block attributes.
+	 * @param {Array}  innerBlocks     Inner blocks.
+	 * @param {Object} extra           Extra data.
+	 * @param {string} extra.innerHTML Stored serialised HTML.
+	 * @return {boolean} True when a hover-variation family is present without
+	 *                    its matching activation class in the stored HTML.
+	 */
+	isEligible(attributes, innerBlocks, { innerHTML }) {
+		if (!innerHTML || !innerHTML.includes('dsgo-stack')) {
+			return false;
+		}
+
+		return hoverVariationClasses(attributes.className).some(
+			(activationClass) => !innerHTML.includes(activationClass)
+		);
+	},
+	save({ attributes }) {
+		const {
+			tagName = 'div',
+			constrainWidth,
+			contentWidth,
+			hoverBackgroundColor,
+			hoverTextColor,
+			hoverIconBackgroundColor,
+			hoverButtonBackgroundColor,
+			overlayColor,
+			shapeDividerTop,
+			shapeDividerTopBackgroundColor,
+			shapeDividerTopHeight,
+			shapeDividerTopWidth,
+			shapeDividerTopFlipX,
+			shapeDividerTopFlipY,
+			shapeDividerTopFront,
+			shapeDividerBottom,
+			shapeDividerBottomBackgroundColor,
+			shapeDividerBottomHeight,
+			shapeDividerBottomWidth,
+			shapeDividerBottomFlipX,
+			shapeDividerBottomFlipY,
+			shapeDividerBottomFront,
+		} = attributes;
+
+		const shapeDividerTopBandColor = convertColorToCSSVar(
+			shapeDividerTopBackgroundColor
+		);
+		const shapeDividerBottomBandColor = convertColorToCSSVar(
+			shapeDividerBottomBackgroundColor
+		);
+
+		// Pre-hover-variation-classes className: overlay class already derives
+		// from the style variation (v7/60c99058), but no hover activation classes.
+		const hasOverlay =
+			!!overlayColor || hasOverlayStyleClass(attributes.className);
+		const className = [
+			'dsgo-stack',
+			!constrainWidth && 'dsgo-no-width-constraint',
+			hasOverlay && 'dsgo-stack--has-overlay',
+			(shapeDividerTop || shapeDividerBottom) &&
+				'dsgo-stack--has-shape-divider',
+		]
+			.filter(Boolean)
+			.join(' ');
+
+		const TagName = tagName || 'div';
+		const blockProps = useBlockProps.save({
+			className,
+			style: {
+				...(hoverBackgroundColor && {
+					'--dsgo-hover-bg-color':
+						convertColorToCSSVar(hoverBackgroundColor),
+				}),
+				...(hoverTextColor && {
+					'--dsgo-hover-text-color':
+						convertColorToCSSVar(hoverTextColor),
+				}),
+				...(hoverIconBackgroundColor && {
+					'--dsgo-parent-hover-icon-bg': convertColorToCSSVar(
+						hoverIconBackgroundColor
+					),
+				}),
+				...(hoverButtonBackgroundColor && {
+					'--dsgo-parent-hover-button-bg': convertColorToCSSVar(
+						hoverButtonBackgroundColor
+					),
+				}),
+				...(overlayColor && {
+					'--dsgo-overlay-color': convertColorToCSSVar(overlayColor),
+					'--dsgo-overlay-opacity': '0.8',
+				}),
+			},
+		});
+
+		const innerStyle = {};
+		if (constrainWidth) {
+			innerStyle.maxWidth =
+				contentWidth ||
+				'var(--wp--style--global--content-size, 1140px)';
+			innerStyle.marginLeft = 'auto';
+			innerStyle.marginRight = 'auto';
+		}
+
+		if (shapeDividerTop) {
+			innerStyle.paddingTop = `${shapeDividerTopHeight || 100}px`;
+		}
+		if (shapeDividerBottom) {
+			innerStyle.paddingBottom = `${shapeDividerBottomHeight || 100}px`;
+		}
+
+		const innerBlocksProps = useInnerBlocksProps.save({
+			className: 'dsgo-stack__inner',
+			style: innerStyle,
+		});
+
+		return (
+			<TagName {...blockProps}>
+				<ShapeDivider
+					shape={shapeDividerTop}
+					position="top"
+					height={shapeDividerTopHeight}
+					width={shapeDividerTopWidth}
+					flipX={shapeDividerTopFlipX}
+					flipY={shapeDividerTopFlipY}
+					front={shapeDividerTopFront}
+					bandColor={shapeDividerTopBandColor}
+				/>
+				<div {...innerBlocksProps} />
+				<ShapeDivider
+					shape={shapeDividerBottom}
+					position="bottom"
+					height={shapeDividerBottomHeight}
+					width={shapeDividerBottomWidth}
+					flipX={shapeDividerBottomFlipX}
+					flipY={shapeDividerBottomFlipY}
+					front={shapeDividerBottomFront}
+					bandColor={shapeDividerBottomBandColor}
+				/>
+			</TagName>
+		);
+	},
+	migrate(attributes) {
+		// Only the serialised hover-activation classes differ; the current
+		// save() derives them from the style variation on className, so no
+		// attribute change.
+		return attributes;
+	},
+};
+
 // Version 7: Overlay class from overlayColor only (before style-kit overlay
 // variations). The current save() also emits `dsgo-stack--has-overlay` when a
 // style-kit overlay variation (`is-style-overlay-*`) is present on className,
@@ -312,6 +531,7 @@ const v7 = {
 		hoverButtonBackgroundColor: { type: 'string', default: '' },
 		overlayColor: { type: 'string', default: '' },
 		shapeDividerTop: { type: 'string', default: '' },
+		shapeDividerTopColor: { type: 'string', default: '' },
 		shapeDividerTopHeight: { type: 'number', default: 100 },
 		shapeDividerTopWidth: { type: 'number', default: 100 },
 		shapeDividerTopFlipX: { type: 'boolean', default: false },
@@ -319,6 +539,7 @@ const v7 = {
 		shapeDividerTopFront: { type: 'boolean', default: false },
 		shapeDividerTopBackgroundColor: { type: 'string', default: '' },
 		shapeDividerBottom: { type: 'string', default: '' },
+		shapeDividerBottomColor: { type: 'string', default: '' },
 		shapeDividerBottomHeight: { type: 'number', default: 100 },
 		shapeDividerBottomWidth: { type: 'number', default: 100 },
 		shapeDividerBottomFlipX: { type: 'boolean', default: false },
@@ -1556,4 +1777,4 @@ const v1 = {
 };
 
 // Export deprecations in reverse chronological order (newest first)
-export default [v7, v6, v5, v4, v3, v2, v1];
+export default [v8, v7, v6, v5, v4, v3, v2, v1];

--- a/src/blocks/section/edit.js
+++ b/src/blocks/section/edit.js
@@ -41,7 +41,10 @@ import {
 	convertPresetToCSSVar,
 } from '../../utils/convert-preset-to-css-var';
 import { useBlockColors } from '../../hooks';
-import { hasOverlayStyleClass } from './utils/has-overlay-style';
+import {
+	hasOverlayStyleClass,
+	hoverVariationClasses,
+} from './utils/has-overlay-style';
 
 /**
  * Section Container Edit Component
@@ -276,6 +279,7 @@ export default function SectionEdit({ attributes, setAttributes, clientId }) {
 		hasOverlay && 'dsgo-stack--has-overlay',
 		(shapeDividerTop || shapeDividerBottom) &&
 			'dsgo-stack--has-shape-divider',
+		...hoverVariationClasses(className),
 	]
 		.filter(Boolean)
 		.join(' ');

--- a/src/blocks/section/edit.js
+++ b/src/blocks/section/edit.js
@@ -41,6 +41,7 @@ import {
 	convertPresetToCSSVar,
 } from '../../utils/convert-preset-to-css-var';
 import { useBlockColors } from '../../hooks';
+import { hasOverlayStyleClass } from './utils/has-overlay-style';
 
 /**
  * Section Container Edit Component
@@ -264,11 +265,15 @@ export default function SectionEdit({ attributes, setAttributes, clientId }) {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
+	// Overlay enabled by explicit overlayColor OR a style-kit overlay variation
+	// (is-style-overlay-*) on className (must match save.js).
+	const hasOverlay = !!overlayColor || hasOverlayStyleClass(className);
+
 	// Build className (must match save.js)
 	const blockClassName = [
 		'dsgo-stack',
 		!constrainWidth && 'dsgo-no-width-constraint',
-		overlayColor && 'dsgo-stack--has-overlay',
+		hasOverlay && 'dsgo-stack--has-overlay',
 		(shapeDividerTop || shapeDividerBottom) &&
 			'dsgo-stack--has-shape-divider',
 	]

--- a/src/blocks/section/editor.scss
+++ b/src/blocks/section/editor.scss
@@ -56,15 +56,18 @@ $inline-block-data-types: (
 	position: relative;
 
 	// Hover background overlay - works with both gradients and solid colors
-	// Using ::after pseudo-element allows smooth opacity transition
-	&[style*="--dsgo-hover-bg-color"]::after {
+	// Using ::after pseudo-element allows smooth opacity transition.
+	// Always present but transparent until --dsgo-hover-bg-color is set, so the
+	// color may come from an inline attribute OR a section style variation's
+	// stylesheet. Mirrors src/blocks/section/style.scss.
+	&::after {
 		content: '';
 		position: absolute;
 		top: 0;
 		left: 0;
 		right: 0;
 		bottom: 0;
-		background: var(--dsgo-hover-bg-color);
+		background: var(--dsgo-hover-bg-color, transparent);
 		opacity: 0;
 		transition: opacity 0.3s ease;
 		pointer-events: none;
@@ -290,15 +293,16 @@ $inline-block-data-types: (
 	}
 
 	// Hover background and text colors using CSS custom properties (must match style.scss)
-	// CRITICAL: Only apply hover when variables are actually set on THIS element
 	&:hover {
-		// Fade in the hover background overlay (::after pseudo-element)
-		// This allows smooth transition from gradient to solid color
-		&[style*="--dsgo-hover-bg-color"]::after {
+		// Fade in the hover background overlay (::after). Safe when unset — the
+		// layer is transparent. Works with an inline attribute or a variation.
+		&::after {
 			opacity: 1;
 		}
 
-		// Only apply text color if hover text color is set
+		// Hover text stays inline-gated (overrides base color with !important;
+		// applying it when unset would clobber the section's own text color).
+		// CRITICAL: Only apply hover text when the variable is set on THIS element.
 		&[style*="--dsgo-hover-text-color"] {
 			color: var(--dsgo-hover-text-color) !important;
 

--- a/src/blocks/section/editor.scss
+++ b/src/blocks/section/editor.scss
@@ -293,25 +293,24 @@ $inline-block-data-types: (
 	}
 
 	// Hover background and text colors using CSS custom properties (must match style.scss)
-	&:hover {
-		// Fade in the hover background overlay (::after). Safe when unset — the
-		// layer is transparent. Works with an inline attribute or a variation.
-		&::after {
-			opacity: 1;
-		}
+	// Fade in the hover background overlay (::after). Safe when unset — the layer
+	// is transparent. Works with an inline attribute or a variation.
+	&:hover::after {
+		opacity: 1;
+	}
 
-		// Hover text stays inline-gated (overrides base color with !important;
-		// applying it when unset would clobber the section's own text color).
-		// CRITICAL: Only apply hover text when the variable is set on THIS element.
-		&[style*="--dsgo-hover-text-color"] {
+	// Hover text: inline-gated for the attribute, class-gated (--has-hover-text)
+	// for an is-style-hover-text-* variation whose stylesheet supplies the var.
+	// Must match style.scss.
+	&[style*="--dsgo-hover-text-color"]:hover,
+	&--has-hover-text:hover {
+		color: var(--dsgo-hover-text-color) !important;
+
+		// Apply text color to all text elements for consistency
+		h1, h2, h3, h4, h5, h6, p, a, span, li, td, th,
+		.wp-block-heading,
+		.wp-block-paragraph {
 			color: var(--dsgo-hover-text-color) !important;
-
-			// Apply text color to all text elements for consistency
-			h1, h2, h3, h4, h5, h6, p, a, span, li, td, th,
-			.wp-block-heading,
-			.wp-block-paragraph {
-				color: var(--dsgo-hover-text-color) !important;
-			}
 		}
 	}
 }

--- a/src/blocks/section/save.js
+++ b/src/blocks/section/save.js
@@ -9,6 +9,7 @@
 
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
+import { hasOverlayStyleClass } from './utils/has-overlay-style';
 import ShapeDivider from './components/ShapeDivider';
 
 /**
@@ -56,11 +57,18 @@ export default function SectionSave({ attributes }) {
 		shapeDividerBottomBackgroundColor
 	);
 
+	// Overlay is enabled by an explicit overlayColor OR by a style-kit overlay
+	// variation (is-style-overlay-*) applied via className. In the variation
+	// case the color is supplied by the variation's stylesheet, so no inline
+	// --dsgo-overlay-color is emitted below.
+	const hasOverlay =
+		!!overlayColor || hasOverlayStyleClass(attributes.className);
+
 	// Build className with conditional no-width-constraint and overlay classes
 	const className = [
 		'dsgo-stack',
 		!constrainWidth && 'dsgo-no-width-constraint',
-		overlayColor && 'dsgo-stack--has-overlay',
+		hasOverlay && 'dsgo-stack--has-overlay',
 		(shapeDividerTop || shapeDividerBottom) &&
 			'dsgo-stack--has-shape-divider',
 	]

--- a/src/blocks/section/save.js
+++ b/src/blocks/section/save.js
@@ -9,7 +9,10 @@
 
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
-import { hasOverlayStyleClass } from './utils/has-overlay-style';
+import {
+	hasOverlayStyleClass,
+	hoverVariationClasses,
+} from './utils/has-overlay-style';
 import ShapeDivider from './components/ShapeDivider';
 
 /**
@@ -64,13 +67,17 @@ export default function SectionSave({ attributes }) {
 	const hasOverlay =
 		!!overlayColor || hasOverlayStyleClass(attributes.className);
 
-	// Build className with conditional no-width-constraint and overlay classes
+	// Build className with conditional no-width-constraint and overlay classes.
+	// Hover activation classes are emitted for hover style variations so their
+	// class-gated CSS can activate (the inline-`style` gate can't see a variation
+	// stylesheet's vars). The inline-attribute hover path keeps its own gate.
 	const className = [
 		'dsgo-stack',
 		!constrainWidth && 'dsgo-no-width-constraint',
 		hasOverlay && 'dsgo-stack--has-overlay',
 		(shapeDividerTop || shapeDividerBottom) &&
 			'dsgo-stack--has-shape-divider',
+		...hoverVariationClasses(attributes.className),
 	]
 		.filter(Boolean)
 		.join(' ');

--- a/src/blocks/section/style.scss
+++ b/src/blocks/section/style.scss
@@ -450,30 +450,29 @@
 		}
 	}
 
-	// Hover background and text colors using CSS custom properties
-	&:hover {
-		// Fade in the hover background overlay (::after pseudo-element). Safe
-		// when no hover color is set — the layer is transparent, so this is a
-		// visual no-op. Works with an inline attribute or a style variation.
-		&::after {
-			opacity: 1;
-		}
+	// Fade in the hover background overlay (::after pseudo-element). Safe when no
+	// hover color is set — the layer is transparent, so this is a visual no-op.
+	// Works with an inline attribute or a style variation.
+	&:hover::after {
+		opacity: 1;
+	}
 
-		// Hover text color still uses an inline-`[style*=…]` gate: unlike the
-		// additive ::after overlay, it overrides the base `color` with
-		// !important, so applying it when unset would clobber the section's own
-		// text color. A style-variation stylesheet can't satisfy this selector —
-		// making it variation-settable needs class-based activation (see PR).
-		// CRITICAL: Only apply hover text when the variable is set on THIS element.
-		&[style*="--dsgo-hover-text-color"] {
+	// Hover text color overrides the base `color` with !important, so it must be
+	// gated to "only when set" or it would clobber the section's own text color.
+	// Two gates cover both sources:
+	//   [style*=…]        — inline var from the block's hoverTextColor attribute
+	//   --has-hover-text  — emitted by the block for an is-style-hover-text-*
+	//                       variation, whose stylesheet supplies the var (the
+	//                       inline gate can't see a stylesheet-set var)
+	&[style*="--dsgo-hover-text-color"]:hover,
+	&--has-hover-text:hover {
+		color: var(--dsgo-hover-text-color) !important;
+
+		// Apply text color to all text elements for consistency
+		h1, h2, h3, h4, h5, h6, p, a, span, li, td, th,
+		.wp-block-heading,
+		.wp-block-paragraph {
 			color: var(--dsgo-hover-text-color) !important;
-
-			// Apply text color to all text elements for consistency
-			h1, h2, h3, h4, h5, h6, p, a, span, li, td, th,
-			.wp-block-heading,
-			.wp-block-paragraph {
-				color: var(--dsgo-hover-text-color) !important;
-			}
 		}
 	}
 }

--- a/src/blocks/section/style.scss
+++ b/src/blocks/section/style.scss
@@ -28,15 +28,21 @@
 
 	// Hover background overlay - works with both gradients and solid colors
 	// Using ::after pseudo-element allows smooth opacity transition
-	// z-index: 0 (below overlay ::before and content)
-	&[style*="--dsgo-hover-bg-color"]::after {
+	// z-index: 0 (below overlay ::before and content).
+	// The layer is always present but transparent until --dsgo-hover-bg-color is
+	// set, so fading it in on hover is a no-op when there is no hover color. This
+	// (rather than an inline-`[style*=…]` gate) lets the color come from EITHER
+	// the block's inline attribute OR a section style variation's stylesheet
+	// (`.is-style-*{ --dsgo-hover-bg-color: … }`). Additive overlay — no base
+	// value is clobbered — so no class-based activation is needed.
+	&::after {
 		content: '';
 		position: absolute;
 		top: 0;
 		left: 0;
 		right: 0;
 		bottom: 0;
-		background: var(--dsgo-hover-bg-color);
+		background: var(--dsgo-hover-bg-color, transparent);
 		opacity: 0;
 		transition: opacity 0.3s ease;
 		pointer-events: none;
@@ -445,15 +451,20 @@
 	}
 
 	// Hover background and text colors using CSS custom properties
-	// CRITICAL: Only apply hover when variables are actually set on THIS element
 	&:hover {
-		// Fade in the hover background overlay (::after pseudo-element)
-		// This allows smooth transition from gradient to solid color
-		&[style*="--dsgo-hover-bg-color"]::after {
+		// Fade in the hover background overlay (::after pseudo-element). Safe
+		// when no hover color is set — the layer is transparent, so this is a
+		// visual no-op. Works with an inline attribute or a style variation.
+		&::after {
 			opacity: 1;
 		}
 
-		// Only apply text color if hover text color is set
+		// Hover text color still uses an inline-`[style*=…]` gate: unlike the
+		// additive ::after overlay, it overrides the base `color` with
+		// !important, so applying it when unset would clobber the section's own
+		// text color. A style-variation stylesheet can't satisfy this selector —
+		// making it variation-settable needs class-based activation (see PR).
+		// CRITICAL: Only apply hover text when the variable is set on THIS element.
 		&[style*="--dsgo-hover-text-color"] {
 			color: var(--dsgo-hover-text-color) !important;
 

--- a/src/blocks/section/test/deprecated.test.js
+++ b/src/blocks/section/test/deprecated.test.js
@@ -69,8 +69,8 @@ const OLD_SVG_MARKUP = `<!-- wp:designsetgo/section {"shapeDividerTop":"wave","s
 // background color (no explicit shapeDividerBottomColor set), matching
 // V4ShapeDivider's inheritance behavior used by deprecations v4/v5/v6.
 // Built from v4's own save() so the fixture is byte-exact.
-// deprecated.js exports deprecations newest-first: [v6, v5, v4, v3, v2, v1].
-const [, , v4Deprecation] = deprecated;
+// deprecated.js exports deprecations newest-first: [v7, v6, v5, v4, v3, v2, v1].
+const [, , , v4Deprecation] = deprecated;
 const OLD_SVG_MARKUP_BOTTOM_INHERITED = buildOldMarkup(
 	{
 		shapeDividerBottom: 'tilt',
@@ -120,8 +120,8 @@ describe('section deprecations - shape divider SVG to class-based migration', ()
 	// deprecation and shows "unexpected or invalid content". The other tests use
 	// wave/tilt, which were NOT redesigned, so they can't catch this.
 	test('deprecations reproduce frozen legacy geometry for redesigned shapes (drops)', () => {
-		// deprecated.js exports newest-first: [v6, v5, v4, v3, v2, v1].
-		const [, , v4Dep, v3Dep] = deprecated;
+		// deprecated.js exports newest-first: [v7, v6, v5, v4, v3, v2, v1].
+		const [, , , v4Dep, v3Dep] = deprecated;
 
 		[v3Dep, v4Dep].forEach((deprecation) => {
 			const markup = buildOldMarkup(
@@ -133,5 +133,73 @@ describe('section deprecations - shape divider SVG to class-based migration', ()
 			// The redesigned single-<path> arc signature must NOT appear.
 			expect(markup).not.toContain('A100,95');
 		});
+	});
+});
+
+describe('section deprecations - style-kit overlay variation migration (v7)', () => {
+	// v7 is the newest deprecation (index 0).
+	const [v7Deprecation] = deprecated;
+
+	// A section carrying a style-kit overlay variation but saved BEFORE the
+	// overlay class was derived from that variation: no dsgo-stack--has-overlay
+	// and no overlayColor attribute. Built from v7's own save() so it is a
+	// byte-faithful reproduction of that pre-change markup.
+	const OLD_OVERLAY_VARIATION_MARKUP = buildOldMarkup(
+		{ className: 'is-style-overlay-dark' },
+		v7Deprecation
+	);
+
+	test('old is-style-overlay-dark section (no overlay class) migrates silently against current save()', () => {
+		expect(OLD_OVERLAY_VARIATION_MARKUP).not.toContain(
+			'dsgo-stack--has-overlay'
+		);
+
+		const [block] = parse(OLD_OVERLAY_VARIATION_MARKUP);
+
+		// Silent migration logs an informational "Block successfully updated".
+		expect(console).toHaveInformed();
+
+		expect(block.name).toBe('designsetgo/section');
+		expect(block.isValid).toBe(true);
+		// migrate() is a passthrough — the variation class is retained and the
+		// current save() now derives the overlay class from it.
+		expect(block.attributes.className).toBe('is-style-overlay-dark');
+	});
+
+	test('isEligible detects an overlay variation lacking the overlay class', () => {
+		const html =
+			'<div class="wp-block-designsetgo-section is-style-overlay-dark dsgo-stack"><div class="dsgo-stack__inner"></div></div>';
+		expect(
+			v7Deprecation.isEligible(
+				{ className: 'is-style-overlay-dark' },
+				[],
+				{ innerHTML: html }
+			)
+		).toBe(true);
+	});
+
+	test('isEligible ignores sections that already carry the overlay class', () => {
+		const html =
+			'<div class="wp-block-designsetgo-section is-style-overlay-dark dsgo-stack dsgo-stack--has-overlay"><div class="dsgo-stack__inner"></div></div>';
+		expect(
+			v7Deprecation.isEligible(
+				{ className: 'is-style-overlay-dark' },
+				[],
+				{ innerHTML: html }
+			)
+		).toBe(false);
+	});
+
+	test('isEligible ignores sections without an overlay variation', () => {
+		const html =
+			'<div class="wp-block-designsetgo-section dsgo-stack"><div class="dsgo-stack__inner"></div></div>';
+		expect(
+			v7Deprecation.isEligible({ className: '' }, [], { innerHTML: html })
+		).toBe(false);
+	});
+
+	test('migrate is a passthrough', () => {
+		const attrs = { className: 'is-style-overlay-dark', overlayColor: '' };
+		expect(v7Deprecation.migrate(attrs)).toBe(attrs);
 	});
 });

--- a/src/blocks/section/test/deprecated.test.js
+++ b/src/blocks/section/test/deprecated.test.js
@@ -22,6 +22,9 @@ import {
 	setCategories,
 	parse,
 	getSaveContent,
+	createBlock,
+	serialize,
+	getBlockContent,
 	// eslint-disable-next-line import/no-unresolved
 } from '@wordpress/block-editor/node_modules/@wordpress/blocks';
 import metadata from '../block.json';
@@ -140,20 +143,35 @@ describe('section deprecations - style-kit overlay variation migration (v7)', ()
 	// v7 is the newest deprecation (index 0).
 	const [v7Deprecation] = deprecated;
 
-	// A section carrying a style-kit overlay variation but saved BEFORE the
-	// overlay class was derived from that variation: no dsgo-stack--has-overlay
-	// and no overlayColor attribute. Built from v7's own save() so it is a
-	// byte-faithful reproduction of that pre-change markup.
-	const OLD_OVERLAY_VARIATION_MARKUP = buildOldMarkup(
-		{ className: 'is-style-overlay-dark' },
-		v7Deprecation
+	// Reproduce content saved BEFORE this change by taking what the block
+	// ACTUALLY serializes today (carrying block.json defaults such as the
+	// spacing padding) and stripping the overlay class. Deriving the fixture
+	// from the real save() — rather than from v7's own save() — is what makes
+	// this a genuine regression guard: v7's `save()` only byte-matches this
+	// markup when v7's attribute schema reproduces block.json's `style` default
+	// (the padding). An earlier version of v7 that omitted that default passed a
+	// tautological buildOldMarkup(v7) fixture but failed against real content.
+	const canonicalMarkup = serialize(
+		createBlock(metadata.name, { className: 'is-style-overlay-dark' })
+	);
+	const OLD_OVERLAY_VARIATION_MARKUP = canonicalMarkup.replace(
+		' dsgo-stack--has-overlay',
+		''
 	);
 
-	test('old is-style-overlay-dark section (no overlay class) migrates silently against current save()', () => {
+	test('canonical markup carries the overlay class and the default spacing padding', () => {
+		// Guards the fixture itself: if either signal disappears the migration
+		// test below stops being meaningful.
+		expect(canonicalMarkup).toContain('dsgo-stack--has-overlay');
 		expect(OLD_OVERLAY_VARIATION_MARKUP).not.toContain(
 			'dsgo-stack--has-overlay'
 		);
+		expect(OLD_OVERLAY_VARIATION_MARKUP).toContain(
+			'--wp--preset--spacing--50'
+		);
+	});
 
+	test('old is-style-overlay-dark section (no overlay class) migrates silently against current save()', () => {
 		const [block] = parse(OLD_OVERLAY_VARIATION_MARKUP);
 
 		// Silent migration logs an informational "Block successfully updated".
@@ -164,6 +182,8 @@ describe('section deprecations - style-kit overlay variation migration (v7)', ()
 		// migrate() is a passthrough — the variation class is retained and the
 		// current save() now derives the overlay class from it.
 		expect(block.attributes.className).toBe('is-style-overlay-dark');
+		// The migrated block re-serializes with the overlay class restored.
+		expect(getBlockContent(block)).toContain('dsgo-stack--has-overlay');
 	});
 
 	test('isEligible detects an overlay variation lacking the overlay class', () => {

--- a/src/blocks/section/test/deprecated.test.js
+++ b/src/blocks/section/test/deprecated.test.js
@@ -72,8 +72,8 @@ const OLD_SVG_MARKUP = `<!-- wp:designsetgo/section {"shapeDividerTop":"wave","s
 // background color (no explicit shapeDividerBottomColor set), matching
 // V4ShapeDivider's inheritance behavior used by deprecations v4/v5/v6.
 // Built from v4's own save() so the fixture is byte-exact.
-// deprecated.js exports deprecations newest-first: [v7, v6, v5, v4, v3, v2, v1].
-const [, , , v4Deprecation] = deprecated;
+// deprecated.js exports deprecations newest-first: [v8, v7, v6, v5, v4, v3, v2, v1].
+const [, , , , v4Deprecation] = deprecated;
 const OLD_SVG_MARKUP_BOTTOM_INHERITED = buildOldMarkup(
 	{
 		shapeDividerBottom: 'tilt',
@@ -123,8 +123,8 @@ describe('section deprecations - shape divider SVG to class-based migration', ()
 	// deprecation and shows "unexpected or invalid content". The other tests use
 	// wave/tilt, which were NOT redesigned, so they can't catch this.
 	test('deprecations reproduce frozen legacy geometry for redesigned shapes (drops)', () => {
-		// deprecated.js exports newest-first: [v7, v6, v5, v4, v3, v2, v1].
-		const [, , , v4Dep, v3Dep] = deprecated;
+		// deprecated.js exports newest-first: [v8, v7, v6, v5, v4, v3, v2, v1].
+		const [, , , , v4Dep, v3Dep] = deprecated;
 
 		[v3Dep, v4Dep].forEach((deprecation) => {
 			const markup = buildOldMarkup(
@@ -140,8 +140,8 @@ describe('section deprecations - shape divider SVG to class-based migration', ()
 });
 
 describe('section deprecations - style-kit overlay variation migration (v7)', () => {
-	// v7 is the newest deprecation (index 0).
-	const [v7Deprecation] = deprecated;
+	// deprecated.js exports newest-first: [v8, v7, v6, v5, v4, v3, v2, v1].
+	const [, v7Deprecation] = deprecated;
 
 	// Reproduce content saved BEFORE this change by taking what the block
 	// ACTUALLY serializes today (carrying block.json defaults such as the
@@ -186,6 +186,28 @@ describe('section deprecations - style-kit overlay variation migration (v7)', ()
 		expect(getBlockContent(block)).toContain('dsgo-stack--has-overlay');
 	});
 
+	test('migration retains shapeDividerTopColor/shapeDividerBottomColor (v7 attribute schema must declare them)', () => {
+		// v6/block.json both declare these legacy/preview-only swatch
+		// attributes. If v7.attributes omitted them, WP would parse the
+		// stored comment JSON without them (a deprecation's own `attributes`
+		// schema is used exclusively, not merged with the current block
+		// type), and migrate()'s passthrough would silently drop the values.
+		const markupWithShapeColors = serialize(
+			createBlock(metadata.name, {
+				className: 'is-style-overlay-dark',
+				shapeDividerTopColor: 'contrast',
+				shapeDividerBottomColor: 'accent',
+			})
+		).replace(' dsgo-stack--has-overlay', '');
+
+		const [block] = parse(markupWithShapeColors);
+
+		expect(console).toHaveInformed();
+		expect(block.isValid).toBe(true);
+		expect(block.attributes.shapeDividerTopColor).toBe('contrast');
+		expect(block.attributes.shapeDividerBottomColor).toBe('accent');
+	});
+
 	test('isEligible detects an overlay variation lacking the overlay class', () => {
 		const html =
 			'<div class="wp-block-designsetgo-section is-style-overlay-dark dsgo-stack"><div class="dsgo-stack__inner"></div></div>';
@@ -221,5 +243,109 @@ describe('section deprecations - style-kit overlay variation migration (v7)', ()
 	test('migrate is a passthrough', () => {
 		const attrs = { className: 'is-style-overlay-dark', overlayColor: '' };
 		expect(v7Deprecation.migrate(attrs)).toBe(attrs);
+	});
+});
+
+describe('section deprecations - style-kit hover variation migration (v8)', () => {
+	// deprecated.js exports newest-first: [v8, v7, v6, v5, v4, v3, v2, v1].
+	const [v8Deprecation] = deprecated;
+
+	// Reproduce content saved BEFORE hover-variation classes existed by taking
+	// the block's REAL current serialization and stripping the hover-text
+	// activation class it now adds. Deriving from the real save() (rather than
+	// v8's own save()) keeps this a genuine regression guard — see the
+	// identical rationale on the v7 overlay fixture above.
+	const canonicalHoverMarkup = serialize(
+		createBlock(metadata.name, { className: 'is-style-hover-text-light' })
+	);
+	const OLD_HOVER_VARIATION_MARKUP = canonicalHoverMarkup.replace(
+		' dsgo-stack--has-hover-text',
+		''
+	);
+
+	test('canonical markup carries the hover-text activation class', () => {
+		expect(canonicalHoverMarkup).toContain('dsgo-stack--has-hover-text');
+		expect(OLD_HOVER_VARIATION_MARKUP).not.toContain(
+			'dsgo-stack--has-hover-text'
+		);
+	});
+
+	test('old is-style-hover-text-light section (no activation class) migrates silently against current save()', () => {
+		const [block] = parse(OLD_HOVER_VARIATION_MARKUP);
+
+		expect(console).toHaveInformed();
+
+		expect(block.name).toBe('designsetgo/section');
+		expect(block.isValid).toBe(true);
+		expect(block.attributes.className).toBe('is-style-hover-text-light');
+		// The migrated block re-serializes with the activation class restored.
+		expect(getBlockContent(block)).toContain('dsgo-stack--has-hover-text');
+	});
+
+	test('isEligible detects a hover-text variation lacking its activation class', () => {
+		const html =
+			'<div class="wp-block-designsetgo-section is-style-hover-text-light dsgo-stack"><div class="dsgo-stack__inner"></div></div>';
+		expect(
+			v8Deprecation.isEligible(
+				{ className: 'is-style-hover-text-light' },
+				[],
+				{ innerHTML: html }
+			)
+		).toBe(true);
+	});
+
+	test('isEligible detects a hover-icon variation lacking its activation class', () => {
+		const html =
+			'<div class="wp-block-designsetgo-section is-style-hover-icon-blue dsgo-stack"><div class="dsgo-stack__inner"></div></div>';
+		expect(
+			v8Deprecation.isEligible(
+				{ className: 'is-style-hover-icon-blue' },
+				[],
+				{ innerHTML: html }
+			)
+		).toBe(true);
+	});
+
+	test('isEligible ignores sections that already carry the matching activation class', () => {
+		const html =
+			'<div class="wp-block-designsetgo-section is-style-hover-text-light dsgo-stack dsgo-stack--has-hover-text"><div class="dsgo-stack__inner"></div></div>';
+		expect(
+			v8Deprecation.isEligible(
+				{ className: 'is-style-hover-text-light' },
+				[],
+				{ innerHTML: html }
+			)
+		).toBe(false);
+	});
+
+	test('isEligible detects a partial mismatch when only one of several hover families is missing its class', () => {
+		const html =
+			'<div class="wp-block-designsetgo-section is-style-hover-text-light is-style-hover-icon-blue dsgo-stack dsgo-stack--has-hover-icon"><div class="dsgo-stack__inner"></div></div>';
+		expect(
+			v8Deprecation.isEligible(
+				{
+					className:
+						'is-style-hover-text-light is-style-hover-icon-blue',
+				},
+				[],
+				{ innerHTML: html }
+			)
+		).toBe(true);
+	});
+
+	test('isEligible ignores sections without a hover variation', () => {
+		const html =
+			'<div class="wp-block-designsetgo-section dsgo-stack"><div class="dsgo-stack__inner"></div></div>';
+		expect(
+			v8Deprecation.isEligible({ className: '' }, [], { innerHTML: html })
+		).toBe(false);
+	});
+
+	test('migrate is a passthrough', () => {
+		const attrs = {
+			className: 'is-style-hover-text-light',
+			hoverTextColor: '',
+		};
+		expect(v8Deprecation.migrate(attrs)).toBe(attrs);
 	});
 });

--- a/src/blocks/section/test/save.test.js
+++ b/src/blocks/section/test/save.test.js
@@ -115,3 +115,41 @@ describe('section save - shape dividers', () => {
 		expect(bottomFlipped).not.toContain('is-flip-y');
 	});
 });
+
+describe('section save - overlay class', () => {
+	test('no overlay by default', () => {
+		const html = serialize(createBlock(metadata.name, {}));
+		expect(html).not.toContain('dsgo-stack--has-overlay');
+	});
+
+	test('overlayColor emits overlay class + inline color var', () => {
+		const html = serialize(
+			createBlock(metadata.name, { overlayColor: 'contrast' })
+		);
+		expect(html).toContain('dsgo-stack--has-overlay');
+		expect(html).toContain('--dsgo-overlay-color');
+	});
+
+	test('is-style-overlay-dark className emits overlay class without inline color var', () => {
+		const html = serialize(
+			createBlock(metadata.name, { className: 'is-style-overlay-dark' })
+		);
+		expect(html).toContain('dsgo-stack--has-overlay');
+		// Color comes from the style variation's stylesheet, not inline.
+		expect(html).not.toContain('--dsgo-overlay-color');
+	});
+
+	test('future is-style-overlay-* variations also enable the overlay', () => {
+		const html = serialize(
+			createBlock(metadata.name, { className: 'is-style-overlay-light' })
+		);
+		expect(html).toContain('dsgo-stack--has-overlay');
+	});
+
+	test('unrelated is-style-* variation does not enable the overlay', () => {
+		const html = serialize(
+			createBlock(metadata.name, { className: 'is-style-rounded' })
+		);
+		expect(html).not.toContain('dsgo-stack--has-overlay');
+	});
+});

--- a/src/blocks/section/test/save.test.js
+++ b/src/blocks/section/test/save.test.js
@@ -153,3 +153,50 @@ describe('section save - overlay class', () => {
 		expect(html).not.toContain('dsgo-stack--has-overlay');
 	});
 });
+
+describe('section save - hover variation activation classes', () => {
+	test('no hover activation classes by default', () => {
+		const html = serialize(createBlock(metadata.name, {}));
+		expect(html).not.toContain('dsgo-stack--has-hover-text');
+		expect(html).not.toContain('dsgo-stack--has-hover-icon');
+		expect(html).not.toContain('dsgo-stack--has-hover-button');
+	});
+
+	test('is-style-hover-text-* emits only the hover-text activation class', () => {
+		const html = serialize(
+			createBlock(metadata.name, {
+				className: 'is-style-hover-text-light',
+			})
+		);
+		expect(html).toContain('dsgo-stack--has-hover-text');
+		expect(html).not.toContain('dsgo-stack--has-hover-icon');
+		expect(html).not.toContain('dsgo-stack--has-hover-button');
+	});
+
+	test('is-style-hover-icon-* emits only the hover-icon activation class', () => {
+		const html = serialize(
+			createBlock(metadata.name, {
+				className: 'is-style-hover-icon-blue',
+			})
+		);
+		expect(html).toContain('dsgo-stack--has-hover-icon');
+		expect(html).not.toContain('dsgo-stack--has-hover-text');
+	});
+
+	test('is-style-hover-button-* emits only the hover-button activation class', () => {
+		const html = serialize(
+			createBlock(metadata.name, {
+				className: 'is-style-hover-button-accent',
+			})
+		);
+		expect(html).toContain('dsgo-stack--has-hover-button');
+		expect(html).not.toContain('dsgo-stack--has-hover-icon');
+	});
+
+	test('setting a hover attribute alone does NOT add an activation class (inline gate handles it)', () => {
+		const html = serialize(
+			createBlock(metadata.name, { hoverTextColor: 'contrast' })
+		);
+		expect(html).not.toContain('dsgo-stack--has-hover-text');
+	});
+});

--- a/src/blocks/section/utils/has-overlay-style.js
+++ b/src/blocks/section/utils/has-overlay-style.js
@@ -1,0 +1,31 @@
+/**
+ * Section overlay style-variation detection.
+ *
+ * A section renders its `::before` overlay whenever the
+ * `dsgo-stack--has-overlay` class is present. Historically that class was
+ * emitted only when the `overlayColor` attribute was set (which also injects
+ * an inline `--dsgo-overlay-color`). Style kits now express the overlay as a
+ * block-style variation (`is-style-overlay-dark`, and any future
+ * `is-style-overlay-*`) that supplies the overlay color via CSS. When such a
+ * variation is applied, the block must still emit the overlay class so the
+ * pseudo-element renders — the color comes from the variation's stylesheet
+ * rather than an inline custom property.
+ *
+ * Detecting the whole `is-style-overlay-` family (not just `-dark`) means new
+ * overlay variations light up without another plugin change.
+ *
+ * Used by both edit.js and save.js so the editor preview and saved markup stay
+ * byte-identical.
+ *
+ * @param {string} [className] The block's `className` attribute value.
+ * @return {boolean} True when an overlay style variation is present.
+ */
+export function hasOverlayStyleClass(className) {
+	if (!className || typeof className !== 'string') {
+		return false;
+	}
+
+	return className
+		.split(/\s+/)
+		.some((token) => token.startsWith('is-style-overlay-'));
+}

--- a/src/blocks/section/utils/has-overlay-style.js
+++ b/src/blocks/section/utils/has-overlay-style.js
@@ -29,3 +29,49 @@ export function hasOverlayStyleClass(className) {
 		.split(/\s+/)
 		.some((token) => token.startsWith('is-style-overlay-'));
 }
+
+/**
+ * Hover style-variation → activation-class map.
+ *
+ * The section's hover-text / child-icon / child-button hover colors override a
+ * base value with `!important`, so their CSS is gated to "only when actually
+ * set" — historically via an inline-`style` attribute selector, which a style
+ * variation's stylesheet can't satisfy. To let a variation drive them, the
+ * block emits a stable activation class the CSS can key off, mirroring the
+ * overlay pattern.
+ *
+ * Each family activates exactly one effect (so a variation that sets only some
+ * of the hover vars never clobbers the others). The section hover *background*
+ * is intentionally absent — it is an additive overlay that is already safe when
+ * unset, so it needs no activation class and works with any variation.
+ */
+const HOVER_VARIATION_FAMILIES = [
+	{ prefix: 'is-style-hover-text-', className: 'dsgo-stack--has-hover-text' },
+	{ prefix: 'is-style-hover-icon-', className: 'dsgo-stack--has-hover-icon' },
+	{
+		prefix: 'is-style-hover-button-',
+		className: 'dsgo-stack--has-hover-button',
+	},
+];
+
+/**
+ * Resolve the hover activation classes a section should emit for the style
+ * variations present on its `className`.
+ *
+ * Used by both edit.js and save.js so the editor preview and saved markup stay
+ * byte-identical.
+ *
+ * @param {string} [className] The block's `className` attribute value.
+ * @return {string[]} Activation classes to add (possibly empty).
+ */
+export function hoverVariationClasses(className) {
+	if (!className || typeof className !== 'string') {
+		return [];
+	}
+
+	const tokens = className.split(/\s+/);
+
+	return HOVER_VARIATION_FAMILIES.filter(({ prefix }) =>
+		tokens.some((token) => token.startsWith(prefix))
+	).map(({ className: activationClass }) => activationClass);
+}


### PR DESCRIPTION
## Summary

Enables style kits to drive a section's background overlay through a block-style variation (`is-style-overlay-dark`, and any future `is-style-overlay-*`) instead of the `overlayColor` attribute.

Previously `designsetgo/section` emitted `dsgo-stack--has-overlay` — the class that renders the `::before` overlay — **only** when the `overlayColor` attribute was set. Moving overlay color into a style-kit class therefore produced no overlay. This change makes the block also emit `dsgo-stack--has-overlay` when an `is-style-overlay-*` variation is present on `className`, so the pseudo-element renders and the color is supplied by the variation's stylesheet.

Unblocks the section-overlay patterns (e.g. `benefits-cover-centered-grid`, `benefits-staggered-icon-cards`) that are migrating overlay color from `overlayColor`/inline styles to the `is-style-overlay-dark` class.

## Changes

- **New `hasOverlayStyleClass()` helper** (`src/blocks/section/utils/has-overlay-style.js`) — detects the whole `is-style-overlay-` family, so future overlay variations work with no further plugin change. Shared by edit + save to keep editor preview and saved markup byte-identical.
- **`save.js` / `edit.js`** — emit `dsgo-stack--has-overlay` when `overlayColor` **or** an overlay variation is present. In the variation case, no inline `--dsgo-overlay-color` is emitted (color comes from the variation's CSS).
- **`deprecated.js`** — new **v7** deprecation (all three parts: `isEligible` / `save` / `migrate`). Sections carrying an overlay variation but saved before this change **migrate silently** rather than showing "Attempt Recovery". `save()` reproduces the pre-change output so it also byte-matches on WP versions that validate the deprecation's save.

## Tests

- Save-level tests for the new overlay-class behavior (variation on/off, `overlayColor` still works, unrelated `is-style-*` ignored, no inline color var for the variation path).
- v7 deprecation tests, including an end-to-end silent-migration round-trip (`console.toHaveInformed()` + `block.isValid`).
- Updated existing deprecation-array destructuring indices for the new v7 entry.

Full suite: `8326 passed`. `eslint` clean, `npm run build` clean, overlay CSS confirmed present in the compiled section stylesheets.

## Note on scope

The pattern markup edits (removing `customOverlayColor` / `style.color.text` / inline colors and adding `is-style-overlay-dark`) live in the external style-kit repo, not this plugin. This PR is the plugin-side prerequisite that makes `is-style-overlay-dark` actually produce an overlay.