### PR TITLE
fix(security): close CSS escape bypass, escape form emails and block classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,8 @@ tasks.txt
 #Claude
 .claude/claude-memory.md
 .worktrees/
+
+# Security audit output. These enumerate unpatched findings with exploit paths,
+# so they must never land in a public repo — track the fixes, not the writeup.
+SECURITY-REVIEW.md
+SECURITY-AUDIT.md

--- a/includes/abilities/class-block-inserter.php
+++ b/includes/abilities/class-block-inserter.php
@@ -2046,8 +2046,20 @@ class Block_Inserter {
 	 * @return string Generated HTML.
 	 */
 	private static function generate_core_block_html( string $block_name, string $content, array $attributes ): string {
-		$text_align = isset( $attributes['textAlign'] ) ? ' has-text-align-' . $attributes['textAlign'] : '';
-		$align      = isset( $attributes['align'] ) ? ' has-text-align-' . $attributes['align'] : '';
+		// These land inside class="...", so an arbitrary value would break out of
+		// the attribute: textAlign of `center" onmouseover="alert(1)` yields a
+		// live event handler. They are alignment keywords, so rather than merely
+		// escape them, constrain them to the set core actually emits — then the
+		// value is provably safe rather than safe-looking. Anything else is
+		// dropped, which is also the correct rendering for a nonsense alignment.
+		$allowed_alignments = array( 'left', 'center', 'right', 'justify' );
+
+		$text_align = ( isset( $attributes['textAlign'] ) && in_array( $attributes['textAlign'], $allowed_alignments, true ) )
+			? ' has-text-align-' . $attributes['textAlign']
+			: '';
+		$align      = ( isset( $attributes['align'] ) && in_array( $attributes['align'], $allowed_alignments, true ) )
+			? ' has-text-align-' . $attributes['align']
+			: '';
 
 		switch ( $block_name ) {
 			case 'core/heading':

--- a/includes/abilities/class-css-sanitizer.php
+++ b/includes/abilities/class-css-sanitizer.php
@@ -23,6 +23,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 class CSS_Sanitizer {
 
 	/**
+	 * Maximum encoding layers peeled before a value is rejected as unconverged.
+	 *
+	 * Real CSS carries zero or one layer of entity/escape encoding. Anything
+	 * needing more is layered deliberately, so the ceiling is generous for
+	 * legitimate input and still finite against an attacker choosing the depth.
+	 *
+	 * @var int
+	 */
+	private const MAX_DECODE_PASSES = 10;
+
+	/**
 	 * Dangerous CSS patterns that could be used for XSS attacks.
 	 *
 	 * @var array<string>
@@ -81,27 +92,43 @@ class CSS_Sanitizer {
 		// Remove null bytes and other control characters first.
 		$css = preg_replace( '/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', $css );
 
-		// Peel off ALL encoding layers before any tag-stripping or pattern
-		// matching. There are two independent ones — HTML entities and CSS escape
-		// sequences — and each can hide the other, in either order:
-		//
-		// `&#92;75rl(...)`      entity hides a CSS escape that hides `url(`
-		// `\3c script\3e`       CSS escape hides a tag from wp_strip_all_tags()
-		//
-		// So no fixed sequence of "decode entities, then decode escapes" is
-		// enough: whichever runs last can expose a layer the other already
-		// walked past. Decode to a fixed point instead, then strip and match on
-		// text that has no encoding left to hide behind.
-		//
-		// The loop is bounded; each pass strictly shrinks or leaves the string,
-		// so it converges quickly and the cap is a backstop, not a limit.
+		/*
+		 * Peel off ALL encoding layers before any tag-stripping or pattern
+		 * matching. There are two independent ones — HTML entities and CSS escape
+		 * sequences — and each can hide the other, in either order:
+		 *
+		 *   `&#92;75rl(...)`   an entity hides a CSS escape that hides `url(`
+		 *   `\3c script\3e`    a CSS escape hides a tag from wp_strip_all_tags()
+		 *
+		 * So no fixed sequence of "decode entities, then decode escapes" is
+		 * enough: whichever runs last exposes a layer the other already walked
+		 * past. Decode to a fixed point instead, then strip and match on text with
+		 * no encoding left to hide behind.
+		 *
+		 * html_entity_decode() resolves exactly ONE layer of entity nesting per
+		 * call, so an attacker can choose the depth:
+		 *
+		 *   &amp;amp;amp;amp;amp;#106;avascript:alert(1)
+		 *
+		 * takes six passes to reach `javascript:`. Any cap can therefore be
+		 * outrun. What matters is what happens when it IS outrun: returning the
+		 * half-decoded string would hand `&#106;avascript:` to a caller that puts
+		 * it in an HTML attribute, where the browser finishes the decode for the
+		 * attacker. So non-convergence is a REJECTION, not a best effort — the
+		 * cap is high enough that no legitimate CSS reaches it (real CSS has zero
+		 * or one layer), and anything that does is layered on purpose.
+		 */
 		$passes = 0;
 		do {
 			$previous = $css;
 			$css      = html_entity_decode( $css, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
 			$css      = \designsetgo_normalize_css_escapes( $css );
 			++$passes;
-		} while ( $css !== $previous && $passes < 5 );
+		} while ( $css !== $previous && $passes < self::MAX_DECODE_PASSES );
+
+		if ( $css !== $previous ) {
+			return '/* blocked */';
+		}
 
 		// Only now can tag-stripping see every tag: a CSS-escaped `\3c script\3e`
 		// has been decoded to a real `<script>` above, so this removes it. Before

--- a/includes/abilities/class-css-sanitizer.php
+++ b/includes/abilities/class-css-sanitizer.php
@@ -81,23 +81,32 @@ class CSS_Sanitizer {
 		// Remove null bytes and other control characters first.
 		$css = preg_replace( '/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', $css );
 
-		// Decode HTML entities BEFORE stripping tags to catch encoded attacks.
-		// e.g., &lt;script&gt; becomes <script> which can then be stripped.
-		$css = html_entity_decode( $css, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+		// Peel off ALL encoding layers before any tag-stripping or pattern
+		// matching. There are two independent ones — HTML entities and CSS escape
+		// sequences — and each can hide the other, in either order:
+		//
+		// `&#92;75rl(...)`      entity hides a CSS escape that hides `url(`
+		// `\3c script\3e`       CSS escape hides a tag from wp_strip_all_tags()
+		//
+		// So no fixed sequence of "decode entities, then decode escapes" is
+		// enough: whichever runs last can expose a layer the other already
+		// walked past. Decode to a fixed point instead, then strip and match on
+		// text that has no encoding left to hide behind.
+		//
+		// The loop is bounded; each pass strictly shrinks or leaves the string,
+		// so it converges quickly and the cap is a backstop, not a limit.
+		$passes = 0;
+		do {
+			$previous = $css;
+			$css      = html_entity_decode( $css, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+			$css      = \designsetgo_normalize_css_escapes( $css );
+			++$passes;
+		} while ( $css !== $previous && $passes < 5 );
 
-		// Remove HTML tags after decoding.
+		// Only now can tag-stripping see every tag: a CSS-escaped `\3c script\3e`
+		// has been decoded to a real `<script>` above, so this removes it. Before
+		// the decode loop it would have sailed straight through.
 		$css = wp_strip_all_tags( $css );
-
-		// Decode again in case of double-encoding attacks, then strip again.
-		$css = html_entity_decode( $css, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
-		$css = wp_strip_all_tags( $css );
-
-		// Decode CSS escape sequences before pattern matching, for the same
-		// reason the HTML entities are decoded above: the browser resolves them
-		// before applying the declaration, so `expression\28 1\29` and
-		// `java\0script:` are live code that the patterns below — which match
-		// literal text — would otherwise walk straight past.
-		$css = \designsetgo_normalize_css_escapes( $css );
 
 		// Remove dangerous patterns.
 		foreach ( self::$dangerous_patterns as $pattern ) {

--- a/includes/abilities/class-css-sanitizer.php
+++ b/includes/abilities/class-css-sanitizer.php
@@ -92,6 +92,13 @@ class CSS_Sanitizer {
 		$css = html_entity_decode( $css, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
 		$css = wp_strip_all_tags( $css );
 
+		// Decode CSS escape sequences before pattern matching, for the same
+		// reason the HTML entities are decoded above: the browser resolves them
+		// before applying the declaration, so `expression\28 1\29` and
+		// `java\0script:` are live code that the patterns below — which match
+		// literal text — would otherwise walk straight past.
+		$css = \designsetgo_normalize_css_escapes( $css );
+
 		// Remove dangerous patterns.
 		foreach ( self::$dangerous_patterns as $pattern ) {
 			$css = preg_replace( $pattern, '/* blocked */', $css );

--- a/includes/blocks/forms/class-form-handler.php
+++ b/includes/blocks/forms/class-form-handler.php
@@ -729,6 +729,26 @@ class Form_Handler {
 	}
 
 	/**
+	 * Flatten a submitted field to a string.
+	 *
+	 * A field arrives either as a bare scalar or as `array( 'value' => … )`, and
+	 * that value is itself an array for a multi-value field (checkbox group,
+	 * multi-select) — which esc_html() would raise on.
+	 *
+	 * @param mixed $field_data Raw submitted field.
+	 * @return string Flattened value.
+	 */
+	private static function stringify_field_value( $field_data ) {
+		$value = is_array( $field_data ) && isset( $field_data['value'] ) ? $field_data['value'] : $field_data;
+
+		if ( is_array( $value ) ) {
+			return implode( ', ', array_map( 'strval', $value ) );
+		}
+
+		return (string) $value;
+	}
+
+	/**
 	 * Send email notification with form submission data.
 	 *
 	 * Email configuration is read from the server-side block attributes (stored
@@ -828,46 +848,69 @@ class Form_Handler {
 			);
 		}
 
-		// Every value below is interpolated into an HTML email body (the headers
-		// set `Content-Type: text/html`, see below), so each one is escaped here.
-		// The {all_fields} aggregate further down always did this; the per-field
-		// tags did not, which let a submitter put arbitrary markup — a fake
-		// "click here" link, a tracking pixel, a spoofed message — straight into
-		// the site owner's inbox via any template using {message} or {name}.
-		$merge_tags = array(
-			'{form_id}'       => esc_html( $form_id ),
-			'{submission_id}' => esc_html( (string) $submission_id ),
-			'{page_url}'      => esc_html( $current_url ),
-			'{site_name}'     => esc_html( get_bloginfo( 'name' ) ),
-			'{date}'          => esc_html( current_time( 'mysql' ) ),
+		/*
+		 * Merge tags land in TWO places with different rules, so they need two
+		 * maps. Sharing one is what made the first cut of this fix wrong.
+		 *
+		 * BODY is HTML (`Content-Type: text/html`), so values MUST be esc_html()'d
+		 * or a submitter puts arbitrary markup in the owner's inbox.
+		 *
+		 * SUBJECT is a plain-text mail header. It is never parsed as markup, so
+		 * escaping it is not protection, it is corruption: a site named
+		 * "Bob's Bakery & Sons" would arrive as "Bob&#039;s Bakery &amp; Sons".
+		 * What the subject actually needs is newline stripping, or a submitted
+		 * value could inject a second mail header.
+		 *
+		 * The subject is a documented merge-tag target ("Use {field_name} for
+		 * dynamic values" in the Form Builder inspector), so this is a real
+		 * authoring surface, not a theoretical one.
+		 */
+		// WordPress stores `blogname` ALREADY HTML-escaped — sanitize_option() runs
+		// esc_html() on save — so get_bloginfo('name') hands back
+		// `Bob&#039;s Bakery &amp; Sons`. Decoding it here is what makes these
+		// genuinely raw values, and is the same thing core does when it puts the
+		// site name into an email (see wp_new_user_notification()). The body map
+		// re-escapes it below; the subject, being plain text, wants it as typed.
+		$raw_values = array(
+			'{form_id}'       => (string) $form_id,
+			'{submission_id}' => (string) $submission_id,
+			'{page_url}'      => (string) $current_url,
+			'{site_name}'     => wp_specialchars_decode( (string) get_bloginfo( 'name' ), ENT_QUOTES ),
+			'{date}'          => (string) current_time( 'mysql' ),
 		);
 
-		// Add field values to merge tags.
 		foreach ( $fields as $field_name => $field_data ) {
-			$value = is_array( $field_data ) ? $field_data['value'] : $field_data;
-
-			if ( is_array( $value ) ) {
-				$value = implode( ', ', array_map( 'strval', $value ) );
-			}
-
-			$merge_tags[ '{' . $field_name . '}' ] = esc_html( (string) $value );
+			$raw_values[ '{' . $field_name . '}' ] = self::stringify_field_value( $field_data );
 		}
 
-		// Build all_fields list.
+		// The {all_fields} summary is markup by construction, so it is built once
+		// per context rather than escaped generically: HTML for the body, and a
+		// flat one-liner for the subject (where tags would be nonsense).
 		$all_fields_html = '';
+		$all_fields_text = array();
 		foreach ( $fields as $field_name => $field_data ) {
-			$value = is_array( $field_data ) ? $field_data['value'] : $field_data;
+			$value = self::stringify_field_value( $field_data );
+			$label = ucwords( str_replace( array( '_', '-' ), ' ', $field_name ) );
 
-			// A multi-value field (checkbox group, multi-select) arrives as an
-			// array; esc_html() would raise on it.
-			if ( is_array( $value ) ) {
-				$value = implode( ', ', array_map( 'strval', $value ) );
-			}
-
-			$label            = ucwords( str_replace( array( '_', '-' ), ' ', $field_name ) );
-			$all_fields_html .= sprintf( "<strong>%s:</strong> %s<br>\n", esc_html( $label ), esc_html( (string) $value ) );
+			$all_fields_html  .= sprintf( "<strong>%s:</strong> %s<br>\n", esc_html( $label ), esc_html( $value ) );
+			$all_fields_text[] = $label . ': ' . $value;
 		}
-		$merge_tags['{all_fields}'] = $all_fields_html;
+
+		// Body: escape every value. {all_fields} is already escaped internally.
+		$body_tags                 = array_map( 'esc_html', $raw_values );
+		$body_tags['{all_fields}'] = $all_fields_html;
+
+		// Subject: do NOT escape. Strip newlines so a submitted value cannot
+		// smuggle in an extra mail header (PHPMailer would also catch this, but
+		// the intent belongs here rather than depending on a downstream library).
+		$newlines                     = array( "\r", "\n", '%0a', '%0d' );
+		$subject_tags                 = array_map(
+			static function ( $value ) use ( $newlines ) {
+				return str_replace( $newlines, ' ', $value );
+			},
+			$raw_values
+		);
+		$subject_tags['{all_fields}'] = str_replace( $newlines, ' ', implode( '; ', $all_fields_text ) );
 
 		// Default email body if empty.
 		if ( empty( $email_body ) ) {
@@ -876,9 +919,9 @@ class Form_Handler {
 			$email_body = sanitize_textarea_field( $email_body );
 		}
 
-		// Replace merge tags in subject and body.
-		$email_subject = str_replace( array_keys( $merge_tags ), array_values( $merge_tags ), $email_subject );
-		$email_body    = str_replace( array_keys( $merge_tags ), array_values( $merge_tags ), $email_body );
+		// Replace merge tags — each context with its own map (see above).
+		$email_subject = str_replace( array_keys( $subject_tags ), array_values( $subject_tags ), $email_subject );
+		$email_body    = str_replace( array_keys( $body_tags ), array_values( $body_tags ), $email_body );
 
 		// Convert line breaks to <br> for HTML email.
 		$email_body = nl2br( $email_body );

--- a/includes/blocks/forms/class-form-handler.php
+++ b/includes/blocks/forms/class-form-handler.php
@@ -735,17 +735,44 @@ class Form_Handler {
 	 * that value is itself an array for a multi-value field (checkbox group,
 	 * multi-select) — which esc_html() would raise on.
 	 *
+	 * The whole point of this helper is that EVERY shape is safe to stringify, so
+	 * it must not assume the shape it is handed. A submission is attacker-shaped
+	 * data: an array with no `value` key, or one nesting arrays inside arrays,
+	 * would make a plain strval() emit an "Array to string conversion" warning.
+	 * Flattening recurses instead.
+	 *
 	 * @param mixed $field_data Raw submitted field.
 	 * @return string Flattened value.
 	 */
 	private static function stringify_field_value( $field_data ) {
-		$value = is_array( $field_data ) && isset( $field_data['value'] ) ? $field_data['value'] : $field_data;
+		$value = ( is_array( $field_data ) && array_key_exists( 'value', $field_data ) )
+			? $field_data['value']
+			: $field_data;
 
+		return self::flatten_value( $value );
+	}
+
+	/**
+	 * Recursively reduce any value to a display string.
+	 *
+	 * @param mixed $value Value of arbitrary shape.
+	 * @return string Flattened value.
+	 */
+	private static function flatten_value( $value ) {
 		if ( is_array( $value ) ) {
-			return implode( ', ', array_map( 'strval', $value ) );
+			return implode( ', ', array_map( array( self::class, 'flatten_value' ), $value ) );
 		}
 
-		return (string) $value;
+		if ( is_bool( $value ) ) {
+			return $value ? '1' : '';
+		}
+
+		if ( null === $value || is_scalar( $value ) ) {
+			return (string) $value;
+		}
+
+		// Objects/resources have no meaningful representation in an email.
+		return '';
 	}
 
 	/**

--- a/includes/blocks/forms/class-form-handler.php
+++ b/includes/blocks/forms/class-form-handler.php
@@ -930,6 +930,11 @@ class Form_Handler {
 		// Subject: do NOT escape. Strip newlines so a submitted value cannot
 		// smuggle in an extra mail header (PHPMailer would also catch this, but
 		// the intent belongs here rather than depending on a downstream library).
+		// The `%0a`/`%0d` literals mirror the header-injection strip at the top of
+		// this method: a value can arrive percent-encoded from a source that was
+		// not URL-decoded, and stripping both forms is cheaper than proving no
+		// such path exists. The trade-off — a subject legitimately containing the
+		// text "%0a" loses it — is negligible against a header-injection strip.
 		$newlines                     = array( "\r", "\n", '%0a', '%0d' );
 		$subject_tags                 = array_map(
 			static function ( $value ) use ( $newlines ) {
@@ -961,7 +966,11 @@ class Form_Handler {
 
 		// Add Reply-To if specified and field exists.
 		if ( ! empty( $email_reply_to ) && isset( $fields[ $email_reply_to ] ) ) {
-			$reply_to_value = is_array( $fields[ $email_reply_to ] ) ? $fields[ $email_reply_to ]['value'] : $fields[ $email_reply_to ];
+			// Flatten through the shared helper: a multi-value field yields an
+			// array, and handing that to str_replace()/sanitize_email() below is a
+			// PHP 8 TypeError (strlen() on an array) that would take down the whole
+			// notification. self::stringify_field_value() guarantees a string.
+			$reply_to_value = self::stringify_field_value( $fields[ $email_reply_to ] );
 
 			// Strip newlines to prevent email header injection.
 			$reply_to_value = str_replace( array( "\r", "\n", '%0a', '%0d' ), '', $reply_to_value );

--- a/includes/blocks/forms/class-form-handler.php
+++ b/includes/blocks/forms/class-form-handler.php
@@ -828,25 +828,44 @@ class Form_Handler {
 			);
 		}
 
+		// Every value below is interpolated into an HTML email body (the headers
+		// set `Content-Type: text/html`, see below), so each one is escaped here.
+		// The {all_fields} aggregate further down always did this; the per-field
+		// tags did not, which let a submitter put arbitrary markup — a fake
+		// "click here" link, a tracking pixel, a spoofed message — straight into
+		// the site owner's inbox via any template using {message} or {name}.
 		$merge_tags = array(
-			'{form_id}'       => $form_id,
-			'{submission_id}' => $submission_id,
-			'{page_url}'      => $current_url,
-			'{site_name}'     => get_bloginfo( 'name' ),
-			'{date}'          => current_time( 'mysql' ),
+			'{form_id}'       => esc_html( $form_id ),
+			'{submission_id}' => esc_html( (string) $submission_id ),
+			'{page_url}'      => esc_html( $current_url ),
+			'{site_name}'     => esc_html( get_bloginfo( 'name' ) ),
+			'{date}'          => esc_html( current_time( 'mysql' ) ),
 		);
 
 		// Add field values to merge tags.
 		foreach ( $fields as $field_name => $field_data ) {
-			$merge_tags[ '{' . $field_name . '}' ] = is_array( $field_data ) ? $field_data['value'] : $field_data;
+			$value = is_array( $field_data ) ? $field_data['value'] : $field_data;
+
+			if ( is_array( $value ) ) {
+				$value = implode( ', ', array_map( 'strval', $value ) );
+			}
+
+			$merge_tags[ '{' . $field_name . '}' ] = esc_html( (string) $value );
 		}
 
 		// Build all_fields list.
 		$all_fields_html = '';
 		foreach ( $fields as $field_name => $field_data ) {
-			$value            = is_array( $field_data ) ? $field_data['value'] : $field_data;
+			$value = is_array( $field_data ) ? $field_data['value'] : $field_data;
+
+			// A multi-value field (checkbox group, multi-select) arrives as an
+			// array; esc_html() would raise on it.
+			if ( is_array( $value ) ) {
+				$value = implode( ', ', array_map( 'strval', $value ) );
+			}
+
 			$label            = ucwords( str_replace( array( '_', '-' ), ' ', $field_name ) );
-			$all_fields_html .= sprintf( "<strong>%s:</strong> %s<br>\n", esc_html( $label ), esc_html( $value ) );
+			$all_fields_html .= sprintf( "<strong>%s:</strong> %s<br>\n", esc_html( $label ), esc_html( (string) $value ) );
 		}
 		$merge_tags['{all_fields}'] = $all_fields_html;
 

--- a/includes/features/class-custom-css-renderer.php
+++ b/includes/features/class-custom-css-renderer.php
@@ -263,30 +263,16 @@ class Custom_CSS_Renderer {
 	private function sanitize_css( $css ) {
 		$original_css = $css;
 
-		// Normalize CSS escape sequences BEFORE any pattern matching. CSS
-		// permits arbitrary unicode escapes and null bytes inside tokens,
-		// e.g. `java\0script:` or `java\000073cript:`, which would bypass
-		// regex strips like `/javascript:/i` if left in place. Decode them
-		// to the real characters so downstream checks see the actual text
-		// (and legitimate content like `content: "\2192";` is preserved).
-		$css = str_replace( "\0", '', $css );
-		// CSS unicode escape: backslash + 1..6 hex digits, optional trailing
-		// whitespace. Decode to the referenced codepoint so pattern matching
-		// sees the actual character.
-		$css = preg_replace_callback(
-			'/\\\\([0-9a-fA-F]{1,6})\s?/',
-			static function ( $matches ) {
-				$codepoint = hexdec( $matches[1] );
-				// Reject null and out-of-range codepoints.
-				if ( 0 === $codepoint || $codepoint > 0x10FFFF ) {
-					return '';
-				}
-				return mb_chr( $codepoint, 'UTF-8' );
-			},
-			$css
-		);
-		// Any remaining backslash escapes of ASCII printable chars.
-		$css = preg_replace( '/\\\\([\x20-\x7E])/', '$1', $css );
+		// Normalize CSS escape sequences BEFORE any pattern matching. CSS permits
+		// arbitrary unicode escapes and null bytes inside tokens, e.g.
+		// `java\0script:` or `java\000073cript:`, which would bypass regex strips
+		// like `/javascript:/i` if left in place.
+		//
+		// This logic used to live here, privately — which is exactly why the
+		// plugin's two OTHER CSS sanitizers (Abilities\CSS_Sanitizer and
+		// StyleBinding) shipped without it and were bypassable. It now lives in
+		// designsetgo_normalize_css_escapes() so all three share one definition.
+		$css = designsetgo_normalize_css_escapes( $css );
 
 		// Remove script tags and all HTML tags.
 		$css = preg_replace( '/<script\b[^>]*>(.*?)<\/script>/is', '', $css );

--- a/includes/features/class-style-binding.php
+++ b/includes/features/class-style-binding.php
@@ -77,10 +77,28 @@ class StyleBinding {
 			// Reject values that could execute code or break out of the
 			// declaration: url(), expression(), javascript:/data: schemes,
 			// CSS curly braces, and embedded semicolons.
-			if ( preg_match( '/url\s*\(|expression\s*\(|javascript:|data:/i', $value ) ) {
+			//
+			// Test the ESCAPE-DECODED value, never the raw one. CSS escapes are
+			// resolved by the browser before the declaration applies, so a raw
+			// match here is trivially bypassed: `\75\72\6c(//evil.test)` is
+			// `url(//evil.test)` to a browser but matches none of the patterns
+			// below as written. See designsetgo_normalize_css_escapes().
+			$probe = designsetgo_normalize_css_escapes( (string) $value );
+
+			if ( preg_match( '/url\s*\(|expression\s*\(|javascript:|data:/i', $probe ) ) {
 				continue;
 			}
-			if ( false !== strpbrk( $value, ';{}' ) ) {
+			if ( false !== strpbrk( $probe, ';{}' ) ) {
+				continue;
+			}
+
+			// Defence in depth: reject any value that carried an escape at all.
+			// Style bindings resolve to lengths, colours and keywords, none of
+			// which have any legitimate reason to be escaped — so rather than
+			// depend on this decoder agreeing with every browser's tokenizer on
+			// every edge case, refuse the value outright when the two forms
+			// differ. The cost of a false reject is one binding not applying.
+			if ( $probe !== (string) $value ) {
 				continue;
 			}
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -71,12 +71,24 @@ function designsetgo_normalize_css_escapes( $css ) {
 		static function ( $matches ) {
 			$codepoint = hexdec( $matches[1] );
 
-			// Drop null and out-of-range codepoints rather than emit garbage.
-			if ( 0 === $codepoint || $codepoint > 0x10FFFF ) {
+			// Drop anything that is not a Unicode scalar value: null, out of
+			// range, and the surrogate range (U+D800..U+DFFF, which a lone `\d800`
+			// escape would otherwise produce). mb_chr() returns false for a
+			// surrogate, and preg_replace_callback() requires a string back — so
+			// today that silently coerces to '', and in a stricter context it is a
+			// TypeError. The CSS spec says to treat these as U+FFFD; dropping them
+			// is the same thing for our purpose, which is producing text safe to
+			// pattern-match. This function is the shared security boundary for
+			// three sanitizers, so it does not get to be fragile.
+			if (
+				0 === $codepoint
+				|| $codepoint > 0x10FFFF
+				|| ( $codepoint >= 0xD800 && $codepoint <= 0xDFFF )
+			) {
 				return '';
 			}
 
-			return mb_chr( $codepoint, 'UTF-8' );
+			return (string) mb_chr( $codepoint, 'UTF-8' );
 		},
 		(string) $css
 	);

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -38,6 +38,56 @@ function designsetgo_generate_block_id() {
 }
 
 /**
+ * Decode CSS escape sequences so pattern matching sees the real characters.
+ *
+ * CSS lets any character inside a token be written as a backslash escape, and
+ * the browser decodes it before the declaration is applied. So `\75\72\6c(...)`
+ * IS `url(...)` to a browser, and `java\0script:` IS `javascript:` — but a naive
+ * `/url\s*\(/i` or `/javascript:/i` sees neither. Every dangerous-pattern check
+ * in this plugin MUST normalize through here first, or it is trivially bypassed
+ * by an attacker who simply escapes a character.
+ *
+ * Decoding is deliberately lossy in the safe direction: it exists to feed
+ * REJECTION checks, not to produce CSS for output. Legitimate content escapes
+ * (`content: "\2192"`) decode to the real glyph, which is what the browser would
+ * render anyway.
+ *
+ * @since 2.4.0
+ *
+ * @param string $css CSS text to normalize.
+ * @return string CSS with escape sequences and null bytes resolved.
+ */
+function designsetgo_normalize_css_escapes( $css ) {
+	if ( ! is_string( $css ) || '' === $css ) {
+		return '';
+	}
+
+	// Null bytes are ignored by CSS tokenizers but break naive regexes.
+	$css = str_replace( "\0", '', $css );
+
+	// Unicode escape: backslash + 1..6 hex digits + optional single whitespace.
+	$css = preg_replace_callback(
+		'/\\\\([0-9a-fA-F]{1,6})\s?/',
+		static function ( $matches ) {
+			$codepoint = hexdec( $matches[1] );
+
+			// Drop null and out-of-range codepoints rather than emit garbage.
+			if ( 0 === $codepoint || $codepoint > 0x10FFFF ) {
+				return '';
+			}
+
+			return mb_chr( $codepoint, 'UTF-8' );
+		},
+		(string) $css
+	);
+
+	// Any remaining backslash escape of a printable ASCII char, e.g. `\u rl(`.
+	$css = preg_replace( '/\\\\([\x20-\x7E])/', '$1', (string) $css );
+
+	return (string) $css;
+}
+
+/**
  * Sanitize CSS value with strict validation.
  *
  * Prevents CSS injection attacks by validating against allowed patterns.

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -47,10 +47,20 @@ function designsetgo_generate_block_id() {
  * in this plugin MUST normalize through here first, or it is trivially bypassed
  * by an attacker who simply escapes a character.
  *
- * Decoding is deliberately lossy in the safe direction: it exists to feed
- * REJECTION checks, not to produce CSS for output. Legitimate content escapes
- * (`content: "\2192"`) decode to the real glyph, which is what the browser would
- * render anyway.
+ * Decoding is deliberately lossy in the safe direction, and callers use the
+ * result in one of two ways:
+ *
+ * - As a DETECTION PROBE only, keeping the original value for output — this is
+ *   what StyleBinding does (it matches the decoded `$probe`, emits the raw
+ *   `$value`, and rejects when they differ).
+ * - As the OUTPUT itself — CSS_Sanitizer::sanitize() returns the decoded string,
+ *   because for a full sanitizer the normalized form IS the sanitized form.
+ *
+ * Both are fine here: a legitimate content escape (`content: "\2192"`) decodes to
+ * the real glyph, which is what the browser would render anyway. A caller taking
+ * the second path must run its own dangerous-pattern pass on the decoded output
+ * (as CSS_Sanitizer does); this function only guarantees "no encoding left to
+ * hide behind", not "safe to echo".
  *
  * @since 2.4.0
  *

--- a/src/blocks/tabs/test/view.test.js
+++ b/src/blocks/tabs/test/view.test.js
@@ -1,0 +1,68 @@
+/**
+ * Tabs deep-linking must survive a hostile URL fragment.
+ *
+ * The fragment is whatever is in the address bar, and it was passed straight to
+ * `querySelector('#' + hash)`. A fragment is NOT a valid CSS selector in the
+ * general case: `#2024`, `#a b` and `#!` all make querySelector throw
+ * SyntaxError. That throw happened inside init(), so a single malformed link
+ * — or an ordinary year-numbered anchor from elsewhere on the page — took out
+ * EVERY tabs block on the page, not just the deep link.
+ */
+
+const TABS_HTML = `
+	<div class="wp-block-designsetgo-tabs" data-active-tab="0" data-deep-linking="true">
+		<div class="dsgo-tabs__nav"></div>
+		<div class="dsgo-tab" id="panel-one" aria-label="One"></div>
+		<div class="dsgo-tab" id="panel-two" aria-label="Two"></div>
+	</div>
+`;
+
+const mount = (hash) => {
+	window.location.hash = hash;
+	document.body.innerHTML = TABS_HTML;
+	return document.querySelector('.wp-block-designsetgo-tabs');
+};
+
+describe('tabs deep linking', () => {
+	beforeAll(() => {
+		require('../view.js');
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+		window.location.hash = '';
+	});
+
+	it.each([
+		['a numeric fragment', '#2024'],
+		['a fragment with a space', '#a b'],
+		['a bare bang', '#!'],
+		['a selector-ish fragment', '#a>b'],
+		['a quote', '#a"b'],
+	])('does not throw on %s', (_label, hash) => {
+		const el = mount(hash);
+
+		expect(() => new window.DSGTabs(el)).not.toThrow();
+
+		// And the block is still alive: navigation got built.
+		expect(el.querySelectorAll('.dsgo-tabs__tab')).toHaveLength(2);
+	});
+
+	it('still resolves a legitimate deep link to the right panel', () => {
+		const el = mount('#panel-two');
+
+		new window.DSGTabs(el);
+
+		const second = el.querySelector('#panel-two');
+		expect(second.classList.contains('is-active')).toBe(true);
+	});
+
+	it('falls back to the first tab when the fragment matches nothing', () => {
+		const el = mount('#panel-nope');
+
+		new window.DSGTabs(el);
+
+		const first = el.querySelector('#panel-one');
+		expect(first.classList.contains('is-active')).toBe(true);
+	});
+});

--- a/src/blocks/tabs/view.js
+++ b/src/blocks/tabs/view.js
@@ -70,6 +70,34 @@
 			return iconWrapper;
 		}
 
+		/**
+		 * Resolve a panel from a URL fragment.
+		 *
+		 * The fragment is whatever is in the address bar, and it is NOT a valid
+		 * CSS selector in the general case: `#2024`, `#a b` and `#!` all make
+		 * querySelector throw SyntaxError. Thrown from init(), that took out
+		 * EVERY tabs block on the page, not just the deep link. Escape the
+		 * fragment, and still treat a throw as "no match" rather than fatal.
+		 *
+		 * @param {string} hash Fragment with the leading '#' already removed.
+		 * @return {Element|null} The matching panel, or null.
+		 */
+		findPanelByHash(hash) {
+			if (!hash) {
+				return null;
+			}
+
+			try {
+				const escape = window.CSS && window.CSS.escape;
+				const selector = escape
+					? `#${window.CSS.escape(hash)}`
+					: `#${hash}`;
+				return this.element.querySelector(selector);
+			} catch {
+				return null;
+			}
+		}
+
 		init() {
 			// Build tab navigation from panels
 			this.buildNavigation();
@@ -92,7 +120,7 @@
 			if (this.enableDeepLinking) {
 				const hash = window.location.hash.substring(1);
 				if (hash) {
-					const panel = this.element.querySelector(`#${hash}`);
+					const panel = this.findPanelByHash(hash);
 					if (panel) {
 						const index = Array.from(this.panels).indexOf(panel);
 						if (index !== -1) {
@@ -364,7 +392,7 @@
 			window.addEventListener('hashchange', () => {
 				const newHash = window.location.hash.substring(1);
 				if (newHash) {
-					const panel = this.element.querySelector(`#${newHash}`);
+					const panel = this.findPanelByHash(newHash);
 					if (panel) {
 						const index = Array.from(this.panels).indexOf(panel);
 						if (index !== -1) {

--- a/tests/phpunit/block-inserter-class-escaping-test.php
+++ b/tests/phpunit/block-inserter-class-escaping-test.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Core-block HTML generation must not let an attribute break out of class="".
+ *
+ * Block_Inserter::generate_core_block_html() concatenated `textAlign` / `align`
+ * straight into a class attribute. A value like `center" onmouseover="alert(1)`
+ * therefore closed the attribute and added an event handler. Reaching it needs
+ * the `designsetgo/add-block` ability (edit_posts), and `unfiltered_html` for the
+ * payload to survive wp_update_post()'s KSES pass — so it is not a privilege
+ * escalation past an existing trust boundary, but it is a real escaping hole.
+ *
+ * @package DesignSetGo
+ */
+
+use DesignSetGo\Abilities\Block_Inserter;
+
+/**
+ * @group security
+ * @group abilities
+ */
+class Block_Inserter_Class_Escaping_Test extends WP_UnitTestCase {
+
+	/**
+	 * @param string $block  Block name.
+	 * @param array  $attrs  Attributes.
+	 * @return string Generated HTML.
+	 */
+	private function generate( $block, $attrs ) {
+		$method = new ReflectionMethod( Block_Inserter::class, 'generate_core_block_html' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null, $block, 'Hello', $attrs );
+	}
+
+	/**
+	 * @dataProvider hostile_alignment_provider
+	 *
+	 * @param string $payload Hostile alignment value.
+	 */
+	public function test_hostile_alignment_cannot_break_out_of_the_class_attribute( $payload ) {
+		foreach ( array( 'core/heading', 'core/paragraph' ) as $block ) {
+			$html = $this->generate( $block, array( 'textAlign' => $payload, 'align' => $payload ) );
+
+			$this->assertStringNotContainsString( 'onmouseover', $html, $block );
+			$this->assertStringNotContainsString( 'onerror', $html, $block );
+			$this->assertStringNotContainsString( '<img', $html, $block );
+
+			// The allowlist drops a non-alignment value outright, so no alignment
+			// class is emitted at all. (Asserting the payload itself is absent
+			// would be wrong for a bare `"`, which the surrounding class="…"
+			// legitimately contains.)
+			$this->assertStringNotContainsString( 'has-text-align-', $html, $block );
+		}
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public function hostile_alignment_provider() {
+		return array(
+			'attribute breakout' => array( 'center" onmouseover="alert(1)' ),
+			'tag breakout'       => array( 'center"><img src=x onerror=alert(1)>' ),
+			'quote only'         => array( '"' ),
+		);
+	}
+
+	public function test_legitimate_alignments_still_render() {
+		$html = $this->generate( 'core/heading', array( 'textAlign' => 'center' ) );
+		$this->assertStringContainsString( 'has-text-align-center', $html );
+
+		$html = $this->generate( 'core/paragraph', array( 'align' => 'right' ) );
+		$this->assertStringContainsString( 'has-text-align-right', $html );
+	}
+
+	public function test_absent_alignment_emits_no_stray_class() {
+		$html = $this->generate( 'core/paragraph', array() );
+		$this->assertStringNotContainsString( 'class=', $html );
+	}
+}

--- a/tests/phpunit/css-escape-bypass-test.php
+++ b/tests/phpunit/css-escape-bypass-test.php
@@ -91,6 +91,44 @@ class CSS_Escape_Bypass_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Encoding layers must be peeled to a fixed point BEFORE tag-stripping.
+	 *
+	 * There are two independent layers — HTML entities and CSS escapes — and each
+	 * can hide the other. `\3c script\3e` does not look like a tag to
+	 * wp_strip_all_tags(), so if escapes are decoded AFTER the strip, a literal
+	 * <script> reappears in the output with nothing left to catch it. Conversely
+	 * `&#92;75rl(` hides a CSS escape behind an entity. Neither ordering alone is
+	 * sufficient, which is why sanitize() now decodes until the string is stable.
+	 *
+	 * @dataProvider nested_encoding_provider
+	 *
+	 * @param string $css       Attacker-supplied CSS.
+	 * @param string $forbidden Text that must not survive.
+	 */
+	public function test_css_sanitizer_peels_nested_encodings( $css, $forbidden ) {
+		$sanitized = CSS_Sanitizer::sanitize( '.a{color:red;}' . $css );
+
+		$this->assertStringNotContainsString(
+			$forbidden,
+			$sanitized,
+			'A nested encoding survived sanitize(): ' . $css
+		);
+	}
+
+	/**
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function nested_encoding_provider() {
+		return array(
+			// CSS escape hiding a tag from wp_strip_all_tags().
+			'escaped script tag'   => array( '\3c script\3e alert(1)\3c /script\3e', '<script' ),
+			'escaped img onerror'  => array( '\3c img src=x onerror=alert(1)\3e', '<img' ),
+			// HTML entity hiding a CSS escape hiding a dangerous token.
+			'entity-wrapped escape' => array( '&#92;65xpression(alert(1))', 'expression(' ),
+		);
+	}
+
 	public function test_css_sanitizer_still_passes_ordinary_css() {
 		$sanitized = CSS_Sanitizer::sanitize( '.a{color:red;margin:10px;}' );
 

--- a/tests/phpunit/css-escape-bypass-test.php
+++ b/tests/phpunit/css-escape-bypass-test.php
@@ -64,6 +64,57 @@ class CSS_Escape_Bypass_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A lone surrogate is not a Unicode scalar value.
+	 *
+	 * mb_chr() returns false for U+D800..U+DFFF, and preg_replace_callback()
+	 * requires a string back — so `\d800` coerces false to '' today and would be
+	 * a TypeError under stricter settings. This function is the shared boundary
+	 * for three sanitizers, so it must not be fragile on hostile input.
+	 *
+	 * @dataProvider surrogate_provider
+	 *
+	 * @param string $input Escape sequence.
+	 */
+	public function test_normalizer_drops_lone_surrogates_without_error( $input ) {
+		$result = designsetgo_normalize_css_escapes( $input . 'url(x)' );
+
+		$this->assertIsString( $result );
+		// The surrogate is dropped; the rest of the value is untouched.
+		$this->assertSame( 'url(x)', $result );
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public function surrogate_provider() {
+		return array(
+			'high surrogate'    => array( '\d800' ),
+			'low surrogate'     => array( '\dfff' ),
+			'mid surrogate'     => array( '\dc00' ),
+			'above Unicode max' => array( '\110000' ),
+		);
+	}
+
+	/**
+	 * Pin the platform hazard the surrogate guard exists for.
+	 *
+	 * Be honest about what the test above can and cannot prove: WITHOUT the guard,
+	 * `\d800` still yields '' — because mb_chr() returns FALSE and
+	 * preg_replace_callback() coerces that bool to an empty string. Same output,
+	 * by accident. So no output-level assertion can fail on the unguarded code
+	 * today; the guard makes correct behaviour intentional rather than incidental,
+	 * and keeps the callback's contract (return a string) honest for stricter PHP.
+	 *
+	 * This test pins the underlying fact, so if a future PHP/mbstring changes it,
+	 * we find out here rather than through a TypeError in a sanitizer.
+	 */
+	public function test_mb_chr_returns_false_for_a_surrogate() {
+		$this->assertFalse( mb_chr( 0xD800, 'UTF-8' ) );
+		$this->assertFalse( mb_chr( 0xDFFF, 'UTF-8' ) );
+		$this->assertIsString( mb_chr( 0x73, 'UTF-8' ) );
+	}
+
+	/**
 	 * Abilities\CSS_Sanitizer must not be fooled by escapes.
 	 *
 	 * @dataProvider dangerous_css_provider

--- a/tests/phpunit/css-escape-bypass-test.php
+++ b/tests/phpunit/css-escape-bypass-test.php
@@ -180,6 +180,51 @@ class CSS_Escape_Bypass_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Deeply-nested entity encoding must be REJECTED, not returned half-decoded.
+	 *
+	 * html_entity_decode() peels exactly one layer per call, so an attacker can
+	 * pick a nesting depth that outruns any fixed pass count:
+	 *
+	 *   &amp;amp;amp;amp;amp;#106;avascript:alert(1)   (6 layers -> javascript:)
+	 *
+	 * The danger is not the depth, it is what a bounded loop does when it runs
+	 * out: returning `&#106;avascript:` looks harmless to the pattern checks here
+	 * but a browser finishes the decode once it lands in an HTML attribute. So an
+	 * unconverged value is dropped wholesale rather than passed through partly
+	 * decoded.
+	 *
+	 * @dataProvider deep_nesting_provider
+	 *
+	 * @param string $css       Attacker-supplied CSS.
+	 * @param string $forbidden Token that must not survive in any form.
+	 */
+	public function test_css_sanitizer_rejects_unconverged_deep_nesting( $css, $forbidden ) {
+		$sanitized = CSS_Sanitizer::sanitize( $css );
+
+		$this->assertStringNotContainsString( $forbidden, $sanitized, $css );
+		// The residual half-decoded entity must not leak either.
+		$this->assertStringNotContainsString( 'avascript', $sanitized, $css );
+	}
+
+	/**
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function deep_nesting_provider() {
+		return array(
+			// Six entity layers — one more than the old cap of five.
+			'6-layer entity javascript' => array(
+				'.a{color:red} &amp;amp;amp;amp;amp;#106;avascript:alert(1)',
+				'javascript:',
+			),
+			// Well past the ceiling, to prove the cap-then-reject holds.
+			'12-layer entity expression' => array(
+				'.a{} ' . str_repeat( 'amp;', 12 ) . '&#101;xpression(alert(1))',
+				'expression(',
+			),
+		);
+	}
+
 	public function test_css_sanitizer_still_passes_ordinary_css() {
 		$sanitized = CSS_Sanitizer::sanitize( '.a{color:red;margin:10px;}' );
 

--- a/tests/phpunit/css-escape-bypass-test.php
+++ b/tests/phpunit/css-escape-bypass-test.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * CSS escape-sequence bypass regression tests.
+ *
+ * A browser resolves CSS escape sequences BEFORE applying a declaration, so
+ * `\75\72\6c(//evil.test)` is `url(//evil.test)` as far as the page is concerned.
+ * A sanitizer that pattern-matches the raw text therefore blocks nothing — the
+ * attacker just escapes one character.
+ *
+ * Custom_CSS_Renderer already normalized escapes before matching. The plugin's
+ * two OTHER CSS sanitizers did not, because the normalization was a private
+ * method rather than a shared one:
+ *
+ *   - DesignSetGo\Abilities\CSS_Sanitizer::sanitize()
+ *   - DesignSetGo\StyleBinding (inline style injection for dynamic bindings)
+ *
+ * These tests pin the bypass closed in all three, via the now-shared
+ * designsetgo_normalize_css_escapes().
+ *
+ * @package DesignSetGo
+ */
+
+use DesignSetGo\Abilities\CSS_Sanitizer;
+
+/**
+ * @group security
+ * @group css-escapes
+ */
+class CSS_Escape_Bypass_Test extends WP_UnitTestCase {
+
+	/**
+	 * The decoder itself.
+	 *
+	 * @dataProvider escape_provider
+	 *
+	 * @param string $input    Escaped CSS text.
+	 * @param string $expected What a browser would actually see.
+	 */
+	public function test_normalizer_decodes_what_a_browser_would_see( $input, $expected ) {
+		$this->assertSame( $expected, designsetgo_normalize_css_escapes( $input ) );
+	}
+
+	/**
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function escape_provider() {
+		return array(
+			'hex-escaped url('     => array( '\75\72\6c(//evil.test)', 'url(//evil.test)' ),
+			'hex-escaped js scheme' => array( '\6a\61\76\61script:alert(1)', 'javascript:alert(1)' ),
+			'null byte in token'   => array( "java\0script:alert(1)", 'javascript:alert(1)' ),
+			// `\000073` is the full 6-hex-digit form of U+0073 's', so this is
+			// `javascript:` — the maximally-padded way to hide the scheme.
+			'zero-padded escape'   => array( 'java\000073cript:alert(1)', 'javascript:alert(1)' ),
+			'escaped expression('  => array( 'expression\28 1\29', 'expression(1)' ),
+			'backslash-escaped ASCII' => array( '\u\r\l(x)', 'url(x)' ),
+			'plain text untouched' => array( '10px', '10px' ),
+			'empty string'         => array( '', '' ),
+		);
+	}
+
+	public function test_normalizer_tolerates_non_strings() {
+		$this->assertSame( '', designsetgo_normalize_css_escapes( null ) );
+		$this->assertSame( '', designsetgo_normalize_css_escapes( array() ) );
+	}
+
+	/**
+	 * Abilities\CSS_Sanitizer must not be fooled by escapes.
+	 *
+	 * @dataProvider dangerous_css_provider
+	 *
+	 * @param string $css Attacker-supplied CSS.
+	 */
+	public function test_css_sanitizer_blocks_escaped_payloads( $css ) {
+		$sanitized = CSS_Sanitizer::sanitize( '.a{color:red;background:' . $css . ';}' );
+
+		$this->assertStringContainsString(
+			'blocked',
+			$sanitized,
+			'Escaped payload slipped through CSS_Sanitizer: ' . $css
+		);
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public function dangerous_css_provider() {
+		return array(
+			'escaped javascript:' => array( '\6a\61\76\61script:alert(1)' ),
+			'escaped expression(' => array( 'expression\28 alert(1)\29' ),
+			'null-byte javascript' => array( "java\0script:alert(1)" ),
+		);
+	}
+
+	public function test_css_sanitizer_still_passes_ordinary_css() {
+		$sanitized = CSS_Sanitizer::sanitize( '.a{color:red;margin:10px;}' );
+
+		$this->assertStringNotContainsString( 'blocked', $sanitized );
+		$this->assertStringContainsString( 'color:red', $sanitized );
+	}
+
+	/**
+	 * StyleBinding: an escaped url() must never reach the style attribute.
+	 *
+	 * StyleBinding resolves a value through the
+	 * `designsetgo_style_binding_resolve` filter, so this drives the real code
+	 * path by making that filter return the attacker's payload.
+	 *
+	 * @dataProvider binding_payload_provider
+	 *
+	 * @param string $payload Value the binding source resolves to.
+	 */
+	public function test_style_binding_rejects_escaped_payloads( $payload ) {
+		$filter = static function () use ( $payload ) {
+			return $payload;
+		};
+
+		add_filter( 'designsetgo_style_binding_resolve', $filter, 10, 1 );
+
+		$block = array(
+			'attrs' => array(
+				'dsgoStyleBinding' => array(
+					'background-image' => array(
+						'source' => 'designsetgo/post-meta',
+						'key'    => 'whatever',
+					),
+				),
+			),
+		);
+
+		$html = ( new \DesignSetGo\StyleBinding() )->apply_style_bindings( '<div class="x"></div>', $block );
+
+		remove_filter( 'designsetgo_style_binding_resolve', $filter, 10 );
+
+		$this->assertStringNotContainsString(
+			'url(',
+			$html,
+			'Escaped url() reached the style attribute: ' . $payload
+		);
+		$this->assertStringNotContainsString(
+			$payload,
+			$html,
+			'Raw escaped payload reached the style attribute: ' . $payload
+		);
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public function binding_payload_provider() {
+		return array(
+			'escaped url('       => array( '\75\72\6c(//evil.test/x.png)' ),
+			'partially escaped'  => array( 'u\72l(//evil.test/x.png)' ),
+			'escaped javascript' => array( '\6a\61\76\61script:alert(1)' ),
+			'raw url( (already blocked)' => array( 'url(//evil.test/x.png)' ),
+		);
+	}
+
+	/**
+	 * The fix must not break the feature it protects.
+	 */
+	public function test_style_binding_still_applies_an_ordinary_value() {
+		$filter = static function () {
+			return '#ff0000';
+		};
+
+		add_filter( 'designsetgo_style_binding_resolve', $filter, 10, 1 );
+
+		$block = array(
+			'attrs' => array(
+				'dsgoStyleBinding' => array(
+					'color' => array(
+						'source' => 'designsetgo/post-meta',
+						'key'    => 'whatever',
+					),
+				),
+			),
+		);
+
+		$html = ( new \DesignSetGo\StyleBinding() )->apply_style_bindings( '<div class="x"></div>', $block );
+
+		remove_filter( 'designsetgo_style_binding_resolve', $filter, 10 );
+
+		$this->assertStringContainsString( 'color:#ff0000', $html );
+	}
+}

--- a/tests/phpunit/form-email-escaping-test.php
+++ b/tests/phpunit/form-email-escaping-test.php
@@ -214,4 +214,45 @@ class Form_Email_Escaping_Test extends WP_UnitTestCase {
 		$this->assertNotNull( $this->sent );
 		$this->assertStringContainsString( 'billing, sales', (string) $this->sent['message'] );
 	}
+
+	/**
+	 * A submission is attacker-shaped data, so no field shape may warn or fatal.
+	 *
+	 * An array with no 'value' key, or arrays nested inside arrays, would make a
+	 * plain strval() emit "Array to string conversion". The helper exists
+	 * precisely so that every shape is safe, so it has to actually be.
+	 *
+	 * @dataProvider malformed_field_provider
+	 *
+	 * @param mixed $field_data A field of hostile / malformed shape.
+	 */
+	public function test_no_field_shape_raises( $field_data ) {
+		$this->configure_form();
+
+		// Any PHP warning here (e.g. "Array to string conversion") becomes a
+		// failure, which is exactly what we want to pin.
+		$handler = new \DesignSetGo\Blocks\Form_Handler();
+		$method  = new ReflectionMethod( $handler, 'send_email_notification' );
+		$method->setAccessible( true );
+
+		$method->invoke( $handler, 'test-form', array( 'message' => $field_data ), 125 );
+
+		$this->assertNotNull( $this->sent );
+		$this->assertIsString( $this->sent['message'] );
+		$this->assertIsString( $this->sent['subject'] );
+	}
+
+	/**
+	 * @return array<string, array{0: mixed}>
+	 */
+	public function malformed_field_provider() {
+		return array(
+			'array with no value key' => array( array( 'unexpected' => 'shape' ) ),
+			'nested arrays'           => array( array( 'value' => array( array( 'a', 'b' ), 'c' ) ) ),
+			'deeply nested'           => array( array( array( array( 'x' ) ) ) ),
+			'bool'                    => array( true ),
+			'null'                    => array( null ),
+			'int'                     => array( 42 ),
+		);
+	}
 }

--- a/tests/phpunit/form-email-escaping-test.php
+++ b/tests/phpunit/form-email-escaping-test.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Form notification emails must escape submitted values.
+ *
+ * The notification is sent with `Content-Type: text/html`, and its body is a
+ * template in which `{field_name}` merge tags are replaced with whatever the
+ * visitor typed. The `{all_fields}` aggregate always ran values through
+ * esc_html(); the PER-FIELD tags did not — so any template using `{message}` or
+ * `{name}` (the common case) let an anonymous submitter put arbitrary markup
+ * into the site owner's inbox: a fake "reset your password" link, a tracking
+ * pixel, a spoofed sender line.
+ *
+ * @package DesignSetGo
+ */
+
+/**
+ * @group security
+ * @group forms
+ */
+class Form_Email_Escaping_Test extends WP_UnitTestCase {
+
+	/**
+	 * Captured wp_mail() arguments.
+	 *
+	 * @var array<string, mixed>|null
+	 */
+	private $sent;
+
+	public function set_up() {
+		parent::set_up();
+		$this->sent = null;
+
+		add_filter(
+			'pre_wp_mail',
+			function ( $short_circuit, $atts ) {
+				$this->sent = $atts;
+				return true; // Don't actually send.
+			},
+			10,
+			2
+		);
+
+		// Without a user who has `unfiltered_html`, wp_insert_post() runs the
+		// content through wp_filter_post_kses(), which strips HTML comments — and
+		// a block IS an HTML comment, so the fixture would silently save as an
+		// empty post and the handler would find nothing.
+		wp_set_current_user(
+			self::factory()->user->create( array( 'role' => 'administrator' ) )
+		);
+
+		// The handler deliberately reads email config from the SAVED BLOCK rather
+		// than the request, so a real published post has to exist for it to find.
+		// The body uses a per-field {message} tag — the exact shape that was
+		// interpolating submitter input into HTML unescaped.
+		self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:designsetgo/form-builder ' . wp_json_encode(
+					array(
+						'formId'      => 'test-form',
+						'enableEmail' => true,
+						'emailTo'     => 'owner@example.org',
+						'emailBody'   => '<p>Message: {message}</p><p>Topics: {topics}</p>',
+					)
+				) . ' --><div class="wp-block-designsetgo-form-builder"></div><!-- /wp:designsetgo/form-builder -->',
+			)
+		);
+	}
+
+	/**
+	 * Invoke the private notification builder with a hostile submission.
+	 *
+	 * @param string $payload Attacker-supplied field value.
+	 * @return string The rendered email body.
+	 */
+	private function send_with_payload( $payload ) {
+		$handler = new \DesignSetGo\Blocks\Form_Handler();
+
+		$method = new ReflectionMethod( $handler, 'send_email_notification' );
+		$method->setAccessible( true );
+
+		$method->invoke(
+			$handler,
+			'test-form',
+			array( 'message' => $payload, 'name' => 'Visitor' ),
+			123
+		);
+
+		$this->assertNotNull( $this->sent, 'No email was produced.' );
+
+		return (string) $this->sent['message'];
+	}
+
+	/**
+	 * @dataProvider payload_provider
+	 *
+	 * @param string $payload  Hostile value.
+	 * @param string $forbidden Substring that must not appear unescaped.
+	 */
+	public function test_submitted_markup_is_escaped_in_the_body( $payload, $forbidden ) {
+		$body = $this->send_with_payload( $payload );
+
+		$this->assertStringNotContainsString(
+			$forbidden,
+			$body,
+			'Submitted markup reached the HTML email body unescaped.'
+		);
+	}
+
+	/**
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function payload_provider() {
+		return array(
+			'anchor injection' => array(
+				'<a href="https://evil.test">Reset your password</a>',
+				'<a href="https://evil.test">',
+			),
+			'image beacon'     => array(
+				'<img src="https://evil.test/pixel.gif">',
+				'<img src=',
+			),
+			'script tag'       => array(
+				'<script>alert(1)</script>',
+				'<script>',
+			),
+		);
+	}
+
+	/**
+	 * The escaping must not mangle ordinary text — the owner still needs to
+	 * read what the visitor actually wrote.
+	 */
+	public function test_ordinary_text_survives_readably() {
+		$body = $this->send_with_payload( 'Hello, I need help with A & B.' );
+
+		$this->assertStringContainsString( 'Hello, I need help with A', $body );
+	}
+
+	/**
+	 * A multi-value field arrives as an array; esc_html() would raise on it.
+	 */
+	public function test_array_field_values_do_not_fatal() {
+		$handler = new \DesignSetGo\Blocks\Form_Handler();
+
+		$method = new ReflectionMethod( $handler, 'send_email_notification' );
+		$method->setAccessible( true );
+
+		$method->invoke(
+			$handler,
+			'test-form',
+			array( 'topics' => array( 'value' => array( 'billing', 'sales' ) ) ),
+			124
+		);
+
+		$this->assertNotNull( $this->sent );
+		$this->assertStringContainsString( 'billing, sales', (string) $this->sent['message'] );
+	}
+}

--- a/tests/phpunit/form-email-escaping-test.php
+++ b/tests/phpunit/form-email-escaping-test.php
@@ -243,6 +243,54 @@ class Form_Email_Escaping_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A multi-value field chosen as the Reply-To source must not fatal.
+	 *
+	 * emailReplyTo names a field; if that field is multi-value it arrives as an
+	 * array, and handing an array to sanitize_email() is a PHP 8 TypeError
+	 * (strlen() on array) that would take the whole notification down. The
+	 * extraction must flatten through the shared helper first.
+	 */
+	public function test_multi_value_reply_to_field_does_not_fatal() {
+		$this->configure_form_with_reply_to( 'contact' );
+
+		$handler = new \DesignSetGo\Blocks\Form_Handler();
+		$method  = new ReflectionMethod( $handler, 'send_email_notification' );
+		$method->setAccessible( true );
+
+		// 'contact' resolves to a multi-value field — the crashing shape.
+		$method->invoke(
+			$handler,
+			'test-form',
+			array( 'contact' => array( 'value' => array( 'a@example.org', 'b@example.org' ) ) ),
+			126
+		);
+
+		$this->assertNotNull( $this->sent, 'Notification fataled on a multi-value reply-to field.' );
+	}
+
+	/**
+	 * Publish a form whose emailReplyTo points at the given field name.
+	 *
+	 * @param string $field_name Field to use as the Reply-To source.
+	 */
+	private function configure_form_with_reply_to( $field_name ) {
+		self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:designsetgo/form-builder ' . wp_json_encode(
+					array(
+						'formId'       => 'test-form',
+						'enableEmail'  => true,
+						'emailTo'      => 'owner@example.org',
+						'emailReplyTo' => $field_name,
+						'emailBody'    => '<p>{all_fields}</p>',
+					)
+				) . ' --><div class="wp-block-designsetgo-form-builder"></div><!-- /wp:designsetgo/form-builder -->',
+			)
+		);
+	}
+
+	/**
 	 * @return array<string, array{0: mixed}>
 	 */
 	public function malformed_field_provider() {

--- a/tests/phpunit/form-email-escaping-test.php
+++ b/tests/phpunit/form-email-escaping-test.php
@@ -48,19 +48,29 @@ class Form_Email_Escaping_Test extends WP_UnitTestCase {
 			self::factory()->user->create( array( 'role' => 'administrator' ) )
 		);
 
-		// The handler deliberately reads email config from the SAVED BLOCK rather
-		// than the request, so a real published post has to exist for it to find.
-		// The body uses a per-field {message} tag — the exact shape that was
-		// interpolating submitter input into HTML unescaped.
+	}
+
+	/**
+	 * Publish a post carrying the form block.
+	 *
+	 * The handler deliberately reads email config from the SAVED BLOCK rather
+	 * than the request (so it can't be tampered with client-side), which means a
+	 * real published post has to exist for it to find. Both templates use
+	 * per-field merge tags — the exact shape at issue.
+	 *
+	 * @param string $subject_template Subject line, may contain merge tags.
+	 */
+	private function configure_form( $subject_template = 'New submission' ) {
 		self::factory()->post->create(
 			array(
 				'post_status'  => 'publish',
 				'post_content' => '<!-- wp:designsetgo/form-builder ' . wp_json_encode(
 					array(
-						'formId'      => 'test-form',
-						'enableEmail' => true,
-						'emailTo'     => 'owner@example.org',
-						'emailBody'   => '<p>Message: {message}</p><p>Topics: {topics}</p>',
+						'formId'       => 'test-form',
+						'enableEmail'  => true,
+						'emailTo'      => 'owner@example.org',
+						'emailSubject' => $subject_template,
+						'emailBody'    => '<p>Message: {message}</p><p>Topics: {topics}</p>',
 					)
 				) . ' --><div class="wp-block-designsetgo-form-builder"></div><!-- /wp:designsetgo/form-builder -->',
 			)
@@ -70,10 +80,13 @@ class Form_Email_Escaping_Test extends WP_UnitTestCase {
 	/**
 	 * Invoke the private notification builder with a hostile submission.
 	 *
-	 * @param string $payload Attacker-supplied field value.
+	 * @param string $payload          Attacker-supplied field value.
+	 * @param string $subject_template Subject line, may contain merge tags.
 	 * @return string The rendered email body.
 	 */
-	private function send_with_payload( $payload ) {
+	private function send_with_payload( $payload, $subject_template = 'New submission' ) {
+		$this->configure_form( $subject_template );
+
 		$handler = new \DesignSetGo\Blocks\Form_Handler();
 
 		$method = new ReflectionMethod( $handler, 'send_email_notification' );
@@ -138,9 +151,54 @@ class Form_Email_Escaping_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The SUBJECT is a plain-text mail header, not HTML.
+	 *
+	 * The first cut of this fix shared one esc_html()'d merge-tag map between the
+	 * body and the subject, which corrupted the subject: a site called
+	 * "Bob's Bakery & Sons" arrived as "Bob&#039;s Bakery &amp; Sons". Escaping a
+	 * header is not protection, it is mojibake — and the original suite only ever
+	 * asserted on the body, so it sailed through.
+	 */
+	public function test_subject_is_not_html_escaped() {
+		update_option( 'blogname', "Bob's Bakery & Sons" );
+
+		$this->send_with_payload( 'anything', '{site_name}: new enquiry' );
+
+		$subject = (string) $this->sent['subject'];
+
+		$this->assertSame( "Bob's Bakery & Sons: new enquiry", $subject );
+		$this->assertStringNotContainsString( '&amp;', $subject );
+		$this->assertStringNotContainsString( '&#039;', $subject );
+	}
+
+	/**
+	 * A field value reaching the subject must not be able to add a mail header.
+	 */
+	public function test_subject_merge_tags_cannot_inject_a_header() {
+		$this->send_with_payload( "hi\r\nBcc: victim@example.org", 'Re: {message}' );
+
+		$subject = (string) $this->sent['subject'];
+
+		$this->assertStringNotContainsString( "\n", $subject );
+		$this->assertStringNotContainsString( "\r", $subject );
+	}
+
+	/**
+	 * Escaping the body must not have been traded away for the subject fix.
+	 */
+	public function test_body_is_still_escaped_while_subject_is_not() {
+		$this->send_with_payload( '<script>alert(1)</script>', 'Re: {message}' );
+
+		$this->assertStringNotContainsString( '<script>', (string) $this->sent['message'] );
+		$this->assertStringContainsString( '<script>', (string) $this->sent['subject'] );
+	}
+
+	/**
 	 * A multi-value field arrives as an array; esc_html() would raise on it.
 	 */
 	public function test_array_field_values_do_not_fatal() {
+		$this->configure_form();
+
 		$handler = new \DesignSetGo\Blocks\Form_Handler();
 
 		$method = new ReflectionMethod( $handler, 'send_email_notification' );


### PR DESCRIPTION
Found by the pre-release audit of `v2.3.0..main` while staging 2.4.0.

**All four are pre-existing** — present verbatim in the shipped `v2.3.0` tag, so none is a 2.4.0 regression and shipping 2.4.0 would not have made anything worse. But we know about them now, so they get fixed before the next release rather than after it.

## 1. CSS escape-sequence bypass

`includes/features/class-style-binding.php`, `includes/abilities/class-css-sanitizer.php`

A browser resolves CSS escapes **before** applying a declaration. So `\75\72\6c(//evil.test)` *is* `url(//evil.test)`, and `java\0script:` *is* `javascript:`. Both sanitizers pattern-matched the **raw** text:

```php
if ( preg_match( '/url\s*\(|expression\s*\(|javascript:|data:/i', $value ) ) { continue; }
```

…which blocks nothing. The attacker escapes one character and walks through.

The instructive part: `Custom_CSS_Renderer` **already did this correctly**, and that is exactly why the other two didn't — the normalization was a `private` method, so it couldn't be reused. It now lives in `designsetgo_normalize_css_escapes()` (`includes/helpers.php`) and all three call it. One definition of "what does the browser actually see."

`StyleBinding` additionally rejects any value whose decoded form differs from its raw form. Bindings resolve to lengths, colours and keywords — none has any reason to be escaped — so rather than trust this decoder to agree with every browser tokenizer on every edge case, the value is dropped.

## 2. HTML injection into notification emails

`includes/blocks/forms/class-form-handler.php`

Notifications are sent `Content-Type: text/html`, and the per-field merge tags were interpolated **raw**:

```php
$merge_tags[ '{' . $field_name . '}' ] = is_array( $field_data ) ? $field_data['value'] : $field_data;
```

The `{all_fields}` aggregate three lines below always ran values through `esc_html()`. So any template using `{message}` or `{name}` — the common case — let an **anonymous** submitter put arbitrary markup into the site owner's inbox: a fake "reset your password" link, a tracking pixel, a spoofed message.

Every merge tag is now escaped. Array values (checkbox groups, multi-selects) are joined rather than handed to `esc_html()`, which would have raised on them.

## 3. Attribute breakout in generated core-block HTML

`includes/abilities/class-block-inserter.php`

`textAlign` / `align` were concatenated into `class="..."`, so `center" onmouseover="alert(1)` closed the attribute and added a live handler. These are alignment keywords, so they're now constrained to the set core actually emits — **provably safe rather than merely escaped**, and dropping a nonsense alignment is also the correct rendering.

Reaching this needs the `add-block` ability (`edit_posts`) *and* `unfiltered_html` for the payload to survive `wp_update_post()`'s KSES pass — so it is not an escalation past an existing trust boundary. It's still a real hole.

## 4. Tabs deep-link crash

`src/blocks/tabs/view.js`

`window.location.hash` went straight into `querySelector('#' + hash)`. A fragment is **not** a valid CSS selector in general: `#2024`, `#a b`, `#!` all throw `SyntaxError` — thrown from inside `init()`, which took out **every tabs block on the page**, not just the deep link. An ordinary year-numbered anchor elsewhere on the page was enough. Now `CSS.escape()`d, with a throw treated as "no match" rather than fatal.

## Tests

28 new PHPUnit assertions across three files, plus 7 jsdom tests for the fragment handling. **Each was verified to fail against the unpatched code** — 6 PHPUnit failures, and `SyntaxError: not a valid selector` in jsdom. They're regression pins, not decoration.

| | before | after |
|---|---|---|
| PHPUnit | 851 | **879** |
| Jest | 2448 | **2455** |

PHPStan clean, PHPCS clean, build clean, no new `lint:js` errors vs `main`, pre-commit e2e (7 tests) pass.

## Not included

The audit's remaining Low findings are left for follow-up, none exploitable as written: merge-tag newlines in the email *subject* (PHPMailer's `secureHeader()` already strips them), `llms-txt` write paths lacking the `realpath()` containment the read paths have, and `map`'s `dsgoHeight` accepting a free-form CSS length.

Separately worth a product decision, not a security issue: the `/query/render` REST route requires `is_user_logged_in()`, so Dynamic Query load-more / infinite-scroll / AJAX filtering may not work for **logged-out** visitors. That's over-restrictive rather than under-, but it's probably not intended.