### PR TITLE
docs: correct icon count from "500+" to "160+" across public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See [CLAUDE.md](.claude/CLAUDE.md) for development learnings and best practices.
 | Category | Features |
 |----------|----------|
 | **🤖 AI Integration** | **WordPress Abilities API** — First plugin with AI-native programmatic access. **Per-URL Markdown** — any published URL returns Markdown when a client sends `Accept: text/markdown`, passes the acceptmarkdown.com contract. |
-| **Blocks** | **53 blocks** across 8+ categories: **Layout (3)** - Row, Section, Grid; **Forms (13)** - Complete form system with AJAX, spam protection, 11 field types; **Interactive (15)** - Tabs, Accordion, Flip Card, Slider, Scroll Slides, Sticky Sections, Scroll Marquee, Scroll Accordion, Image Accordion, Counters, Progress, Comparison Table, Timeline, Modal, Modal Trigger; **Dynamic Query (6)** - Query, Pagination, Filter, Results, Group Header, No Results; **Typography & Navigation (3)** - Advanced Heading, Breadcrumbs (Schema.org), Table of Contents; **Visual (9)** - 500+ Icons, Icon Button, Icon List, Pills, Cards, Dividers, Countdown, Blobs, Dynamic Image; **Media & Location (2)** - Fifty Fifty split layout, Map (OSM + Google Maps); **WooCommerce (2)** - Product Categories Grid, Product Showcase Hero |
+| **Blocks** | **53 blocks** across 8+ categories: **Layout (3)** - Row, Section, Grid; **Forms (13)** - Complete form system with AJAX, spam protection, 11 field types; **Interactive (15)** - Tabs, Accordion, Flip Card, Slider, Scroll Slides, Sticky Sections, Scroll Marquee, Scroll Accordion, Image Accordion, Counters, Progress, Comparison Table, Timeline, Modal, Modal Trigger; **Dynamic Query (6)** - Query, Pagination, Filter, Results, Group Header, No Results; **Typography & Navigation (3)** - Advanced Heading, Breadcrumbs (Schema.org), Table of Contents; **Visual (9)** - 160+ Icons, Icon Button, Icon List, Pills, Cards, Dividers, Countdown, Blobs, Dynamic Image; **Media & Location (2)** - Fifty Fifty split layout, Map (OSM + Google Maps); **WooCommerce (2)** - Product Categories Grid, Product Showcase Hero |
 | **Extensions** | **16 Extensions** - Block Animations (24 effects), Sticky Header, Clickable Groups, Background Video, Responsive Visibility, Hover Effects, Conditional Visibility, Dynamic Tags, Style Binding, SVG Patterns (25+), Max Width, Custom CSS, Grid Span, Grid Mobile Order, Reveal Control, Text Alignment Inheritance |
 | **Patterns** | Pre-designed layouts (Hero, CTA, Features, FAQ) |
 | **FSE Ready** | Full Site Editing compatible, theme.json integration, dual categorization |
@@ -162,7 +162,7 @@ npm run plugin-zip
 - Plus child blocks: Accordion Item, Tab, Slide, Flip Card Face, Image Accordion Item, Scroll Accordion Item, Counter, Timeline Item
 
 #### Content & UI Elements (10 Blocks)
-- **Icon** - 500+ icons with shapes, sizes, and animations
+- **Icon** - 160+ icons with shapes, sizes, and animations
 - **Icon Button** - Icon-based buttons with extensive styling options
 - **Icon List** - Lists with custom icons and formatting
 - **Card** - Content cards with images, headers, and call-to-action buttons

--- a/docs/README.md
+++ b/docs/README.md
@@ -391,7 +391,7 @@ See [BLOCK-TEMPLATE-EDIT.js](./templates/BLOCK-TEMPLATE-EDIT.js) for complete ex
 - **Interactive blocks**: 15 (Tabs, Accordion, Modal, Modal Trigger, Flip Card, Slider, Scroll Slides, Sticky Sections, Scroll Marquee, Scroll Accordion, Image Accordion, Counter Group, Progress Bar, Comparison Table, Timeline)
 - **Dynamic Query blocks**: 6 (Query, Pagination, Filter, Results, Group Header, No Results)
 - **Typography & Navigation**: 3 (Advanced Heading, Breadcrumbs, Table of Contents)
-- **Visual blocks**: 9 (500+ Icons, Icon Button, Icon List, Pills, Cards, Dividers, Countdown, Blobs, Dynamic Image)
+- **Visual blocks**: 9 (160+ Icons, Icon Button, Icon List, Pills, Cards, Dividers, Countdown, Blobs, Dynamic Image)
 - **Media & Location**: 2 (Fifty Fifty, Map)
 - **WooCommerce blocks**: 2 (Product Categories Grid, Product Showcase Hero)
 - **Extensions**: 16

