### PR TITLE
feat(svg-patterns): inherit pattern preset from theme.json global styles

### DIFF
--- a/docs/plans/2026-07-07-svg-pattern-theme-inheritance.md
+++ b/docs/plans/2026-07-07-svg-pattern-theme-inheritance.md
@@ -1,0 +1,681 @@
+# SVG Pattern — Theme Inheritance Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let the SVG-pattern background extension inherit a full pattern preset (type + color + opacity + scale) from theme.json / FSE global styles, selectable per block via a new "Theme default" choice, falling back to an in-plugin default when no theme value is set — mirroring the shape-divider theme-inheritance work.
+
+**Architecture:** The SVG pattern is a block extension on `core/group` + `designsetgo/section`. It is **server-rendered**: `save()` writes lean data attributes (`data-dsgo-svg-pattern`, `-color`, `-opacity`, `-scale`) and PHP (`SVG_Pattern_Renderer`) generates the SVG data URI at render time. We add a new attribute *value* `'inherit'` for `dsgoSvgPatternType` (not a schema change — no deprecation). When a block's type is `'inherit'`, both the PHP renderer and the editor resolve the pattern preset from `settings.custom.designsetgo.svgPattern` (`type`/`color`/`opacity`/`scale`), each field falling back to an in-plugin default (`dot-grid`, `#9c92ac`, `0.4`, `1`). The Style-Kit value that populates those settings lives in the external `native-ui` repo (out of scope here); the in-plugin fallback guarantees it works with no kit.
+
+**Tech Stack:** WordPress block editor (`@wordpress/hooks`, `@wordpress/block-editor` `useSettings`), Jest (`wp-scripts test-unit-js`) for save/attribute unit tests, PHP (`wp_get_global_settings`, `WP_HTML_Tag_Processor`) for server render.
+
+**Decisions already locked (from brainstorming):**
+- Resolve the inherited slug/preset **server-side (PHP) + editor JS** — keep the existing server render; do NOT rewrite to CSS masks. Preserves `opacity`/`scale`/`fixed` exactly.
+- Theme provides a **full preset**: `type`, `color`, `opacity`, `scale`. `fixed` stays a per-block toggle (not themed).
+- Opt-in is an **explicit "Theme default" tile** in the pattern picker → sets `dsgoSvgPatternType: 'inherit'`.
+- In-plugin fallback slug: **`dot-grid`** (the neutral equivalent of shape-divider's `wave`).
+- When a block inherits, it adopts the theme preset **wholesale**; the per-block Color / Opacity / Scale controls are hidden while inheriting (Enable / Fixed / Clear stay). Choosing an explicit pattern restores them.
+
+**Key reference files (read before starting):**
+- `src/extensions/svg-patterns/constants.js` — `SUPPORTED_BLOCKS`, `DEFAULTS`, `RANGES`.
+- `src/extensions/svg-patterns/editor.js` — `addSvgPatternEditorStyles` (editor preview), `addSvgPatternSaveProps` (save), `stripLegacySvgPatternStyles`.
+- `src/extensions/svg-patterns/attributes.js` — attribute registration + existing `legacyColorDeprecation`.
+- `src/extensions/svg-patterns/components/SvgPatternsPanel.js` — inspector UI + picker.
+- `src/extensions/svg-patterns/patterns.js` + `pattern-data.js` — `PATTERNS`, `PATTERN_IDS`, `getPatternBackground`.
+- `includes/features/class-svg-pattern-renderer.php` — server render + `resolve_color_value`.
+- `src/hooks/useIconDefaults.js` — canonical `useSettings('custom.designsetgo.…')` editor read.
+- `includes/features/class-icon-injector.php:134` + `src/blocks/map/render.php:45` — canonical `wp_get_global_settings(['custom','designsetgo',…])` PHP read.
+- `docs/plans/2026-07-01-shape-divider-theme-inheritance.md` — the precedent this mirrors.
+- `.claude/CLAUDE.md` → "Deprecations", "Style Imports (MANDATORY)", inspector IA notes.
+
+---
+
+## Task 0: Confirm clean baseline
+
+The worktree is already created (`.worktrees/svg-pattern-theme-inheritance`, branch `claude/svg-pattern-theme-inheritance`, off `origin/main`) with deps installed and a green unit baseline (2072 tests).
+
+**Step 1:** Re-confirm green before touching anything:
+
+```bash
+npx wp-scripts test-unit-js 2>&1 | tail -5
+```
+Expected: `Tests: 2072 passed`.
+
+**Step 2:** Commit this plan:
+
+```bash
+git add docs/plans/2026-07-07-svg-pattern-theme-inheritance.md
+git commit -m "docs: svg-pattern theme-inheritance implementation plan"
+```
+
+---
+
+## Task 1: Shared inherit constants + preset resolver (JS)
+
+Introduce the `'inherit'` sentinel and a single JS resolver that turns the theme preset (+ fallbacks) into a concrete `{ type, color, opacity, scale }`. Both the editor preview and the panel consume it, so it must be DRY.
+
+**Files:**
+- Modify: `src/extensions/svg-patterns/constants.js`
+- Create: `src/extensions/svg-patterns/utils/resolve-inherited-pattern.js`
+- Test: `tests/unit/extensions/svg-patterns/resolve-inherited-pattern.test.js`
+
+**Step 1: Add constants.** Append to `constants.js`:
+
+```js
+/**
+ * Sentinel value for dsgoSvgPatternType meaning "inherit the theme's
+ * SVG pattern preset from settings.custom.designsetgo.svgPattern".
+ */
+export const INHERIT = 'inherit';
+
+/**
+ * In-plugin fallback preset used when a block inherits but the theme
+ * (Style Kit) sets nothing. Each field falls back independently.
+ */
+export const INHERIT_FALLBACK = {
+	type: 'dot-grid',
+	color: DEFAULTS.color,
+	opacity: DEFAULTS.opacity,
+	scale: DEFAULTS.scale,
+};
+```
+
+**Step 2: Write the failing test.**
+
+```js
+// tests/unit/extensions/svg-patterns/resolve-inherited-pattern.test.js
+import { resolveInheritedPattern } from '../../../../src/extensions/svg-patterns/utils/resolve-inherited-pattern';
+import { INHERIT_FALLBACK } from '../../../../src/extensions/svg-patterns/constants';
+import { PATTERNS } from '../../../../src/extensions/svg-patterns/pattern-data';
+
+test( 'falls back to in-plugin defaults when theme preset is empty', () => {
+	expect( resolveInheritedPattern( undefined ) ).toEqual( INHERIT_FALLBACK );
+	expect( resolveInheritedPattern( {} ) ).toEqual( INHERIT_FALLBACK );
+} );
+
+test( 'uses theme values when present', () => {
+	const themed = resolveInheritedPattern( {
+		type: 'waves',
+		color: '#123456',
+		opacity: 0.2,
+		scale: 2,
+	} );
+	expect( themed ).toEqual( {
+		type: 'waves',
+		color: '#123456',
+		opacity: 0.2,
+		scale: 2,
+	} );
+} );
+
+test( 'each field falls back independently', () => {
+	const partial = resolveInheritedPattern( { type: 'grain' } );
+	expect( partial.type ).toBe( 'grain' );
+	expect( partial.color ).toBe( INHERIT_FALLBACK.color );
+	expect( partial.opacity ).toBe( INHERIT_FALLBACK.opacity );
+	expect( partial.scale ).toBe( INHERIT_FALLBACK.scale );
+} );
+
+test( 'rejects an unknown theme pattern slug and falls back', () => {
+	const bad = resolveInheritedPattern( { type: 'not-a-real-pattern' } );
+	expect( PATTERNS[ bad.type ] ).toBeDefined();
+	expect( bad.type ).toBe( INHERIT_FALLBACK.type );
+} );
+```
+
+**Step 3: Run it — verify FAIL** (module not found):
+
+```bash
+npx wp-scripts test-unit-js tests/unit/extensions/svg-patterns/resolve-inherited-pattern.test.js
+```
+
+**Step 4: Implement the resolver.** Create `utils/resolve-inherited-pattern.js`:
+
+```js
+/**
+ * SVG Patterns Extension - Inherited-preset resolver
+ *
+ * Turns a theme.json preset (settings.custom.designsetgo.svgPattern) into a
+ * concrete { type, color, opacity, scale }, applying in-plugin fallbacks per
+ * field. Shared by the editor preview and the inspector panel.
+ *
+ * @package
+ */
+
+import { INHERIT_FALLBACK } from '../constants';
+import { PATTERNS } from '../pattern-data';
+
+/**
+ * @param {?Object} preset Raw theme preset object, or nullish.
+ * @return {{type: string, color: string, opacity: number, scale: number}}
+ *         Fully-resolved pattern config.
+ */
+export function resolveInheritedPattern( preset ) {
+	const p = preset && typeof preset === 'object' ? preset : {};
+
+	const type =
+		typeof p.type === 'string' && PATTERNS[ p.type ]
+			? p.type
+			: INHERIT_FALLBACK.type;
+
+	const color =
+		typeof p.color === 'string' && p.color !== ''
+			? p.color
+			: INHERIT_FALLBACK.color;
+
+	const opacity =
+		typeof p.opacity === 'number' ? p.opacity : INHERIT_FALLBACK.opacity;
+
+	const scale =
+		typeof p.scale === 'number' ? p.scale : INHERIT_FALLBACK.scale;
+
+	return { type, color, opacity, scale };
+}
+```
+
+**Step 5: Run — verify PASS.**
+
+```bash
+npx wp-scripts test-unit-js tests/unit/extensions/svg-patterns/resolve-inherited-pattern.test.js
+```
+
+**Step 6: Commit.**
+
+```bash
+git add src/extensions/svg-patterns/constants.js \
+        src/extensions/svg-patterns/utils/resolve-inherited-pattern.js \
+        tests/unit/extensions/svg-patterns/resolve-inherited-pattern.test.js
+git commit -m "feat(svg-patterns): add inherit sentinel + theme-preset resolver"
+```
+
+---
+
+## Task 2: Save props — allow `inherit`, omit baked values (JS)
+
+Let `'inherit'` through the save guard and, when inheriting, emit only the type marker + class (the renderer supplies color/opacity/scale from the theme).
+
+**Files:**
+- Modify: `src/extensions/svg-patterns/editor.js` (`addSvgPatternSaveProps`)
+- Test: `tests/unit/extensions/svg-patterns/save-props.test.js`
+
+**Step 1: Write the failing test.** `addSvgPatternSaveProps` is not exported today — export it first (see Step 3), then:
+
+```js
+// tests/unit/extensions/svg-patterns/save-props.test.js
+import { addSvgPatternSaveProps } from '../../../../src/extensions/svg-patterns/editor';
+
+const blockType = { name: 'designsetgo/section' };
+
+test( 'explicit pattern writes color/opacity/scale data attrs', () => {
+	const props = addSvgPatternSaveProps( {}, blockType, {
+		dsgoSvgPatternEnabled: true,
+		dsgoSvgPatternType: 'waves',
+		dsgoSvgPatternColor: '#123456',
+		dsgoSvgPatternOpacity: 0.3,
+		dsgoSvgPatternScale: 2,
+	} );
+	expect( props[ 'data-dsgo-svg-pattern' ] ).toBe( 'waves' );
+	expect( props[ 'data-dsgo-svg-pattern-opacity' ] ).toBe( '0.3' );
+	expect( props[ 'data-dsgo-svg-pattern-scale' ] ).toBe( '2' );
+	expect( props.className ).toContain( 'has-dsgo-svg-pattern' );
+} );
+
+test( 'inherit writes only the type marker, omits color/opacity/scale', () => {
+	const props = addSvgPatternSaveProps( {}, blockType, {
+		dsgoSvgPatternEnabled: true,
+		dsgoSvgPatternType: 'inherit',
+	} );
+	expect( props[ 'data-dsgo-svg-pattern' ] ).toBe( 'inherit' );
+	expect( props ).not.toHaveProperty( 'data-dsgo-svg-pattern-color' );
+	expect( props ).not.toHaveProperty( 'data-dsgo-svg-pattern-opacity' );
+	expect( props ).not.toHaveProperty( 'data-dsgo-svg-pattern-scale' );
+	expect( props.className ).toContain( 'has-dsgo-svg-pattern' );
+} );
+
+test( 'disabled pattern is untouched', () => {
+	const props = addSvgPatternSaveProps( {}, blockType, {
+		dsgoSvgPatternEnabled: false,
+		dsgoSvgPatternType: 'inherit',
+	} );
+	expect( props ).not.toHaveProperty( 'data-dsgo-svg-pattern' );
+} );
+```
+
+**Step 2: Run — verify FAIL** (`addSvgPatternSaveProps` not exported / inherit rejected).
+
+```bash
+npx wp-scripts test-unit-js tests/unit/extensions/svg-patterns/save-props.test.js
+```
+
+**Step 3: Implement.** In `editor.js`:
+
+1. Add `import { INHERIT } from './constants';` (extend the existing constants import).
+2. Change `function addSvgPatternSaveProps(...)` to `export function addSvgPatternSaveProps(...)`.
+3. Update the guard so `inherit` is allowed:
+
+```js
+	const isInherit = dsgoSvgPatternType === INHERIT;
+
+	if (
+		!SUPPORTED_BLOCKS.includes(blockType.name) ||
+		!dsgoSvgPatternEnabled ||
+		!dsgoSvgPatternType ||
+		(!isInherit && !PATTERN_IDS.includes(dsgoSvgPatternType))
+	) {
+		return extraProps;
+	}
+```
+
+4. Short-circuit the inherit branch (emit marker + class only) before the existing explicit-pattern return:
+
+```js
+	if (isInherit) {
+		return {
+			...extraProps,
+			className: [extraProps.className, 'has-dsgo-svg-pattern']
+				.filter(Boolean)
+				.join(' '),
+			style: extraProps.style || {},
+			'data-dsgo-svg-pattern': INHERIT,
+		};
+	}
+```
+
+Leave the existing explicit-pattern block (color/opacity/scale data attrs) exactly as-is below it.
+
+**Step 4: Run — verify PASS.**
+
+```bash
+npx wp-scripts test-unit-js tests/unit/extensions/svg-patterns/save-props.test.js
+```
+
+**Step 5: Commit.**
+
+```bash
+git add src/extensions/svg-patterns/editor.js tests/unit/extensions/svg-patterns/save-props.test.js
+git commit -m "feat(svg-patterns): emit inherit marker in save props, omit baked preset"
+```
+
+---
+
+## Task 3: Editor live preview resolves inherit (JS)
+
+`addSvgPatternEditorStyles` must render the correct preview when a block inherits: resolve the theme preset via `useSettings`, then feed the resolved `{type,color,opacity,scale}` to `getPatternBackground`.
+
+**Files:**
+- Modify: `src/extensions/svg-patterns/editor.js` (`addSvgPatternEditorStyles`)
+
+> No new unit test — this HOC renders editor chrome (hooks + `BlockListBlock`); it's covered by the manual editor smoke test in Task 6. Keep the change minimal and obviously correct.
+
+**Step 1:** Add imports to `editor.js`:
+
+```js
+import { useSettings } from '@wordpress/block-editor';
+import { INHERIT } from './constants';
+import { resolveInheritedPattern } from './utils/resolve-inherited-pattern';
+```
+
+**Step 2:** Inside the returned component, before the existing `resolvedColor` `useSelect`, read the theme preset and compute the effective config. `useSettings` must be called unconditionally (Rules of Hooks):
+
+```js
+	const isInherit = dsgoSvgPatternType === INHERIT;
+
+	// Theme preset lives at settings.custom.designsetgo.svgPattern.
+	// useSettings reads one leaf at a time; pull the four fields we need.
+	const [themeType, themeColor, themeOpacity, themeScale] = useSettings(
+		'custom.designsetgo.svgPattern.type',
+		'custom.designsetgo.svgPattern.color',
+		'custom.designsetgo.svgPattern.opacity',
+		'custom.designsetgo.svgPattern.scale'
+	);
+
+	const inherited = useMemo(
+		() =>
+			resolveInheritedPattern({
+				type: themeType,
+				color: themeColor,
+				opacity: themeOpacity,
+				scale: themeScale,
+			}),
+		[themeType, themeColor, themeOpacity, themeScale]
+	);
+```
+
+**Step 3:** Update `isActive` so `inherit` counts as active even though it isn't in `PATTERNS`:
+
+```js
+	const isActive =
+		dsgoSvgPatternEnabled &&
+		dsgoSvgPatternType &&
+		(isInherit || PATTERNS[dsgoSvgPatternType]);
+```
+
+**Step 4:** Compute the effective pattern id / color / opacity / scale, preferring the inherited preset when inheriting. The existing `resolvedColor` `useSelect` already resolves preset slugs → hex for the *block* color; when inheriting, the color comes from `inherited.color`, which may itself be a `var:preset|color|slug` or `var(--wp--preset--color--slug)` string. Normalize it through the same resolver the block color uses. Simplest correct approach: feed the effective raw color into the existing resolver by making `resolvedColor`'s dependency the effective color.
+
+Refactor the `resolvedColor` `useSelect` to resolve `effectiveRawColor` instead of `dsgoSvgPatternColor`:
+
+```js
+	const effectiveRawColor = isInherit ? inherited.color : dsgoSvgPatternColor;
+
+	const resolvedColor = useSelect(
+		(select) => {
+			if (!effectiveRawColor || typeof effectiveRawColor !== 'string') {
+				return DEFAULTS.color;
+			}
+			// Accept both var:preset|color|slug and var(--wp--preset--color--slug).
+			const presetMatch = effectiveRawColor.match(
+				/^var:preset\|color\|(.+)$/
+			);
+			const cssVarMatch = effectiveRawColor.match(
+				/^var\(--wp--preset--color--(.+)\)$/
+			);
+			const slug = presetMatch?.[1] || cssVarMatch?.[1];
+			if (!slug) {
+				return effectiveRawColor;
+			}
+			const settings = select(blockEditorStore).getSettings();
+			const colors = settings.colors || [];
+			const found = colors.find((c) => c.slug === slug);
+			return found?.color || DEFAULTS.color;
+		},
+		[effectiveRawColor]
+	);
+```
+
+**Step 5:** Update the `bg` `useMemo` to use the effective type/opacity/scale:
+
+```js
+	const bg = useMemo(() => {
+		if (!isActive) {
+			return null;
+		}
+		const effType = isInherit ? inherited.type : dsgoSvgPatternType;
+		const effOpacity = isInherit
+			? inherited.opacity
+			: dsgoSvgPatternOpacity ?? DEFAULTS.opacity;
+		const effScale = isInherit
+			? inherited.scale
+			: dsgoSvgPatternScale ?? DEFAULTS.scale;
+		return getPatternBackground(
+			effType,
+			resolvedColor,
+			effOpacity,
+			effScale
+		);
+	}, [
+		isActive,
+		isInherit,
+		inherited,
+		dsgoSvgPatternType,
+		resolvedColor,
+		dsgoSvgPatternOpacity,
+		dsgoSvgPatternScale,
+	]);
+```
+
+The rest of the HOC (wrapperProps assembly, `dsgoSvgPatternFixed`) is unchanged.
+
+**Step 6: Build to confirm no syntax/lint break.**
+
+```bash
+npm run build 2>&1 | tail -5 && npx wp-scripts test-unit-js 2>&1 | tail -5
+```
+Expected: build succeeds; all unit tests still pass.
+
+**Step 7: Commit.**
+
+```bash
+git add src/extensions/svg-patterns/editor.js
+git commit -m "feat(svg-patterns): resolve inherited theme preset in editor preview"
+```
+
+---
+
+## Task 4: Panel — "Theme default" tile + hide baked controls (JS)
+
+Add the opt-in UI: a "Theme default" tile at the top of the picker (previewing the resolved theme pattern), and hide Color / Opacity / Scale while inheriting.
+
+**Files:**
+- Modify: `src/extensions/svg-patterns/components/SvgPatternsPanel.js`
+
+**Step 1:** Add imports:
+
+```js
+import { useSettings } from '@wordpress/block-editor';
+import { INHERIT } from '../constants';
+import { resolveInheritedPattern } from '../utils/resolve-inherited-pattern';
+```
+
+**Step 2:** Inside the component, compute the inherited preset (same `useSettings` read as Task 3) and `const isInherit = dsgoSvgPatternType === INHERIT;`.
+
+**Step 3:** Render a "Theme default" tile as the first item in the picker (before the category groups). Reuse `PatternThumbnail`-style markup but preview the *resolved* theme pattern:
+
+```jsx
+{/* Theme default (inherit) tile */}
+<div className="dsgo-svg-pattern-picker__group">
+	<div className="dsgo-svg-pattern-picker__group-label">
+		{__('Theme', 'designsetgo')}
+	</div>
+	<div className="dsgo-svg-pattern-picker__grid">
+		<PatternThumbnail
+			patternId={inherited.type}
+			isActive={isInherit}
+			onClick={() =>
+				setAttributes({ dsgoSvgPatternType: INHERIT })
+			}
+			label={__('Theme default', 'designsetgo')}
+		/>
+	</div>
+</div>
+```
+
+Extend `PatternThumbnail` to accept an optional `label` prop overriding `pattern.label` (default to `pattern.label` when omitted) so the tooltip reads "Theme default".
+
+**Step 4:** Update the "Selected:" line so inherit shows a friendly label:
+
+```jsx
+<strong>
+	{isInherit
+		? __('Theme default', 'designsetgo')
+		: PATTERNS[dsgoSvgPatternType]?.label}
+</strong>
+```
+
+**Step 5:** Gate the baked controls. Wrap the **Color** `InspectorControls group="color"` block and the **Opacity** + **Scale** `RangeControl`s so they only render when `!isInherit`. When inheriting, show a short note in their place inside the main panel:
+
+```jsx
+{isInherit && (
+	<p className="dsgo-svg-pattern-picker__inherit-note">
+		{__(
+			'Pattern, color, opacity and scale are inherited from your theme. Choose a pattern above to customize them.',
+			'designsetgo'
+		)}
+	</p>
+)}
+```
+
+Keep the **Enable**, **Fixed**, and **Clear** controls available in all states. (Fixed stays per-block.) The color panel condition becomes `dsgoSvgPatternEnabled && dsgoSvgPatternType && !isInherit`.
+
+**Step 6: Build + lint.**
+
+```bash
+npm run build 2>&1 | tail -5 && npm run lint:js 2>&1 | tail -15
+```
+Expected: clean build, no new lint errors in the touched files.
+
+**Step 7: Commit.**
+
+```bash
+git add src/extensions/svg-patterns/components/SvgPatternsPanel.js
+git commit -m "feat(svg-patterns): add Theme default tile, hide baked controls while inheriting"
+```
+
+---
+
+## Task 5: PHP renderer resolves inherit from global settings
+
+Mirror the JS resolver server-side: when `data-dsgo-svg-pattern` is `inherit`, pull the preset from `wp_get_global_settings(['custom','designsetgo','svgPattern'])` and apply the same fallbacks.
+
+**Files:**
+- Modify: `includes/features/class-svg-pattern-renderer.php`
+
+**Step 1:** Add a private fallback constant + resolver method. Near the top of the class add:
+
+```php
+	/**
+	 * In-plugin fallback preset for inherited SVG patterns (mirrors the JS
+	 * INHERIT_FALLBACK in constants.js). Used when the theme sets nothing.
+	 *
+	 * @var array{type:string,color:string,opacity:float,scale:float}
+	 */
+	private const INHERIT_FALLBACK = array(
+		'type'    => 'dot-grid',
+		'color'   => '#9c92ac',
+		'opacity' => 0.4,
+		'scale'   => 1.0,
+	);
+```
+
+Add the resolver method (mirrors `resolveInheritedPattern`):
+
+```php
+	/**
+	 * Resolve the inherited SVG pattern preset from theme global settings,
+	 * applying per-field in-plugin fallbacks.
+	 *
+	 * @param array $patterns Known pattern definitions (allowlist for type).
+	 * @return array{type:string,color:string,opacity:float,scale:float}
+	 */
+	private function resolve_inherited_pattern( $patterns ) {
+		$preset = wp_get_global_settings( array( 'custom', 'designsetgo', 'svgPattern' ) );
+		if ( ! is_array( $preset ) ) {
+			$preset = array();
+		}
+
+		$type = isset( $preset['type'] ) && is_string( $preset['type'] ) && isset( $patterns[ $preset['type'] ] )
+			? $preset['type']
+			: self::INHERIT_FALLBACK['type'];
+
+		$color = isset( $preset['color'] ) && is_string( $preset['color'] ) && '' !== $preset['color']
+			? $preset['color']
+			: self::INHERIT_FALLBACK['color'];
+
+		$opacity = isset( $preset['opacity'] ) && is_numeric( $preset['opacity'] )
+			? (float) $preset['opacity']
+			: self::INHERIT_FALLBACK['opacity'];
+
+		$scale = isset( $preset['scale'] ) && is_numeric( $preset['scale'] )
+			? (float) $preset['scale']
+			: self::INHERIT_FALLBACK['scale'];
+
+		return array(
+			'type'    => $type,
+			'color'   => $color,
+			'opacity' => $opacity,
+			'scale'   => $scale,
+		);
+	}
+```
+
+> Note: theme `color` may be `var(--wp--preset--color--slug)` — the existing `resolve_color_value()` already converts that to hex, and the inject flow runs the color through it (Step 2), so no extra handling is needed.
+
+**Step 2:** In `inject_svg_pattern()`, branch on `inherit` right after validating `$pattern_type` is non-empty and BEFORE the `isset( $patterns[ $pattern_type ] )` allowlist check (because `inherit` is not a pattern key):
+
+```php
+		$pattern_type = $processor->get_attribute( 'data-dsgo-svg-pattern' );
+		if ( empty( $pattern_type ) ) {
+			return $block_content;
+		}
+
+		$patterns = $this->get_patterns();
+
+		if ( 'inherit' === $pattern_type ) {
+			$preset       = $this->resolve_inherited_pattern( $patterns );
+			$pattern_type = $preset['type'];
+			$color        = $preset['color'];
+			$opacity      = $preset['opacity'];
+			$scale        = $preset['scale'];
+		} else {
+			// Validate pattern type against known patterns (allowlist).
+			if ( ! isset( $patterns[ $pattern_type ] ) ) {
+				return $block_content;
+			}
+			$color   = $processor->get_attribute( 'data-dsgo-svg-pattern-color' );
+			$color   = $color ? $color : '#9c92ac';
+			$opacity = (float) ( $processor->get_attribute( 'data-dsgo-svg-pattern-opacity' ) ?? 0.4 );
+			$scale   = (float) ( $processor->get_attribute( 'data-dsgo-svg-pattern-scale' ) ?? 1 );
+		}
+
+		// Shared normalization for both paths.
+		$color   = sanitize_text_field( $this->resolve_color_value( sanitize_text_field( $color ) ) );
+		$opacity = max( 0.05, min( 1, $opacity ) );
+		$scale   = max( 0.25, min( 4, $scale ) );
+```
+
+Remove the now-duplicated `$color`/`$opacity`/`$scale`/clamp lines that previously sat below (they're folded into the branch above). The rest of the method (`$cache_key`, SVG build, style injection, `dsgoSvgPatternFixed` from `$block['attrs']`) is unchanged and works for both paths.
+
+> `dsgoSvgPatternFixed` is still read from `$block['attrs']`, so the per-block Fixed toggle keeps working even while inheriting. Good.
+
+**Step 3: Lint PHP.**
+
+```bash
+npm run lint:php 2>&1 | tail -20
+```
+Expected: no new errors in `class-svg-pattern-renderer.php`.
+
+**Step 4: Commit.**
+
+```bash
+git add includes/features/class-svg-pattern-renderer.php
+git commit -m "feat(svg-patterns): resolve inherited theme preset in PHP renderer"
+```
+
+---
+
+## Task 6: Editor + frontend verification (manual)
+
+**Prereqs:** `npm run build` done; wp-env running (`npx wp-env start`).
+
+**Step 1: No-kit fallback (editor).** Insert a Section (or core Group). SVG Pattern panel → Enable. Confirm a **"Theme default"** tile appears first and previews the `dot-grid` fallback. Select it → confirm the live editor preview shows dots and the Color / Opacity / Scale controls disappear, replaced by the inherit note. Enable / Fixed / Clear remain.
+
+**Step 2: No-kit fallback (frontend).** Save + view the post. Confirm the pattern renders (server injects `dot-grid` at `#9c92ac`, opacity `0.4`, scale `1`). View source: the block carries `data-dsgo-svg-pattern="inherit"` and no baked color/opacity/scale attrs, and the rendered `style` has `--dsgo-svg-pattern-image`/`--dsgo-svg-pattern-size`.
+
+**Step 3: Themed preset.** Temporarily add to the active theme's `theme.json` (or a child) under `settings.custom`:
+
+```json
+"designsetgo": { "svgPattern": { "type": "waves", "color": "var(--wp--preset--color--primary)", "opacity": 0.15, "scale": 2 } }
+```
+
+Reload editor: the "Theme default" tile + inheriting blocks now preview **waves** in the primary color at the themed opacity/scale. Frontend matches. Remove the temp theme.json edit after.
+
+**Step 4: Explicit still works.** Pick an explicit pattern (e.g. Hexagons) on the same block → controls reappear, baked data attrs return, renders independently of the theme preset.
+
+**Step 5: Fixed while inheriting.** With Theme default selected, toggle Fixed → confirm `--dsgo-svg-pattern-attachment:fixed` appears on the frontend element.
+
+**Step 6: Record results** in the PR description / commit notes (editor + frontend, both `core/group` and `designsetgo/section`).
+
+---
+
+## Task 7: Full verification + finish
+
+**Step 1: Full gate (per CLAUDE.md pre-commit).**
+
+```bash
+npm run build && npm run lint:js && npm run lint:css && npm run lint:php
+npx wp-scripts test-unit-js 2>&1 | tail -5
+```
+Expected: all green; unit count = 2072 + new tests.
+
+**Step 2: Confirm no deprecation regressions.** Open an existing post that used an explicit SVG pattern saved before this change → confirm it still renders and shows no "Attempt Recovery" (the existing `legacyColorDeprecation` is untouched; `inherit` only affects new content).
+
+**Step 3:** Finish per superpowers:finishing-a-development-branch (PR or merge). PR body should note the companion `native-ui` change that sets `settings.custom.designsetgo.svgPattern` is a separate repo/PR.
+
+---
+
+## Risks & Notes
+
+- **`useSettings` multi-return:** `useSettings('a','b',...)` returns an array in argument order. Keep the destructure order aligned with the paths.
+- **Color format from theme:** the theme `color` may be a raw hex, a `var(--wp--preset--color--slug)`, or a `var:preset|color|slug`. PHP `resolve_color_value()` handles the `var(--wp--preset--color--slug)` form; the editor resolver (Task 3, Step 4) handles both `var:` and `var(--wp--…)`. Raw hex passes through both. If a kit stores a bare slug (no `var()`), it will fall through as an invalid color and the SVG builder swaps in `#9c92ac` — acceptable; document that kits should use `var(--wp--preset--color--slug)`.
+- **No schema change / no new deprecation:** `inherit` is a new *value* of an existing `string` attribute. Existing content is byte-identical; the existing `legacyColorDeprecation` stays. Do NOT add a deprecation.
+- **`isActive` gate:** `inherit` is deliberately not in `PATTERNS`/`PATTERN_IDS`, so every `PATTERNS[type]` / `PATTERN_IDS.includes(type)` guard must special-case it (Tasks 2–4). Grep for those guards before finishing.
+- **Style imports:** no new CSS classes are introduced (reuse `has-dsgo-svg-pattern` + existing `--dsgo-svg-pattern-*` vars), so the MANDATORY style-import check is N/A — but the tiny `dsgo-svg-pattern-picker__inherit-note` styling, if any, goes in the extension's existing `editor.scss` (editor-only; the note never renders on the frontend).
+- **Scope:** the Style-Kit value under `settings.custom.designsetgo.svgPattern` lives in the external `native-ui` repo — a separate PR, exactly like shape-divider Task 8.

--- a/includes/features/class-svg-pattern-renderer.php
+++ b/includes/features/class-svg-pattern-renderer.php
@@ -77,7 +77,9 @@ class SVG_Pattern_Renderer {
 	 * @return array{type:string,color:string,opacity:float,scale:float}
 	 */
 	private function resolve_inherited_pattern( $patterns ) {
-		$preset = wp_get_global_settings( array( 'custom', 'designsetgo', 'svgPattern' ) );
+		$preset = function_exists( 'wp_get_global_settings' )
+			? wp_get_global_settings( array( 'custom', 'designsetgo', 'svgPattern' ) )
+			: null;
 		if ( ! is_array( $preset ) ) {
 			$preset = array();
 		}
@@ -90,11 +92,14 @@ class SVG_Pattern_Renderer {
 			? $preset['color']
 			: self::INHERIT_FALLBACK['color'];
 
-		$opacity = isset( $preset['opacity'] ) && is_numeric( $preset['opacity'] )
+		// Match the JS resolver's strict numeric check: accept only real
+		// int/float values (theme.json numbers parse as such), not numeric
+		// strings, so editor preview and frontend never diverge.
+		$opacity = isset( $preset['opacity'] ) && ( is_int( $preset['opacity'] ) || is_float( $preset['opacity'] ) )
 			? (float) $preset['opacity']
 			: self::INHERIT_FALLBACK['opacity'];
 
-		$scale = isset( $preset['scale'] ) && is_numeric( $preset['scale'] )
+		$scale = isset( $preset['scale'] ) && ( is_int( $preset['scale'] ) || is_float( $preset['scale'] ) )
 			? (float) $preset['scale']
 			: self::INHERIT_FALLBACK['scale'];
 

--- a/includes/features/class-svg-pattern-renderer.php
+++ b/includes/features/class-svg-pattern-renderer.php
@@ -38,6 +38,16 @@ class SVG_Pattern_Renderer {
 	private $svg_cache = array();
 
 	/**
+	 * Per-request cache of the resolved inherited preset.
+	 *
+	 * The theme preset can't change within a request, so resolve it once
+	 * rather than per inheriting block (mirrors the get_patterns() cache).
+	 *
+	 * @var array{type:string,color:string,opacity:float,scale:float}|null
+	 */
+	private $inherited_preset = null;
+
+	/**
 	 * In-plugin fallback preset for inherited SVG patterns (mirrors the JS
 	 * INHERIT_FALLBACK in constants.js). Used when the theme sets nothing.
 	 *
@@ -77,6 +87,10 @@ class SVG_Pattern_Renderer {
 	 * @return array{type:string,color:string,opacity:float,scale:float}
 	 */
 	private function resolve_inherited_pattern( $patterns ) {
+		if ( null !== $this->inherited_preset ) {
+			return $this->inherited_preset;
+		}
+
 		$preset = function_exists( 'wp_get_global_settings' )
 			? wp_get_global_settings( array( 'custom', 'designsetgo', 'svgPattern' ) )
 			: null;
@@ -103,12 +117,14 @@ class SVG_Pattern_Renderer {
 			? (float) $preset['scale']
 			: self::INHERIT_FALLBACK['scale'];
 
-		return array(
+		$this->inherited_preset = array(
 			'type'    => $type,
 			'color'   => $color,
 			'opacity' => $opacity,
 			'scale'   => $scale,
 		);
+
+		return $this->inherited_preset;
 	}
 
 	/**

--- a/includes/features/class-svg-pattern-renderer.php
+++ b/includes/features/class-svg-pattern-renderer.php
@@ -38,6 +38,19 @@ class SVG_Pattern_Renderer {
 	private $svg_cache = array();
 
 	/**
+	 * In-plugin fallback preset for inherited SVG patterns (mirrors the JS
+	 * INHERIT_FALLBACK in constants.js). Used when the theme sets nothing.
+	 *
+	 * @var array{type:string,color:string,opacity:float,scale:float}
+	 */
+	private const INHERIT_FALLBACK = array(
+		'type'    => 'dot-grid',
+		'color'   => '#9c92ac',
+		'opacity' => 0.4,
+		'scale'   => 1.0,
+	);
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -54,6 +67,43 @@ class SVG_Pattern_Renderer {
 			$this->patterns = \designsetgo_get_svg_pattern_data();
 		}
 		return $this->patterns;
+	}
+
+	/**
+	 * Resolve the inherited SVG pattern preset from theme global settings,
+	 * applying per-field in-plugin fallbacks.
+	 *
+	 * @param array $patterns Known pattern definitions (allowlist for type).
+	 * @return array{type:string,color:string,opacity:float,scale:float}
+	 */
+	private function resolve_inherited_pattern( $patterns ) {
+		$preset = wp_get_global_settings( array( 'custom', 'designsetgo', 'svgPattern' ) );
+		if ( ! is_array( $preset ) ) {
+			$preset = array();
+		}
+
+		$type = isset( $preset['type'] ) && is_string( $preset['type'] ) && isset( $patterns[ $preset['type'] ] )
+			? $preset['type']
+			: self::INHERIT_FALLBACK['type'];
+
+		$color = isset( $preset['color'] ) && is_string( $preset['color'] ) && '' !== $preset['color']
+			? $preset['color']
+			: self::INHERIT_FALLBACK['color'];
+
+		$opacity = isset( $preset['opacity'] ) && is_numeric( $preset['opacity'] )
+			? (float) $preset['opacity']
+			: self::INHERIT_FALLBACK['opacity'];
+
+		$scale = isset( $preset['scale'] ) && is_numeric( $preset['scale'] )
+			? (float) $preset['scale']
+			: self::INHERIT_FALLBACK['scale'];
+
+		return array(
+			'type'    => $type,
+			'color'   => $color,
+			'opacity' => $opacity,
+			'scale'   => $scale,
+		);
 	}
 
 	/**
@@ -246,19 +296,27 @@ class SVG_Pattern_Renderer {
 			return $block_content;
 		}
 
-		// Validate pattern type against known patterns (allowlist).
 		$patterns = $this->get_patterns();
-		if ( ! isset( $patterns[ $pattern_type ] ) ) {
-			return $block_content;
+
+		if ( 'inherit' === $pattern_type ) {
+			$preset       = $this->resolve_inherited_pattern( $patterns );
+			$pattern_type = $preset['type'];
+			$color        = $preset['color'];
+			$opacity      = $preset['opacity'];
+			$scale        = $preset['scale'];
+		} else {
+			// Validate pattern type against known patterns (allowlist).
+			if ( ! isset( $patterns[ $pattern_type ] ) ) {
+				return $block_content;
+			}
+			$color   = $processor->get_attribute( 'data-dsgo-svg-pattern-color' );
+			$color   = $color ? $color : '#9c92ac';
+			$opacity = (float) ( $processor->get_attribute( 'data-dsgo-svg-pattern-opacity' ) ?? 0.4 );
+			$scale   = (float) ( $processor->get_attribute( 'data-dsgo-svg-pattern-scale' ) ?? 1 );
 		}
 
-		$color = $processor->get_attribute( 'data-dsgo-svg-pattern-color' );
-		$color = sanitize_text_field( $color ? $color : '#9c92ac' );
-		$color = sanitize_text_field( $this->resolve_color_value( $color ) );
-		$opacity = (float) ( $processor->get_attribute( 'data-dsgo-svg-pattern-opacity' ) ?? 0.4 );
-		$scale   = (float) ( $processor->get_attribute( 'data-dsgo-svg-pattern-scale' ) ?? 1 );
-
-		// Clamp values.
+		// Shared normalization for both paths.
+		$color   = sanitize_text_field( $this->resolve_color_value( sanitize_text_field( $color ) ) );
 		$opacity = max( 0.05, min( 1, $opacity ) );
 		$scale   = max( 0.25, min( 4, $scale ) );
 

--- a/includes/features/class-svg-pattern-renderer.php
+++ b/includes/features/class-svg-pattern-renderer.php
@@ -116,9 +116,10 @@ class SVG_Pattern_Renderer {
 	 *
 	 * CSS variables cannot be used inside SVG data URIs because the SVG
 	 * is an external document that doesn't inherit the page's CSS custom
-	 * properties. This method extracts the slug from
-	 * "var(--wp--preset--color--{slug})" and looks up the actual hex
-	 * value in the global settings palette.
+	 * properties. This method extracts the slug from either the CSS-var form
+	 * "var(--wp--preset--color--{slug})" or the block-attribute shorthand
+	 * "var:preset|color|{slug}" and looks up the actual hex value in the
+	 * global settings palette.
 	 *
 	 * @param string $color Color value, possibly a CSS variable.
 	 * @return string Resolved hex color or the original value.
@@ -128,8 +129,11 @@ class SVG_Pattern_Renderer {
 			return $color;
 		}
 
-		// Match CSS variable format: var(--wp--preset--color--{slug}).
-		if ( ! preg_match( '/^var\(--wp--preset--color--(.+)\)$/', $color, $matches ) ) {
+		// Accept both the CSS-var form var(--wp--preset--color--{slug}) and the
+		// block-attribute shorthand var:preset|color|{slug}, mirroring the
+		// editor resolver so inherited theme colors resolve identically.
+		if ( ! preg_match( '/^var\(--wp--preset--color--(.+)\)$/', $color, $matches )
+			&& ! preg_match( '/^var:preset\|color\|(.+)$/', $color, $matches ) ) {
 			return $color;
 		}
 

--- a/src/extensions/svg-patterns/components/SvgPatternsPanel.js
+++ b/src/extensions/svg-patterns/components/SvgPatternsPanel.js
@@ -20,8 +20,9 @@ import {
 	InspectorControls,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
+	useSettings,
 } from '@wordpress/block-editor';
-import { RANGES, DEFAULTS } from '../constants';
+import { RANGES, DEFAULTS, INHERIT } from '../constants';
 import {
 	PATTERNS,
 	PATTERN_IDS,
@@ -32,6 +33,7 @@ import {
 	encodeColorValue,
 	decodeColorValue,
 } from '../../../utils/encode-color-value';
+import { resolveInheritedPattern } from '../utils/resolve-inherited-pattern';
 
 /**
  * Pattern thumbnail preview
@@ -40,9 +42,10 @@ import {
  * @param {string}   props.patternId Pattern ID
  * @param {boolean}  props.isActive  Whether this pattern is selected
  * @param {Function} props.onClick   Click handler
+ * @param {string}   [props.label]   Optional label override for the tooltip
  * @return {JSX.Element} Pattern thumbnail
  */
-function PatternThumbnail({ patternId, isActive, onClick }) {
+function PatternThumbnail({ patternId, isActive, onClick, label }) {
 	const pattern = PATTERNS[patternId];
 	const bg = useMemo(
 		() => getPatternBackground(patternId, '#6b7280', 0.6, 1),
@@ -57,7 +60,7 @@ function PatternThumbnail({ patternId, isActive, onClick }) {
 		<Button
 			className={`dsgo-svg-pattern-thumb${isActive ? ' is-active' : ''}`}
 			onClick={onClick}
-			label={pattern.label}
+			label={label || pattern.label}
 			showTooltip
 		>
 			<span
@@ -95,6 +98,26 @@ export default function SvgPatternsPanel({
 		dsgoSvgPatternFixed,
 	} = attributes;
 
+	const isInherit = dsgoSvgPatternType === INHERIT;
+
+	const [themeType, themeColor, themeOpacity, themeScale] = useSettings(
+		'custom.designsetgo.svgPattern.type',
+		'custom.designsetgo.svgPattern.color',
+		'custom.designsetgo.svgPattern.opacity',
+		'custom.designsetgo.svgPattern.scale'
+	);
+
+	const inherited = useMemo(
+		() =>
+			resolveInheritedPattern({
+				type: themeType,
+				color: themeColor,
+				opacity: themeOpacity,
+				scale: themeScale,
+			}),
+		[themeType, themeColor, themeOpacity, themeScale]
+	);
+
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
 
 	// Group patterns by category
@@ -113,7 +136,7 @@ export default function SvgPatternsPanel({
 	return (
 		<Fragment>
 			{/* Color Settings - In Styles > Color Panel */}
-			{dsgoSvgPatternEnabled && dsgoSvgPatternType && (
+			{dsgoSvgPatternEnabled && dsgoSvgPatternType && !isInherit && (
 				<InspectorControls group="color">
 					<ColorGradientSettingsDropdown
 						panelId={clientId}
@@ -165,6 +188,28 @@ export default function SvgPatternsPanel({
 						<>
 							{/* Pattern Picker */}
 							<div className="dsgo-svg-pattern-picker">
+								{/* Theme default (inherit) tile */}
+								<div className="dsgo-svg-pattern-picker__group">
+									<div className="dsgo-svg-pattern-picker__group-label">
+										{__('Theme', 'designsetgo')}
+									</div>
+									<div className="dsgo-svg-pattern-picker__grid">
+										<PatternThumbnail
+											patternId={inherited.type}
+											isActive={isInherit}
+											onClick={() =>
+												setAttributes({
+													dsgoSvgPatternType: INHERIT,
+												})
+											}
+											label={__(
+												'Theme default',
+												'designsetgo'
+											)}
+										/>
+									</div>
+								</div>
+
 								{Object.entries(CATEGORIES).map(
 									([catKey, catLabel]) => {
 										const ids = groupedPatterns[catKey];
@@ -211,10 +256,13 @@ export default function SvgPatternsPanel({
 									<span>
 										{__('Selected:', 'designsetgo')}{' '}
 										<strong>
-											{
-												PATTERNS[dsgoSvgPatternType]
-													?.label
-											}
+											{isInherit
+												? __(
+														'Theme default',
+														'designsetgo'
+													)
+												: PATTERNS[dsgoSvgPatternType]
+														?.label}
 										</strong>
 									</span>
 									<Button
@@ -231,37 +279,56 @@ export default function SvgPatternsPanel({
 								</HStack>
 							)}
 
-							{/* Opacity Control */}
-							<RangeControl
-								label={__('Pattern Opacity', 'designsetgo')}
-								value={dsgoSvgPatternOpacity}
-								onChange={(value) =>
-									setAttributes({
-										dsgoSvgPatternOpacity: value,
-									})
-								}
-								min={RANGES.opacity.min}
-								max={RANGES.opacity.max}
-								step={RANGES.opacity.step}
-							/>
+							{!isInherit && (
+								<>
+									{/* Opacity Control */}
+									<RangeControl
+										label={__(
+											'Pattern Opacity',
+											'designsetgo'
+										)}
+										value={dsgoSvgPatternOpacity}
+										onChange={(value) =>
+											setAttributes({
+												dsgoSvgPatternOpacity: value,
+											})
+										}
+										min={RANGES.opacity.min}
+										max={RANGES.opacity.max}
+										step={RANGES.opacity.step}
+									/>
 
-							{/* Scale Control */}
-							<RangeControl
-								label={__('Pattern Scale', 'designsetgo')}
-								value={dsgoSvgPatternScale}
-								onChange={(value) =>
-									setAttributes({
-										dsgoSvgPatternScale: value,
-									})
-								}
-								min={RANGES.scale.min}
-								max={RANGES.scale.max}
-								step={RANGES.scale.step}
-								help={__(
-									'Scale the pattern size. 1 = original size.',
-									'designsetgo'
-								)}
-							/>
+									{/* Scale Control */}
+									<RangeControl
+										label={__(
+											'Pattern Scale',
+											'designsetgo'
+										)}
+										value={dsgoSvgPatternScale}
+										onChange={(value) =>
+											setAttributes({
+												dsgoSvgPatternScale: value,
+											})
+										}
+										min={RANGES.scale.min}
+										max={RANGES.scale.max}
+										step={RANGES.scale.step}
+										help={__(
+											'Scale the pattern size. 1 = original size.',
+											'designsetgo'
+										)}
+									/>
+								</>
+							)}
+
+							{isInherit && (
+								<p className="dsgo-svg-pattern-picker__inherit-note">
+									{__(
+										'Pattern, color, opacity and scale are inherited from your theme. Choose a pattern above to customize them.',
+										'designsetgo'
+									)}
+								</p>
+							)}
 
 							{/* Fixed Background */}
 							<ToggleControl

--- a/src/extensions/svg-patterns/components/SvgPatternsPanel.js
+++ b/src/extensions/svg-patterns/components/SvgPatternsPanel.js
@@ -20,7 +20,6 @@ import {
 	InspectorControls,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
-	useSettings,
 } from '@wordpress/block-editor';
 import { RANGES, DEFAULTS, INHERIT } from '../constants';
 import {
@@ -33,7 +32,7 @@ import {
 	encodeColorValue,
 	decodeColorValue,
 } from '../../../utils/encode-color-value';
-import { resolveInheritedPattern } from '../utils/resolve-inherited-pattern';
+import { useInheritedSvgPattern } from '../use-inherited-svg-pattern';
 
 /**
  * Pattern thumbnail preview
@@ -100,23 +99,8 @@ export default function SvgPatternsPanel({
 
 	const isInherit = dsgoSvgPatternType === INHERIT;
 
-	const [themeType, themeColor, themeOpacity, themeScale] = useSettings(
-		'custom.designsetgo.svgPattern.type',
-		'custom.designsetgo.svgPattern.color',
-		'custom.designsetgo.svgPattern.opacity',
-		'custom.designsetgo.svgPattern.scale'
-	);
-
-	const inherited = useMemo(
-		() =>
-			resolveInheritedPattern({
-				type: themeType,
-				color: themeColor,
-				opacity: themeOpacity,
-				scale: themeScale,
-			}),
-		[themeType, themeColor, themeOpacity, themeScale]
-	);
+	// Resolved theme preset, shared with the editor preview HOC via this hook.
+	const inherited = useInheritedSvgPattern();
 
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
 

--- a/src/extensions/svg-patterns/constants.js
+++ b/src/extensions/svg-patterns/constants.js
@@ -36,3 +36,20 @@ export const RANGES = {
 		step: 0.25,
 	},
 };
+
+/**
+ * Sentinel value for dsgoSvgPatternType meaning "inherit the theme's
+ * SVG pattern preset from settings.custom.designsetgo.svgPattern".
+ */
+export const INHERIT = 'inherit';
+
+/**
+ * In-plugin fallback preset used when a block inherits but the theme
+ * (Style Kit) sets nothing. Each field falls back independently.
+ */
+export const INHERIT_FALLBACK = {
+	type: 'dot-grid',
+	color: DEFAULTS.color,
+	opacity: DEFAULTS.opacity,
+	scale: DEFAULTS.scale,
+};

--- a/src/extensions/svg-patterns/editor.js
+++ b/src/extensions/svg-patterns/editor.js
@@ -8,15 +8,12 @@ import { addFilter } from '@wordpress/hooks';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { Fragment, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import {
-	store as blockEditorStore,
-	useSettings,
-} from '@wordpress/block-editor';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import SvgPatternsPanel from './components/SvgPatternsPanel';
 import { SUPPORTED_BLOCKS, DEFAULTS, INHERIT } from './constants';
 import { getPatternBackground, PATTERNS, PATTERN_IDS } from './patterns';
 import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
-import { resolveInheritedPattern } from './utils/resolve-inherited-pattern';
+import { useInheritedSvgPattern } from './use-inherited-svg-pattern';
 
 /**
  * Add SVG pattern controls to the block editor
@@ -67,26 +64,9 @@ const addSvgPatternEditorStyles = createHigherOrderComponent(
 
 			const isInherit = dsgoSvgPatternType === INHERIT;
 
-			// Theme preset lives at settings.custom.designsetgo.svgPattern.
-			// useSettings reads one leaf at a time; pull the four fields we need.
-			const [themeType, themeColor, themeOpacity, themeScale] =
-				useSettings(
-					'custom.designsetgo.svgPattern.type',
-					'custom.designsetgo.svgPattern.color',
-					'custom.designsetgo.svgPattern.opacity',
-					'custom.designsetgo.svgPattern.scale'
-				);
-
-			const inherited = useMemo(
-				() =>
-					resolveInheritedPattern({
-						type: themeType,
-						color: themeColor,
-						opacity: themeOpacity,
-						scale: themeScale,
-					}),
-				[themeType, themeColor, themeOpacity, themeScale]
-			);
+			// Theme preset (settings.custom.designsetgo.svgPattern), resolved
+			// with fallbacks. Shared with the inspector panel via this hook.
+			const inherited = useInheritedSvgPattern();
 
 			const isActive =
 				dsgoSvgPatternEnabled &&

--- a/src/extensions/svg-patterns/editor.js
+++ b/src/extensions/svg-patterns/editor.js
@@ -11,7 +11,7 @@ import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import SvgPatternsPanel from './components/SvgPatternsPanel';
 import { SUPPORTED_BLOCKS, DEFAULTS, INHERIT } from './constants';
-import { getPatternBackground, PATTERNS, PATTERN_IDS } from './patterns';
+import { getPatternBackground, PATTERN_IDS } from './patterns';
 import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
 import { useInheritedSvgPattern } from './use-inherited-svg-pattern';
 
@@ -71,7 +71,7 @@ const addSvgPatternEditorStyles = createHigherOrderComponent(
 			const isActive =
 				dsgoSvgPatternEnabled &&
 				dsgoSvgPatternType &&
-				(isInherit || PATTERNS[dsgoSvgPatternType]);
+				(isInherit || PATTERN_IDS.includes(dsgoSvgPatternType));
 
 			const effectiveRawColor = isInherit
 				? inherited.color

--- a/src/extensions/svg-patterns/editor.js
+++ b/src/extensions/svg-patterns/editor.js
@@ -8,11 +8,15 @@ import { addFilter } from '@wordpress/hooks';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { Fragment, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	store as blockEditorStore,
+	useSettings,
+} from '@wordpress/block-editor';
 import SvgPatternsPanel from './components/SvgPatternsPanel';
 import { SUPPORTED_BLOCKS, DEFAULTS, INHERIT } from './constants';
 import { getPatternBackground, PATTERNS, PATTERN_IDS } from './patterns';
 import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
+import { resolveInheritedPattern } from './utils/resolve-inherited-pattern';
 
 /**
  * Add SVG pattern controls to the block editor
@@ -61,10 +65,37 @@ const addSvgPatternEditorStyles = createHigherOrderComponent(
 				dsgoSvgPatternFixed,
 			} = attributes;
 
+			const isInherit = dsgoSvgPatternType === INHERIT;
+
+			// Theme preset lives at settings.custom.designsetgo.svgPattern.
+			// useSettings reads one leaf at a time; pull the four fields we need.
+			const [themeType, themeColor, themeOpacity, themeScale] =
+				useSettings(
+					'custom.designsetgo.svgPattern.type',
+					'custom.designsetgo.svgPattern.color',
+					'custom.designsetgo.svgPattern.opacity',
+					'custom.designsetgo.svgPattern.scale'
+				);
+
+			const inherited = useMemo(
+				() =>
+					resolveInheritedPattern({
+						type: themeType,
+						color: themeColor,
+						opacity: themeOpacity,
+						scale: themeScale,
+					}),
+				[themeType, themeColor, themeOpacity, themeScale]
+			);
+
 			const isActive =
 				dsgoSvgPatternEnabled &&
 				dsgoSvgPatternType &&
-				PATTERNS[dsgoSvgPatternType];
+				(isInherit || PATTERNS[dsgoSvgPatternType]);
+
+			const effectiveRawColor = isInherit
+				? inherited.color
+				: dsgoSvgPatternColor;
 
 			// Resolve preset color slugs to hex values. CSS variables
 			// cannot be used inside SVG data URIs because the SVG is an
@@ -72,28 +103,31 @@ const addSvgPatternEditorStyles = createHigherOrderComponent(
 			const resolvedColor = useSelect(
 				(select) => {
 					if (
-						!dsgoSvgPatternColor ||
-						typeof dsgoSvgPatternColor !== 'string'
+						!effectiveRawColor ||
+						typeof effectiveRawColor !== 'string'
 					) {
 						return DEFAULTS.color;
 					}
 
-					// Parse WordPress preset format: var:preset|color|{slug}
-					const presetMatch = dsgoSvgPatternColor.match(
+					// Accept both var:preset|color|slug and var(--wp--preset--color--slug).
+					const presetMatch = effectiveRawColor.match(
 						/^var:preset\|color\|(.+)$/
 					);
-					if (!presetMatch) {
+					const cssVarMatch = effectiveRawColor.match(
+						/^var\(--wp--preset--color--(.+)\)$/
+					);
+					const slug = presetMatch?.[1] || cssVarMatch?.[1];
+					if (!slug) {
 						// Already a raw color value (hex, rgb, etc.)
-						return dsgoSvgPatternColor;
+						return effectiveRawColor;
 					}
 
-					const slug = presetMatch[1];
 					const settings = select(blockEditorStore).getSettings();
 					const colors = settings.colors || [];
 					const found = colors.find((c) => c.slug === slug);
 					return found?.color || DEFAULTS.color;
 				},
-				[dsgoSvgPatternColor]
+				[effectiveRawColor]
 			);
 
 			// Memoize SVG generation to avoid re-encoding on every render
@@ -101,14 +135,23 @@ const addSvgPatternEditorStyles = createHigherOrderComponent(
 				if (!isActive) {
 					return null;
 				}
+				const effType = isInherit ? inherited.type : dsgoSvgPatternType;
+				const effOpacity = isInherit
+					? inherited.opacity
+					: (dsgoSvgPatternOpacity ?? DEFAULTS.opacity);
+				const effScale = isInherit
+					? inherited.scale
+					: (dsgoSvgPatternScale ?? DEFAULTS.scale);
 				return getPatternBackground(
-					dsgoSvgPatternType,
+					effType,
 					resolvedColor,
-					dsgoSvgPatternOpacity ?? DEFAULTS.opacity,
-					dsgoSvgPatternScale ?? DEFAULTS.scale
+					effOpacity,
+					effScale
 				);
 			}, [
 				isActive,
+				isInherit,
+				inherited,
 				dsgoSvgPatternType,
 				resolvedColor,
 				dsgoSvgPatternOpacity,

--- a/src/extensions/svg-patterns/editor.js
+++ b/src/extensions/svg-patterns/editor.js
@@ -10,7 +10,7 @@ import { Fragment, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import SvgPatternsPanel from './components/SvgPatternsPanel';
-import { SUPPORTED_BLOCKS, DEFAULTS } from './constants';
+import { SUPPORTED_BLOCKS, DEFAULTS, INHERIT } from './constants';
 import { getPatternBackground, PATTERNS, PATTERN_IDS } from './patterns';
 import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
 
@@ -164,7 +164,7 @@ addFilter(
  * @param {Object} attributes Block attributes
  * @return {Object} Modified props
  */
-function addSvgPatternSaveProps(extraProps, blockType, attributes) {
+export function addSvgPatternSaveProps(extraProps, blockType, attributes) {
 	const {
 		dsgoSvgPatternEnabled,
 		dsgoSvgPatternType,
@@ -173,13 +173,26 @@ function addSvgPatternSaveProps(extraProps, blockType, attributes) {
 		dsgoSvgPatternScale,
 	} = attributes;
 
+	const isInherit = dsgoSvgPatternType === INHERIT;
+
 	if (
 		!SUPPORTED_BLOCKS.includes(blockType.name) ||
 		!dsgoSvgPatternEnabled ||
 		!dsgoSvgPatternType ||
-		!PATTERN_IDS.includes(dsgoSvgPatternType)
+		(!isInherit && !PATTERN_IDS.includes(dsgoSvgPatternType))
 	) {
 		return extraProps;
+	}
+
+	if (isInherit) {
+		return {
+			...extraProps,
+			className: [extraProps.className, 'has-dsgo-svg-pattern']
+				.filter(Boolean)
+				.join(' '),
+			style: extraProps.style || {},
+			'data-dsgo-svg-pattern': INHERIT,
+		};
 	}
 
 	const safeOpacity =

--- a/src/extensions/svg-patterns/editor.scss
+++ b/src/extensions/svg-patterns/editor.scss
@@ -32,6 +32,14 @@
 		margin-bottom: 12px;
 		font-size: 12px;
 	}
+
+	// Shown in place of the color/opacity/scale controls while inheriting.
+	&__inherit-note {
+		margin: 8px 0 4px;
+		font-size: 12px;
+		font-style: italic;
+		color: #757575;
+	}
 }
 
 // Pattern thumbnail button — scoped specificity to avoid !important

--- a/src/extensions/svg-patterns/patterns.js
+++ b/src/extensions/svg-patterns/patterns.js
@@ -117,10 +117,13 @@ export function getPatternBackground(patternId, color, opacity, scale = 1) {
 		return null;
 	}
 
-	const pattern = PATTERNS[patternId];
-	if (!pattern) {
+	// Own-property check, not a truthy bracket lookup: inherited
+	// Object.prototype names ("constructor", "toString", …) must not resolve
+	// to a function here and blow up the destructure below.
+	if (!Object.prototype.hasOwnProperty.call(PATTERNS, patternId)) {
 		return null;
 	}
+	const pattern = PATTERNS[patternId];
 
 	const safeScale = Math.max(0.25, Math.min(4, Number(scale) || 1));
 	const svg = buildPatternSvg(pattern, color, opacity);

--- a/src/extensions/svg-patterns/use-inherited-svg-pattern.js
+++ b/src/extensions/svg-patterns/use-inherited-svg-pattern.js
@@ -1,0 +1,33 @@
+/**
+ * SVG Patterns Extension - Inherited-preset hook
+ *
+ * Reads the theme's SVG pattern preset from
+ * settings.custom.designsetgo.svgPattern and resolves it (with per-field
+ * fallbacks) to a concrete { type, color, opacity, scale }. Shared by the
+ * editor preview HOC and the inspector panel so the two never drift.
+ *
+ * @package
+ */
+
+import { useMemo } from '@wordpress/element';
+import { useSettings } from '@wordpress/block-editor';
+import { resolveInheritedPattern } from './utils/resolve-inherited-pattern';
+
+/**
+ * @return {{type: string, color: string, opacity: number, scale: number}}
+ *         The fully-resolved inherited pattern preset.
+ */
+export function useInheritedSvgPattern() {
+	// useSettings reads one leaf at a time; pull the four fields we need.
+	const [type, color, opacity, scale] = useSettings(
+		'custom.designsetgo.svgPattern.type',
+		'custom.designsetgo.svgPattern.color',
+		'custom.designsetgo.svgPattern.opacity',
+		'custom.designsetgo.svgPattern.scale'
+	);
+
+	return useMemo(
+		() => resolveInheritedPattern({ type, color, opacity, scale }),
+		[type, color, opacity, scale]
+	);
+}

--- a/src/extensions/svg-patterns/utils/resolve-inherited-pattern.js
+++ b/src/extensions/svg-patterns/utils/resolve-inherited-pattern.js
@@ -1,0 +1,39 @@
+/**
+ * SVG Patterns Extension - Inherited-preset resolver
+ *
+ * Turns a theme.json preset (settings.custom.designsetgo.svgPattern) into a
+ * concrete { type, color, opacity, scale }, applying in-plugin fallbacks per
+ * field. Shared by the editor preview and the inspector panel.
+ *
+ * @package
+ */
+
+import { INHERIT_FALLBACK } from '../constants';
+import { PATTERNS } from '../pattern-data';
+
+/**
+ * @param {?Object} preset Raw theme preset object, or nullish.
+ * @return {{type: string, color: string, opacity: number, scale: number}}
+ *         Fully-resolved pattern config.
+ */
+export function resolveInheritedPattern(preset) {
+	const p = preset && typeof preset === 'object' ? preset : {};
+
+	const type =
+		typeof p.type === 'string' && PATTERNS[p.type]
+			? p.type
+			: INHERIT_FALLBACK.type;
+
+	const color =
+		typeof p.color === 'string' && p.color !== ''
+			? p.color
+			: INHERIT_FALLBACK.color;
+
+	const opacity =
+		typeof p.opacity === 'number' ? p.opacity : INHERIT_FALLBACK.opacity;
+
+	const scale =
+		typeof p.scale === 'number' ? p.scale : INHERIT_FALLBACK.scale;
+
+	return { type, color, opacity, scale };
+}

--- a/src/extensions/svg-patterns/utils/resolve-inherited-pattern.js
+++ b/src/extensions/svg-patterns/utils/resolve-inherited-pattern.js
@@ -8,8 +8,28 @@
  * @package
  */
 
-import { INHERIT_FALLBACK } from '../constants';
+import { INHERIT_FALLBACK, RANGES } from '../constants';
 import { PATTERNS } from '../pattern-data';
+
+/**
+ * Clamp a numeric preset value into a range, falling back when it isn't a
+ * finite number. Mirrors the PHP renderer's `max( min, min( max, value ) )`
+ * clamps so editor preview and frontend render never diverge (e.g. a theme
+ * opacity of 0 clamps to the range minimum in both places, not to the
+ * fallback in one and the minimum in the other).
+ *
+ * @param {*}      value    Raw preset value.
+ * @param {number} min      Range minimum.
+ * @param {number} max      Range maximum.
+ * @param {number} fallback Value used when `value` isn't a finite number.
+ * @return {number} Clamped value or the fallback.
+ */
+function clampNumber(value, min, max, fallback) {
+	if (typeof value !== 'number' || !Number.isFinite(value)) {
+		return fallback;
+	}
+	return Math.max(min, Math.min(max, value));
+}
 
 /**
  * @param {?Object} preset Raw theme preset object, or nullish.
@@ -29,11 +49,19 @@ export function resolveInheritedPattern(preset) {
 			? p.color
 			: INHERIT_FALLBACK.color;
 
-	const opacity =
-		typeof p.opacity === 'number' ? p.opacity : INHERIT_FALLBACK.opacity;
+	const opacity = clampNumber(
+		p.opacity,
+		RANGES.opacity.min,
+		RANGES.opacity.max,
+		INHERIT_FALLBACK.opacity
+	);
 
-	const scale =
-		typeof p.scale === 'number' ? p.scale : INHERIT_FALLBACK.scale;
+	const scale = clampNumber(
+		p.scale,
+		RANGES.scale.min,
+		RANGES.scale.max,
+		INHERIT_FALLBACK.scale
+	);
 
 	return { type, color, opacity, scale };
 }

--- a/src/extensions/svg-patterns/utils/resolve-inherited-pattern.js
+++ b/src/extensions/svg-patterns/utils/resolve-inherited-pattern.js
@@ -9,7 +9,7 @@
  */
 
 import { INHERIT_FALLBACK, RANGES } from '../constants';
-import { PATTERNS } from '../pattern-data';
+import { PATTERN_IDS } from '../pattern-data';
 
 /**
  * Clamp a numeric preset value into a range, falling back when it isn't a
@@ -39,8 +39,12 @@ function clampNumber(value, min, max, fallback) {
 export function resolveInheritedPattern(preset) {
 	const p = preset && typeof preset === 'object' ? preset : {};
 
+	// Use the PATTERN_IDS allowlist (own keys), not a truthy PATTERNS[type]
+	// bracket lookup — the latter would accept inherited Object.prototype
+	// property names like "constructor"/"toString" as valid patterns, which
+	// then crash getPatternBackground() when it destructures a missing shape.
 	const type =
-		typeof p.type === 'string' && PATTERNS[p.type]
+		typeof p.type === 'string' && PATTERN_IDS.includes(p.type)
 			? p.type
 			: INHERIT_FALLBACK.type;
 

--- a/tests/phpunit/extensions/svg-pattern-renderer-test.php
+++ b/tests/phpunit/extensions/svg-pattern-renderer-test.php
@@ -120,6 +120,52 @@ class SvgPatternRendererTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A themed color in the block-attribute shorthand (var:preset|color|slug)
+	 * resolves to its palette hex, matching the editor resolver which accepts
+	 * both that form and var(--wp--preset--color--slug).
+	 */
+	public function test_inherit_resolves_preset_slug_color_shorthand() {
+		add_filter(
+			'wp_theme_json_data_theme',
+			static function ( $theme_json ) {
+				return $theme_json->update_with(
+					array(
+						'version'  => 2,
+						'settings' => array(
+							'color'  => array(
+								'palette' => array(
+									array(
+										'slug'  => 'dsgotest',
+										'color' => '#abcdef',
+										'name'  => 'DSGo Test',
+									),
+								),
+							),
+							'custom' => array(
+								'designsetgo' => array(
+									'svgPattern' => array(
+										'type'  => 'dot-grid',
+										'color' => 'var:preset|color|dsgotest',
+									),
+								),
+							),
+						),
+					)
+				);
+			}
+		);
+		wp_clean_theme_json_cache();
+
+		$html   = '<div class="has-dsgo-svg-pattern" data-dsgo-svg-pattern="inherit"></div>';
+		$result = $this->renderer->inject_svg_pattern( $html, $this->make_block( $html ) );
+
+		// rawurlencode('#abcdef') === '%23abcdef' inside the SVG data URI.
+		$this->assertStringContainsString( '%23abcdef', $result );
+		// The in-plugin gray fallback must NOT win once the slug resolves.
+		$this->assertStringNotContainsString( '%239c92ac', $result );
+	}
+
+	/**
 	 * An unknown themed pattern slug falls back to dot-grid, not a broken render.
 	 */
 	public function test_inherit_rejects_unknown_theme_type() {

--- a/tests/phpunit/extensions/svg-pattern-renderer-test.php
+++ b/tests/phpunit/extensions/svg-pattern-renderer-test.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Tests for the SVG_Pattern_Renderer server-side inherit resolution.
+ *
+ * Covers the theme-inheritance path added alongside the JS resolver: a block
+ * whose `data-dsgo-svg-pattern` is "inherit" pulls its preset (type/color/
+ * opacity/scale) from settings.custom.designsetgo.svgPattern, falling back to
+ * the in-plugin defaults (dot-grid / #9c92ac / 0.4 / 1) per field. Explicit
+ * patterns must keep rendering byte-for-byte as before.
+ *
+ * @package DesignSetGo
+ */
+
+namespace DesignSetGo\Tests;
+
+use WP_UnitTestCase;
+use DesignSetGo\SVG_Pattern_Renderer;
+
+/**
+ * SVG Pattern Renderer Test Case.
+ */
+class SvgPatternRendererTest extends WP_UnitTestCase {
+
+	/**
+	 * Renderer instance.
+	 *
+	 * @var SVG_Pattern_Renderer
+	 */
+	private SVG_Pattern_Renderer $renderer;
+
+	/**
+	 * Set up test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->renderer = new SVG_Pattern_Renderer();
+	}
+
+	/**
+	 * Remove any injected theme.json data between tests.
+	 */
+	public function tear_down(): void {
+		remove_all_filters( 'wp_theme_json_data_theme' );
+		wp_clean_theme_json_cache();
+		parent::tear_down();
+	}
+
+	/**
+	 * Build a minimal block array for the render_block filter.
+	 *
+	 * @param string $html  Saved block HTML.
+	 * @param array  $attrs Block attributes.
+	 * @return array
+	 */
+	private function make_block( string $html, array $attrs = array() ): array {
+		return array(
+			'blockName'   => 'designsetgo/section',
+			'attrs'       => $attrs,
+			'innerBlocks' => array(),
+			'innerHTML'   => $html,
+		);
+	}
+
+	/**
+	 * Inject the given theme preset under settings.custom.designsetgo.svgPattern.
+	 *
+	 * @param array $preset Preset array (type/color/opacity/scale).
+	 */
+	private function set_theme_preset( array $preset ): void {
+		add_filter(
+			'wp_theme_json_data_theme',
+			static function ( $theme_json ) use ( $preset ) {
+				return $theme_json->update_with(
+					array(
+						'version'  => 2,
+						'settings' => array(
+							'custom' => array(
+								'designsetgo' => array(
+									'svgPattern' => $preset,
+								),
+							),
+						),
+					)
+				);
+			}
+		);
+		wp_clean_theme_json_cache();
+	}
+
+	/**
+	 * Inherit with no theme preset falls back to the dot-grid default (24x24).
+	 */
+	public function test_inherit_falls_back_to_dot_grid() {
+		$html   = '<div class="has-dsgo-svg-pattern" data-dsgo-svg-pattern="inherit"></div>';
+		$result = $this->renderer->inject_svg_pattern( $html, $this->make_block( $html ) );
+
+		$this->assertStringContainsString( '--dsgo-svg-pattern-image:url(&quot;data:image/svg+xml,', $result );
+		$this->assertStringContainsString( '--dsgo-svg-pattern-size:24px 24px', $result );
+	}
+
+	/**
+	 * Inherit adopts the themed pattern type + scale (waves 120x40 @ scale 2 => 240x80).
+	 */
+	public function test_inherit_adopts_theme_preset() {
+		$this->set_theme_preset(
+			array(
+				'type'    => 'waves',
+				'color'   => '#123456',
+				'opacity' => 0.15,
+				'scale'   => 2,
+			)
+		);
+
+		$html   = '<div class="has-dsgo-svg-pattern" data-dsgo-svg-pattern="inherit"></div>';
+		$result = $this->renderer->inject_svg_pattern( $html, $this->make_block( $html ) );
+
+		// waves is 120x40; scale 2 => 240x80. Proves the themed type + scale won.
+		$this->assertStringContainsString( '--dsgo-svg-pattern-size:240px 80px', $result );
+		$this->assertStringContainsString( '--dsgo-svg-pattern-image:url(&quot;data:image/svg+xml,', $result );
+	}
+
+	/**
+	 * An unknown themed pattern slug falls back to dot-grid, not a broken render.
+	 */
+	public function test_inherit_rejects_unknown_theme_type() {
+		$this->set_theme_preset( array( 'type' => 'not-a-real-pattern' ) );
+
+		$html   = '<div class="has-dsgo-svg-pattern" data-dsgo-svg-pattern="inherit"></div>';
+		$result = $this->renderer->inject_svg_pattern( $html, $this->make_block( $html ) );
+
+		$this->assertStringContainsString( '--dsgo-svg-pattern-size:24px 24px', $result );
+	}
+
+	/**
+	 * Explicit patterns still render from their own data attributes, unchanged.
+	 */
+	public function test_explicit_pattern_unchanged() {
+		$html   = '<div class="has-dsgo-svg-pattern" data-dsgo-svg-pattern="waves" data-dsgo-svg-pattern-color="#ff0000" data-dsgo-svg-pattern-opacity="0.3" data-dsgo-svg-pattern-scale="1"></div>';
+		$result = $this->renderer->inject_svg_pattern( $html, $this->make_block( $html ) );
+
+		// waves 120x40 at scale 1.
+		$this->assertStringContainsString( '--dsgo-svg-pattern-size:120px 40px', $result );
+		$this->assertStringContainsString( '--dsgo-svg-pattern-image:url(&quot;data:image/svg+xml,', $result );
+	}
+
+	/**
+	 * An unknown explicit pattern slug bails and leaves content untouched.
+	 */
+	public function test_unknown_explicit_pattern_bails() {
+		$html   = '<div class="has-dsgo-svg-pattern" data-dsgo-svg-pattern="not-a-real-pattern"></div>';
+		$result = $this->renderer->inject_svg_pattern( $html, $this->make_block( $html ) );
+
+		$this->assertSame( $html, $result );
+	}
+
+	/**
+	 * The per-block Fixed toggle still applies while inheriting.
+	 */
+	public function test_fixed_toggle_applies_while_inheriting() {
+		$html   = '<div class="has-dsgo-svg-pattern" data-dsgo-svg-pattern="inherit"></div>';
+		$block  = $this->make_block( $html, array( 'dsgoSvgPatternFixed' => true ) );
+		$result = $this->renderer->inject_svg_pattern( $html, $block );
+
+		$this->assertStringContainsString( '--dsgo-svg-pattern-attachment:fixed', $result );
+	}
+}

--- a/tests/phpunit/extensions/svg-pattern-renderer-test.php
+++ b/tests/phpunit/extensions/svg-pattern-renderer-test.php
@@ -40,6 +40,9 @@ class SvgPatternRendererTest extends WP_UnitTestCase {
 	 * Remove any injected theme.json data between tests.
 	 */
 	public function tear_down(): void {
+		// The renderer's constructor registers this on every set_up(); drop it
+		// so callbacks against dead instances don't accumulate across the suite.
+		remove_filter( 'render_block', array( $this->renderer, 'inject_svg_pattern' ), 10 );
 		remove_all_filters( 'wp_theme_json_data_theme' );
 		wp_clean_theme_json_cache();
 		parent::tear_down();

--- a/tests/unit/extensions/svg-patterns/get-pattern-background.test.js
+++ b/tests/unit/extensions/svg-patterns/get-pattern-background.test.js
@@ -1,0 +1,32 @@
+import {
+	getPatternBackground,
+	PATTERN_IDS,
+} from '../../../../src/extensions/svg-patterns/patterns';
+
+test('returns a background object for a known pattern id', () => {
+	const bg = getPatternBackground(PATTERN_IDS[0], '#123456', 0.4, 1);
+	expect(bg).toMatchObject({
+		backgroundImage: expect.stringContaining('data:image/svg+xml'),
+		backgroundSize: expect.any(String),
+	});
+});
+
+test('returns null for an unknown pattern id', () => {
+	expect(
+		getPatternBackground('not-a-real-pattern', '#000', 0.4, 1)
+	).toBeNull();
+});
+
+test('returns null (not a crash) for Object.prototype property names', () => {
+	// A truthy PATTERNS[id] lookup would return a function here and throw in
+	// the width/height/paths destructure; the own-property guard prevents it.
+	[
+		'constructor',
+		'toString',
+		'hasOwnProperty',
+		'valueOf',
+		'__proto__',
+	].forEach((name) => {
+		expect(getPatternBackground(name, '#000', 0.4, 1)).toBeNull();
+	});
+});

--- a/tests/unit/extensions/svg-patterns/resolve-inherited-pattern.test.js
+++ b/tests/unit/extensions/svg-patterns/resolve-inherited-pattern.test.js
@@ -1,5 +1,8 @@
 import { resolveInheritedPattern } from '../../../../src/extensions/svg-patterns/utils/resolve-inherited-pattern';
-import { INHERIT_FALLBACK } from '../../../../src/extensions/svg-patterns/constants';
+import {
+	INHERIT_FALLBACK,
+	RANGES,
+} from '../../../../src/extensions/svg-patterns/constants';
 import { PATTERNS } from '../../../../src/extensions/svg-patterns/pattern-data';
 
 test('falls back to in-plugin defaults when theme preset is empty', () => {
@@ -34,4 +37,31 @@ test('rejects an unknown theme pattern slug and falls back', () => {
 	const bad = resolveInheritedPattern({ type: 'not-a-real-pattern' });
 	expect(PATTERNS[bad.type]).toBeDefined();
 	expect(bad.type).toBe(INHERIT_FALLBACK.type);
+});
+
+test('clamps zero opacity/scale to the range minimum (matches PHP)', () => {
+	// PHP clamps opacity to >= 0.05 and scale to >= 0.25; 0 must NOT fall
+	// back to the default (which would render differently on the frontend).
+	const clamped = resolveInheritedPattern({ opacity: 0, scale: 0 });
+	expect(clamped.opacity).toBe(RANGES.opacity.min);
+	expect(clamped.scale).toBe(RANGES.scale.min);
+});
+
+test('clamps out-of-range opacity/scale to the range bounds', () => {
+	const high = resolveInheritedPattern({ opacity: 5, scale: 99 });
+	expect(high.opacity).toBe(RANGES.opacity.max);
+	expect(high.scale).toBe(RANGES.scale.max);
+
+	const low = resolveInheritedPattern({ opacity: -1, scale: -3 });
+	expect(low.opacity).toBe(RANGES.opacity.min);
+	expect(low.scale).toBe(RANGES.scale.min);
+});
+
+test('non-finite numeric values fall back to defaults', () => {
+	const nan = resolveInheritedPattern({
+		opacity: Number.NaN,
+		scale: Number.POSITIVE_INFINITY,
+	});
+	expect(nan.opacity).toBe(INHERIT_FALLBACK.opacity);
+	expect(nan.scale).toBe(INHERIT_FALLBACK.scale);
 });

--- a/tests/unit/extensions/svg-patterns/resolve-inherited-pattern.test.js
+++ b/tests/unit/extensions/svg-patterns/resolve-inherited-pattern.test.js
@@ -39,6 +39,22 @@ test('rejects an unknown theme pattern slug and falls back', () => {
 	expect(bad.type).toBe(INHERIT_FALLBACK.type);
 });
 
+test('rejects Object.prototype property names as pattern types', () => {
+	// A truthy PATTERNS[type] lookup would accept these; the PATTERN_IDS
+	// allowlist must not, or getPatternBackground() crashes downstream.
+	[
+		'constructor',
+		'toString',
+		'hasOwnProperty',
+		'valueOf',
+		'__proto__',
+	].forEach((name) => {
+		const resolved = resolveInheritedPattern({ type: name });
+		expect(resolved.type).toBe(INHERIT_FALLBACK.type);
+		expect(PATTERNS[resolved.type]).toBeDefined();
+	});
+});
+
 test('clamps zero opacity/scale to the range minimum (matches PHP)', () => {
 	// PHP clamps opacity to >= 0.05 and scale to >= 0.25; 0 must NOT fall
 	// back to the default (which would render differently on the frontend).

--- a/tests/unit/extensions/svg-patterns/resolve-inherited-pattern.test.js
+++ b/tests/unit/extensions/svg-patterns/resolve-inherited-pattern.test.js
@@ -1,0 +1,37 @@
+import { resolveInheritedPattern } from '../../../../src/extensions/svg-patterns/utils/resolve-inherited-pattern';
+import { INHERIT_FALLBACK } from '../../../../src/extensions/svg-patterns/constants';
+import { PATTERNS } from '../../../../src/extensions/svg-patterns/pattern-data';
+
+test('falls back to in-plugin defaults when theme preset is empty', () => {
+	expect(resolveInheritedPattern(undefined)).toEqual(INHERIT_FALLBACK);
+	expect(resolveInheritedPattern({})).toEqual(INHERIT_FALLBACK);
+});
+
+test('uses theme values when present', () => {
+	const themed = resolveInheritedPattern({
+		type: 'waves',
+		color: '#123456',
+		opacity: 0.2,
+		scale: 2,
+	});
+	expect(themed).toEqual({
+		type: 'waves',
+		color: '#123456',
+		opacity: 0.2,
+		scale: 2,
+	});
+});
+
+test('each field falls back independently', () => {
+	const partial = resolveInheritedPattern({ type: 'grain' });
+	expect(partial.type).toBe('grain');
+	expect(partial.color).toBe(INHERIT_FALLBACK.color);
+	expect(partial.opacity).toBe(INHERIT_FALLBACK.opacity);
+	expect(partial.scale).toBe(INHERIT_FALLBACK.scale);
+});
+
+test('rejects an unknown theme pattern slug and falls back', () => {
+	const bad = resolveInheritedPattern({ type: 'not-a-real-pattern' });
+	expect(PATTERNS[bad.type]).toBeDefined();
+	expect(bad.type).toBe(INHERIT_FALLBACK.type);
+});

--- a/tests/unit/extensions/svg-patterns/save-props.test.js
+++ b/tests/unit/extensions/svg-patterns/save-props.test.js
@@ -1,0 +1,37 @@
+import { addSvgPatternSaveProps } from '../../../../src/extensions/svg-patterns/editor';
+
+const blockType = { name: 'designsetgo/section' };
+
+test('explicit pattern writes color/opacity/scale data attrs', () => {
+	const props = addSvgPatternSaveProps({}, blockType, {
+		dsgoSvgPatternEnabled: true,
+		dsgoSvgPatternType: 'waves',
+		dsgoSvgPatternColor: '#123456',
+		dsgoSvgPatternOpacity: 0.3,
+		dsgoSvgPatternScale: 2,
+	});
+	expect(props['data-dsgo-svg-pattern']).toBe('waves');
+	expect(props['data-dsgo-svg-pattern-opacity']).toBe('0.3');
+	expect(props['data-dsgo-svg-pattern-scale']).toBe('2');
+	expect(props.className).toContain('has-dsgo-svg-pattern');
+});
+
+test('inherit writes only the type marker, omits color/opacity/scale', () => {
+	const props = addSvgPatternSaveProps({}, blockType, {
+		dsgoSvgPatternEnabled: true,
+		dsgoSvgPatternType: 'inherit',
+	});
+	expect(props['data-dsgo-svg-pattern']).toBe('inherit');
+	expect(props).not.toHaveProperty('data-dsgo-svg-pattern-color');
+	expect(props).not.toHaveProperty('data-dsgo-svg-pattern-opacity');
+	expect(props).not.toHaveProperty('data-dsgo-svg-pattern-scale');
+	expect(props.className).toContain('has-dsgo-svg-pattern');
+});
+
+test('disabled pattern is untouched', () => {
+	const props = addSvgPatternSaveProps({}, blockType, {
+		dsgoSvgPatternEnabled: false,
+		dsgoSvgPatternType: 'inherit',
+	});
+	expect(props).not.toHaveProperty('data-dsgo-svg-pattern');
+});


### PR DESCRIPTION
## Summary

Lets the SVG-pattern background (block extension on `core/group` + `designsetgo/section`) inherit a full pattern preset from theme.json / FSE global styles, mirroring the shape-divider theme-inheritance work.

- New `'inherit'` value for `dsgoSvgPatternType` — selectable via a **"Theme default"** tile in the pattern picker. It is a new attribute *value*, not a schema change, so there is **no deprecation** and existing content is untouched.
- When a block inherits, it adopts the theme preset at `settings.custom.designsetgo.svgPattern` = `{ type, color, opacity, scale }`. Each field falls back independently to an in-plugin default (`dot-grid` / `#9c92ac` / `0.4` / `1`), so it works with no Style Kit present.
- Resolution is mirrored in JS (editor preview + panel via `useSettings`) and PHP (`SVG_Pattern_Renderer` via `wp_get_global_settings`), sharing one fallback contract. Explicit patterns render byte-for-byte as before.
- While inheriting, the per-block Color / Opacity / Scale controls hide behind an explanatory note; Enable / Fixed / Clear stay. `fixed` remains a per-block toggle (not themed).
- Save side emits only `data-dsgo-svg-pattern="inherit"` + the class when inheriting (no baked color/opacity/scale); the server renderer supplies them from the theme.

The actual Style-Kit values under `settings.custom.designsetgo.svgPattern` ship in the external `native-ui` repo (separate PR); this PR provides the in-plugin fallback.

## Test Plan

- [x] JS unit suite green (2079 passing), incl. new resolver + save-props tests
- [x] PHPUnit `SvgPatternRendererTest` (6/6) — fallback, **themed preset via `wp_get_global_settings`** (waves @ scale 2 → 240×80, themed color/opacity), explicit-pattern unchanged, unknown-slug bail, fixed-while-inheriting
- [x] Build clean; lint JS / CSS / PHP clean on changed files
- [x] Browser smoke test (wp-env):
  - Editor: inherit → dot-grid fallback preview paints; panel shows "Theme default" active, hides Opacity/Scale, keeps Fixed
  - Panel regression: switching to an explicit pattern restores the controls
  - Frontend: `data-dsgo-svg-pattern="inherit"` with no leaked baked attrs; server injects a working data-URI and the pattern paints
- [x] No schema change / no deprecation (`attributes.js` untouched)
