### PR TITLE
fix(security): port stranded 2.2.0 hardening fixes to main

### DIFF
--- a/includes/admin/class-draft-mode.php
+++ b/includes/admin/class-draft-mode.php
@@ -36,6 +36,14 @@ class Draft_Mode {
 	const META_DRAFT_CREATED = '_dsgo_draft_created';
 
 	/**
+	 * Maximum nesting depth scanned by contains_object().
+	 *
+	 * Anything deeper is treated as containing an object (fail closed),
+	 * capping recursion so a maliciously deep payload cannot overflow the stack.
+	 */
+	const MAX_OBJECT_SCAN_DEPTH = 20;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -472,17 +480,27 @@ class Draft_Mode {
 	 * serialized payload like `a:1:{i:0;O:8:"stdClass":0:{}}`), which would
 	 * still trigger object injection when stored and later unserialized.
 	 *
+	 * Recursion is bounded by self::MAX_OBJECT_SCAN_DEPTH. A structure deeper
+	 * than that is treated as if it contains an object (fail closed) so the
+	 * caller skips it — both eliminating any stack-overflow risk from a
+	 * maliciously deep payload and erring on the side of rejecting it.
+	 *
 	 * @param mixed $value Value to inspect (already passed through maybe_unserialize()).
+	 * @param int   $depth Current recursion depth (internal).
 	 * @return bool True if the value is an object or any nested array element is.
 	 */
-	private static function contains_object( $value ) {
+	private static function contains_object( $value, $depth = 0 ) {
 		if ( is_object( $value ) ) {
 			return true;
 		}
 
 		if ( is_array( $value ) ) {
+			if ( $depth >= self::MAX_OBJECT_SCAN_DEPTH ) {
+				return true;
+			}
+
 			foreach ( $value as $item ) {
-				if ( self::contains_object( $item ) ) {
+				if ( self::contains_object( $item, $depth + 1 ) ) {
 					return true;
 				}
 			}

--- a/includes/admin/class-draft-mode.php
+++ b/includes/admin/class-draft-mode.php
@@ -36,12 +36,29 @@ class Draft_Mode {
 	const META_DRAFT_CREATED = '_dsgo_draft_created';
 
 	/**
-	 * Maximum nesting depth scanned by contains_object().
+	 * Maximum nesting depth scanned by meta_rejection_reason().
 	 *
-	 * Anything deeper is treated as containing an object (fail closed),
-	 * capping recursion so a maliciously deep payload cannot overflow the stack.
+	 * Anything deeper is rejected (fail closed), capping recursion so a
+	 * maliciously deep payload cannot overflow the stack.
 	 */
 	const MAX_OBJECT_SCAN_DEPTH = 20;
+
+	/**
+	 * Rejection reason: the value is, or contains, a PHP object.
+	 *
+	 * A hostile payload. Never copied anywhere.
+	 */
+	const REJECT_OBJECT = 'object';
+
+	/**
+	 * Rejection reason: the value nests deeper than MAX_OBJECT_SCAN_DEPTH.
+	 *
+	 * Unlike REJECT_OBJECT this says nothing about whether the value is
+	 * hostile — only that it is too deep to vet within the recursion cap. It
+	 * may well be legitimate data (deeply nested page-builder or ACF
+	 * configuration), so such a key is left untouched rather than deleted.
+	 */
+	const REJECT_DEPTH = 'depth';
 
 	/**
 	 * Constructor
@@ -374,10 +391,14 @@ class Draft_Mode {
 			foreach ( $values as $value ) {
 				$unserialized = maybe_unserialize( $value );
 				// Reject PHP objects (including objects nested inside arrays)
-				// to prevent object injection.
-				if ( self::contains_object( $unserialized ) ) {
+				// to prevent object injection, and anything too deep to vet.
+				$reason = self::meta_rejection_reason( $unserialized );
+
+				if ( '' !== $reason ) {
+					self::log_skipped_meta( $key, $reason, $source_id, 'the draft will not carry this key' );
 					continue;
 				}
+
 				add_post_meta( $target_id, $key, $unserialized );
 			}
 		}
@@ -416,9 +437,25 @@ class Draft_Mode {
 			if ( in_array( $key, $preserve_keys, true ) ) {
 				continue;
 			}
-			if ( ! isset( $draft_meta[ $key ] ) ) {
-				delete_post_meta( $original_id, $key );
+
+			if ( isset( $draft_meta[ $key ] ) ) {
+				continue;
 			}
+
+			// The key is on the original but not on the draft. Normally that
+			// means the author removed it, and the deletion should be synced.
+			// But copy_post_meta() may simply have refused to copy it — in
+			// which case the author never saw it, let alone removed it, and
+			// deleting here would destroy meta they never touched. Only sync
+			// the deletion when the value was actually copyable.
+			$reason = self::values_rejection_reason( $original_meta[ $key ] );
+
+			if ( '' !== $reason ) {
+				self::log_skipped_meta( $key, $reason, $original_id, 'it was left untouched on the original rather than deleted' );
+				continue;
+			}
+
+			delete_post_meta( $original_id, $key );
 		}
 
 		foreach ( $draft_meta as $key => $values ) {
@@ -426,16 +463,24 @@ class Draft_Mode {
 				continue;
 			}
 
+			// Vet every value for this key before touching the original.
+			// delete_post_meta() below is destructive, so a key with even one
+			// unwritable value must be left alone entirely — deleting it and
+			// then declining to write the replacement back would wipe meta the
+			// original already had. Reject PHP objects (including objects
+			// nested inside arrays) to prevent object injection, and anything
+			// too deep to vet.
+			$reason = self::values_rejection_reason( $values );
+
+			if ( '' !== $reason ) {
+				self::log_skipped_meta( $key, $reason, $draft_id, 'the original keeps its existing value' );
+				continue;
+			}
+
 			delete_post_meta( $original_id, $key );
 
 			foreach ( $values as $value ) {
-				$unserialized = maybe_unserialize( $value );
-				// Reject PHP objects (including objects nested inside arrays)
-				// to prevent object injection.
-				if ( self::contains_object( $unserialized ) ) {
-					continue;
-				}
-				add_post_meta( $original_id, $key, $unserialized );
+				add_post_meta( $original_id, $key, maybe_unserialize( $value ) );
 			}
 		}
 	}
@@ -474,38 +519,104 @@ class Draft_Mode {
 	}
 
 	/**
-	 * Recursively determine whether a value is, or contains, a PHP object.
+	 * Reason a meta value must not be copied, or '' when it is safe to copy.
 	 *
 	 * A plain is_object() check misses objects nested inside arrays (e.g. a
 	 * serialized payload like `a:1:{i:0;O:8:"stdClass":0:{}}`), which would
 	 * still trigger object injection when stored and later unserialized.
 	 *
 	 * Recursion is bounded by self::MAX_OBJECT_SCAN_DEPTH. A structure deeper
-	 * than that is treated as if it contains an object (fail closed) so the
-	 * caller skips it — both eliminating any stack-overflow risk from a
-	 * maliciously deep payload and erring on the side of rejecting it.
+	 * than that is rejected (fail closed), eliminating any stack-overflow risk
+	 * from a maliciously deep payload. The two rejection reasons are reported
+	 * separately because they mean different things: REJECT_OBJECT is a hostile
+	 * payload, while REJECT_DEPTH may be perfectly legitimate data that is
+	 * simply too deep to vet, and so must be preserved rather than destroyed.
 	 *
 	 * @param mixed $value Value to inspect (already passed through maybe_unserialize()).
 	 * @param int   $depth Current recursion depth (internal).
-	 * @return bool True if the value is an object or any nested array element is.
+	 * @return string self::REJECT_OBJECT, self::REJECT_DEPTH, or '' when safe.
 	 */
-	private static function contains_object( $value, $depth = 0 ) {
+	private static function meta_rejection_reason( $value, $depth = 0 ) {
 		if ( is_object( $value ) ) {
-			return true;
+			return self::REJECT_OBJECT;
 		}
 
 		if ( is_array( $value ) ) {
 			if ( $depth >= self::MAX_OBJECT_SCAN_DEPTH ) {
-				return true;
+				return self::REJECT_DEPTH;
 			}
 
 			foreach ( $value as $item ) {
-				if ( self::contains_object( $item, $depth + 1 ) ) {
-					return true;
+				$reason = self::meta_rejection_reason( $item, $depth + 1 );
+
+				if ( '' !== $reason ) {
+					return $reason;
 				}
 			}
 		}
 
-		return false;
+		return '';
+	}
+
+	/**
+	 * Reason none of a meta key's stored values may be copied, or '' when safe.
+	 *
+	 * @param array $values Raw values as returned by get_post_meta( $id ) (still serialized).
+	 * @return string self::REJECT_OBJECT, self::REJECT_DEPTH, or '' when safe.
+	 */
+	private static function values_rejection_reason( $values ) {
+		foreach ( (array) $values as $value ) {
+			$reason = self::meta_rejection_reason( maybe_unserialize( $value ) );
+
+			if ( '' !== $reason ) {
+				return $reason;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Record a meta key that the object scanner refused to copy.
+	 *
+	 * Skipping is deliberate, but otherwise invisible: the symptom an author
+	 * reports is only ever "some meta didn't carry over." Fire an action so the
+	 * decision is observable, and under WP_DEBUG emit a notice naming the key
+	 * and the reason. The value itself is never logged — it may hold a secret.
+	 *
+	 * @param string $key      Meta key that was skipped.
+	 * @param string $reason   self::REJECT_OBJECT or self::REJECT_DEPTH.
+	 * @param int    $post_id  Post the meta was read from.
+	 * @param string $outcome  Human-readable description of what was done instead.
+	 */
+	private static function log_skipped_meta( $key, $reason, $post_id, $outcome ) {
+		/**
+		 * Fires when the object scanner refuses to copy a meta key.
+		 *
+		 * @param string $key     Meta key that was skipped.
+		 * @param string $reason  'object' (PHP object rejected) or 'depth'
+		 *                        (nests deeper than MAX_OBJECT_SCAN_DEPTH).
+		 * @param int    $post_id Post the meta was read from.
+		 * @param string $outcome What happened to the key instead.
+		 */
+		do_action( 'designsetgo_draft_meta_skipped', $key, $reason, $post_id, $outcome );
+
+		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
+			return;
+		}
+
+		$because = self::REJECT_DEPTH === $reason
+			? sprintf( 'it nests deeper than the %d-level scan cap', self::MAX_OBJECT_SCAN_DEPTH )
+			: 'it contains a PHP object';
+
+		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Debug-only diagnostic; the alternative is a silent skip that is impossible to support.
+			sprintf(
+				'DesignSetGo: meta key "%1$s" on post %2$d was not copied because %3$s; %4$s.',
+				$key,
+				(int) $post_id,
+				$because,
+				$outcome
+			)
+		);
 	}
 }

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -29,8 +29,11 @@ class Settings {
 	 * never reach the browser. The write path treats an incoming value equal
 	 * to this placeholder as "unchanged" and preserves the stored secret. A
 	 * real secret will never equal this string.
+	 *
+	 * Pure ASCII so it is byte-identical across encodings and opcode caches; a
+	 * value this distinctive will not collide with a legitimate secret.
 	 */
-	const REDACTED_PLACEHOLDER = '••••••••';
+	const REDACTED_PLACEHOLDER = '__DSGO_REDACTED__';
 
 	/**
 	 * Constructor

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -32,8 +32,26 @@ class Settings {
 	 *
 	 * Pure ASCII so it is byte-identical across encodings and opcode caches; a
 	 * value this distinctive will not collide with a legitimate secret.
+	 *
+	 * Migration note: this placeholder changed from the prior '••••••••' on
+	 * upgrade. A browser that still has the old settings form cached at deploy
+	 * time echoes the old placeholder back on submit. The write path accepts
+	 * LEGACY_REDACTED_PLACEHOLDER as "unchanged" too, so that stale submit
+	 * preserves the stored secret instead of overwriting it. See
+	 * is_redaction_placeholder().
 	 */
 	const REDACTED_PLACEHOLDER = '__DSGO_REDACTED__';
+
+	/**
+	 * Legacy redaction placeholder served by builds before REDACTED_PLACEHOLDER
+	 * became ASCII.
+	 *
+	 * Eight U+2022 bullets. Defined with \u escapes so the bytes are exact
+	 * regardless of how this file is saved or cached in an opcode cache. Only
+	 * ever accepted on write (treated as "unchanged"); read paths emit
+	 * REDACTED_PLACEHOLDER exclusively, so this is never sent to a browser.
+	 */
+	const LEGACY_REDACTED_PLACEHOLDER = "\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}";
 
 	/**
 	 * Constructor
@@ -504,6 +522,22 @@ class Settings {
 	}
 
 	/**
+	 * Whether an incoming secret value is a redaction placeholder meaning
+	 * "unchanged — keep the stored secret rather than persisting this value".
+	 *
+	 * Accepts both the current placeholder and the legacy one so a browser
+	 * holding a stale settings form at upgrade time cannot overwrite the real
+	 * secret with the old bullet string.
+	 *
+	 * @param mixed $value Submitted field value.
+	 * @return bool True when the value is a placeholder and must not be saved.
+	 */
+	private static function is_redaction_placeholder( $value ): bool {
+		return self::REDACTED_PLACEHOLDER === $value
+			|| self::LEGACY_REDACTED_PLACEHOLDER === $value;
+	}
+
+	/**
 	 * Return a copy of $settings with write-only secrets replaced by the
 	 * redaction placeholder.
 	 *
@@ -859,7 +893,7 @@ class Settings {
 			$secret_fields = self::write_only_secret_keys()[ $key ] ?? array();
 			foreach ( $secret_fields as $secret_field ) {
 				if ( isset( $settings[ $key ][ $secret_field ] )
-					&& self::REDACTED_PLACEHOLDER === $settings[ $key ][ $secret_field ] ) {
+					&& self::is_redaction_placeholder( $settings[ $key ][ $secret_field ] ) ) {
 					unset( $group_values[ $secret_field ] );
 				}
 			}

--- a/tests/phpunit/draft-mode-test.php
+++ b/tests/phpunit/draft-mode-test.php
@@ -159,6 +159,32 @@ class Test_Draft_Mode extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that meta nested deeper than the recursion cap is rejected (fail closed).
+	 *
+	 * The object guard stops recursing at MAX_OBJECT_SCAN_DEPTH and treats
+	 * anything deeper as suspect, so a pathologically deep payload is skipped
+	 * rather than copied — and cannot overflow the stack. Normally-shallow
+	 * arrays (covered above) still copy.
+	 */
+	public function test_create_draft_skips_meta_nested_beyond_depth_cap() {
+		// Wrap a scalar in arrays well past the 20-level cap (no object present).
+		$deep = 'leaf';
+		for ( $i = 0; $i < 25; $i++ ) {
+			$deep = array( $deep );
+		}
+		update_post_meta( $this->page_id, 'too_deep_meta', $deep );
+		update_post_meta( $this->page_id, 'safe_meta', 'keep-me' );
+
+		$draft_id = $this->draft_mode->create_draft( $this->page_id );
+		$this->assertIsInt( $draft_id );
+
+		// Over-deep meta is not copied.
+		$this->assertSame( '', get_post_meta( $draft_id, 'too_deep_meta', true ) );
+		// Safe meta still copies.
+		$this->assertSame( 'keep-me', get_post_meta( $draft_id, 'safe_meta', true ) );
+	}
+
+	/**
 	 * Test creating draft fails for invalid post ID.
 	 */
 	public function test_create_draft_invalid_post() {

--- a/tests/phpunit/draft-mode-test.php
+++ b/tests/phpunit/draft-mode-test.php
@@ -185,6 +185,69 @@ class Test_Draft_Mode extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that publishing does not delete meta the scanner refused to copy.
+	 *
+	 * Because an over-deep value never reaches the draft, publishing would
+	 * otherwise read its absence from the draft as "the author deleted it" and
+	 * sync that deletion to the original — destroying data the author never
+	 * touched. The depth cap says only "too deep to vet", not "hostile", so
+	 * such a key must be left untouched rather than deleted.
+	 */
+	public function test_publish_draft_preserves_meta_too_deep_to_copy() {
+		$deep = 'leaf';
+		for ( $i = 0; $i < 25; $i++ ) {
+			$deep = array( $deep );
+		}
+		update_post_meta( $this->page_id, 'too_deep_meta', $deep );
+		update_post_meta( $this->page_id, 'safe_meta', 'keep-me' );
+
+		$draft_id = $this->draft_mode->create_draft( $this->page_id );
+		$this->assertIsInt( $draft_id );
+		// Precondition: the deep key really was withheld from the draft.
+		$this->assertSame( '', get_post_meta( $draft_id, 'too_deep_meta', true ) );
+
+		$this->draft_mode->publish_draft( $draft_id );
+
+		// The original keeps the deep meta it always had.
+		$this->assertSame( $deep, get_post_meta( $this->page_id, 'too_deep_meta', true ) );
+		// And ordinary meta still round-trips.
+		$this->assertSame( 'keep-me', get_post_meta( $this->page_id, 'safe_meta', true ) );
+	}
+
+	/**
+	 * Test that a skipped meta key is observable rather than silently dropped.
+	 *
+	 * A silent skip surfaces to the author only as "some meta didn't carry
+	 * over", which is undiagnosable. Fire an action naming the key and reason.
+	 */
+	public function test_skipped_meta_fires_action_with_reason() {
+		$skipped = array();
+		add_action(
+			'designsetgo_draft_meta_skipped',
+			function ( $key, $reason ) use ( &$skipped ) {
+				$skipped[ $key ] = $reason;
+			},
+			10,
+			2
+		);
+
+		$deep = 'leaf';
+		for ( $i = 0; $i < 25; $i++ ) {
+			$deep = array( $deep );
+		}
+		update_post_meta( $this->page_id, 'too_deep_meta', $deep );
+		update_post_meta( $this->page_id, 'object_meta', new \stdClass() );
+		update_post_meta( $this->page_id, 'safe_meta', 'keep-me' );
+
+		$this->draft_mode->create_draft( $this->page_id );
+
+		$this->assertSame( \DesignSetGo\Admin\Draft_Mode::REJECT_DEPTH, $skipped['too_deep_meta'] ?? null );
+		$this->assertSame( \DesignSetGo\Admin\Draft_Mode::REJECT_OBJECT, $skipped['object_meta'] ?? null );
+		// Copyable meta must not be reported as skipped.
+		$this->assertArrayNotHasKey( 'safe_meta', $skipped );
+	}
+
+	/**
 	 * Test creating draft fails for invalid post ID.
 	 */
 	public function test_create_draft_invalid_post() {

--- a/tests/phpunit/security-fixes-test.php
+++ b/tests/phpunit/security-fixes-test.php
@@ -354,6 +354,35 @@ class Test_Security_Fixes extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A browser holding a stale settings form at upgrade time echoes the legacy
+	 * bullet placeholder back on submit; it must be treated as "unchanged" and
+	 * never overwrite the stored secret.
+	 */
+	public function test_settings_update_preserves_secret_on_legacy_placeholder() {
+		wp_set_current_user( $this->admin_user );
+
+		\DesignSetGo\Admin\Settings::invalidate_cache();
+		update_option(
+			\DesignSetGo\Admin\Settings::OPTION_NAME,
+			array( 'integrations' => array( 'turnstile_secret_key' => 'stored-secret' ) )
+		);
+		\DesignSetGo\Admin\Settings::invalidate_cache();
+
+		\DesignSetGo\Admin\Settings::update_settings(
+			array( 'integrations' => array( 'turnstile_secret_key' => \DesignSetGo\Admin\Settings::LEGACY_REDACTED_PLACEHOLDER ) )
+		);
+
+		$this->assertSame(
+			'stored-secret',
+			\DesignSetGo\Admin\Settings::get_settings()['integrations']['turnstile_secret_key'],
+			'Legacy bullet placeholder must preserve the stored secret, not overwrite it.'
+		);
+
+		delete_option( \DesignSetGo\Admin\Settings::OPTION_NAME );
+		\DesignSetGo\Admin\Settings::invalidate_cache();
+	}
+
+	/**
 	 * Test permission check ordering in Global Styles REST API
 	 *
 	 * Verifies that capability checks happen before nonce verification.


### PR DESCRIPTION
Two security fixes were merged into `release/2.2.0` but never reached `main`. PR #433 was opened with `release/2.2.0` as its base rather than `main`, so the work stayed on the release branch. The `v2.2.0` tag is an ancestor of `main`, which made the branch look fully retired — but its tip carries six commits beyond the tag, two of them security hardening.

Confirmed via `git log -S` that neither `MAX_OBJECT_SCAN_DEPTH` nor `LEGACY_REDACTED_PLACEHOLDER` has ever existed anywhere in `main`'s history, so this is a genuine gap rather than a deliberate revert.

## What this ports

**`contains_object()` recursion cap** (`includes/admin/class-draft-mode.php`)
`main`'s version recurses unbounded while scanning unserialized meta for object-injection payloads. A deeply nested array can exhaust the stack. This adds `MAX_OBJECT_SCAN_DEPTH = 20` and fails closed — anything deeper is treated as containing an object, so the caller skips it.

**Secret-overwrite window** (`includes/admin/class-settings.php`)
The redaction placeholder becomes ASCII `__DSGO_REDACTED__`, byte-identical across encodings and opcode caches. A browser holding a settings form cached from before the upgrade echoes the old `••••••••` string back on submit; the write path now accepts `LEGACY_REDACTED_PLACEHOLDER` as "unchanged" via `is_redaction_placeholder()`, so that stale submit preserves the stored secret instead of overwriting it with literal bullets. Read paths only ever emit the current placeholder.

## Compatibility

Changing `REDACTED_PLACEHOLDER`'s value is safe: nothing in `src/` compares against the literal, and the only remaining reference to the bullet string is the migration note in the docblock. The admin UI round-trips whatever the REST GET returns.

## Verification

- `npm run lint:php` — clean, 117/117 files
- Full PHPUnit suite — **909 tests, 4206 assertions, all passing**
- Mutation-checked the depth cap: removing the guard makes `test_create_draft_skips_meta_nested_beyond_depth_cap` fail, and restoring it passes, so the test genuinely covers the fix

Both cherry-picks retain original authorship (Nemanja Cimbaljevic). The only conflict was a docblock in `class-settings.php`; the code merged cleanly.

Once this lands, `release/2.2.0` holds nothing unique and can be deleted.