--- a/docs/guides/AI-ASSISTED-DEVELOPMENT.md
+++ b/docs/guides/AI-ASSISTED-DEVELOPMENT.md
@@ -747,7 +747,7 @@ After AI generates code, always:
 **Initial prompt:**
 ```
 "Create an Icon block that:
-- Supports 500+ icons from a curated library
+- Supports 160+ icons from a curated library
 - Has size controls (px, %, em, rem)
 - Supports color controls (text, background)
 - Has alignment options

--- a/readme.txt
+++ b/readme.txt
@@ -42,7 +42,7 @@ DesignSetGo brings forms, sliders, dynamic queries, animations, and parallax to 
 * **Interactive** (15) — Tabs, Accordion, Modal, Modal Trigger, Flip Card, Slider, Scroll Slides, Sticky Sections, Scroll Marquee, Scroll Accordion, Image Accordion, Counter, Progress, Comparison Table, Timeline
 * **Dynamic Query** (6) — Query, Pagination, Filter, Results, Group Header, No Results
 * **Typography & Navigation** — Advanced Heading, Breadcrumbs (Schema.org), Table of Contents
-* **Visual** (9) — 500+ Icons, Icon Button, Icon List, Pills, Cards, Dividers, Countdown, Blobs, Dynamic Image
+* **Visual** (9) — 160+ Icons, Icon Button, Icon List, Pills, Cards, Dividers, Countdown, Blobs, Dynamic Image
 * **Media & Location** — Fifty Fifty split layout, Map (Google Maps + OpenStreetMap)
 * **WooCommerce** — Product Categories Grid, Product Showcase Hero
 * **Extensions** (16) — Animations, Parallax, Text Reveal, Expanding Background, Sticky Header, Hover Effects, Clickable Groups, Background Video, Responsive Visibility, Conditional Visibility, Max Width, Custom CSS, Grid Span, Grid Mobile Order, SVG Patterns (25+), Reveal Control
@@ -87,7 +87,7 @@ Yes to both. All blocks work in the Site Editor, templates, and template parts. 
 2. Tabs block with horizontal orientation, icons, and multiple style options
 3. Accordion block with collapsible panels and smooth animations
 4. Counter Group block with animated statistics and number formatting
-5. Icon block with 500+ icons, shape styles, and customization options
+5. Icon block with 160+ icons, shape styles, and customization options
 6. Progress Bar block with animated fills and multiple display styles
 7. Block animation controls showing entrance effects and timing options
 10. Mobile responsive preview in the editor

--- a/wiki-content/Blocks-Reference.md
+++ b/wiki-content/Blocks-Reference.md
@@ -176,10 +176,10 @@ Complete reference guide for all DesignSetGo blocks organized by category.
 ### Icon
 **Name**: `designsetgo/icon`
 **Category**: Design
-**Description**: Display icons from a library of 500+ icons with optional shapes, animations, and hover effects.
+**Description**: Display icons from a library of 160+ icons with optional shapes, animations, and hover effects.
 
 **Key Features**:
-- 500+ icon library
+- 160+ icon library
 - Multiple icon shapes (circle, square, rounded)
 - Size customization
 - Color controls (icon, background, border)

--- a/wiki-content/Home.md
+++ b/wiki-content/Home.md
@@ -27,7 +27,7 @@
 - **[Image Accordion](Image-Accordion-Block)** - Expandable image panels for portfolios and galleries
 
 ### Content Elements
-- **[Icon](Icon-Block)** - 500+ icons with shapes, animations, and hover effects
+- **[Icon](Icon-Block)** - 160+ icons with shapes, animations, and hover effects
 - **[Icon Button](Icon-Button-Block)** - Icon-based buttons with multiple styles
 - **[Icon List](Icon-List-Block)** - Lists with custom icons for each item
 - **[Pill](Pill-Block)** - Badge/tag components with customizable styles


### PR DESCRIPTION
## Description

The plugin's docs claim the Icon block offers **"500+ icons"**, but the actual, user-facing library holds **161**. This PR corrects the count to **"160+"** everywhere it appears in public-facing documentation.

## Type of Change

- [x] Documentation update

## Related Issue

Closes #

## Changes Made

- Verified the real icon count: the Icon block's `edit.js` renders `IconPicker`, which sources its list from `getIconNames()` → `Object.keys(SVG_ICONS)` in `src/blocks/icon/utils/svg-icons.js`. That library contains **161 icons**, confirmed by four independent counts (161 `<svg>`, 161 `</svg>`, 161 `viewBox`, 161 key entries).
- Confirmed the secondary `dashicons-library.js` (225 dashicon names via `ALL_ICONS`) and its `IconSettingsPanel.js` picker are **dead code** — nothing imports/renders them, so they don't contribute to the user-facing count. Even combined (161 + 225 = 386) the total never reaches 500.
- Corrected `"500+"` → `"160+"` in the six public-facing docs:
  - `readme.txt` — features list (Visual (9)) and Screenshot #5
  - `README.md` — Visual (9) blocks row and Icon feature bullet
  - `docs/README.md` — Visual blocks summary
  - `docs/guides/AI-ASSISTED-DEVELOPMENT.md` — icon capability note
  - `wiki-content/Blocks-Reference.md` — Icon block description and feature bullet
  - `wiki-content/Home.md` — Icon block link
- Left the internal `docs/planning/BLOCKS-ROADMAP.md` note untouched, as it reads as an aspirational planning target rather than a current-state product claim.

## Testing

- [x] Documentation-only change — no code paths affected; verified no remaining `"500+ icon(s)"` occurrences outside the internal roadmap doc.

## Additional Notes

Context: this work started from a WordPress.org import warning that the `readme.txt` Changelog section exceeded the 5,000-word limit. That specific issue was already resolved on `main` (trimmed 5,817 → ~1,000 words in a prior PR; currently 1,342 words, well under the limit), so no changelog change was needed. During that review, the "500+ icons" overstatement surfaced and is corrected here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DScwm5Nw42H61KhUuGDxf7)_