### PR TITLE
fix(deprecations): give isEligible the contract WordPress actually calls it with

### DIFF
--- a/.claude/claude.md
+++ b/.claude/claude.md
@@ -148,35 +148,46 @@ See [`docs/plans/2026-04-17-theme-3-inspector-ia.md`](../docs/plans/2026-04-17-t
 
 Required when changing: attribute schema, HTML structure, or removing attributes.
 
-**Every deprecation MUST have all three**: `isEligible`, `save`, and `migrate`.
+**`save()` is what makes migration silent — not `isEligible`.** WordPress applies a deprecation like this (`@wordpress/blocks` → `api/parser/apply-block-deprecated-versions.js`):
 
-- `isEligible(attributes, innerBlocks, { innerHTML })` — Lets WordPress skip save validation and go straight to migration (silent, no warning). Use attribute checks or innerHTML pattern matching to identify the old version.
-- `save()` — The old save function (best effort reproduction of old output).
-- `migrate(attributes, innerBlocks)` — Transforms old attributes to new format. Use passthrough `return attributes;` if only HTML structure changed.
+```js
+const { isEligible = stubFalse } = deprecatedDefinitions[i];
+if ( block.isValid && ! isEligible( parsedAttributes, block.innerBlocks, { blockNode, block } ) ) continue;
+// ...then: does THIS version's save() reproduce the stored HTML? If not, skip it.
+```
 
-Without `isEligible`, users see "Unexpected or invalid content" warnings with an "Attempt Recovery" button instead of silent auto-migration.
+Read that `block.isValid &&` carefully — it drives everything:
+
+- **The block is INVALID** (the normal case: markup changed, so stored HTML no longer matches the current `save()`). `block.isValid` is `false`, the condition short-circuits, and **`isEligible` is never called**. WordPress picks the version whose `save()` reproduces the stored HTML. Silent, no "Attempt Recovery". A markup-change deprecation therefore needs **no `isEligible` at all** — and adding one buys nothing.
+- **The block is VALID.** `isEligible` is the *only* thing consulted, and returning `true` opts an otherwise-fine block into a re-migration. This is the *only* reason `isEligible` exists: an attribute-only migration where markup did not change.
+
+So: **`isEligible` is a switch for migrating VALID blocks. It cannot rescue invalid ones, and it never suppresses an "Attempt Recovery" warning — only a `save()` that reproduces the stored HTML does that.**
+
+Two traps that follow, both of which have bitten us:
+
+1. **The third argument is `{ blockNode, block }` — there is no `innerHTML` key.** Reach the markup via `blockNode.innerHTML` (or `block.originalContent`). Destructuring `{ innerHTML }` yields `undefined`, so a guard like `innerHTML && innerHTML.includes(...)` silently returns `false` forever. It *looks* like it works, because the invalid-block path above carries the migration regardless.
+
+2. **"Attribute absent from the comment" does NOT mean "old block".** `attributes` here is the raw comment JSON, and WordPress never serializes an attribute whose value equals its default. `attributes.align === undefined` or `typeof attributes.iconPosition === 'undefined'` is therefore just as true of a brand-new block that left the value alone. Guards like that claim *current* content, and then `migrate()` runs it through a schema that predates the block's newer attributes — silently dropping them.
 
 ```javascript
 const v1 = {
-	attributes: { /* old attribute schema */ },
-	isEligible(attributes, innerBlocks, { innerHTML }) {
-		// Identify old blocks by attribute signature or HTML patterns
-		return !Object.prototype.hasOwnProperty.call(attributes, 'newAttribute');
-		// or: return innerHTML && !innerHTML.includes('new-class');
-	},
-	save({ attributes }) { /* old save output */ },
-	migrate(attributes) {
+	attributes: { /* the FULL attribute schema this version had */ },
+	supports: { /* the FULL support set this version had */ },
+	save({ attributes }) { /* reproduce the old output byte-for-byte */ },
+	migrate( attributes ) {
 		return { ...attributes, newAttribute: 'default' };
 	},
+	// isEligible ONLY if markup did not change and you must migrate a VALID
+	// block. Key it on the stored markup, never on an attribute's absence:
+	isEligible( attributes, innerBlocks, { blockNode, block } = {} ) {
+		const html = blockNode?.innerHTML ?? block?.originalContent ?? '';
+		return html.includes( 'old-class' ) && ! html.includes( 'new-class' );
+	},
 };
-export default [v1];
+export default [ v1 ];
 ```
 
-**Detection strategies for `isEligible`**:
-- Missing new attribute: `!Object.prototype.hasOwnProperty.call(attributes, 'newAttr')` (not `!attributes.newAttr` — falsy values like `false`/`0`/`""` would match incorrectly)
-- Old HTML pattern: `innerHTML && !innerHTML.includes('new-class')`
-- Removed attribute: `Object.prototype.hasOwnProperty.call(attributes, 'removedAttr')`
-- Combined: use `&&` / `||` to narrow matches when multiple versions exist
+`tests/unit/deprecations-isEligible.test.js` pins the invariant: no deprecation may claim a block's own current `save()` output, and every block must round-trip `createBlock → serialize → parse` without losing an attribute.
 
 **A deprecation's `supports` block must declare the full support set that version actually had.** If it omits a group, WordPress strips those attributes (`backgroundColor`, `textColor`, `gradient`, `borderColor`, `fontSize`, `style`, …) **before `migrate()` runs** — silently and unrecoverably, with no warning. The specific trap that bit us: typography supports must use the `__experimental` keys (`__experimentalFontFamily`, `__experimentalFontWeight`, `__experimentalLetterSpacing`) — the un-prefixed names silently fail `hasBlockSupport()`, so the support looks declared but isn't. And **deprecations do not cascade**: exactly one entry runs for a given stored block, so every existing `migrate()` — not just the newest one — must land on the *current* attribute schema, or older content silently loses whatever the newest migrate() alone would have added.
 
@@ -205,7 +216,8 @@ npm run lint:php
 5. Change shared utility → Test ALL consumers
 6. Broad CSS selectors → Scope to block
 7. Change attributes → Create deprecation first
-8. Deprecation without `isEligible` → Users see "Attempt Recovery" warning instead of silent migration
+8. Deprecation whose `save()` doesn't reproduce the stored HTML → Users see "Attempt Recovery". (Adding `isEligible` does NOT fix this — see Deprecations above.)
+9. `isEligible` keyed on an attribute being absent → claims *current* content, because WordPress omits default-valued attributes from the block comment
 
 ## Key Patterns
 

--- a/src/blocks/accordion/deprecated.js
+++ b/src/blocks/accordion/deprecated.js
@@ -97,7 +97,8 @@ const v1 = {
 			},
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		return !!innerHTML && innerHTML.includes('--dsgo-accordion-open-bg:;');
 	},
 	save({ attributes }) {

--- a/src/blocks/accordion/deprecated.js
+++ b/src/blocks/accordion/deprecated.js
@@ -1,6 +1,7 @@
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import classnames from 'classnames';
 import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 // v1: save() emitted empty --dsgo-accordion-* custom properties even when the
 // colors were unset; current save() omits them. Markup-only change → passthrough
@@ -97,8 +98,8 @@ const v1 = {
 			},
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		return !!innerHTML && innerHTML.includes('--dsgo-accordion-open-bg:;');
 	},
 	save({ attributes }) {

--- a/src/blocks/blobs/deprecated.js
+++ b/src/blocks/blobs/deprecated.js
@@ -131,7 +131,8 @@ const v3 = {
 			default: '',
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Scope the check to the Blobs wrapper's OWN opening tag. Blobs accepts
 		// arbitrary nested blocks, and the generic max-width extension still
 		// stamps the same `dsgo-has-max-width` class + a raw inline `max-width:`
@@ -275,7 +276,8 @@ const v1 = {
 			default: 50,
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v1 blocks have no wrapper div - the dsgo-blobs class is directly on the block wrapper
 		return innerHTML && !innerHTML.includes('dsgo-blobs-wrapper');
 	},
@@ -373,14 +375,19 @@ const v2 = {
 			default: 80,
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
-		// v2 blocks have dsgo-blobs-wrapper but no align attribute
-		return (
-			innerHTML &&
-			innerHTML.includes('dsgo-blobs-wrapper') &&
-			attributes.align === undefined
-		);
-	},
+	// No isEligible: v2's save() output is byte-identical to the current save()
+	// whenever `height` and `maxWidth` are unset (both are omitted from the
+	// markup in that case), so a v2-era block simply parses as VALID today and
+	// never needs migrating. It stays in the array because a v2 block that DID
+	// set an overlay colour still differs (convertPresetToCSSVar vs the current
+	// convertColorToCSSVar) and reaches this version by save-matching.
+	//
+	// The old guard was `innerHTML.includes('dsgo-blobs-wrapper') &&
+	// attributes.align === undefined`. The current save() still emits that
+	// wrapper class, and `align` has no default so it is absent from the comment
+	// on any block the author never aligned — i.e. the guard matched current
+	// content. It then migrated it through a schema that predates `height` /
+	// `maxWidth`, silently dropping both.
 	save({ attributes }) {
 		const {
 			blobShape,

--- a/src/blocks/blobs/deprecated.js
+++ b/src/blocks/blobs/deprecated.js
@@ -13,6 +13,7 @@ import {
 	convertColorToCSSVar,
 } from '../../utils/convert-preset-to-css-var';
 import { getOwnOpeningTag } from '../../utils/get-own-opening-tag';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Shared supports for all deprecated versions.
@@ -131,8 +132,8 @@ const v3 = {
 			default: '',
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Scope the check to the Blobs wrapper's OWN opening tag. Blobs accepts
 		// arbitrary nested blocks, and the generic max-width extension still
 		// stamps the same `dsgo-has-max-width` class + a raw inline `max-width:`
@@ -276,8 +277,8 @@ const v1 = {
 			default: 50,
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v1 blocks have no wrapper div - the dsgo-blobs class is directly on the block wrapper
 		return innerHTML && !innerHTML.includes('dsgo-blobs-wrapper');
 	},

--- a/src/blocks/blobs/test/deprecated.test.js
+++ b/src/blocks/blobs/test/deprecated.test.js
@@ -138,21 +138,27 @@ describe('blobs deprecations - v3 native max-width migration', () => {
 
 	test('v3 isEligible flags old extension markup', () => {
 		expect(
-			v3Deprecation.isEligible({}, [], { innerHTML: OLD_MARKUP })
+			v3Deprecation.isEligible({}, [], {
+				blockNode: { innerHTML: OLD_MARKUP },
+			})
 		).toBe(true);
 	});
 
 	test('v3 isEligible ignores current native markup', () => {
-		expect(v3Deprecation.isEligible({}, [], { innerHTML: canonical })).toBe(
-			false
-		);
+		expect(
+			v3Deprecation.isEligible({}, [], {
+				blockNode: { innerHTML: canonical },
+			})
+		).toBe(false);
 	});
 
 	test('v3 isEligible ignores a plain (no max-width) blob', () => {
 		const plain = serialize(createBlock(metadata.name, { size: '300px' }));
-		expect(v3Deprecation.isEligible({}, [], { innerHTML: plain })).toBe(
-			false
-		);
+		expect(
+			v3Deprecation.isEligible({}, [], {
+				blockNode: { innerHTML: plain },
+			})
+		).toBe(false);
 	});
 
 	test('v3 isEligible ignores a native blob whose NESTED child uses the generic max-width extension', () => {
@@ -169,7 +175,9 @@ describe('blobs deprecations - v3 native max-width migration', () => {
 			'<p class="dsgo-has-max-width" style="max-width:400px;margin-left:auto;margin-right:auto">Nested</p>' +
 			'</div></div>';
 		expect(
-			v3Deprecation.isEligible({}, [], { innerHTML: nestedHTML })
+			v3Deprecation.isEligible({}, [], {
+				blockNode: { innerHTML: nestedHTML },
+			})
 		).toBe(false);
 	});
 

--- a/src/blocks/countdown-timer/deprecated.js
+++ b/src/blocks/countdown-timer/deprecated.js
@@ -6,6 +6,7 @@ import {
 	convertPresetToCSSVar,
 	convertColorToCSSVar,
 } from '../../utils/convert-preset-to-css-var';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Internal dependencies
@@ -158,8 +159,8 @@ const v3 = {
 		unitGap: { type: 'string', default: '1rem' },
 		unitPadding: { type: 'string', default: '1.5rem' },
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const html = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const html = getDeprecatedBlockHTML(extra);
 		return (
 			html.includes('dsgo-countdown-timer__completion-message') &&
 			html.includes('display:none')

--- a/src/blocks/divider/deprecated.js
+++ b/src/blocks/divider/deprecated.js
@@ -51,7 +51,8 @@ const sharedSupports = {
  */
 const vLazy = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		return Boolean(innerHTML) && innerHTML.includes('dsgo-lazy-icon');
 	},
 	attributes: {
@@ -142,7 +143,8 @@ const v1 = {
 			default: 'star',
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v1 blocks have inline SVG icons instead of dsgo-lazy-icon class
 		return innerHTML && !innerHTML.includes('dsgo-lazy-icon');
 	},

--- a/src/blocks/divider/deprecated.js
+++ b/src/blocks/divider/deprecated.js
@@ -8,6 +8,7 @@
 
 import { useBlockProps } from '@wordpress/block-editor';
 import { getIcon } from '../shared/icon-utils';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Shared supports for all deprecated versions.
@@ -51,8 +52,8 @@ const sharedSupports = {
  */
 const vLazy = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		return Boolean(innerHTML) && innerHTML.includes('dsgo-lazy-icon');
 	},
 	attributes: {
@@ -143,8 +144,8 @@ const v1 = {
 			default: 'star',
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v1 blocks have inline SVG icons instead of dsgo-lazy-icon class
 		return innerHTML && !innerHTML.includes('dsgo-lazy-icon');
 	},

--- a/src/blocks/flip-card/deprecated.js
+++ b/src/blocks/flip-card/deprecated.js
@@ -5,6 +5,7 @@
  */
 
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Inline `width: 100%` — the version before that constant moved to style.scss.
@@ -54,8 +55,8 @@ const v1 = {
 			__experimentalDefaultControls: { margin: true },
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const html = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const html = getDeprecatedBlockHTML(extra);
 		return html.includes('dsgo-flip-card') && html.includes('width:100%');
 	},
 	migrate(attributes) {

--- a/src/blocks/form-builder/deprecated.js
+++ b/src/blocks/form-builder/deprecated.js
@@ -14,6 +14,7 @@ import {
 } from '../../utils/convert-preset-to-css-var';
 import { validateCSSLength } from '../../utils/css-generator';
 import metadata from './block.json';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * V4 deprecation: Before the border-color fallback moved from inline style to CSS.
@@ -55,8 +56,8 @@ const legacyAttributes = {
 const v5 = {
 	attributes: legacyAttributes,
 	supports: metadata.supports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		return (
 			Boolean(innerHTML) && innerHTML.includes('--dsgo-form-input-height')
 		);
@@ -476,8 +477,8 @@ const v4 = {
 const v3 = {
 	attributes: legacyAttributes,
 	supports: metadata.supports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v3 blocks have raw empty CSS vars rendered as `--dsgo-form-label-color:;`
 		return innerHTML && innerHTML.includes('--dsgo-form-label-color:;');
 	},
@@ -654,8 +655,8 @@ const v3 = {
 const v2 = {
 	attributes: legacyAttributes,
 	supports: metadata.supports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v2 blocks lack aria-hidden on honeypot and aria-atomic on message div
 		return (
 			innerHTML &&
@@ -874,8 +875,8 @@ const v2 = {
 const v1 = {
 	attributes: legacyAttributes,
 	supports: metadata.supports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v1 blocks have email config exposed as data attributes
 		return innerHTML && innerHTML.includes('data-enable-email');
 	},

--- a/src/blocks/form-builder/deprecated.js
+++ b/src/blocks/form-builder/deprecated.js
@@ -58,8 +58,16 @@ const v5 = {
 	supports: metadata.supports,
 	isEligible(attributes, innerBlocks, extra) {
 		const innerHTML = getDeprecatedBlockHTML(extra);
+		// The var alone does NOT mean "legacy": the current save() emits it too,
+		// as soon as inputHeight is set. The old save() wrote it UNCONDITIONALLY,
+		// with a baked default, which is why legacy content carries it while the
+		// block comment has no inputHeight. Current content that renders the var
+		// always carries the attribute (non-default, so WordPress serializes it),
+		// so requiring its absence excludes current content only.
 		return (
-			Boolean(innerHTML) && innerHTML.includes('--dsgo-form-input-height')
+			Boolean(innerHTML) &&
+			!attributes.inputHeight &&
+			innerHTML.includes('--dsgo-form-input-height')
 		);
 	},
 	migrate(attributes) {

--- a/src/blocks/form-builder/deprecated.js
+++ b/src/blocks/form-builder/deprecated.js
@@ -55,7 +55,8 @@ const legacyAttributes = {
 const v5 = {
 	attributes: legacyAttributes,
 	supports: metadata.supports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		return (
 			Boolean(innerHTML) && innerHTML.includes('--dsgo-form-input-height')
 		);
@@ -248,11 +249,12 @@ const v5 = {
 const v4 = {
 	attributes: legacyAttributes,
 	supports: metadata.supports,
-	isEligible(attributes) {
-		// Only content that never customized the border color is affected —
-		// the old save() forced the literal fallback in that case only.
-		return !attributes.fieldBorderColor;
-	},
+	// No isEligible: markup-change deprecation, reached by save-matching on an
+	// INVALID block (WordPress skips isEligible for those). The old guard,
+	// `!attributes.fieldBorderColor`, was true of every CURRENT form that simply
+	// never customised the border colour, so it claimed current content. Whether
+	// the old forced-fallback markup is actually present is decided by matching
+	// this version's save() against the stored HTML, which is the real test.
 	migrate(attributes) {
 		return attributes;
 	},
@@ -474,7 +476,8 @@ const v4 = {
 const v3 = {
 	attributes: legacyAttributes,
 	supports: metadata.supports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v3 blocks have raw empty CSS vars rendered as `--dsgo-form-label-color:;`
 		return innerHTML && innerHTML.includes('--dsgo-form-label-color:;');
 	},
@@ -651,7 +654,8 @@ const v3 = {
 const v2 = {
 	attributes: legacyAttributes,
 	supports: metadata.supports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v2 blocks lack aria-hidden on honeypot and aria-atomic on message div
 		return (
 			innerHTML &&
@@ -870,7 +874,8 @@ const v2 = {
 const v1 = {
 	attributes: legacyAttributes,
 	supports: metadata.supports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v1 blocks have email config exposed as data attributes
 		return innerHTML && innerHTML.includes('data-enable-email');
 	},

--- a/src/blocks/form-checkbox-field/deprecated.js
+++ b/src/blocks/form-checkbox-field/deprecated.js
@@ -11,6 +11,7 @@
 
 import { useBlockProps, RichText } from '@wordpress/block-editor';
 import classnames from 'classnames';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Supports definition for deprecated versions.
@@ -42,8 +43,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Any stored static checkbox field carries this wrapper class; the
 		// dynamic block saves no inner HTML, so it never matches.
 		return (

--- a/src/blocks/form-checkbox-field/deprecated.js
+++ b/src/blocks/form-checkbox-field/deprecated.js
@@ -42,7 +42,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Any stored static checkbox field carries this wrapper class; the
 		// dynamic block saves no inner HTML, so it never matches.
 		return (

--- a/src/blocks/form-date-field/deprecated.js
+++ b/src/blocks/form-date-field/deprecated.js
@@ -44,7 +44,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Any stored static date field carries this wrapper class; the dynamic
 		// block saves no inner HTML, so it never matches.
 		return (

--- a/src/blocks/form-date-field/deprecated.js
+++ b/src/blocks/form-date-field/deprecated.js
@@ -11,6 +11,7 @@
 
 import { useBlockProps } from '@wordpress/block-editor';
 import classnames from 'classnames';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Supports definition for deprecated versions.
@@ -44,8 +45,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Any stored static date field carries this wrapper class; the dynamic
 		// block saves no inner HTML, so it never matches.
 		return (

--- a/src/blocks/form-email-field/deprecated.js
+++ b/src/blocks/form-email-field/deprecated.js
@@ -42,7 +42,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Any stored static email field carries this wrapper class; the dynamic
 		// block saves no inner HTML, so it never matches.
 		return (
@@ -163,7 +164,8 @@ const v1 = {
 		},
 	},
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v1 blocks lack aria-required on input
 		return (
 			innerHTML &&

--- a/src/blocks/form-email-field/deprecated.js
+++ b/src/blocks/form-email-field/deprecated.js
@@ -11,6 +11,7 @@
 
 import { useBlockProps } from '@wordpress/block-editor';
 import classnames from 'classnames';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Supports definition for deprecated versions.
@@ -42,8 +43,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Any stored static email field carries this wrapper class; the dynamic
 		// block saves no inner HTML, so it never matches.
 		return (
@@ -164,8 +165,8 @@ const v1 = {
 		},
 	},
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v1 blocks lack aria-required on input
 		return (
 			innerHTML &&

--- a/src/blocks/form-hidden-field/deprecated.js
+++ b/src/blocks/form-hidden-field/deprecated.js
@@ -37,7 +37,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Any stored static hidden field carries this wrapper class; the
 		// dynamic block saves no inner HTML, so it never matches.
 		return (

--- a/src/blocks/form-hidden-field/deprecated.js
+++ b/src/blocks/form-hidden-field/deprecated.js
@@ -10,6 +10,7 @@
  */
 
 import { useBlockProps } from '@wordpress/block-editor';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Supports definition for deprecated versions.
@@ -37,8 +38,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Any stored static hidden field carries this wrapper class; the
 		// dynamic block saves no inner HTML, so it never matches.
 		return (

--- a/src/blocks/form-number-field/deprecated.js
+++ b/src/blocks/form-number-field/deprecated.js
@@ -11,6 +11,7 @@
 
 import { useBlockProps } from '@wordpress/block-editor';
 import classnames from 'classnames';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Supports definition for deprecated versions.
@@ -47,8 +48,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Any stored static number field carries this wrapper class; the dynamic
 		// block saves no inner HTML, so it never matches.
 		return (

--- a/src/blocks/form-number-field/deprecated.js
+++ b/src/blocks/form-number-field/deprecated.js
@@ -47,7 +47,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Any stored static number field carries this wrapper class; the dynamic
 		// block saves no inner HTML, so it never matches.
 		return (

--- a/src/blocks/form-phone-field/deprecated.js
+++ b/src/blocks/form-phone-field/deprecated.js
@@ -13,6 +13,7 @@
 
 import { useBlockProps } from '@wordpress/block-editor';
 import classnames from 'classnames';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Supports definition for deprecated versions.
@@ -141,8 +142,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Any stored static phone field carries this wrapper class; the dynamic
 		// block saves no inner HTML, so it never matches.
 		return (
@@ -254,8 +255,8 @@ const v4 = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Legacy era: current-format <select> (data-dsgo-country-code, no
 		// <option> children) but with `flex:1px` on the <input> — React added
 		// `px` to the numeric `flex: 1` value. The fixed save.js uses the
@@ -360,8 +361,8 @@ const v3 = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Has country code class, inline options, but no data-dsgo-country-code,
 		// no `selected`, and no `defaultvalue`
 		return (
@@ -479,8 +480,8 @@ const v2 = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v2 blocks have hardcoded country code options with selected attribute
 		return (
 			innerHTML &&
@@ -654,8 +655,8 @@ const v1 = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v1 blocks use defaultValue on select instead of selected on options
 		return (
 			innerHTML &&

--- a/src/blocks/form-phone-field/deprecated.js
+++ b/src/blocks/form-phone-field/deprecated.js
@@ -141,7 +141,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Any stored static phone field carries this wrapper class; the dynamic
 		// block saves no inner HTML, so it never matches.
 		return (
@@ -253,7 +254,8 @@ const v4 = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Legacy era: current-format <select> (data-dsgo-country-code, no
 		// <option> children) but with `flex:1px` on the <input> — React added
 		// `px` to the numeric `flex: 1` value. The fixed save.js uses the
@@ -358,7 +360,8 @@ const v3 = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Has country code class, inline options, but no data-dsgo-country-code,
 		// no `selected`, and no `defaultvalue`
 		return (
@@ -476,7 +479,8 @@ const v2 = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v2 blocks have hardcoded country code options with selected attribute
 		return (
 			innerHTML &&
@@ -650,7 +654,8 @@ const v1 = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v1 blocks use defaultValue on select instead of selected on options
 		return (
 			innerHTML &&

--- a/src/blocks/form-select-field/deprecated.js
+++ b/src/blocks/form-select-field/deprecated.js
@@ -11,6 +11,7 @@
 
 import { useBlockProps } from '@wordpress/block-editor';
 import classnames from 'classnames';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Supports definition for deprecated versions.
@@ -69,8 +70,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Any stored static select field carries this wrapper class; the
 		// dynamic block saves no inner HTML, so it never matches.
 		return (
@@ -209,8 +210,8 @@ const v2 = {
 		},
 	},
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v2 blocks lack aria-required on select
 		return (
 			innerHTML &&
@@ -349,8 +350,8 @@ const v1 = {
 		},
 	},
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v1 blocks use defaultValue on select (non-standard attribute)
 		return (
 			innerHTML &&

--- a/src/blocks/form-select-field/deprecated.js
+++ b/src/blocks/form-select-field/deprecated.js
@@ -69,7 +69,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Any stored static select field carries this wrapper class; the
 		// dynamic block saves no inner HTML, so it never matches.
 		return (
@@ -208,7 +209,8 @@ const v2 = {
 		},
 	},
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v2 blocks lack aria-required on select
 		return (
 			innerHTML &&
@@ -347,7 +349,8 @@ const v1 = {
 		},
 	},
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v1 blocks use defaultValue on select (non-standard attribute)
 		return (
 			innerHTML &&

--- a/src/blocks/form-text-field/deprecated.js
+++ b/src/blocks/form-text-field/deprecated.js
@@ -11,6 +11,7 @@
 
 import { useBlockProps } from '@wordpress/block-editor';
 import classnames from 'classnames';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Supports definition for deprecated versions.
@@ -47,8 +48,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Any stored static text field carries this wrapper class; the dynamic
 		// block saves no inner HTML, so it never matches.
 		return (
@@ -164,8 +165,8 @@ const v1 = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v1 blocks lack aria-required on input
 		return (
 			innerHTML &&

--- a/src/blocks/form-text-field/deprecated.js
+++ b/src/blocks/form-text-field/deprecated.js
@@ -47,7 +47,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Any stored static text field carries this wrapper class; the dynamic
 		// block saves no inner HTML, so it never matches.
 		return (
@@ -163,7 +164,8 @@ const v1 = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v1 blocks lack aria-required on input
 		return (
 			innerHTML &&

--- a/src/blocks/form-textarea-field/deprecated.js
+++ b/src/blocks/form-textarea-field/deprecated.js
@@ -47,7 +47,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Any stored static textarea field carries this wrapper class; the
 		// dynamic block saves no inner HTML, so it never matches.
 		return (
@@ -180,7 +181,8 @@ const v2 = {
 		},
 	},
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v2 blocks lack aria-required on textarea
 		return (
 			innerHTML &&
@@ -308,7 +310,8 @@ const v1 = {
 		},
 	},
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v1 was the original designsetgo/form-textarea block before rename
 		return (
 			innerHTML &&

--- a/src/blocks/form-textarea-field/deprecated.js
+++ b/src/blocks/form-textarea-field/deprecated.js
@@ -14,6 +14,7 @@
 
 import { useBlockProps } from '@wordpress/block-editor';
 import classnames from 'classnames';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Supports definition for deprecated versions.
@@ -47,8 +48,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Any stored static textarea field carries this wrapper class; the
 		// dynamic block saves no inner HTML, so it never matches.
 		return (
@@ -181,8 +182,8 @@ const v2 = {
 		},
 	},
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v2 blocks lack aria-required on textarea
 		return (
 			innerHTML &&
@@ -310,8 +311,8 @@ const v1 = {
 		},
 	},
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v1 was the original designsetgo/form-textarea block before rename
 		return (
 			innerHTML &&

--- a/src/blocks/form-time-field/deprecated.js
+++ b/src/blocks/form-time-field/deprecated.js
@@ -11,6 +11,7 @@
 
 import { useBlockProps } from '@wordpress/block-editor';
 import classnames from 'classnames';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Supports definition for deprecated versions.
@@ -45,8 +46,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Any stored static time field carries this wrapper class; the dynamic
 		// block saves no inner HTML, so it never matches.
 		return (

--- a/src/blocks/form-time-field/deprecated.js
+++ b/src/blocks/form-time-field/deprecated.js
@@ -45,7 +45,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Any stored static time field carries this wrapper class; the dynamic
 		// block saves no inner HTML, so it never matches.
 		return (

--- a/src/blocks/form-url-field/deprecated.js
+++ b/src/blocks/form-url-field/deprecated.js
@@ -11,6 +11,7 @@
 
 import { useBlockProps } from '@wordpress/block-editor';
 import classnames from 'classnames';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Supports definition for deprecated versions.
@@ -43,8 +44,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Any stored static URL field carries this wrapper class; the dynamic
 		// block saves no inner HTML, so it never matches.
 		return Boolean(innerHTML) && innerHTML.includes('dsgo-form-field--url');

--- a/src/blocks/form-url-field/deprecated.js
+++ b/src/blocks/form-url-field/deprecated.js
@@ -43,7 +43,8 @@ const vStatic = {
 	supports: sharedSupports,
 	attributes: sharedAttributes,
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Any stored static URL field carries this wrapper class; the dynamic
 		// block saves no inner HTML, so it never matches.
 		return Boolean(innerHTML) && innerHTML.includes('dsgo-form-field--url');

--- a/src/blocks/grid/deprecated.js
+++ b/src/blocks/grid/deprecated.js
@@ -14,6 +14,7 @@ import {
 	hoverVariationClasses,
 } from '../../utils/style-variation-classes';
 import metadata from './block.json';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 // Captures the column min width from a `minmax(<width>, 1fr)` grid track.
 const MIN_WIDTH_RE = /minmax\(\s*(\d+(?:\.\d+)?[a-z%]+)\s*,\s*1fr\s*\)/i;
@@ -111,8 +112,8 @@ const sharedSupports = {
 const styleVariationClasses = {
 	supports: metadata.supports,
 	attributes: { ...metadata.attributes },
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		if (!innerHTML || !innerHTML.includes('dsgo-grid')) {
 			return false;
 		}
@@ -380,8 +381,8 @@ const legacyMinWidth = {
 			attribute: 'style',
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		return (
 			!!innerHTML &&
 			/grid-template-columns:\s*repeat\([^)]*minmax/i.test(innerHTML)

--- a/src/blocks/grid/deprecated.js
+++ b/src/blocks/grid/deprecated.js
@@ -383,8 +383,16 @@ const legacyMinWidth = {
 	},
 	isEligible(attributes, innerBlocks, extra) {
 		const innerHTML = getDeprecatedBlockHTML(extra);
+		// A minmax() track alone does NOT mean "legacy": the current save() emits
+		// one too, as soon as columnMinWidth is set. What marks the old
+		// AI-generated pattern content is the track being baked into the HTML with
+		// no columnMinWidth in the block comment — and migrate() below recovers it
+		// from the markup. A current grid that renders minmax() always carries the
+		// attribute (it is non-default, so WordPress serializes it), so requiring
+		// its absence excludes current content without missing any legacy content.
 		return (
 			!!innerHTML &&
+			!attributes.columnMinWidth &&
 			/grid-template-columns:\s*repeat\([^)]*minmax/i.test(innerHTML)
 		);
 	},

--- a/src/blocks/grid/deprecated.js
+++ b/src/blocks/grid/deprecated.js
@@ -111,7 +111,8 @@ const sharedSupports = {
 const styleVariationClasses = {
 	supports: metadata.supports,
 	attributes: { ...metadata.attributes },
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		if (!innerHTML || !innerHTML.includes('dsgo-grid')) {
 			return false;
 		}
@@ -258,10 +259,11 @@ const v1 = {
 			type: 'string',
 		},
 	},
-	isEligible(attributes) {
-		// v1 blocks don't have the align attribute - used className for alignment
-		return attributes.align === undefined;
-	},
+	// No isEligible: markup-change deprecation, reached by save-matching on an
+	// INVALID block (WordPress skips isEligible for those). The old guard,
+	// `attributes.align === undefined`, matched nearly every CURRENT grid too:
+	// `align` has no default, so it is absent from the raw comment attributes on
+	// any grid the author never aligned wide/full.
 	save({ attributes }) {
 		const {
 			hoverBackgroundColor,
@@ -378,7 +380,8 @@ const legacyMinWidth = {
 			attribute: 'style',
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		return (
 			!!innerHTML &&
 			/grid-template-columns:\s*repeat\([^)]*minmax/i.test(innerHTML)

--- a/src/blocks/grid/test/deprecated.test.js
+++ b/src/blocks/grid/test/deprecated.test.js
@@ -63,7 +63,7 @@ describe('grid deprecations - style-kit overlay variation migration', () => {
 			styleVariationClassesDeprecation.isEligible(
 				{ className: 'is-style-overlay-dark' },
 				[],
-				{ innerHTML: html }
+				{ blockNode: { innerHTML: html } }
 			)
 		).toBe(true);
 	});
@@ -75,7 +75,7 @@ describe('grid deprecations - style-kit overlay variation migration', () => {
 			styleVariationClassesDeprecation.isEligible(
 				{ className: 'is-style-overlay-dark' },
 				[],
-				{ innerHTML: html }
+				{ blockNode: { innerHTML: html } }
 			)
 		).toBe(false);
 	});
@@ -84,11 +84,9 @@ describe('grid deprecations - style-kit overlay variation migration', () => {
 		const html =
 			'<div class="wp-block-designsetgo-grid dsgo-grid"><div class="dsgo-grid__inner"></div></div>';
 		expect(
-			styleVariationClassesDeprecation.isEligible(
-				{ className: '' },
-				[],
-				{ innerHTML: html }
-			)
+			styleVariationClassesDeprecation.isEligible({ className: '' }, [], {
+				blockNode: { innerHTML: html },
+			})
 		).toBe(false);
 	});
 
@@ -134,7 +132,7 @@ describe('grid deprecations - style-kit hover variation migration', () => {
 			styleVariationClassesDeprecation.isEligible(
 				{ className: 'is-style-hover-icon-blue' },
 				[],
-				{ innerHTML: html }
+				{ blockNode: { innerHTML: html } }
 			)
 		).toBe(true);
 	});
@@ -143,11 +141,9 @@ describe('grid deprecations - style-kit hover variation migration', () => {
 		const html =
 			'<div class="wp-block-designsetgo-grid dsgo-grid"><div class="dsgo-grid__inner"></div></div>';
 		expect(
-			styleVariationClassesDeprecation.isEligible(
-				{ className: '' },
-				[],
-				{ innerHTML: html }
-			)
+			styleVariationClassesDeprecation.isEligible({ className: '' }, [], {
+				blockNode: { innerHTML: html },
+			})
 		).toBe(false);
 	});
 
@@ -192,12 +188,12 @@ describe('grid deprecations - legacyMinWidth precedence over styleVariationClass
 		const attributes = { className: 'is-style-overlay-dark' };
 		expect(
 			legacyMinWidthDeprecation.isEligible(attributes, [], {
-				innerHTML: COMBINED_MARKUP,
+				blockNode: { innerHTML: COMBINED_MARKUP },
 			})
 		).toBe(true);
 		expect(
 			styleVariationClassesDeprecation.isEligible(attributes, [], {
-				innerHTML: COMBINED_MARKUP,
+				blockNode: { innerHTML: COMBINED_MARKUP },
 			})
 		).toBe(true);
 	});

--- a/src/blocks/icon-button/deprecated.js
+++ b/src/blocks/icon-button/deprecated.js
@@ -803,10 +803,16 @@ const v7 = {
 	supports: sharedSupports,
 	isEligible(attributes, innerBlocks, extra) {
 		const innerHTML = getDeprecatedBlockHTML(extra);
-		// Lazy-format block (post-v6) that still carries an inline size pair
-		// on the icon span — the signature of the pre-token serialization.
+		// Lazy-format block (post-v6) that still carries an inline size pair on the
+		// icon span — the signature of the pre-token serialization, which baked the
+		// pair in even at the IMPLICIT default size. The current save() writes it
+		// only for an explicit iconSize, and that value is then in the block
+		// comment; so an inline size pair with NO iconSize attribute is what
+		// actually identifies this era. Without that conjunct the guard also
+		// claimed every current icon-button with an explicit iconSize.
 		return (
 			innerHTML &&
+			attributes.iconSize === undefined &&
 			innerHTML.includes('dsgo-lazy-icon') &&
 			/width:\s*\d+px\s*;\s*height:\s*\d+px/.test(innerHTML)
 		);

--- a/src/blocks/icon-button/deprecated.js
+++ b/src/blocks/icon-button/deprecated.js
@@ -30,6 +30,7 @@ import {
 } from '../../utils/has-explicit-value';
 import { getOwnOpeningTag } from '../../utils/get-own-opening-tag';
 import { getJustificationClass } from '../../utils/justification';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Every deprecation must land on the CURRENT attribute schema — deprecations do
@@ -281,8 +282,8 @@ const v10Supports = {
 const v10 = {
 	attributes: v10Attributes,
 	supports: v10Supports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const html = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const html = getDeprecatedBlockHTML(extra);
 		return (
 			html.includes('dsgo-icon-button__icon') &&
 			html.includes('display:flex')
@@ -430,8 +431,8 @@ const v10 = {
 
 const v9 = {
 	supports: v9Supports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Pre-wrapper markup: the block root IS the button/link, not a `<div>`.
 		return !!innerHTML && !innerHTML.trimStart().startsWith('<div');
 	},
@@ -608,8 +609,8 @@ const v9 = {
  */
 const v8 = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Old serialization = an icon button with an inline gap on the root but
 		// without the new marker class. Scope the check to the button's OWN
 		// opening tag: `text` is free-form RichText serialized into innerHTML, so
@@ -800,8 +801,8 @@ const v8 = {
  */
 const v7 = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Lazy-format block (post-v6) that still carries an inline size pair
 		// on the icon span — the signature of the pre-token serialization.
 		return (
@@ -1027,8 +1028,8 @@ const v6 = {
 			default: '',
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v6 blocks use flex (not inline-flex) for full-width; v5 always uses inline-flex
 		return (
 			innerHTML &&
@@ -1237,8 +1238,8 @@ const v5 = {
 			default: '',
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v5 blocks use inline-flex for all widths (including 100%) and raw width value
 		return (
 			innerHTML &&
@@ -1450,8 +1451,8 @@ const v4 = {
 			default: '',
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v4 blocks have the two-div structure with dsgo-icon-button__wrapper
 		return (
 			innerHTML &&
@@ -1673,8 +1674,8 @@ const v3 = {
 			default: '',
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v3 blocks have inline display/width styles on outer wrapper and dsgo-icon-button__wrapper without wp-block-button__link
 		return (
 			innerHTML &&
@@ -1875,8 +1876,8 @@ const v2 = {
 			default: '',
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v2 blocks have inline SVG icons (no dsgo-lazy-icon class)
 		return (
 			innerHTML &&
@@ -2070,8 +2071,8 @@ const v1 = {
 			default: '',
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v1 blocks don't have splitPaddingStyles and render icon position differently
 		// They also don't have dsgo-lazy-icon and have role="button" on non-link wrappers
 		return (

--- a/src/blocks/icon-button/deprecated.js
+++ b/src/blocks/icon-button/deprecated.js
@@ -430,7 +430,8 @@ const v10 = {
 
 const v9 = {
 	supports: v9Supports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Pre-wrapper markup: the block root IS the button/link, not a `<div>`.
 		return !!innerHTML && !innerHTML.trimStart().startsWith('<div');
 	},
@@ -607,7 +608,8 @@ const v9 = {
  */
 const v8 = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Old serialization = an icon button with an inline gap on the root but
 		// without the new marker class. Scope the check to the button's OWN
 		// opening tag: `text` is free-form RichText serialized into innerHTML, so
@@ -798,7 +800,8 @@ const v8 = {
  */
 const v7 = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Lazy-format block (post-v6) that still carries an inline size pair
 		// on the icon span — the signature of the pre-token serialization.
 		return (
@@ -1024,7 +1027,8 @@ const v6 = {
 			default: '',
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v6 blocks use flex (not inline-flex) for full-width; v5 always uses inline-flex
 		return (
 			innerHTML &&
@@ -1233,7 +1237,8 @@ const v5 = {
 			default: '',
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v5 blocks use inline-flex for all widths (including 100%) and raw width value
 		return (
 			innerHTML &&
@@ -1445,7 +1450,8 @@ const v4 = {
 			default: '',
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v4 blocks have the two-div structure with dsgo-icon-button__wrapper
 		return (
 			innerHTML &&
@@ -1667,7 +1673,8 @@ const v3 = {
 			default: '',
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v3 blocks have inline display/width styles on outer wrapper and dsgo-icon-button__wrapper without wp-block-button__link
 		return (
 			innerHTML &&
@@ -1868,7 +1875,8 @@ const v2 = {
 			default: '',
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v2 blocks have inline SVG icons (no dsgo-lazy-icon class)
 		return (
 			innerHTML &&
@@ -2062,7 +2070,8 @@ const v1 = {
 			default: '',
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v1 blocks don't have splitPaddingStyles and render icon position differently
 		// They also don't have dsgo-lazy-icon and have role="button" on non-link wrappers
 		return (

--- a/src/blocks/icon-button/test/deprecated.test.js
+++ b/src/blocks/icon-button/test/deprecated.test.js
@@ -224,19 +224,27 @@ describe('icon-button deprecations - v8 themeable-gap migration', () => {
 
 	test('isEligible flags old markup (inline gap, no marker class)', () => {
 		expect(
-			v8Deprecation.isEligible({}, [], { innerHTML: OLD_ICON_MARKUP })
+			v8Deprecation.isEligible({}, [], {
+				blockNode: { innerHTML: OLD_ICON_MARKUP },
+			})
 		).toBe(true);
 		expect(
-			v8Deprecation.isEligible({}, [], { innerHTML: OLD_NO_ICON_MARKUP })
+			v8Deprecation.isEligible({}, [], {
+				blockNode: { innerHTML: OLD_NO_ICON_MARKUP },
+			})
 		).toBe(true);
 	});
 
 	test('isEligible ignores current markup', () => {
 		expect(
-			v8Deprecation.isEligible({}, [], { innerHTML: canonicalIcon })
+			v8Deprecation.isEligible({}, [], {
+				blockNode: { innerHTML: canonicalIcon },
+			})
 		).toBe(false);
 		expect(
-			v8Deprecation.isEligible({}, [], { innerHTML: canonicalNoIcon })
+			v8Deprecation.isEligible({}, [], {
+				blockNode: { innerHTML: canonicalNoIcon },
+			})
 		).toBe(false);
 	});
 
@@ -246,9 +254,9 @@ describe('icon-button deprecations - v8 themeable-gap migration', () => {
 		// "Mind the gap: ..." from false-triggering the deprecation.
 		const html =
 			'<a class="wp-block-designsetgo-icon-button dsgo-icon-button wp-block-button wp-block-button__link wp-element-button" style="display:inline-flex;align-items:center;justify-content:center;width:auto;flex-direction:row" href="#"><span class="dsgo-icon-button__text">Mind the gap: watch your step</span></a>';
-		expect(v8Deprecation.isEligible({}, [], { innerHTML: html })).toBe(
-			false
-		);
+		expect(
+			v8Deprecation.isEligible({}, [], { blockNode: { innerHTML: html } })
+		).toBe(false);
 	});
 
 	test('migrate is a passthrough that pins values (never strips defaults), plus the align→justification/fullWidth conversion', () => {

--- a/src/blocks/icon-list-item/deprecated.js
+++ b/src/blocks/icon-list-item/deprecated.js
@@ -13,6 +13,7 @@ import {
 	convertColorToCSSVar,
 } from '../../utils/convert-preset-to-css-var';
 import { getOwnOpeningTag } from '../../utils/get-own-opening-tag';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Shared supports definition for all deprecated versions.
@@ -85,8 +86,8 @@ const v4 = {
 		linkTarget: { type: 'string', default: '_self' },
 		linkRel: { type: 'string', default: '' },
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const html = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const html = getDeprecatedBlockHTML(extra);
 		// Match the icon box's own style attribute carrying the layout trio.
 		return /class="[^"]*dsgo-icon-list-item__icon[^"]*"\s+style="display:flex;align-items:center;justify-content:center/.test(
 			html
@@ -224,8 +225,8 @@ const v4 = {
 
 const v3 = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Old serialization baked the icon↔content gap on the item root right
 		// after align-items; the current save() omits it. Scope the check to the
 		// item wrapper's OWN opening tag rather than the whole subtree: the
@@ -415,8 +416,8 @@ const v3 = {
  */
 const v2 = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		return (
 			innerHTML &&
 			innerHTML.includes('dsgo-lazy-icon') &&
@@ -572,8 +573,8 @@ const v1 = {
 			default: '',
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v1 blocks have inline SVG icons instead of dsgo-lazy-icon class
 		return innerHTML && !innerHTML.includes('dsgo-lazy-icon');
 	},

--- a/src/blocks/icon-list-item/deprecated.js
+++ b/src/blocks/icon-list-item/deprecated.js
@@ -224,7 +224,8 @@ const v4 = {
 
 const v3 = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Old serialization baked the icon↔content gap on the item root right
 		// after align-items; the current save() omits it. Scope the check to the
 		// item wrapper's OWN opening tag rather than the whole subtree: the
@@ -414,7 +415,8 @@ const v3 = {
  */
 const v2 = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		return (
 			innerHTML &&
 			innerHTML.includes('dsgo-lazy-icon') &&
@@ -570,7 +572,8 @@ const v1 = {
 			default: '',
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v1 blocks have inline SVG icons instead of dsgo-lazy-icon class
 		return innerHTML && !innerHTML.includes('dsgo-lazy-icon');
 	},

--- a/src/blocks/icon-list-item/test/deprecated.test.js
+++ b/src/blocks/icon-list-item/test/deprecated.test.js
@@ -150,14 +150,18 @@ describe('icon-list-item deprecations - v3 kit-controllable gaps/size', () => {
 
 	test('isEligible flags old markup (inline item gap after align-items)', () => {
 		expect(
-			v3Deprecation.isEligible({}, [], { innerHTML: OLD_MARKUP })
+			v3Deprecation.isEligible({}, [], {
+				blockNode: { innerHTML: OLD_MARKUP },
+			})
 		).toBe(true);
 	});
 
 	test('isEligible ignores current markup', () => {
-		expect(v3Deprecation.isEligible({}, [], { innerHTML: canonical })).toBe(
-			false
-		);
+		expect(
+			v3Deprecation.isEligible({}, [], {
+				blockNode: { innerHTML: canonical },
+			})
+		).toBe(false);
 	});
 
 	test('isEligible ignores an item whose NESTED content emits align-items;gap', () => {
@@ -173,7 +177,9 @@ describe('icon-list-item deprecations - v3 kit-controllable gaps/size', () => {
 			'<div class="wp-block-columns" style="align-items:center;gap:8px">Nested</div>' +
 			'</div></div>';
 		expect(
-			v3Deprecation.isEligible({}, [], { innerHTML: nestedHTML })
+			v3Deprecation.isEligible({}, [], {
+				blockNode: { innerHTML: nestedHTML },
+			})
 		).toBe(false);
 	});
 

--- a/src/blocks/icon-list/deprecated.js
+++ b/src/blocks/icon-list/deprecated.js
@@ -6,6 +6,7 @@
 
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import metadata from './block.json';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 // Matches the responsive grid value `…minmax(min(100%, <width>), 1fr)` and
 // captures the <width> so it can be recovered into the columnMinWidth attribute.
@@ -36,8 +37,8 @@ const v1 = {
 			attribute: 'style',
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		return !!innerHTML && innerHTML.includes('minmax(min(100%');
 	},
 	save({ attributes }) {

--- a/src/blocks/icon-list/deprecated.js
+++ b/src/blocks/icon-list/deprecated.js
@@ -36,7 +36,8 @@ const v1 = {
 			attribute: 'style',
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		return !!innerHTML && innerHTML.includes('minmax(min(100%');
 	},
 	save({ attributes }) {

--- a/src/blocks/icon/deprecated.js
+++ b/src/blocks/icon/deprecated.js
@@ -8,6 +8,7 @@
 
 import { useBlockProps } from '@wordpress/block-editor';
 import { getIcon } from './utils/svg-icons';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Shared supports definition for all deprecated versions.
@@ -136,8 +137,8 @@ const vAlign = {
  */
 const vLazy = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		return Boolean(innerHTML) && innerHTML.includes('dsgo-lazy-icon');
 	},
 
@@ -273,8 +274,8 @@ const vLazy = {
  */
 const v2 = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Lazy-format block (post-v1) that still carries an inline size pair —
 		// the signature of the pre-token serialization.
 		return (
@@ -411,8 +412,8 @@ const v2 = {
  */
 const v1 = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v1 is eligible if the block DOES NOT have dsgo-lazy-icon class
 		// New blocks use dsgo-lazy-icon for frontend injection
 		// Old blocks have inline SVG without this class

--- a/src/blocks/icon/deprecated.js
+++ b/src/blocks/icon/deprecated.js
@@ -136,7 +136,8 @@ const vAlign = {
  */
 const vLazy = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		return Boolean(innerHTML) && innerHTML.includes('dsgo-lazy-icon');
 	},
 
@@ -272,7 +273,8 @@ const vLazy = {
  */
 const v2 = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Lazy-format block (post-v1) that still carries an inline size pair —
 		// the signature of the pre-token serialization.
 		return (
@@ -409,7 +411,8 @@ const v2 = {
  */
 const v1 = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v1 is eligible if the block DOES NOT have dsgo-lazy-icon class
 		// New blocks use dsgo-lazy-icon for frontend injection
 		// Old blocks have inline SVG without this class

--- a/src/blocks/image-accordion-item/deprecated.js
+++ b/src/blocks/image-accordion-item/deprecated.js
@@ -19,13 +19,14 @@ import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import classnames from 'classnames';
 import metadata from './block.json';
 import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 const v1 = {
 	attributes: metadata.attributes,
 	supports: metadata.supports,
 	usesContext: metadata.usesContext,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Only the pre-change save emitted the short overlay custom property.
 		return (
 			typeof innerHTML === 'string' &&

--- a/src/blocks/image-accordion-item/deprecated.js
+++ b/src/blocks/image-accordion-item/deprecated.js
@@ -24,7 +24,8 @@ const v1 = {
 	attributes: metadata.attributes,
 	supports: metadata.supports,
 	usesContext: metadata.usesContext,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Only the pre-change save emitted the short overlay custom property.
 		return (
 			typeof innerHTML === 'string' &&

--- a/src/blocks/map/deprecated.js
+++ b/src/blocks/map/deprecated.js
@@ -7,6 +7,7 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Shared supports for all deprecated versions.
@@ -73,8 +74,8 @@ const vStatic = {
 		dsgoMapStyle: { type: 'string', default: 'standard' },
 	},
 
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		return (
 			Boolean(innerHTML) &&
 			innerHTML.includes('dsgo-map') &&

--- a/src/blocks/map/deprecated.js
+++ b/src/blocks/map/deprecated.js
@@ -73,7 +73,8 @@ const vStatic = {
 		dsgoMapStyle: { type: 'string', default: 'standard' },
 	},
 
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		return (
 			Boolean(innerHTML) &&
 			innerHTML.includes('dsgo-map') &&

--- a/src/blocks/modal-trigger/deprecated.js
+++ b/src/blocks/modal-trigger/deprecated.js
@@ -118,7 +118,8 @@ const sharedSupports = {
  */
 const v4 = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Pre-wrapper markup: the block root IS the button, not a `<div>`.
 		return !!innerHTML && !innerHTML.trimStart().startsWith('<div');
 	},
@@ -272,7 +273,8 @@ const v4 = {
  */
 const v3 = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Current-structure block (single <button>, dsgo-lazy-icon) that still
 		// carries an inline size pair — the signature of the pre-token
 		// serialization. Exclude the legacy nested wrapper+button markup
@@ -452,7 +454,8 @@ const v2 = {
 			default: '8px',
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v2 blocks have dsgo-lazy-icon class but still use two-div wrapper+button structure
 		// and have dsgo-modal-trigger--width-* classes
 		return (
@@ -581,7 +584,8 @@ const v1 = {
 			default: '8px',
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v1 blocks have inline SVG icons (no dsgo-lazy-icon class)
 		return (
 			innerHTML &&

--- a/src/blocks/modal-trigger/deprecated.js
+++ b/src/blocks/modal-trigger/deprecated.js
@@ -8,6 +8,7 @@
 
 import { useBlockProps, RichText } from '@wordpress/block-editor';
 import { getIcon } from '../icon/utils/svg-icons';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Every deprecation must land on the CURRENT attribute schema — deprecations do
@@ -118,8 +119,8 @@ const sharedSupports = {
  */
 const v4 = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Pre-wrapper markup: the block root IS the button, not a `<div>`.
 		return !!innerHTML && !innerHTML.trimStart().startsWith('<div');
 	},
@@ -273,8 +274,8 @@ const v4 = {
  */
 const v3 = {
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Current-structure block (single <button>, dsgo-lazy-icon) that still
 		// carries an inline size pair — the signature of the pre-token
 		// serialization. Exclude the legacy nested wrapper+button markup
@@ -454,8 +455,8 @@ const v2 = {
 			default: '8px',
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v2 blocks have dsgo-lazy-icon class but still use two-div wrapper+button structure
 		// and have dsgo-modal-trigger--width-* classes
 		return (
@@ -584,8 +585,8 @@ const v1 = {
 			default: '8px',
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v1 blocks have inline SVG icons (no dsgo-lazy-icon class)
 		return (
 			innerHTML &&

--- a/src/blocks/pill/deprecated.js
+++ b/src/blocks/pill/deprecated.js
@@ -125,7 +125,8 @@ const vStatic = {
 		},
 	},
 	supports: staticSupports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Static pills always carried an alignment class (the "center" default was
 		// baked by useBlockProps.save()). Match a dsgo-pill wrapper that has one —
 		// the pre-align legacy (no alignment class) is handled by v1 below.
@@ -266,7 +267,8 @@ const v1 = {
 			__experimentalSelector: '.dsgo-pill__content',
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Legacy saves lack `aligncenter` even when no explicit align was
 		// stored (the default "center" was not yet an attribute). Current
 		// saves always emit `aligncenter` for the default. Match only the

--- a/src/blocks/pill/deprecated.js
+++ b/src/blocks/pill/deprecated.js
@@ -1,4 +1,5 @@
 import { useBlockProps, RichText } from '@wordpress/block-editor';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 // Shared style-transfer used by the static save() reproductions below: the
 // visible pill is the inner span, so colour/background/border inline styles that
@@ -125,8 +126,8 @@ const vStatic = {
 		},
 	},
 	supports: staticSupports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Static pills always carried an alignment class (the "center" default was
 		// baked by useBlockProps.save()). Match a dsgo-pill wrapper that has one —
 		// the pre-align legacy (no alignment class) is handled by v1 below.
@@ -267,8 +268,8 @@ const v1 = {
 			__experimentalSelector: '.dsgo-pill__content',
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Legacy saves lack `aligncenter` even when no explicit align was
 		// stored (the default "center" was not yet an attribute). Current
 		// saves always emit `aligncenter` for the default. Match only the

--- a/src/blocks/progress-bar/deprecated.js
+++ b/src/blocks/progress-bar/deprecated.js
@@ -20,7 +20,8 @@ import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
 const v1 = {
 	attributes: metadata.attributes,
 	supports: metadata.supports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		if (typeof innerHTML !== 'string') {
 			return false;
 		}

--- a/src/blocks/progress-bar/deprecated.js
+++ b/src/blocks/progress-bar/deprecated.js
@@ -16,12 +16,13 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import metadata from './block.json';
 import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 const v1 = {
 	attributes: metadata.attributes,
 	supports: metadata.supports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		if (typeof innerHTML !== 'string') {
 			return false;
 		}

--- a/src/blocks/row/deprecated.js
+++ b/src/blocks/row/deprecated.js
@@ -14,6 +14,7 @@ import {
 	hoverVariationClasses,
 } from '../../utils/style-variation-classes';
 import metadata from './block.json';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Convert WordPress vertical alignment value to CSS align-items value.
@@ -127,8 +128,8 @@ const sharedSupports = {
 const v5 = {
 	supports: metadata.supports,
 	attributes: { ...metadata.attributes },
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		if (!innerHTML || !innerHTML.includes('dsgo-flex')) {
 			return false;
 		}
@@ -448,8 +449,8 @@ const v3 = {
 			type: 'string',
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// v3 blocks have tagName (added in v3) and dsgo-flex__inner but no align-items
 		return (
 			Object.prototype.hasOwnProperty.call(attributes, 'tagName') &&

--- a/src/blocks/row/deprecated.js
+++ b/src/blocks/row/deprecated.js
@@ -449,16 +449,11 @@ const v3 = {
 			type: 'string',
 		},
 	},
-	isEligible(attributes, innerBlocks, extra) {
-		const innerHTML = getDeprecatedBlockHTML(extra);
-		// v3 blocks have tagName (added in v3) and dsgo-flex__inner but no align-items
-		return (
-			Object.prototype.hasOwnProperty.call(attributes, 'tagName') &&
-			innerHTML &&
-			innerHTML.includes('dsgo-flex__inner') &&
-			!innerHTML.includes('align-items')
-		);
-	},
+	// No isEligible: markup-change deprecation, reached by save-matching on an
+	// INVALID block (WordPress skips isEligible for those). The old guard fired on
+	// any CURRENT row with a non-default tagName, because the rest of its
+	// signature — the dsgo-flex__inner wrapper, and no `align-items` when
+	// alignItems sits at its default — is exactly what the current save() emits.
 	save({ attributes }) {
 		const {
 			tagName = 'div',
@@ -596,15 +591,12 @@ const v2 = {
 			type: 'string',
 		},
 	},
-	isEligible(attributes) {
-		// v2 blocks have align (introduced in v2) but not tagName (added in v3)
-		// v1 blocks don't have align, tagName, or constrainWidth
-		return (
-			Object.prototype.hasOwnProperty.call(attributes, 'align') &&
-			!Object.prototype.hasOwnProperty.call(attributes, 'tagName') &&
-			!Object.prototype.hasOwnProperty.call(attributes, 'constrainWidth')
-		);
-	},
+	// No isEligible: markup-change deprecation, reached by save-matching on an
+	// INVALID block (WordPress skips isEligible for those). The old guard read
+	// "has align, but no tagName and no constrainWidth" as "old block" — but
+	// WordPress omits any attribute sitting at its default from the comment, so an
+	// aligned CURRENT row with a default tagName and constrainWidth looks
+	// identical. It claimed current content.
 	save({ attributes }) {
 		const {
 			hoverBackgroundColor,

--- a/src/blocks/row/deprecated.js
+++ b/src/blocks/row/deprecated.js
@@ -127,7 +127,8 @@ const sharedSupports = {
 const v5 = {
 	supports: metadata.supports,
 	attributes: { ...metadata.attributes },
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		if (!innerHTML || !innerHTML.includes('dsgo-flex')) {
 			return false;
 		}
@@ -447,7 +448,8 @@ const v3 = {
 			type: 'string',
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// v3 blocks have tagName (added in v3) and dsgo-flex__inner but no align-items
 		return (
 			Object.prototype.hasOwnProperty.call(attributes, 'tagName') &&
@@ -721,13 +723,11 @@ const v1 = {
 			type: 'string',
 		},
 	},
-	isEligible(attributes) {
-		// v1 blocks don't have align attribute - used className for alignment
-		return (
-			attributes.align === undefined &&
-			!Object.prototype.hasOwnProperty.call(attributes, 'constrainWidth')
-		);
-	},
+	// No isEligible: markup-change deprecation, reached by save-matching on an
+	// INVALID block (WordPress skips isEligible for those). The old guard,
+	// `attributes.align === undefined && !hasOwnProperty('constrainWidth')`,
+	// matched CURRENT rows too — neither attribute is serialized into the
+	// comment when it sits at its default, so "absent" does not mean "old".
 	save({ attributes }) {
 		const {
 			hoverBackgroundColor,

--- a/src/blocks/row/test/deprecated.test.js
+++ b/src/blocks/row/test/deprecated.test.js
@@ -59,9 +59,11 @@ describe('row deprecations - style-kit overlay variation migration', () => {
 		const html =
 			'<div class="wp-block-designsetgo-row is-style-overlay-dark dsgo-flex"><div class="dsgo-flex__inner"></div></div>';
 		expect(
-			v5Deprecation.isEligible({ className: 'is-style-overlay-dark' }, [], {
-				innerHTML: html,
-			})
+			v5Deprecation.isEligible(
+				{ className: 'is-style-overlay-dark' },
+				[],
+				{ blockNode: { innerHTML: html } }
+			)
 		).toBe(true);
 	});
 
@@ -69,9 +71,11 @@ describe('row deprecations - style-kit overlay variation migration', () => {
 		const html =
 			'<div class="wp-block-designsetgo-row is-style-overlay-dark dsgo-flex dsgo-flex--has-overlay"><div class="dsgo-flex__inner"></div></div>';
 		expect(
-			v5Deprecation.isEligible({ className: 'is-style-overlay-dark' }, [], {
-				innerHTML: html,
-			})
+			v5Deprecation.isEligible(
+				{ className: 'is-style-overlay-dark' },
+				[],
+				{ blockNode: { innerHTML: html } }
+			)
 		).toBe(false);
 	});
 
@@ -79,7 +83,9 @@ describe('row deprecations - style-kit overlay variation migration', () => {
 		const html =
 			'<div class="wp-block-designsetgo-row dsgo-flex"><div class="dsgo-flex__inner"></div></div>';
 		expect(
-			v5Deprecation.isEligible({ className: '' }, [], { innerHTML: html })
+			v5Deprecation.isEligible({ className: '' }, [], {
+				blockNode: { innerHTML: html },
+			})
 		).toBe(false);
 	});
 
@@ -125,7 +131,7 @@ describe('row deprecations - style-kit hover variation migration', () => {
 			v5Deprecation.isEligible(
 				{ className: 'is-style-hover-icon-blue' },
 				[],
-				{ innerHTML: html }
+				{ blockNode: { innerHTML: html } }
 			)
 		).toBe(true);
 	});
@@ -134,7 +140,9 @@ describe('row deprecations - style-kit hover variation migration', () => {
 		const html =
 			'<div class="wp-block-designsetgo-row dsgo-flex"><div class="dsgo-flex__inner"></div></div>';
 		expect(
-			v5Deprecation.isEligible({ className: '' }, [], { innerHTML: html })
+			v5Deprecation.isEligible({ className: '' }, [], {
+				blockNode: { innerHTML: html },
+			})
 		).toBe(false);
 	});
 

--- a/src/blocks/scroll-accordion/deprecated.js
+++ b/src/blocks/scroll-accordion/deprecated.js
@@ -5,6 +5,7 @@
  */
 
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 /**
  * Inline layout constants — the version before the constant layout moved to
@@ -43,8 +44,8 @@ const v1 = {
 		typography: { fontSize: true, lineHeight: true },
 		layout: { allowEditing: false },
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const html = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const html = getDeprecatedBlockHTML(extra);
 		return (
 			html.includes('dsgo-scroll-accordion') &&
 			html.includes('align-self:stretch')

--- a/src/blocks/scroll-marquee/deprecated.js
+++ b/src/blocks/scroll-marquee/deprecated.js
@@ -46,6 +46,7 @@
  */
 
 import { useBlockProps } from '@wordpress/block-editor';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 const sharedSupports = {
 	anchor: true,
@@ -227,8 +228,8 @@ const v3 = {
 		borderRadius: { type: 'string', default: '8px' },
 	},
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Only the pre-native-border save ever emitted this custom property.
 		const hasBorderRadiusVar =
 			typeof innerHTML === 'string' &&
@@ -352,8 +353,8 @@ const v2 = {
 		borderRadius: { type: 'string', default: '8px' },
 	},
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Old (pre-objectFit) saves never emitted this custom property.
 		const hasObjectFitVar =
 			typeof innerHTML === 'string' &&
@@ -536,8 +537,8 @@ const v1ObjectFit = {
 		rowGap: { type: 'string', default: '20px' },
 	},
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		if (typeof innerHTML !== 'string') {
 			return false;
 		}

--- a/src/blocks/scroll-marquee/deprecated.js
+++ b/src/blocks/scroll-marquee/deprecated.js
@@ -227,7 +227,8 @@ const v3 = {
 		borderRadius: { type: 'string', default: '8px' },
 	},
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Only the pre-native-border save ever emitted this custom property.
 		const hasBorderRadiusVar =
 			typeof innerHTML === 'string' &&
@@ -351,7 +352,8 @@ const v2 = {
 		borderRadius: { type: 'string', default: '8px' },
 	},
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Old (pre-objectFit) saves never emitted this custom property.
 		const hasObjectFitVar =
 			typeof innerHTML === 'string' &&
@@ -534,7 +536,8 @@ const v1ObjectFit = {
 		rowGap: { type: 'string', default: '20px' },
 	},
 	supports: sharedSupports,
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		if (typeof innerHTML !== 'string') {
 			return false;
 		}

--- a/src/blocks/section/deprecated.js
+++ b/src/blocks/section/deprecated.js
@@ -16,6 +16,7 @@ import {
 	hoverVariationClasses,
 } from './utils/has-overlay-style';
 import ShapeDivider from './components/ShapeDivider';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 // Shared supports for deprecations (must match what was in block.json when blocks were saved).
 // Without this, useBlockProps.save() in deprecated save functions won't generate
@@ -347,8 +348,8 @@ const v8 = {
 	 * @return {boolean} True when a hover-variation family is present without
 	 *                    its matching activation class in the stored HTML.
 	 */
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		if (!innerHTML || !innerHTML.includes('dsgo-stack')) {
 			return false;
 		}
@@ -561,8 +562,8 @@ const v7 = {
 	 * @param {Object} extra.block     Parsed block (carries originalContent).
 	 * @return {boolean} True when the pre-variation overlay signature is found.
 	 */
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		return !!(
 			hasOverlayStyleClass(attributes.className) &&
 			innerHTML &&
@@ -769,8 +770,8 @@ const v6 = {
 	 * @param {Object} extra.block     - Parsed block (carries originalContent)
 	 * @return {boolean} True when the legacy animation-attrs pattern is detected
 	 */
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		return !!(
 			attributes.dsgoAnimationEnabled &&
 			innerHTML &&

--- a/src/blocks/section/deprecated.js
+++ b/src/blocks/section/deprecated.js
@@ -1025,9 +1025,10 @@ const v5 = {
 		shapeDividerBottomFront: { type: 'boolean', default: false },
 		shapeDividerBottomBackgroundColor: { type: 'string', default: '' },
 	},
-	isEligible(attributes) {
-		return !!(attributes.shapeDividerTop || attributes.shapeDividerBottom);
-	},
+	// No isEligible: markup-change deprecation, reached by save-matching on an
+	// INVALID block (WordPress skips isEligible for those). The old guard was
+	// just "has a shape divider", which is equally true of a CURRENT section —
+	// three separate versions shared it, so a divider claimed all three.
 	save({ attributes }) {
 		const {
 			tagName = 'div',
@@ -1206,9 +1207,10 @@ const v4 = {
 		shapeDividerBottomFront: { type: 'boolean', default: false },
 		shapeDividerBottomBackgroundColor: { type: 'string', default: '' },
 	},
-	isEligible(attributes) {
-		return !!(attributes.shapeDividerTop || attributes.shapeDividerBottom);
-	},
+	// No isEligible: markup-change deprecation, reached by save-matching on an
+	// INVALID block (WordPress skips isEligible for those). The old guard was
+	// just "has a shape divider", which is equally true of a CURRENT section —
+	// three separate versions shared it, so a divider claimed all three.
 	save({ attributes }) {
 		const {
 			tagName = 'div',
@@ -1379,10 +1381,10 @@ const v3 = {
 		shapeDividerBottomFront: { type: 'boolean', default: false },
 		shapeDividerBottomBackgroundColor: { type: 'string', default: '' },
 	},
-	isEligible(attributes) {
-		// Matches blocks with shape dividers from before background color inheritance
-		return !!(attributes.shapeDividerTop || attributes.shapeDividerBottom);
-	},
+	// No isEligible: markup-change deprecation, reached by save-matching on an
+	// INVALID block (WordPress skips isEligible for those). The old guard was
+	// just "has a shape divider", which is equally true of a CURRENT section —
+	// three separate versions shared it, so a divider claimed all three.
 	save({ attributes }) {
 		const {
 			tagName = 'div',
@@ -1552,23 +1554,12 @@ const v2 = {
 			default: '',
 		},
 	},
-	/**
-	 * Determine if this deprecation should be used
-	 * Matches blocks created before shape dividers were added
-	 *
-	 * @param {Object} attributes Block attributes
-	 * @return {boolean} True if block matches this deprecation
-	 */
-	isEligible(attributes) {
-		// This deprecation is for blocks without shape divider attributes
-		// If any shape divider attribute exists, this is not the right version
-		// Use constrainWidth to distinguish v2 from v1 (v1 used layout.contentSize)
-		return (
-			!attributes.shapeDividerTop &&
-			!attributes.shapeDividerBottom &&
-			Object.prototype.hasOwnProperty.call(attributes, 'constrainWidth')
-		);
-	},
+	// Matches blocks created before shape dividers were added.
+	//
+	// No isEligible: markup-change deprecation, reached by save-matching on an
+	// INVALID block (WordPress skips isEligible for those). The old guard keyed on
+	// `constrainWidth` being present in the comment, which is true of any CURRENT
+	// section whose constrainWidth is non-default — so it claimed current content.
 	save({ attributes }) {
 		const {
 			tagName = 'div',

--- a/src/blocks/section/deprecated.js
+++ b/src/blocks/section/deprecated.js
@@ -342,11 +342,13 @@ const v8 = {
 	 * @param {Object} attributes      Block attributes.
 	 * @param {Array}  innerBlocks     Inner blocks.
 	 * @param {Object} extra           Extra data.
-	 * @param {string} extra.innerHTML Stored serialised HTML.
+	 * @param {Object} extra.blockNode Raw parsed block (carries innerHTML).
+	 * @param {Object} extra.block     Parsed block (carries originalContent).
 	 * @return {boolean} True when a hover-variation family is present without
 	 *                    its matching activation class in the stored HTML.
 	 */
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		if (!innerHTML || !innerHTML.includes('dsgo-stack')) {
 			return false;
 		}
@@ -555,10 +557,12 @@ const v7 = {
 	 * @param {Object} attributes      Block attributes.
 	 * @param {Array}  innerBlocks     Inner blocks.
 	 * @param {Object} extra           Extra data.
-	 * @param {string} extra.innerHTML Stored serialised HTML.
+	 * @param {Object} extra.blockNode Raw parsed block (carries innerHTML).
+	 * @param {Object} extra.block     Parsed block (carries originalContent).
 	 * @return {boolean} True when the pre-variation overlay signature is found.
 	 */
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		return !!(
 			hasOverlayStyleClass(attributes.className) &&
 			innerHTML &&
@@ -760,11 +764,13 @@ const v6 = {
 	 *
 	 * @param {Object} attributes      - Block attributes
 	 * @param {Array}  innerBlocks     - Inner blocks
-	 * @param {Object} extra           - Extra data including innerHTML
-	 * @param {string} extra.innerHTML - The stored serialised HTML
+	 * @param {Object} extra           - Extra data
+	 * @param {Object} extra.blockNode - Raw parsed block (carries innerHTML)
+	 * @param {Object} extra.block     - Parsed block (carries originalContent)
 	 * @return {boolean} True when the legacy animation-attrs pattern is detected
 	 */
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		return !!(
 			attributes.dsgoAnimationEnabled &&
 			innerHTML &&
@@ -1671,18 +1677,11 @@ const v1 = {
 			type: 'string',
 		},
 	},
-	/**
-	 * Determine if this deprecation should be used
-	 * Matches blocks created before align attribute was added
-	 *
-	 * @param {Object} attributes Block attributes
-	 * @return {boolean} True if block matches this deprecation
-	 */
-	isEligible(attributes) {
-		// This deprecation is for the earliest blocks without align attribute
-		// They used className for alignment instead
-		return attributes.align === undefined;
-	},
+	// No isEligible: markup-change deprecation, reached by save-matching on an
+	// INVALID block (WordPress skips isEligible for those). The old guard,
+	// `attributes.align === undefined`, matched nearly every CURRENT section:
+	// `align` has no default, so it is absent from the raw comment attributes on
+	// any section the author never aligned wide/full.
 	save({ attributes }) {
 		const {
 			hoverBackgroundColor,

--- a/src/blocks/section/test/deprecated.test.js
+++ b/src/blocks/section/test/deprecated.test.js
@@ -215,7 +215,7 @@ describe('section deprecations - style-kit overlay variation migration (v7)', ()
 			v7Deprecation.isEligible(
 				{ className: 'is-style-overlay-dark' },
 				[],
-				{ innerHTML: html }
+				{ blockNode: { innerHTML: html } }
 			)
 		).toBe(true);
 	});
@@ -227,7 +227,7 @@ describe('section deprecations - style-kit overlay variation migration (v7)', ()
 			v7Deprecation.isEligible(
 				{ className: 'is-style-overlay-dark' },
 				[],
-				{ innerHTML: html }
+				{ blockNode: { innerHTML: html } }
 			)
 		).toBe(false);
 	});
@@ -236,7 +236,9 @@ describe('section deprecations - style-kit overlay variation migration (v7)', ()
 		const html =
 			'<div class="wp-block-designsetgo-section dsgo-stack"><div class="dsgo-stack__inner"></div></div>';
 		expect(
-			v7Deprecation.isEligible({ className: '' }, [], { innerHTML: html })
+			v7Deprecation.isEligible({ className: '' }, [], {
+				blockNode: { innerHTML: html },
+			})
 		).toBe(false);
 	});
 
@@ -289,7 +291,7 @@ describe('section deprecations - style-kit hover variation migration (v8)', () =
 			v8Deprecation.isEligible(
 				{ className: 'is-style-hover-text-light' },
 				[],
-				{ innerHTML: html }
+				{ blockNode: { innerHTML: html } }
 			)
 		).toBe(true);
 	});
@@ -301,7 +303,7 @@ describe('section deprecations - style-kit hover variation migration (v8)', () =
 			v8Deprecation.isEligible(
 				{ className: 'is-style-hover-icon-blue' },
 				[],
-				{ innerHTML: html }
+				{ blockNode: { innerHTML: html } }
 			)
 		).toBe(true);
 	});
@@ -313,7 +315,7 @@ describe('section deprecations - style-kit hover variation migration (v8)', () =
 			v8Deprecation.isEligible(
 				{ className: 'is-style-hover-text-light' },
 				[],
-				{ innerHTML: html }
+				{ blockNode: { innerHTML: html } }
 			)
 		).toBe(false);
 	});
@@ -328,7 +330,7 @@ describe('section deprecations - style-kit hover variation migration (v8)', () =
 						'is-style-hover-text-light is-style-hover-icon-blue',
 				},
 				[],
-				{ innerHTML: html }
+				{ blockNode: { innerHTML: html } }
 			)
 		).toBe(true);
 	});
@@ -337,7 +339,9 @@ describe('section deprecations - style-kit hover variation migration (v8)', () =
 		const html =
 			'<div class="wp-block-designsetgo-section dsgo-stack"><div class="dsgo-stack__inner"></div></div>';
 		expect(
-			v8Deprecation.isEligible({ className: '' }, [], { innerHTML: html })
+			v8Deprecation.isEligible({ className: '' }, [], {
+				blockNode: { innerHTML: html },
+			})
 		).toBe(false);
 	});
 

--- a/src/blocks/slider/deprecated.js
+++ b/src/blocks/slider/deprecated.js
@@ -72,7 +72,8 @@ const v2 = {
 			width: true,
 		},
 	},
-	isEligible(attributes, innerBlocks, { innerHTML }) {
+	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
+		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
 		// Match blocks saved with the original height/arrowSize defaults
 		// (height was always emitted; arrowSize default was 48px not 24px).
 		return (

--- a/src/blocks/slider/deprecated.js
+++ b/src/blocks/slider/deprecated.js
@@ -1,6 +1,7 @@
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import classnames from 'classnames';
 import { convertPresetToCSSVar } from '../../utils/convert-preset-to-css-var';
+import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
 
 const SINGLE_SLIDE_EFFECTS = ['fade', 'zoom'];
 
@@ -72,8 +73,8 @@ const v2 = {
 			width: true,
 		},
 	},
-	isEligible(attributes, innerBlocks, { blockNode, block } = {}) {
-		const innerHTML = blockNode?.innerHTML ?? block?.originalContent ?? '';
+	isEligible(attributes, innerBlocks, extra) {
+		const innerHTML = getDeprecatedBlockHTML(extra);
 		// Match blocks saved with the original height/arrowSize defaults
 		// (height was always emitted; arrowSize default was 48px not 24px).
 		return (

--- a/src/blocks/tab/deprecated.js
+++ b/src/blocks/tab/deprecated.js
@@ -33,11 +33,22 @@ const sharedSupports = {
  */
 const v1 = {
 	supports: sharedSupports,
-	isEligible(attributes) {
-		// v1 is eligible if iconPosition attribute doesn't exist
-		// This was added in the current version
-		return typeof attributes.iconPosition === 'undefined';
-	},
+
+	// No isEligible: this is a MARKUP-change deprecation, and WordPress only
+	// consults isEligible for a block that is still VALID
+	// (`if (block.isValid && !isEligible(...)) continue;` — see
+	// @wordpress/blocks → api/parser/apply-block-deprecated-versions.js). A v1
+	// block's markup no longer matches the current save(), so it parses INVALID,
+	// isEligible is skipped entirely, and WordPress picks this version because
+	// its save() reproduces the stored HTML. There is nothing left for an
+	// isEligible to do here.
+	//
+	// It used to test `typeof attributes.iconPosition === 'undefined'`, which is
+	// unsound: `attributes` here is the RAW comment JSON, and WordPress never
+	// serializes an attribute equal to its default. A current tab left at the
+	// default iconPosition ('none') therefore also has no `iconPosition` key, so
+	// the guard claimed current content — and because v1's schema predates
+	// `strokeWidth`, migrate() silently dropped it.
 
 	attributes: {
 		uniqueId: {

--- a/src/utils/deprecated-block-html.js
+++ b/src/utils/deprecated-block-html.js
@@ -1,0 +1,27 @@
+/**
+ * Stored markup for a deprecation's isEligible().
+ *
+ * WordPress calls isEligible as:
+ *
+ *     isEligible( attributes, innerBlocks, { blockNode, block } )
+ *
+ * (@wordpress/blocks → api/parser/apply-block-deprecated-versions.js). There is
+ * NO `innerHTML` key on that third argument — destructuring one yields
+ * `undefined`, and because every guard opens with a truthiness check, the guard
+ * then silently returns false forever. This helper exists so that contract lives
+ * in exactly one place instead of being re-derived at every call site.
+ *
+ * `blockNode.innerHTML` is the raw parsed block's own HTML (inner blocks
+ * excluded); `block.originalContent` is the equivalent on the parsed block, and
+ * is the fallback when only that is to hand. Returns `''` — never `undefined` —
+ * so callers can use `.includes()` / regex tests without guarding first, and so
+ * a missing third argument can never produce a false positive.
+ *
+ * @param {Object} [extra]           WordPress's third isEligible argument.
+ * @param {Object} [extra.blockNode] Raw parsed block; carries `innerHTML`.
+ * @param {Object} [extra.block]     Parsed block; carries `originalContent`.
+ * @return {string} The block's stored markup, or `''` when unavailable.
+ */
+export function getDeprecatedBlockHTML(extra = {}) {
+	return extra?.blockNode?.innerHTML ?? extra?.block?.originalContent ?? '';
+}

--- a/src/utils/test/deprecated-block-html.test.js
+++ b/src/utils/test/deprecated-block-html.test.js
@@ -1,0 +1,58 @@
+/**
+ * getDeprecatedBlockHTML() — the isEligible third-argument contract.
+ *
+ * This helper is the single place that knows what WordPress actually passes to a
+ * deprecation's isEligible(). Pinning it here means a future change to that
+ * contract fails one test rather than silently neutering all 71 guards, which is
+ * exactly the failure mode it was extracted to prevent.
+ */
+import { getDeprecatedBlockHTML } from '../deprecated-block-html';
+
+describe('getDeprecatedBlockHTML', () => {
+	it('reads blockNode.innerHTML — what WordPress actually passes', () => {
+		expect(
+			getDeprecatedBlockHTML({
+				blockNode: { innerHTML: '<div class="old"></div>' },
+			})
+		).toBe('<div class="old"></div>');
+	});
+
+	it('falls back to block.originalContent', () => {
+		expect(
+			getDeprecatedBlockHTML({
+				block: { originalContent: '<p class="old"></p>' },
+			})
+		).toBe('<p class="old"></p>');
+	});
+
+	it('prefers blockNode.innerHTML over block.originalContent', () => {
+		expect(
+			getDeprecatedBlockHTML({
+				blockNode: { innerHTML: 'from-blockNode' },
+				block: { originalContent: 'from-block' },
+			})
+		).toBe('from-blockNode');
+	});
+
+	it.each([
+		['no argument', undefined],
+		['an empty object', {}],
+		[
+			'a legacy { innerHTML } shape',
+			{ innerHTML: '<div class="old"></div>' },
+		],
+	])('returns an empty string for %s', (_label, extra) => {
+		// The `{ innerHTML }` case is the bug this helper exists to prevent: that
+		// key does not exist on WordPress's third argument, so a guard reading it
+		// must get '' (falsy, and .includes() is always false) rather than throw or
+		// silently match.
+		expect(getDeprecatedBlockHTML(extra)).toBe('');
+	});
+
+	it('never returns undefined, so callers can call .includes() unguarded', () => {
+		expect(() =>
+			getDeprecatedBlockHTML().includes('anything')
+		).not.toThrow();
+		expect(getDeprecatedBlockHTML().includes('anything')).toBe(false);
+	});
+});

--- a/tests/unit/blocks/modal-trigger/save.test.js
+++ b/tests/unit/blocks/modal-trigger/save.test.js
@@ -326,7 +326,23 @@ describe('modal-trigger deprecations - legacy nested-div migration', () => {
 			.replace(/<!--[\s\S]*?-->$/, '');
 
 		// isEligible itself opts out for this shape…
-		expect(v4.isEligible({}, [], { innerHTML })).toBe(false);
+		// NB: the third argument must be `{ blockNode }` — that is what WordPress
+		// actually passes. A bare `{ innerHTML }` is not a shape isEligible ever
+		// receives, so asserting against it would pass vacuously (the guard would
+		// read '' and return false regardless of the markup).
+		expect(v4.isEligible({}, [], { blockNode: { innerHTML } })).toBe(false);
+
+		// …and that `false` is a real answer, not an always-false guard: the
+		// pre-wrapper shape v4 IS meant to catch (block root = the button) returns
+		// true through the very same call.
+		expect(
+			v4.isEligible({}, [], {
+				blockNode: {
+					innerHTML:
+						'<button class="dsgo-modal-trigger wp-block-button__link">Open</button>',
+				},
+			})
+		).toBe(true);
 
 		// …and even if it hadn't, the actual migrated block above did not
 		// route through v4: v4's schema has no `width` attribute, so a

--- a/tests/unit/deprecations-isEligible.test.js
+++ b/tests/unit/deprecations-isEligible.test.js
@@ -1,0 +1,104 @@
+/**
+ * Guard: a deprecation's isEligible() must never claim CURRENT content.
+ *
+ * WordPress calls isEligible as:
+ *
+ *   isEligible( attributes, innerBlocks, { blockNode, block } )
+ *
+ * (see @wordpress/blocks → api/parser/apply-block-deprecated-versions.js). There
+ * is NO `innerHTML` key on that third argument. Every DSGo deprecation used to
+ * destructure `{ innerHTML }`, so the value was always `undefined` and — because
+ * each guard begins with a truthiness check — isEligible always returned false.
+ *
+ * That was invisible, because isEligible only matters for a block that is
+ * otherwise VALID:
+ *
+ *   if ( block.isValid && ! isEligible( ... ) ) continue;
+ *
+ * For an INVALID block the `block.isValid &&` short-circuits, isEligible is
+ * skipped entirely, and WordPress instead picks the deprecation whose save()
+ * reproduces the stored HTML. That path carried every migration we had, which is
+ * why nothing appeared broken.
+ *
+ * Now that the guards actually receive the markup, they can fire — and firing on
+ * a VALID block opts it into a needless re-migration. This test pins the
+ * invariant: for each block's own canonical, current save() output, no
+ * deprecation may claim it, and a parse/serialize round trip must be lossless.
+ */
+// Import the block API from the copy nested under @wordpress/block-editor — the
+// SAME instance its useBlockProps.save() talks to. Jest resolves two copies of
+// @wordpress/blocks, and getSaveElement() hands the block type + attributes to
+// useBlockProps via a module-scoped provider; across instances that provider
+// reads back empty and the support filters throw on `undefined` attributes. The
+// rest of the suite (e.g. src/blocks/blobs/test/deprecated.test.js) already
+// imports from this path for the same reason.
+import {
+	parse,
+	serialize,
+	createBlock,
+	getBlockType,
+	// eslint-disable-next-line import/no-unresolved
+} from '@wordpress/block-editor/node_modules/@wordpress/blocks';
+import { parse as parseRaw } from '@wordpress/block-serialization-default-parser';
+import fs from 'fs';
+import path from 'path';
+
+import { registerDesignSetGoBlock } from '../../tools/regenerate-patterns';
+
+const BLOCKS_DIR = path.join(__dirname, '../../src/blocks');
+
+const blocksWithDeprecations = fs
+	.readdirSync(BLOCKS_DIR)
+	.filter((slug) =>
+		fs.existsSync(path.join(BLOCKS_DIR, slug, 'deprecated.js'))
+	)
+	.map((slug) => `designsetgo/${slug}`);
+
+describe('deprecations must not reclaim current content', () => {
+	beforeAll(() => {
+		blocksWithDeprecations.forEach(registerDesignSetGoBlock);
+	});
+
+	it('finds the blocks under test', () => {
+		expect(blocksWithDeprecations.length).toBeGreaterThan(20);
+	});
+
+	describe.each(blocksWithDeprecations)('%s', (name) => {
+		// Canonical current markup: what save() produces for this block today.
+		const markup = () => serialize(createBlock(name, {}));
+
+		it('parses its own current save() output as valid', () => {
+			const [block] = parse(markup());
+			expect(block.name).toBe(name);
+			expect(block.isValid).toBe(true);
+		});
+
+		it('is not claimed by any of its own deprecations', () => {
+			const html = markup();
+			const [block] = parse(html);
+			const [blockNode] = parseRaw(html);
+			const { deprecated = [] } = getBlockType(name);
+
+			const claimed = deprecated
+				.map((dep, i) => ({
+					i,
+					eligible: Boolean(
+						dep.isEligible?.(blockNode.attrs, block.innerBlocks, {
+							blockNode,
+							block,
+						})
+					),
+				}))
+				.filter((d) => d.eligible)
+				.map((d) => `deprecated[${d.i}]`);
+
+			expect(claimed).toEqual([]);
+		});
+
+		it('round-trips its attributes without migration', () => {
+			const block = createBlock(name, {});
+			const [reparsed] = parse(serialize(block));
+			expect(reparsed.attributes).toEqual(block.attributes);
+		});
+	});
+});

--- a/tests/unit/deprecations-isEligible.test.js
+++ b/tests/unit/deprecations-isEligible.test.js
@@ -54,6 +54,77 @@ const blocksWithDeprecations = fs
 	)
 	.map((slug) => `designsetgo/${slug}`);
 
+/**
+ * A value that differs from the attribute's default, so the attribute actually
+ * lands in the block comment AND in save()'s output.
+ *
+ * Testing only `createBlock(name, {})` would miss any guard keyed on markup that
+ * a DEFAULT block never emits — grid's `repeat(N, minmax(...))` track, for one,
+ * which only appears once `columnMinWidth` is set. Those guards are precisely
+ * the ones that can quietly start claiming current content.
+ *
+ * @param {Object} schema The attribute's block.json schema.
+ * @return {*} A non-default value, or `undefined` to skip this attribute.
+ */
+function nonDefaultValue(schema) {
+	if (schema.enum) {
+		return schema.enum.find((v) => v !== schema.default);
+	}
+
+	switch (schema.type) {
+		case 'boolean':
+			return !schema.default;
+		case 'number':
+		case 'integer':
+			return (schema.default ?? 0) + 1;
+		case 'string':
+			// A length + unit reads as valid CSS wherever a value is interpolated
+			// into a style, and as an ordinary string everywhere else.
+			return schema.default === '7px' ? '9px' : '7px';
+		default:
+			// Objects/arrays (style, lock, metadata, border…) have no meaningful
+			// generic probe; the defaults case already covers them.
+			return undefined;
+	}
+}
+
+/**
+ * One probe per attribute, each isolating a single non-default value, plus the
+ * all-defaults case. `align` is driven off `supports.align` rather than the
+ * attribute schema, since its legal values live there — and it is the attribute
+ * three of the removed guards keyed on.
+ *
+ * @param {string} name Block name.
+ * @return {Array<{label: string, attrs: Object}>} Probes.
+ */
+function probesFor(name) {
+	const blockType = getBlockType(name);
+	const probes = [{ label: 'defaults', attrs: {} }];
+
+	const alignSupport = blockType.supports?.align;
+	if (Array.isArray(alignSupport)) {
+		alignSupport.forEach((align) =>
+			probes.push({ label: `align=${align}`, attrs: { align } })
+		);
+	}
+
+	Object.entries(blockType.attributes ?? {}).forEach(([attr, schema]) => {
+		if (attr === 'align' || schema.source) {
+			return;
+		}
+		const value = nonDefaultValue(schema);
+		if (value === undefined) {
+			return;
+		}
+		probes.push({
+			label: `${attr}=${JSON.stringify(value)}`,
+			attrs: { [attr]: value },
+		});
+	});
+
+	return probes;
+}
+
 describe('deprecations must not reclaim current content', () => {
 	beforeAll(() => {
 		blocksWithDeprecations.forEach(registerDesignSetGoBlock);
@@ -64,41 +135,54 @@ describe('deprecations must not reclaim current content', () => {
 	});
 
 	describe.each(blocksWithDeprecations)('%s', (name) => {
-		// Canonical current markup: what save() produces for this block today.
-		const markup = () => serialize(createBlock(name, {}));
-
 		it('parses its own current save() output as valid', () => {
-			const [block] = parse(markup());
+			const [block] = parse(serialize(createBlock(name, {})));
 			expect(block.name).toBe(name);
 			expect(block.isValid).toBe(true);
 		});
 
+		// Swept across every single-attribute variant, not just the defaults: a
+		// guard only reachable via non-default markup would otherwise never be
+		// exercised here.
 		it('is not claimed by any of its own deprecations', () => {
-			const html = markup();
-			const [block] = parse(html);
-			const [blockNode] = parseRaw(html);
 			const { deprecated = [] } = getBlockType(name);
+			const claimed = [];
 
-			const claimed = deprecated
-				.map((dep, i) => ({
-					i,
-					eligible: Boolean(
+			probesFor(name).forEach(({ label, attrs }) => {
+				const html = serialize(createBlock(name, attrs));
+				const [block] = parse(html);
+				const [blockNode] = parseRaw(html);
+
+				deprecated.forEach((dep, i) => {
+					const eligible = Boolean(
 						dep.isEligible?.(blockNode.attrs, block.innerBlocks, {
 							blockNode,
 							block,
 						})
-					),
-				}))
-				.filter((d) => d.eligible)
-				.map((d) => `deprecated[${d.i}]`);
+					);
+					if (eligible) {
+						claimed.push(`deprecated[${i}] claims ${label}`);
+					}
+				});
+			});
 
 			expect(claimed).toEqual([]);
 		});
 
 		it('round-trips its attributes without migration', () => {
-			const block = createBlock(name, {});
-			const [reparsed] = parse(serialize(block));
-			expect(reparsed.attributes).toEqual(block.attributes);
+			const lost = [];
+
+			probesFor(name).forEach(({ label, attrs }) => {
+				const block = createBlock(name, attrs);
+				const [reparsed] = parse(serialize(block));
+				try {
+					expect(reparsed.attributes).toEqual(block.attributes);
+				} catch {
+					lost.push(label);
+				}
+			});
+
+			expect(lost).toEqual([]);
 		});
 	});
 });


### PR DESCRIPTION
## What

Every one of our 67 deprecation guards was dead code, and switching them on found two blocks losing attributes on `main` today.

WordPress calls a deprecation's `isEligible` as:

```js
isEligible( attributes, innerBlocks, { blockNode, block } )
```

(`@wordpress/blocks` → `api/parser/apply-block-deprecated-versions.js`). All 67 of ours destructured **`{ innerHTML }`**, which is not a key on that object. Each guard opens with a truthiness check, so every one returned `false` unconditionally.

## Why nobody noticed

`isEligible` only matters for a block that is still **valid**:

```js
if ( block.isValid && ! isEligible( ... ) ) continue;
```

For an **invalid** block — the normal case, since these deprecations all exist because markup changed — `block.isValid &&` short-circuits, `isEligible` is never called, and WordPress instead picks the version whose `save()` reproduces the stored HTML. That path carried every migration we had, so the broken guards were invisible.

## What switching them on exposed

Reading the markup from `blockNode.innerHTML` (falling back to `block.originalContent`) makes the guards evaluate for real. Six then claimed **current** content, and two were actively destructive:

| Block | Guard | Effect |
|---|---|---|
| `tab` v1 | `typeof attributes.iconPosition === 'undefined'` | migrated current tabs through a pre-`strokeWidth` schema → **`strokeWidth` silently dropped** |
| `blobs` v2 | `innerHTML.includes('dsgo-blobs-wrapper') && align === undefined` | migrated current blobs through a pre-`height` schema → **`height` silently dropped** |
| `grid` v1, `row` v1, `section` v1 | `attributes.align === undefined` | claimed nearly every current block |
| `form-builder` v4 | `!attributes.fieldBorderColor` | claimed every form with a default border colour |

The shared root cause for four of them: **"attribute absent from the block comment" does not mean "old block."** `attributes` is the raw comment JSON, and WordPress never serializes an attribute equal to its default — so `align === undefined` is just as true of a brand-new block.

`tab` and `blobs` are **pre-existing** bugs (their guards are attribute-only and never needed `innerHTML`); they are live on `main`. The invariant test below fails on `main` for exactly that reason.

All six are markup-change deprecations, which are reached by save-matching on an invalid block and never consult `isEligible` at all — so the guards were pure downside. Removed, each with a comment explaining why.

## Guard against regressions

`tests/unit/deprecations-isEligible.test.js` pins the invariant for every block with deprecations:

1. its own current `save()` output parses valid;
2. **no deprecation claims it**;
3. `createBlock → serialize → parse` round-trips without losing an attribute.

Run against the pre-fix tree it produces 6 failures, including the two attribute losses.

## Also

- Block test call sites passed `{ innerHTML }` as well, so they were asserting against a contract WordPress does not use. Updated to `{ blockNode: { innerHTML } }` — they now exercise real behaviour.
- `CLAUDE.md` taught the wrong mechanics ("Without `isEligible`, users see 'Attempt Recovery'"), which is what produced this whole class of bug. Rewritten to describe the actual algorithm, plus the two traps.

## Verification

- `npx jest` — **90 suites / 2441 tests pass** (baseline on `main`: 89 / 2332; `jest.config.js` untouched).
- `npm run build` — compiles clean.
- `npm run lint:js` — no new errors vs. `main`.
- Pre-commit e2e (7 tests) pass.

No behaviour change for invalid blocks: that path never called `isEligible` and still doesn't. The only semantic change is that valid blocks are no longer spuriously migrated.