### PR TITLE
fix(patterns): add missing @package docblock tag

### DIFF
--- a/patterns/hero/hero-saas-startup.php
+++ b/patterns/hero/hero-saas-startup.php
@@ -5,15 +5,17 @@
  * Categories: dsgo-hero
  * Description: A SaaS startup hero with bold headline, description, free trial CTA, and product feature highlights
  * Keywords: hero, saas, startup, software, product, trial
+ *
+ * @package DesignSetGo
  */
 
 defined( 'ABSPATH' ) || exit;
 
 return array(
-	'title'      => __( 'SaaS Startup Hero', 'designsetgo' ),
-	'categories' => array( 'dsgo-hero' ),
+	'title'         => __( 'SaaS Startup Hero', 'designsetgo' ),
+	'categories'    => array( 'dsgo-hero' ),
 	'viewportWidth' => 1200,
-	'content'    => '<!-- wp:designsetgo/section {"style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}},"backgroundColor":"base-2","metadata":{"categories":["dsgo-hero"],"patternName":"designsetgo/hero/hero-saas-startup","name":"SaaS / Startup Homepage"}} -->
+	'content'       => '<!-- wp:designsetgo/section {"style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}},"backgroundColor":"base-2","metadata":{"categories":["dsgo-hero"],"patternName":"designsetgo/hero/hero-saas-startup","name":"SaaS / Startup Homepage"}} -->
 <div class="wp-block-designsetgo-section alignfull dsgo-stack has-base-2-background-color has-background" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><div class="dsgo-stack__inner" style="max-width:var(--wp--style--global--content-size, 1140px);margin-left:auto;margin-right:auto"><!-- wp:designsetgo/blobs {"align":"center","blobAnimation":"float","size":"80%","height":"600px","maxWidth":"800px","style":{"spacing":{"margin":{"bottom":"0"}}}} -->
 <div class="wp-block-designsetgo-blobs aligncenter dsgo-blobs-wrapper dsgo-has-max-width" style="margin-bottom:0;--dsgo-blob-max-width:800px"><div class="dsgo-blobs dsgo-blobs--shape-1 dsgo-blobs--float" style="--dsgo-blob-size:80%;--dsgo-blob-height:600px;--dsgo-blob-animation-duration:8s;--dsgo-blob-animation-easing:ease-in-out" data-blob-animation="float"><div class="dsgo-blobs__shape"><div class="dsgo-blobs__content"><!-- wp:designsetgo/section {"constrainWidth":false,"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}}} -->
 <div class="wp-block-designsetgo-section alignfull dsgo-stack dsgo-no-width-constraint" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><div class="dsgo-stack__inner"><!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"},"spacing":{"margin":{"top":"var:preset|spacing|30"}}},"fontSize":"xx-large"} -->

--- a/patterns/homepage/homepage-saas.php
+++ b/patterns/homepage/homepage-saas.php
@@ -5,15 +5,17 @@
  * Categories: dsgo-homepage
  * Description: A modern homepage for SaaS products and tech startups with hero, features, pricing, testimonials, and FAQ
  * Keywords: homepage, saas, startup, tech, modern, pricing, features
+ *
+ * @package DesignSetGo
  */
 
 defined( 'ABSPATH' ) || exit;
 
 return array(
-	'title'      => __( 'SaaS / Startup Homepage', 'designsetgo' ),
-	'categories' => array( 'dsgo-homepage' ),
+	'title'         => __( 'SaaS / Startup Homepage', 'designsetgo' ),
+	'categories'    => array( 'dsgo-homepage' ),
 	'viewportWidth' => 1200,
-	'content'    => '<!-- wp:designsetgo/section {"style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}},"backgroundColor":"base-2","metadata":{"categories":["dsgo-homepage"],"patternName":"designsetgo/homepage/homepage-saas","name":"SaaS / Startup Homepage"}} -->
+	'content'       => '<!-- wp:designsetgo/section {"style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}},"backgroundColor":"base-2","metadata":{"categories":["dsgo-homepage"],"patternName":"designsetgo/homepage/homepage-saas","name":"SaaS / Startup Homepage"}} -->
 <div class="wp-block-designsetgo-section alignfull dsgo-stack has-base-2-background-color has-background" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><div class="dsgo-stack__inner" style="max-width:var(--wp--style--global--content-size, 1140px);margin-left:auto;margin-right:auto"><!-- wp:designsetgo/blobs {"align":"center","blobShape":"shape-3","blobAnimation":"morph-2","size":"80%","maxWidth":"800px","style":{"spacing":{"margin":{"bottom":"0"}}}} -->
 <div class="wp-block-designsetgo-blobs aligncenter dsgo-blobs-wrapper dsgo-has-max-width" style="margin-bottom:0;--dsgo-blob-max-width:800px"><div class="dsgo-blobs dsgo-blobs--shape-3 dsgo-blobs--morph-2" style="--dsgo-blob-size:80%;--dsgo-blob-animation-duration:8s;--dsgo-blob-animation-easing:ease-in-out" data-blob-animation="morph-2"><div class="dsgo-blobs__shape"><div class="dsgo-blobs__content"><!-- wp:designsetgo/section {"constrainWidth":false,"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}}} -->
 <div class="wp-block-designsetgo-section alignfull dsgo-stack dsgo-no-width-constraint" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><div class="dsgo-stack__inner"><!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"},"spacing":{"margin":{"top":"var:preset|spacing|30"}}},"fontSize":"xx-large"} -->


### PR DESCRIPTION
## Summary

- Adds the missing `@package DesignSetGo` tag to the file docblock in `patterns/hero/hero-saas-startup.php` and `patterns/homepage/homepage-saas.php` (required by the `Squiz.Commenting.FileComment.MissingPackageTag` phpcs sniff)
- Auto-fixed the pre-existing array double-arrow alignment warnings in both files via `phpcbf` while in there

Found while cross-checking PR #444's new VIPMinimum ruleset against recent work — this specific gap is unrelated to #444 (reproduces identically against the current `phpcs.xml`) and is outside the default `composer run lint` scope (`patterns/` isn't in the linted `<file>` list), so it wasn't blocking anything. Fixing it anyway since it's a one-line, zero-risk polish.

## Test plan

- [x] `vendor/bin/phpcs --standard=phpcs.xml patterns/hero/hero-saas-startup.php patterns/homepage/homepage-saas.php` → 0 errors, 0 warnings
- [x] `php -l` on both files → no syntax errors
- [x] PHPUnit pattern-loader suite (`--filter=patterns_loader`) → 36/36 passing
- [x] Pre-commit e2e smoke suite → 7/7 passing