### PR TITLE
fix(image-accordion): gate overlay markup on enableOverlay

### DIFF
--- a/src/blocks/image-accordion/deprecated.js
+++ b/src/blocks/image-accordion/deprecated.js
@@ -193,4 +193,148 @@ const v1 = {
 	},
 };
 
-export default [v1];
+/**
+ * Version 2: Before overlay output was gated on `enableOverlay`
+ *
+ * This format (post height/gap refactor) always baked the three overlay custom
+ * properties (`--dsgo-image-accordion-overlay-color` / `-opacity` /
+ * `-opacity-expanded`) and a `data-enable-overlay` marker onto the root element,
+ * even when the overlay was disabled. Because the item's overlay pseudo-element
+ * is gated on the `--has-overlay` class (driven by the enableOverlay context,
+ * not this markup), those properties were dead weight whenever the overlay was
+ * off — and, more importantly, an author could not remove them from a pattern's
+ * HTML because save() regenerated them from the (still-set) attributes.
+ *
+ * The current save() emits the overlay properties and `data-enable-overlay` ONLY
+ * when `enableOverlay` is true. The enabled output is byte-identical to this
+ * version, so overlay-on blocks (the overwhelming majority, since enableOverlay
+ * defaults true) match the current save() directly and never reach this
+ * deprecation. Only overlay-off blocks — which this version serialized WITH the
+ * now-omitted overlay properties and `data-enable-overlay="false"` — mismatch the
+ * current save() and are routed here so they re-serialize into the leaner format.
+ *
+ * `migrate` is a passthrough: the attributes already describe the block exactly
+ * (enableOverlay:false plus whatever overlay values were set), so no attribute
+ * change is needed — only a re-save into the current markup. There is no
+ * `isEligible`: the enabled output is byte-identical to the current save(), so
+ * a valid overlay-on block can't be told apart from current markup and must not
+ * be force-migrated; only the genuinely stale overlay-off markup reaches here.
+ */
+const v2 = {
+	supports: sharedSupports,
+
+	attributes: {
+		height: {
+			type: 'string',
+		},
+		gap: {
+			type: 'string',
+		},
+		expandedRatio: {
+			type: 'number',
+			default: 3,
+		},
+		transitionDuration: {
+			type: 'string',
+			default: '0.5s',
+		},
+		enableOverlay: {
+			type: 'boolean',
+			default: true,
+		},
+		overlayColor: {
+			type: 'string',
+			default: '#000000',
+		},
+		overlayOpacity: {
+			type: 'number',
+			default: 40,
+		},
+		overlayOpacityExpanded: {
+			type: 'number',
+			default: 20,
+		},
+		triggerType: {
+			type: 'string',
+			default: 'hover',
+			enum: ['hover', 'click'],
+		},
+		defaultExpanded: {
+			type: 'number',
+			default: 0,
+		},
+	},
+
+	save({ attributes }) {
+		const {
+			height,
+			gap,
+			expandedRatio,
+			transitionDuration,
+			enableOverlay,
+			overlayColor,
+			overlayOpacity,
+			overlayOpacityExpanded,
+			triggerType,
+			defaultExpanded,
+		} = attributes;
+
+		// Same classes as edit.js - MUST MATCH EXACTLY
+		const accordionClasses = classnames('dsgo-image-accordion', {
+			'dsgo-image-accordion--hover': triggerType === 'hover',
+			'dsgo-image-accordion--click': triggerType === 'click',
+		});
+
+		// Height/gap already omit-when-unset (post-refactor). The distinguishing
+		// trait of this version is that the overlay props and data-enable-overlay
+		// were ALWAYS written, regardless of enableOverlay.
+		const hasExplicitHeight =
+			typeof height === 'string' && height.trim() !== '';
+		const hasExplicitGap = typeof gap === 'string' && gap.trim() !== '';
+
+		const customStyles = {
+			...(hasExplicitHeight && {
+				'--dsgo-image-accordion-height': height,
+			}),
+			...(hasExplicitGap && { '--dsgo-image-accordion-gap': gap }),
+			'--dsgo-image-accordion-expanded-ratio': String(expandedRatio), // Unitless
+			'--dsgo-image-accordion-transition': transitionDuration,
+			'--dsgo-image-accordion-overlay-color':
+				convertColorToCSSVar(overlayColor),
+			'--dsgo-image-accordion-overlay-opacity': String(
+				overlayOpacity / 100
+			), // Unitless
+			'--dsgo-image-accordion-overlay-opacity-expanded': String(
+				overlayOpacityExpanded / 100
+			), // Unitless
+		};
+
+		const blockProps = useBlockProps.save({
+			className: accordionClasses,
+			style: customStyles,
+			'data-trigger-type': triggerType,
+			'data-default-expanded': defaultExpanded,
+			'data-enable-overlay': enableOverlay,
+		});
+
+		const innerBlocksProps = useInnerBlocksProps.save({
+			className: 'dsgo-image-accordion__items',
+		});
+
+		return (
+			<div {...blockProps}>
+				<div {...innerBlocksProps} />
+			</div>
+		);
+	},
+
+	migrate(attributes) {
+		// Passthrough: attributes already describe the block; only the markup
+		// changes (overlay props/data-enable-overlay dropped when disabled).
+		return attributes;
+	},
+};
+
+// Newest-first: v2 (overlay always emitted) is newer than v1 (height/gap
+// always inline). WordPress tries them in this order after the current save().
+export default [v2, v1];

