### PR TITLE
feat(modal,scroll-slides): back hardcoded labels & overlay opacity with real attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Scrolling Gallery: native border controls** — Width, style, color, and radius replace the old single border-radius field.
 - **SVG Patterns: theme-inheritable default** — A pattern can inherit a "Theme default" preset (type, color, opacity, scale) set at the theme level, so a Style Kit can restyle every pattern site-wide; each block can still override it. (#446)
 - **Row & Grid: Style Kit overlay and hover-state variations** — Row and Grid now support the same background-overlay and hover-state style variations as Section, so a Style Kit's overlay/hover styling applies consistently across all three layout blocks. (#445, #447)
+- **Scroll Slides: overlay opacity control** — The color overlay above each slide's background is now adjustable via an "Overlay Opacity" slider instead of a fixed 80%, so contrast can be tuned when the background image is bright. Existing blocks are unchanged (they keep the 80% default).
+- **Modal: accessible label controls** — New "Accessible Label" and "Close Button Label" fields let authors customize the dialog's and close button's `aria-label` for screen readers. Both default to the previous English strings ("Modal" / "Close modal") when left empty, so existing modals are unchanged.
 
 ### Changed
 - **Icon, Divider, Map, and form field blocks render dynamically** — They always reflect the current theme and store cleaner markup; existing blocks migrate automatically.
@@ -25,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Progress Bar no longer bakes a default color into saved markup** — An unset bar/track color now inherits the theme instead of a fixed hex value. (#440)
 
 ### Bug Fixes
+- **Modal: custom accessible label now works** — The dialog's `aria-label` read a `modalLabel` attribute that was never registered, so a custom label could never take effect and it always fell back to "Modal". The attribute is now registered and wired to the new "Accessible Label" control.
 - **Icon List frontend parity** — Items show their fill / outline and stroke on the frontend, matching the editor.
 - **SVG Patterns / Form Builder color baking** — No longer bake default colors into saved markup, so they inherit the theme's colors.
 - **Abilities API quote / backslash handling** — Content with quotes or backslashes saved through AI-assisted edits is no longer altered.

--- a/src/blocks/modal/block.json
+++ b/src/blocks/modal/block.json
@@ -94,6 +94,10 @@
 			"type": "string",
 			"default": ""
 		},
+		"modalLabel": {
+			"type": "string",
+			"default": ""
+		},
 		"allowHashTrigger": {
 			"type": "boolean",
 			"default": true
@@ -217,6 +221,10 @@
 		"closeButtonSize": {
 			"type": "number",
 			"default": 24
+		},
+		"closeButtonLabel": {
+			"type": "string",
+			"default": ""
 		},
 		"closeButtonIconColor": {
 			"type": "string",

--- a/src/blocks/modal/components/CloseButtonSettings.js
+++ b/src/blocks/modal/components/CloseButtonSettings.js
@@ -109,7 +109,7 @@ export default function CloseButtonSettings({ attributes, setAttributes }) {
 			{showCloseButton && (
 				<DsgoInspectorPanel.Item
 					label={__('Close Button Label', 'designsetgo')}
-					hasValue={() => closeButtonLabel !== ''}
+					hasValue={() => closeButtonLabel.trim() !== ''}
 					onDeselect={() => setAttributes({ closeButtonLabel: '' })}
 					isShownByDefault
 				>

--- a/src/blocks/modal/components/CloseButtonSettings.js
+++ b/src/blocks/modal/components/CloseButtonSettings.js
@@ -121,7 +121,7 @@ export default function CloseButtonSettings({ attributes, setAttributes }) {
 						}
 						placeholder={__('Close modal', 'designsetgo')}
 						help={__(
-							'Accessible label for the close button (aria-label). Defaults to "Close modal" when empty.',
+							'Accessible label for the close button (aria-label). Defaults to "Close modal" when left blank.',
 							'designsetgo'
 						)}
 						__next40pxDefaultSize

--- a/src/blocks/modal/components/CloseButtonSettings.js
+++ b/src/blocks/modal/components/CloseButtonSettings.js
@@ -12,13 +12,18 @@ import { __ } from '@wordpress/i18n';
 import {
 	RangeControl,
 	SelectControl,
+	TextControl,
 	ToggleControl,
 } from '@wordpress/components';
 import { DsgoInspectorPanel } from '../../../components/shared';
 
 export default function CloseButtonSettings({ attributes, setAttributes }) {
-	const { showCloseButton, closeButtonPosition, closeButtonSize } =
-		attributes;
+	const {
+		showCloseButton,
+		closeButtonPosition,
+		closeButtonSize,
+		closeButtonLabel,
+	} = attributes;
 
 	return (
 		<>
@@ -95,6 +100,29 @@ export default function CloseButtonSettings({ attributes, setAttributes }) {
 						min={16}
 						max={48}
 						step={2}
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				</DsgoInspectorPanel.Item>
+			)}
+
+			{showCloseButton && (
+				<DsgoInspectorPanel.Item
+					label={__('Close Button Label', 'designsetgo')}
+					hasValue={() => closeButtonLabel !== ''}
+					onDeselect={() => setAttributes({ closeButtonLabel: '' })}
+					isShownByDefault
+				>
+					<TextControl
+						label={__('Close Button Label', 'designsetgo')}
+						value={closeButtonLabel}
+						onChange={(value) =>
+							setAttributes({ closeButtonLabel: value })
+						}
+						help={__(
+							'Accessible label for the close button (aria-label). Defaults to "Close modal" when empty.',
+							'designsetgo'
+						)}
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
 					/>

--- a/src/blocks/modal/components/CloseButtonSettings.js
+++ b/src/blocks/modal/components/CloseButtonSettings.js
@@ -119,6 +119,7 @@ export default function CloseButtonSettings({ attributes, setAttributes }) {
 						onChange={(value) =>
 							setAttributes({ closeButtonLabel: value })
 						}
+						placeholder={__('Close modal', 'designsetgo')}
 						help={__(
 							'Accessible label for the close button (aria-label). Defaults to "Close modal" when empty.',
 							'designsetgo'

--- a/src/blocks/modal/components/ModalSettings.js
+++ b/src/blocks/modal/components/ModalSettings.js
@@ -18,10 +18,30 @@ import {
 import { DsgoInspectorPanel } from '../../../components/shared';
 
 export default function ModalSettings({ attributes, setAttributes }) {
-	const { modalId, width, maxWidth, height, maxHeight } = attributes;
+	const { modalId, modalLabel, width, maxWidth, height, maxHeight } =
+		attributes;
 
 	return (
 		<>
+			<DsgoInspectorPanel.Item
+				label={__('Accessible Label', 'designsetgo')}
+				hasValue={() => modalLabel !== ''}
+				onDeselect={() => setAttributes({ modalLabel: '' })}
+				isShownByDefault
+			>
+				<TextControl
+					label={__('Accessible Label', 'designsetgo')}
+					value={modalLabel}
+					onChange={(value) => setAttributes({ modalLabel: value })}
+					help={__(
+						'Describes the modal for screen readers (aria-label). Defaults to "Modal" when empty.',
+						'designsetgo'
+					)}
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+			</DsgoInspectorPanel.Item>
+
 			<DsgoInspectorPanel.Item
 				label={__('Modal ID', 'designsetgo')}
 				hasValue={() =>

--- a/src/blocks/modal/components/ModalSettings.js
+++ b/src/blocks/modal/components/ModalSettings.js
@@ -35,7 +35,7 @@ export default function ModalSettings({ attributes, setAttributes }) {
 					onChange={(value) => setAttributes({ modalLabel: value })}
 					placeholder={__('Modal', 'designsetgo')}
 					help={__(
-						'Describes the modal for screen readers (aria-label). Defaults to "Modal" when empty.',
+						'Describes the modal for screen readers (aria-label). Defaults to "Modal" when left blank.',
 						'designsetgo'
 					)}
 					__next40pxDefaultSize

--- a/src/blocks/modal/components/ModalSettings.js
+++ b/src/blocks/modal/components/ModalSettings.js
@@ -33,6 +33,7 @@ export default function ModalSettings({ attributes, setAttributes }) {
 					label={__('Accessible Label', 'designsetgo')}
 					value={modalLabel}
 					onChange={(value) => setAttributes({ modalLabel: value })}
+					placeholder={__('Modal', 'designsetgo')}
 					help={__(
 						'Describes the modal for screen readers (aria-label). Defaults to "Modal" when empty.',
 						'designsetgo'

--- a/src/blocks/modal/components/ModalSettings.js
+++ b/src/blocks/modal/components/ModalSettings.js
@@ -25,7 +25,7 @@ export default function ModalSettings({ attributes, setAttributes }) {
 		<>
 			<DsgoInspectorPanel.Item
 				label={__('Accessible Label', 'designsetgo')}
-				hasValue={() => modalLabel !== ''}
+				hasValue={() => modalLabel.trim() !== ''}
 				onDeselect={() => setAttributes({ modalLabel: '' })}
 				isShownByDefault
 			>

--- a/src/blocks/modal/edit.js
+++ b/src/blocks/modal/edit.js
@@ -311,7 +311,7 @@ export default function ModalEdit({ attributes, setAttributes, clientId }) {
 										) || undefined,
 								}}
 								aria-label={
-									closeButtonLabel ||
+									closeButtonLabel?.trim() ||
 									__('Close modal', 'designsetgo')
 								}
 								disabled
@@ -361,7 +361,7 @@ export default function ModalEdit({ attributes, setAttributes, clientId }) {
 											) || undefined,
 									}}
 									aria-label={
-										closeButtonLabel ||
+										closeButtonLabel?.trim() ||
 										__('Close modal', 'designsetgo')
 									}
 									disabled

--- a/src/blocks/modal/edit.js
+++ b/src/blocks/modal/edit.js
@@ -45,6 +45,7 @@ export default function ModalEdit({ attributes, setAttributes, clientId }) {
 		showCloseButton,
 		closeButtonPosition,
 		closeButtonSize,
+		closeButtonLabel,
 		closeButtonIconColor,
 		closeButtonBgColor,
 	} = attributes;
@@ -163,9 +164,11 @@ export default function ModalEdit({ attributes, setAttributes, clientId }) {
 							animationDuration: 300,
 							overlayOpacity: 80,
 							overlayBlur: 0,
+							modalLabel: '',
 							showCloseButton: true,
 							closeButtonPosition: 'inside-top-right',
 							closeButtonSize: 24,
+							closeButtonLabel: '',
 							closeOnBackdrop: true,
 							closeOnEsc: true,
 							disableBodyScroll: true,
@@ -307,7 +310,10 @@ export default function ModalEdit({ attributes, setAttributes, clientId }) {
 											closeButtonBgColor
 										) || undefined,
 								}}
-								aria-label={__('Close modal', 'designsetgo')}
+								aria-label={
+									closeButtonLabel ||
+									__('Close modal', 'designsetgo')
+								}
 								disabled
 							>
 								<svg
@@ -354,10 +360,10 @@ export default function ModalEdit({ attributes, setAttributes, clientId }) {
 												closeButtonBgColor
 											) || undefined,
 									}}
-									aria-label={__(
-										'Close modal',
-										'designsetgo'
-									)}
+									aria-label={
+										closeButtonLabel ||
+										__('Close modal', 'designsetgo')
+									}
 									disabled
 								>
 									<svg

--- a/src/blocks/modal/save.js
+++ b/src/blocks/modal/save.js
@@ -55,9 +55,8 @@ export default function save({ attributes }) {
 		role: 'dialog',
 		'aria-modal': 'true',
 		// Use aria-label for accessibility; do not set aria-labelledby unless title element is guaranteed
-		'aria-label': attributes.modalLabel
-			? attributes.modalLabel
-			: __('Modal', 'designsetgo'),
+		'aria-label':
+			attributes.modalLabel?.trim() || __('Modal', 'designsetgo'),
 		'aria-hidden': 'true',
 		'data-dsgo-modal': 'true',
 		'data-modal-id': modalId,
@@ -104,7 +103,9 @@ export default function save({ attributes }) {
 					convertColorToCSSVar(closeButtonBgColor) || undefined,
 			}}
 			type="button"
-			aria-label={closeButtonLabel || __('Close modal', 'designsetgo')}
+			aria-label={
+				closeButtonLabel?.trim() || __('Close modal', 'designsetgo')
+			}
 		>
 			<svg
 				width="100%"

--- a/src/blocks/modal/save.js
+++ b/src/blocks/modal/save.js
@@ -43,6 +43,7 @@ export default function save({ attributes }) {
 		showCloseButton,
 		closeButtonPosition,
 		closeButtonSize,
+		closeButtonLabel,
 		closeButtonIconColor,
 		closeButtonBgColor,
 		disableBodyScroll,
@@ -103,7 +104,7 @@ export default function save({ attributes }) {
 					convertColorToCSSVar(closeButtonBgColor) || undefined,
 			}}
 			type="button"
-			aria-label={__('Close modal', 'designsetgo')}
+			aria-label={closeButtonLabel || __('Close modal', 'designsetgo')}
 		>
 			<svg
 				width="100%"

--- a/src/blocks/scroll-slides/block.json
+++ b/src/blocks/scroll-slides/block.json
@@ -36,6 +36,10 @@
 			"type": "string",
 			"default": ""
 		},
+		"overlayOpacity": {
+			"type": "number",
+			"default": 80
+		},
 		"overlayAutoApplied": {
 			"type": "boolean",
 			"default": false

--- a/src/blocks/scroll-slides/components/ScrollSlidesInspector.js
+++ b/src/blocks/scroll-slides/components/ScrollSlidesInspector.js
@@ -16,6 +16,7 @@ import {
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 } from '@wordpress/block-editor';
 import {
+	RangeControl,
 	ToggleControl,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalUnitControl as UnitControl,
@@ -42,6 +43,7 @@ export default function ScrollSlidesInspector({
 		constrainWidth,
 		contentWidth,
 		overlayColor,
+		overlayOpacity,
 		navColor,
 		navActiveColor,
 	} = attributes;
@@ -61,6 +63,7 @@ export default function ScrollSlidesInspector({
 							maxHeight: '900px',
 							constrainWidth: true,
 							contentWidth: '',
+							overlayOpacity: 80,
 						})
 					}
 				>
@@ -181,6 +184,37 @@ export default function ScrollSlidesInspector({
 									{ value: 'vw', label: 'vw' },
 								]}
 								__next40pxDefaultSize
+							/>
+						</DsgoInspectorPanel.Item>
+					)}
+
+					{overlayColor && (
+						<DsgoInspectorPanel.Item
+							label={__('Overlay Opacity', 'designsetgo')}
+							hasValue={() => overlayOpacity !== 80}
+							onDeselect={() =>
+								setAttributes({ overlayOpacity: 80 })
+							}
+							isShownByDefault
+						>
+							<RangeControl
+								label={__('Overlay Opacity', 'designsetgo')}
+								value={overlayOpacity}
+								onChange={(value) =>
+									setAttributes({
+										overlayOpacity:
+											value === undefined ? 80 : value,
+									})
+								}
+								min={0}
+								max={100}
+								step={1}
+								help={__(
+									'Opacity of the color overlay above each slide background.',
+									'designsetgo'
+								)}
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
 							/>
 						</DsgoInspectorPanel.Item>
 					)}

--- a/src/blocks/scroll-slides/edit.js
+++ b/src/blocks/scroll-slides/edit.js
@@ -37,6 +37,7 @@ export default function Edit({ attributes, setAttributes, clientId, context }) {
 		constrainWidth,
 		contentWidth,
 		overlayColor,
+		overlayOpacity,
 		navColor,
 		navActiveColor,
 	} = attributes;
@@ -172,7 +173,7 @@ export default function Edit({ attributes, setAttributes, clientId, context }) {
 			minHeight: editorHeight,
 			...(overlayColor && {
 				'--dsgo-overlay-color': convertColorToCSSVar(overlayColor),
-				'--dsgo-overlay-opacity': '0.8',
+				'--dsgo-overlay-opacity': String(overlayOpacity / 100),
 			}),
 			...(navColor && {
 				'--dsgo-nav-color': convertColorToCSSVar(navColor),

--- a/src/blocks/scroll-slides/edit.js
+++ b/src/blocks/scroll-slides/edit.js
@@ -166,6 +166,13 @@ export default function Edit({ attributes, setAttributes, clientId, context }) {
 
 	const hasEditorBg = Object.keys(editorBgStyle).length > 0;
 
+	// Clamp to [0, 100] and fall back to the 80 default for non-finite values,
+	// mirroring render.php and save.js so the preview matches the frontend.
+	const overlayOpacityFraction =
+		(Number.isFinite(overlayOpacity)
+			? Math.min(100, Math.max(0, overlayOpacity))
+			: 80) / 100;
+
 	const blockProps = useBlockProps({
 		className: blockClassName,
 		'data-dsgo-active-slide': clampedActive,
@@ -173,7 +180,7 @@ export default function Edit({ attributes, setAttributes, clientId, context }) {
 			minHeight: editorHeight,
 			...(overlayColor && {
 				'--dsgo-overlay-color': convertColorToCSSVar(overlayColor),
-				'--dsgo-overlay-opacity': String(overlayOpacity / 100),
+				'--dsgo-overlay-opacity': String(overlayOpacityFraction),
 			}),
 			...(navColor && {
 				'--dsgo-nav-color': convertColorToCSSVar(navColor),

--- a/src/blocks/scroll-slides/edit.js
+++ b/src/blocks/scroll-slides/edit.js
@@ -19,6 +19,7 @@ import { useMemo, useState } from '@wordpress/element';
  */
 import './editor.scss';
 import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
+import { overlayOpacityFraction } from '../../utils/overlay-opacity';
 import ScrollSlidesPlaceholder from './components/ScrollSlidesPlaceholder';
 import ScrollSlidesInspector from './components/ScrollSlidesInspector';
 import useQueryHostPreview, {
@@ -166,13 +167,6 @@ export default function Edit({ attributes, setAttributes, clientId, context }) {
 
 	const hasEditorBg = Object.keys(editorBgStyle).length > 0;
 
-	// Clamp to [0, 100] and fall back to the 80 default for non-finite values,
-	// mirroring render.php and save.js so the preview matches the frontend.
-	const overlayOpacityFraction =
-		(Number.isFinite(overlayOpacity)
-			? Math.min(100, Math.max(0, overlayOpacity))
-			: 80) / 100;
-
 	const blockProps = useBlockProps({
 		className: blockClassName,
 		'data-dsgo-active-slide': clampedActive,
@@ -180,7 +174,9 @@ export default function Edit({ attributes, setAttributes, clientId, context }) {
 			minHeight: editorHeight,
 			...(overlayColor && {
 				'--dsgo-overlay-color': convertColorToCSSVar(overlayColor),
-				'--dsgo-overlay-opacity': String(overlayOpacityFraction),
+				'--dsgo-overlay-opacity': String(
+					overlayOpacityFraction(overlayOpacity)
+				),
 			}),
 			...(navColor && {
 				'--dsgo-nav-color': convertColorToCSSVar(navColor),

--- a/src/blocks/scroll-slides/render.php
+++ b/src/blocks/scroll-slides/render.php
@@ -112,6 +112,9 @@ if ( ! function_exists( 'designsetgo_render_scroll_slides' ) ) {
 
 		$style_parts = array();
 		if ( '' !== $atts['overlayColor'] ) {
+			// Clamp to [0, 100] and fall back to 80 for non-numeric values. Mirrors
+			// the JS overlayOpacityFraction() util (src/utils/overlay-opacity.js)
+			// used by save.js/edit.js — keep the two in sync.
 			$overlay_opacity = is_numeric( $atts['overlayOpacity'] ) ? (float) $atts['overlayOpacity'] : 80.0;
 			$overlay_opacity = max( 0.0, min( 100.0, $overlay_opacity ) ) / 100;
 			$style_parts[]   = '--dsgo-overlay-color:' . $color_to_css( $atts['overlayColor'] );

--- a/src/blocks/scroll-slides/render.php
+++ b/src/blocks/scroll-slides/render.php
@@ -71,6 +71,7 @@ if ( ! function_exists( 'designsetgo_render_scroll_slides' ) ) {
 				'constrainWidth' => true,
 				'contentWidth'   => '',
 				'overlayColor'   => '',
+				'overlayOpacity' => 80,
 				'navColor'       => '',
 				'navActiveColor' => '',
 			)
@@ -111,8 +112,10 @@ if ( ! function_exists( 'designsetgo_render_scroll_slides' ) ) {
 
 		$style_parts = array();
 		if ( '' !== $atts['overlayColor'] ) {
-			$style_parts[] = '--dsgo-overlay-color:' . $color_to_css( $atts['overlayColor'] );
-			$style_parts[] = '--dsgo-overlay-opacity:0.8';
+			$overlay_opacity = is_numeric( $atts['overlayOpacity'] ) ? (float) $atts['overlayOpacity'] : 80.0;
+			$overlay_opacity = max( 0.0, min( 100.0, $overlay_opacity ) ) / 100;
+			$style_parts[]   = '--dsgo-overlay-color:' . $color_to_css( $atts['overlayColor'] );
+			$style_parts[]   = '--dsgo-overlay-opacity:' . rtrim( rtrim( sprintf( '%.4F', $overlay_opacity ), '0' ), '.' );
 		}
 		if ( '' !== $atts['navColor'] ) {
 			$style_parts[] = '--dsgo-nav-color:' . $color_to_css( $atts['navColor'] );

--- a/src/blocks/scroll-slides/save.js
+++ b/src/blocks/scroll-slides/save.js
@@ -7,6 +7,7 @@ import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
+import { overlayOpacityFraction } from '../../utils/overlay-opacity';
 
 export default function Save({ attributes }) {
 	const {
@@ -29,13 +30,6 @@ export default function Save({ attributes }) {
 		.filter(Boolean)
 		.join(' ');
 
-	// Clamp to [0, 100] and fall back to the 80 default for non-finite values,
-	// mirroring render.php so the JS and PHP paths agree on out-of-range input.
-	const overlayOpacityFraction =
-		(Number.isFinite(overlayOpacity)
-			? Math.min(100, Math.max(0, overlayOpacity))
-			: 80) / 100;
-
 	const blockProps = useBlockProps.save({
 		className,
 		'data-dsgo-min-height': minHeight || '100vh',
@@ -43,7 +37,9 @@ export default function Save({ attributes }) {
 		style: {
 			...(overlayColor && {
 				'--dsgo-overlay-color': convertColorToCSSVar(overlayColor),
-				'--dsgo-overlay-opacity': String(overlayOpacityFraction),
+				'--dsgo-overlay-opacity': String(
+					overlayOpacityFraction(overlayOpacity)
+				),
 			}),
 			...(navColor && {
 				'--dsgo-nav-color': convertColorToCSSVar(navColor),

--- a/src/blocks/scroll-slides/save.js
+++ b/src/blocks/scroll-slides/save.js
@@ -29,6 +29,13 @@ export default function Save({ attributes }) {
 		.filter(Boolean)
 		.join(' ');
 
+	// Clamp to [0, 100] and fall back to the 80 default for non-finite values,
+	// mirroring render.php so the JS and PHP paths agree on out-of-range input.
+	const overlayOpacityFraction =
+		(Number.isFinite(overlayOpacity)
+			? Math.min(100, Math.max(0, overlayOpacity))
+			: 80) / 100;
+
 	const blockProps = useBlockProps.save({
 		className,
 		'data-dsgo-min-height': minHeight || '100vh',
@@ -36,7 +43,7 @@ export default function Save({ attributes }) {
 		style: {
 			...(overlayColor && {
 				'--dsgo-overlay-color': convertColorToCSSVar(overlayColor),
-				'--dsgo-overlay-opacity': String(overlayOpacity / 100),
+				'--dsgo-overlay-opacity': String(overlayOpacityFraction),
 			}),
 			...(navColor && {
 				'--dsgo-nav-color': convertColorToCSSVar(navColor),

--- a/src/blocks/scroll-slides/save.js
+++ b/src/blocks/scroll-slides/save.js
@@ -15,6 +15,7 @@ export default function Save({ attributes }) {
 		constrainWidth,
 		contentWidth,
 		overlayColor,
+		overlayOpacity,
 		navColor,
 		navActiveColor,
 	} = attributes;
@@ -35,7 +36,7 @@ export default function Save({ attributes }) {
 		style: {
 			...(overlayColor && {
 				'--dsgo-overlay-color': convertColorToCSSVar(overlayColor),
-				'--dsgo-overlay-opacity': '0.8',
+				'--dsgo-overlay-opacity': String(overlayOpacity / 100),
 			}),
 			...(navColor && {
 				'--dsgo-nav-color': convertColorToCSSVar(navColor),

--- a/src/utils/overlay-opacity.js
+++ b/src/utils/overlay-opacity.js
@@ -1,0 +1,22 @@
+/**
+ * overlayOpacityFraction
+ *
+ * Convert a percent overlay-opacity attribute (0–100) into a CSS opacity
+ * fraction (0–1). Out-of-range values are clamped to [0, 100] and non-finite
+ * values fall back to the 80% default.
+ *
+ * Shared by scroll-slides save.js (frontend markup) and edit.js (editor
+ * preview) so the two paths can't drift. The PHP render path
+ * (src/blocks/scroll-slides/render.php) mirrors this same clamp/fallback and
+ * must be kept in sync manually.
+ *
+ * @param {number} percent Opacity as a percentage (0–100).
+ * @return {number} Opacity as a fraction in [0, 1].
+ */
+export function overlayOpacityFraction(percent) {
+	const clamped = Number.isFinite(percent)
+		? Math.min(100, Math.max(0, percent))
+		: 80;
+
+	return clamped / 100;
+}

--- a/src/utils/test/overlay-opacity.test.js
+++ b/src/utils/test/overlay-opacity.test.js
@@ -1,0 +1,36 @@
+/**
+ * Tests for overlayOpacityFraction — the shared percent→fraction clamp/fallback
+ * used by scroll-slides save.js and edit.js (and mirrored in render.php).
+ *
+ * @package
+ */
+
+import { overlayOpacityFraction } from '../overlay-opacity';
+
+describe('overlayOpacityFraction', () => {
+	it('maps the 80 default to 0.8 (backward compatible)', () => {
+		expect(overlayOpacityFraction(80)).toBe(0.8);
+	});
+
+	it('maps a mid-range percent to a fraction', () => {
+		expect(overlayOpacityFraction(50)).toBe(0.5);
+	});
+
+	it('preserves 0 (not treated as unset)', () => {
+		expect(overlayOpacityFraction(0)).toBe(0);
+	});
+
+	it('clamps above-range values to 1', () => {
+		expect(overlayOpacityFraction(150)).toBe(1);
+	});
+
+	it('clamps below-range values to 0', () => {
+		expect(overlayOpacityFraction(-20)).toBe(0);
+	});
+
+	it('falls back to 0.8 for non-finite values', () => {
+		expect(overlayOpacityFraction(undefined)).toBe(0.8);
+		expect(overlayOpacityFraction(NaN)).toBe(0.8);
+		expect(overlayOpacityFraction(Infinity)).toBe(0.8);
+	});
+});

--- a/tests/phpunit/blocks/scroll-slides/render-test.php
+++ b/tests/phpunit/blocks/scroll-slides/render-test.php
@@ -67,4 +67,59 @@ class DesignSetGo_Scroll_Slides_Render_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'dsgo-scroll-slides', $html );
 		$this->assertStringContainsString( 'panel one', $html );
 	}
+
+	/**
+	 * The PHP overlay-opacity formatter must produce the same fraction the JS
+	 * overlayOpacityFraction() util does (src/utils/overlay-opacity.js): the 80
+	 * default maps to 0.8, percent maps to a fraction, and out-of-range values
+	 * clamp to [0, 1]. Guards against the two hand-synced paths silently drifting.
+	 *
+	 * Regex boundaries (negative lookahead) assert the exact numeric value without
+	 * depending on how core serializes the trailing style delimiter.
+	 *
+	 * @dataProvider data_overlay_opacity
+	 *
+	 * @param int    $opacity  The overlayOpacity attribute (percent).
+	 * @param string $fraction Regex-escaped expected fraction string.
+	 */
+	public function test_query_mode_overlay_opacity_matches_js( $opacity, $fraction ) {
+		$query_id = 'slidesOpacity';
+
+		$block          = new stdClass();
+		$block->context = array( 'designsetgo/queryId' => $query_id );
+
+		$GLOBALS['designsetgo_query_items_html'] = array(
+			$query_id => '<div class="dsgo-scroll-slide">panel</div>',
+		);
+
+		$html = $this->render(
+			array(
+				'overlayColor'   => '#000000',
+				'overlayOpacity' => $opacity,
+			),
+			'',
+			$block
+		);
+
+		unset( $GLOBALS['designsetgo_query_items_html'] );
+
+		$this->assertMatchesRegularExpression(
+			'/--dsgo-overlay-opacity:' . $fraction . '(?![.\d])/',
+			$html,
+			"overlayOpacity {$opacity} should render fraction {$fraction}"
+		);
+	}
+
+	/**
+	 * @return array<string, array{0:int,1:string}> opacity => regex-escaped fraction.
+	 */
+	public function data_overlay_opacity() {
+		return array(
+			'default 80 => 0.8'      => array( 80, '0\.8' ),
+			'mid 50 => 0.5'          => array( 50, '0\.5' ),
+			'zero preserved'         => array( 0, '0' ),
+			'above range clamps to 1' => array( 150, '1' ),
+			'below range clamps to 0' => array( -20, '0' ),
+		);
+	}
 }

--- a/tests/unit/modal-labels.test.js
+++ b/tests/unit/modal-labels.test.js
@@ -1,0 +1,84 @@
+/**
+ * Modal Block - accessible label attributes in save()
+ *
+ * Covers the two aria-label fallbacks the recent PR made configurable:
+ *  - the dialog wrapper's `modalLabel` (previously a dead attribute reference
+ *    that always fell back to "Modal"), and
+ *  - the close button's `closeButtonLabel` (previously hardcoded "Close modal").
+ *
+ * For each: an empty value and a whitespace-only value must fall back to the
+ * meaningful default (a blank/space-only aria-label is worse than the default
+ * for screen readers), and a real value must pass through verbatim.
+ *
+ * The existing tests/unit/modal.test.js only exercises the frontend DSGModal
+ * interactivity class, not the save() markup — this file covers save().
+ *
+ * @package
+ */
+
+// @wordpress/block-editor ships its own nested copy of @wordpress/blocks.
+// useBlockProps.save() (used by the block's save()) resolves block supports
+// against THAT copy's registry, so registration/serialization must go through
+// the same instance.
+const {
+	registerBlockType,
+	unregisterBlockType,
+	createBlock,
+	serialize,
+} = require('@wordpress/block-editor/node_modules/@wordpress/blocks');
+
+import metadata from '../../src/blocks/modal/block.json';
+import save from '../../src/blocks/modal/save';
+
+const html = (attributes) => serialize(createBlock(metadata.name, attributes));
+
+describe('Modal save() - accessible labels', () => {
+	beforeAll(() => {
+		// The custom 'designsetgo' category isn't registered in the jest
+		// environment; category is irrelevant to save serialization, so use a
+		// built-in one to avoid an unrelated invalid-category warning.
+		registerBlockType(metadata.name, {
+			...metadata,
+			category: 'design',
+			save,
+		});
+	});
+
+	afterAll(() => {
+		unregisterBlockType(metadata.name);
+	});
+
+	describe('dialog aria-label (modalLabel)', () => {
+		it('falls back to the default when empty', () => {
+			expect(html({})).toContain('aria-label="Modal"');
+		});
+
+		it('falls back to the default when whitespace-only', () => {
+			expect(html({ modalLabel: '   ' })).toContain('aria-label="Modal"');
+		});
+
+		it('uses a custom label verbatim', () => {
+			expect(html({ modalLabel: 'Newsletter signup' })).toContain(
+				'aria-label="Newsletter signup"'
+			);
+		});
+	});
+
+	describe('close button aria-label (closeButtonLabel)', () => {
+		it('falls back to the default when empty', () => {
+			expect(html({})).toContain('aria-label="Close modal"');
+		});
+
+		it('falls back to the default when whitespace-only', () => {
+			expect(html({ closeButtonLabel: '  ' })).toContain(
+				'aria-label="Close modal"'
+			);
+		});
+
+		it('uses a custom label verbatim', () => {
+			expect(html({ closeButtonLabel: 'Dismiss' })).toContain(
+				'aria-label="Dismiss"'
+			);
+		});
+	});
+});

--- a/tests/unit/scroll-slides-overlay-opacity.test.js
+++ b/tests/unit/scroll-slides-overlay-opacity.test.js
@@ -1,0 +1,81 @@
+/**
+ * Scroll Slides Block - overlay opacity attribute in save()
+ *
+ * The overlay scrim opacity used to be hardcoded at 0.8 with no control. It is
+ * now backed by an `overlayOpacity` attribute (percent, default 80). These tests
+ * guard:
+ *  - backward compatibility: the default still emits `--dsgo-overlay-opacity:0.8`;
+ *  - a custom value maps percent → fraction;
+ *  - out-of-range / non-finite values are clamped to [0,100] and fall back to the
+ *    80 default respectively, matching the PHP render path (render.php).
+ *
+ * The overlay custom properties are only emitted when an overlay color is set,
+ * so every case sets `overlayColor`.
+ *
+ * @package
+ */
+
+const {
+	registerBlockType,
+	unregisterBlockType,
+	createBlock,
+	serialize,
+} = require('@wordpress/block-editor/node_modules/@wordpress/blocks');
+
+import metadata from '../../src/blocks/scroll-slides/block.json';
+import save from '../../src/blocks/scroll-slides/save';
+
+const html = (attributes) => serialize(createBlock(metadata.name, attributes));
+
+describe('Scroll Slides save() - overlay opacity', () => {
+	beforeAll(() => {
+		// The custom 'designsetgo' category isn't registered in the jest
+		// environment; category is irrelevant to save serialization, so use a
+		// built-in one to avoid an unrelated invalid-category warning.
+		registerBlockType(metadata.name, {
+			...metadata,
+			category: 'design',
+			save,
+		});
+	});
+
+	afterAll(() => {
+		unregisterBlockType(metadata.name);
+	});
+
+	it('emits the default 0.8 opacity (backward compatible)', () => {
+		expect(html({ overlayColor: '#000000' })).toContain(
+			'--dsgo-overlay-opacity:0.8'
+		);
+	});
+
+	it('maps a custom percent value to a fraction', () => {
+		expect(html({ overlayColor: '#000000', overlayOpacity: 50 })).toContain(
+			'--dsgo-overlay-opacity:0.5'
+		);
+	});
+
+	it('emits 0 for a zero value (not treated as unset)', () => {
+		expect(html({ overlayColor: '#000000', overlayOpacity: 0 })).toContain(
+			'--dsgo-overlay-opacity:0'
+		);
+	});
+
+	it('clamps an above-range value to 1', () => {
+		expect(
+			html({ overlayColor: '#000000', overlayOpacity: 150 })
+		).toContain('--dsgo-overlay-opacity:1');
+	});
+
+	it('clamps a below-range value to 0', () => {
+		expect(
+			html({ overlayColor: '#000000', overlayOpacity: -20 })
+		).toContain('--dsgo-overlay-opacity:0');
+	});
+
+	it('does not emit overlay custom properties without an overlay color', () => {
+		expect(html({ overlayOpacity: 50 })).not.toContain(
+			'--dsgo-overlay-opacity'
+		);
+	});
+});


### PR DESCRIPTION
## Description

Continues the effort to eliminate hardcoded, uncontrollable values from block `save()` output. Reviewed the five reported items; three were genuine and are fixed here, two were already covered by WordPress core Border block-support (details under Additional Notes).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Related Issue

Closes #

## Changes Made

- **`designsetgo/scroll-slides` — overlay opacity control.** The overlay scrim opacity was hardcoded at `0.8` in `save.js`, `edit.js`, and `render.php` (query mode). Added an `overlayOpacity` attribute (default `80`) and an "Overlay Opacity" slider that appears once an overlay color is set. The `80` default reproduces the previous `0.8` output.
- **`designsetgo/modal` — dead `modalLabel` attribute fixed.** `save.js` read `attributes.modalLabel` but the attribute was never registered in `block.json`, so a custom dialog `aria-label` could never take effect and always fell back to `"Modal"`. Registered `modalLabel` and wired it to a new "Accessible Label" control.
- **`designsetgo/modal` — close-button label control.** The close button's `aria-label` (`"Close modal"`) was unconditionally hardcoded. Added a `closeButtonLabel` attribute plus a "Close Button Label" control; falls back to the previous string when empty. Editor preview mirrors the same fallback.
- Updated the unreleased `2.4.0` CHANGELOG section.

## Testing

- [x] Tested in WordPress editor
- [x] No console errors
- [x] No PHP errors

Verification performed:
- `npm run build` — compiles cleanly (only pre-existing asset-size warnings).
- `wp-scripts lint-js` on all changed files — clean.
- `php -l src/blocks/scroll-slides/render.php` — no syntax errors.
- `test:unit` modal suite — 33/33 pass.

## Backward compatibility

Every new attribute's default/empty value reproduces the prior markup byte-for-byte (`modalLabel: '' → "Modal"`, `closeButtonLabel: '' → "Close modal"`, `overlayOpacity: 80 → 0.8`), so **no block deprecations are required** and existing content validates unchanged.

## Additional Notes

Two of the five reported items were reviewed and left as-is because WordPress core Border block-support already provides the control:

- **`designsetgo/pill` border-radius** — the block registers `__experimentalBorder.radius`, and the `border-radius: 999px` fallback in CSS uses no `!important`. An author can override it (including setting `0` as the off switch) via the Border → Radius control; `render.php` already moves the border style group onto `.dsgo-pill__content` where the fallback lives. The original report itself noted this claim was overstated.
- **`designsetgo/slider` style-variation radius** — the block also registers `__experimentalBorder.radius`. The per-variation radii (`.dsgo-slider--classic { border-radius: 8px }`, etc.) are plain class selectors that any inline Border → Radius value overrides, including `0`.

Adding dedicated "disable radius" attributes to these two would duplicate core support and bake redundant values into saved markup, which runs counter to the goal of this cleanup series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACY5FuAq6EyXS6tqJHtEMb

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACY5FuAq6EyXS6tqJHtEMb)_