--- a/src/blocks/image-accordion/edit.js
+++ b/src/blocks/image-accordion/edit.js
@@ -110,6 +110,22 @@ export default function ImageAccordionEdit({
 	const hasExplicitHeight = hasExplicitString(height);
 	const hasExplicitGap = hasExplicitString(gap);
 
+	// Overlay custom properties are emitted only when the overlay is enabled
+	// (parity with save.js) so the editor preview matches the frontend: with the
+	// overlay off the items skip `--has-overlay` and these values go unused.
+	const overlayStyles = enableOverlay
+		? {
+				'--dsgo-image-accordion-overlay-color':
+					convertColorToCSSVar(overlayColor),
+				'--dsgo-image-accordion-overlay-opacity': String(
+					overlayOpacity / 100
+				), // Unitless
+				'--dsgo-image-accordion-overlay-opacity-expanded': String(
+					overlayOpacityExpanded / 100
+				), // Unitless
+			}
+		: {};
+
 	// Apply settings as CSS custom properties for consistent styling
 	// Note: Unitless values must be strings to prevent React from adding 'px'
 	const customStyles = {
@@ -119,12 +135,7 @@ export default function ImageAccordionEdit({
 		...(hasExplicitGap && { '--dsgo-image-accordion-gap': gap }),
 		'--dsgo-image-accordion-expanded-ratio': String(expandedRatio), // Unitless
 		'--dsgo-image-accordion-transition': transitionDuration,
-		'--dsgo-image-accordion-overlay-color':
-			convertColorToCSSVar(overlayColor),
-		'--dsgo-image-accordion-overlay-opacity': String(overlayOpacity / 100), // Unitless
-		'--dsgo-image-accordion-overlay-opacity-expanded': String(
-			overlayOpacityExpanded / 100
-		), // Unitless
+		...overlayStyles,
 	};
 
 	// Block wrapper props

--- a/src/blocks/image-accordion/save.js
+++ b/src/blocks/image-accordion/save.js
@@ -31,6 +31,28 @@ export default function ImageAccordionSave({ attributes }) {
 	const hasExplicitHeight = hasExplicitString(height);
 	const hasExplicitGap = hasExplicitString(gap);
 
+	// The overlay custom properties (color/opacity/opacity-expanded) and the
+	// data-enable-overlay marker are emitted ONLY when the overlay is enabled.
+	// Nothing consumes them when the overlay is off — the item skips the
+	// `--has-overlay` class (driven by the enableOverlay context, not this
+	// markup), so its overlay pseudo-element never renders and these values are
+	// dead weight. Omitting them keeps the saved markup honest (overlay off →
+	// no overlay styling in the HTML) and lets patterns/authors turn the overlay
+	// off and have it actually gone instead of save() regenerating it from the
+	// attribute defaults. MUST MATCH edit.js.
+	const overlayStyles = enableOverlay
+		? {
+				'--dsgo-image-accordion-overlay-color':
+					convertColorToCSSVar(overlayColor),
+				'--dsgo-image-accordion-overlay-opacity': String(
+					overlayOpacity / 100
+				), // Unitless
+				'--dsgo-image-accordion-overlay-opacity-expanded': String(
+					overlayOpacityExpanded / 100
+				), // Unitless
+			}
+		: {};
+
 	// Apply settings as CSS custom properties - MUST MATCH edit.js
 	// Note: Unitless values must be strings to prevent React from adding 'px'
 	const customStyles = {
@@ -40,12 +62,7 @@ export default function ImageAccordionSave({ attributes }) {
 		...(hasExplicitGap && { '--dsgo-image-accordion-gap': gap }),
 		'--dsgo-image-accordion-expanded-ratio': String(expandedRatio), // Unitless
 		'--dsgo-image-accordion-transition': transitionDuration,
-		'--dsgo-image-accordion-overlay-color':
-			convertColorToCSSVar(overlayColor),
-		'--dsgo-image-accordion-overlay-opacity': String(overlayOpacity / 100), // Unitless
-		'--dsgo-image-accordion-overlay-opacity-expanded': String(
-			overlayOpacityExpanded / 100
-		), // Unitless
+		...overlayStyles,
 	};
 
 	// Use .save() variant for save function
@@ -54,7 +71,10 @@ export default function ImageAccordionSave({ attributes }) {
 		style: customStyles,
 		'data-trigger-type': triggerType,
 		'data-default-expanded': defaultExpanded,
-		'data-enable-overlay': enableOverlay,
+		// Emit the boolean marker only when the overlay is on so the enabled
+		// output stays byte-identical to prior versions (data-enable-overlay="true")
+		// and a disabled overlay leaves no trace in the markup.
+		...(enableOverlay && { 'data-enable-overlay': enableOverlay }),
 	});
 
 	const innerBlocksProps = useInnerBlocksProps.save({

--- a/src/blocks/image-accordion/test/deprecated.test.js
+++ b/src/blocks/image-accordion/test/deprecated.test.js
@@ -31,8 +31,8 @@ setCategories([{ slug: 'designsetgo', title: 'DesignSetGo' }]);
 
 registerBlockType(metadata.name, { ...metadata, save, deprecated });
 
-// deprecated.js exports newest-first: [v1].
-const [v1Deprecation] = deprecated;
+// deprecated.js exports newest-first: [v2, v1].
+const [v2Deprecation, v1Deprecation] = deprecated;
 
 describe('image-accordion save() - themeable height/gap', () => {
 	test('default (unset) save omits the inline height/gap custom props', () => {
@@ -174,5 +174,113 @@ describe('image-accordion deprecations - v1 themeable height/gap migration', () 
 				triggerType: 'hover',
 			})
 		).toEqual({ height: '600px', gap: '12px', triggerType: 'hover' });
+	});
+});
+
+describe('image-accordion save() - overlay gated on enableOverlay', () => {
+	test('overlay enabled (default) emits the overlay props and data-enable-overlay', () => {
+		const markup = serialize(createBlock(metadata.name));
+		expect(markup).toContain('--dsgo-image-accordion-overlay-color:');
+		expect(markup).toContain('--dsgo-image-accordion-overlay-opacity:');
+		expect(markup).toContain(
+			'--dsgo-image-accordion-overlay-opacity-expanded:'
+		);
+		expect(markup).toContain('data-enable-overlay="true"');
+	});
+
+	test('overlay disabled omits all three overlay props and data-enable-overlay', () => {
+		const markup = serialize(
+			createBlock(metadata.name, { enableOverlay: false })
+		);
+		expect(markup).not.toContain('--dsgo-image-accordion-overlay-color:');
+		expect(markup).not.toContain('--dsgo-image-accordion-overlay-opacity:');
+		expect(markup).not.toContain(
+			'--dsgo-image-accordion-overlay-opacity-expanded:'
+		);
+		expect(markup).not.toContain('data-enable-overlay');
+		// Non-overlay custom props are still present.
+		expect(markup).toContain('--dsgo-image-accordion-expanded-ratio:');
+		expect(markup).toContain('data-trigger-type="hover"');
+	});
+
+	test('overlay disabled ignores custom overlay opacity/color attribute values', () => {
+		// Even with non-default overlay values set, disabling the overlay must
+		// leave no overlay trace in the markup — the whole point of the fix.
+		// Inspect the rendered HTML only — the attribute values still live in the
+		// block comment (that is correct; they persist so re-enabling restores
+		// them), they just must not surface in the markup.
+		const html = getBlockContent(
+			createBlock(metadata.name, {
+				enableOverlay: false,
+				overlayOpacity: 60,
+				overlayOpacityExpanded: 35,
+				overlayColor: '#123456',
+			})
+		);
+		expect(html).not.toContain('--dsgo-image-accordion-overlay');
+		expect(html).not.toContain('#123456');
+		expect(html).not.toContain('data-enable-overlay');
+	});
+});
+
+describe('image-accordion deprecations - v2 overlay-gating migration', () => {
+	test('an overlay-ON block matches the current save() directly (no deprecation)', () => {
+		// The enabled output is byte-identical to v2, so overlay-on content is
+		// valid without any migration. No toHaveInformed() assertion here means a
+		// spurious deprecation pass would trip the jest-console matcher.
+		const markup = serialize(createBlock(metadata.name));
+		const [block] = parse(markup);
+		expect(block.isValid).toBe(true);
+		expect(block.attributes.enableOverlay).toBe(true);
+		expect(getBlockContent(block)).toContain('data-enable-overlay="true"');
+	});
+
+	test('old overlay-OFF markup (overlay props + data-enable-overlay="false") migrates silently and re-serializes lean', () => {
+		// Reconstruct the v2 overlay-off format: the overlay props and
+		// data-enable-overlay were baked in even with the overlay disabled.
+		// Build it from a current disabled block, then splice the stale bits back.
+		const disabled = serialize(
+			createBlock(metadata.name, { enableOverlay: false })
+		);
+		const OLD_OFF = disabled
+			.replace(
+				'--dsgo-image-accordion-transition:0.5s',
+				'--dsgo-image-accordion-transition:0.5s;--dsgo-image-accordion-overlay-color:#000000;--dsgo-image-accordion-overlay-opacity:0.4;--dsgo-image-accordion-overlay-opacity-expanded:0.2'
+			)
+			.replace(
+				'data-default-expanded="0"',
+				'data-default-expanded="0" data-enable-overlay="false"'
+			);
+
+		// Sanity: the stale markup really carries the bits the current save drops.
+		expect(OLD_OFF).toContain(
+			'--dsgo-image-accordion-overlay-color:#000000'
+		);
+		expect(OLD_OFF).toContain('data-enable-overlay="false"');
+
+		const [block] = parse(OLD_OFF);
+
+		expect(console).toHaveInformed();
+		expect(block.name).toBe('designsetgo/image-accordion');
+		expect(block.isValid).toBe(true);
+		expect(block.attributes.enableOverlay).toBe(false);
+		// Re-serialized markup drops the dead overlay props and the marker.
+		const migrated = getBlockContent(block);
+		expect(migrated).not.toContain('--dsgo-image-accordion-overlay');
+		expect(migrated).not.toContain('data-enable-overlay');
+	});
+
+	test('v2 migrate is a passthrough', () => {
+		expect(
+			v2Deprecation.migrate({
+				enableOverlay: false,
+				overlayOpacity: 40,
+				triggerType: 'hover',
+			})
+		).toEqual({
+			enableOverlay: false,
+			overlayOpacity: 40,
+			triggerType: 'hover',
+		});
 	});
 });


### PR DESCRIPTION
## Description

The Image Accordion block's `save()` unconditionally emitted the three overlay custom properties and a `data-enable-overlay` marker onto the root element — **even when the overlay was disabled**:

```
style="…;--dsgo-image-accordion-overlay-color:#000000;--dsgo-image-accordion-overlay-opacity:0.6;--dsgo-image-accordion-overlay-opacity-expanded:0.35" data-enable-overlay="true"
```

Because the item's overlay pseudo-element is gated on the `--has-overlay` class — which is driven by the `enableOverlay` **context**, not this markup — those values were dead weight whenever the overlay was off. More importantly, a pattern/content author could not remove them from the HTML: deleting the vars triggered a block-validation mismatch because `save()` regenerated them from the still-set attributes (`overlayOpacity`, `overlayOpacityExpanded`, and the `overlayColor` default) on the next parse.

Now the overlay properties and `data-enable-overlay` are emitted **only when `enableOverlay` is true**. Turning the overlay off actually removes it from the saved markup.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue

Closes #

## Changes Made

- `save.js`: gate the three `--dsgo-image-accordion-overlay-*` custom properties and the `data-enable-overlay` marker on `enableOverlay`. The **enabled** output is byte-identical to before, so overlay-on content (the default) is unaffected; a disabled overlay leaves no overlay trace in the HTML.
- `edit.js`: mirror the same gating so the editor preview matches the frontend.
- `deprecated.js`: add a `v2` deprecation reproducing the prior always-emit format, so existing overlay-off content re-serializes into the leaner markup instead of showing WordPress's "unexpected or invalid content / Attempt Recovery" prompt. `migrate` is a passthrough (attributes already describe the block; only the markup changes). No `isEligible` — the enabled output is byte-identical to the current `save()`, so a valid overlay-on block must not be force-migrated.
- `test/deprecated.test.js`: add coverage for the overlay gating (enabled emits props + marker; disabled omits all three props and the marker, ignoring custom overlay attribute values) and the `v2` migration (overlay-on matches current `save()` directly with no deprecation; stale overlay-off markup migrates silently and re-serializes lean).

## Testing

- [x] Unit tests: `wp-scripts test-unit-js src/blocks/image-accordion/test/deprecated.test.js` — 15/15 passing
- [x] `wp-scripts lint-js` on changed files — clean
- [x] `wp-scripts build` — compiles successfully
- [ ] Tested in WordPress editor
- [ ] Tested on frontend
- [ ] No console errors

## Additional Notes

Nothing at runtime consumes the parent's overlay custom properties or `data-enable-overlay` attribute when the overlay is off (`data-enable-overlay` is not read by `view.js`; the item's overlay comes from the `enableOverlay` context via the `--has-overlay` class), so omitting them is behavior-preserving for the overlay-off case. The overlay-on output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNtw62N423dqmJnvQvNm2S

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNtw62N423dqmJnvQvNm2S)_