### PR TITLE
fix(draft-mode): preserve excluded meta on publish; make depth cap filterable

### DIFF
--- a/includes/admin/class-draft-mode.php
+++ b/includes/admin/class-draft-mode.php
@@ -36,12 +36,23 @@ class Draft_Mode {
 	const META_DRAFT_CREATED = '_dsgo_draft_created';
 
 	/**
-	 * Maximum nesting depth scanned by meta_rejection_reason().
+	 * Default maximum nesting depth scanned by meta_rejection_reason().
 	 *
 	 * Anything deeper is rejected (fail closed), capping recursion so a
-	 * maliciously deep payload cannot overflow the stack.
+	 * maliciously deep payload cannot overflow the stack. Raise it for a
+	 * specific site with the designsetgo_draft_max_object_scan_depth filter.
 	 */
 	const MAX_OBJECT_SCAN_DEPTH = 20;
+
+	/**
+	 * Hard ceiling on the scan depth, whatever the filter asks for.
+	 *
+	 * The depth cap's whole purpose is to bound recursion, so the filter that
+	 * relaxes it must not be able to remove that bound entirely. This sits far
+	 * above any plausible real structure and far below a stack overflow, so the
+	 * guarantee holds no matter what an integrator passes.
+	 */
+	const ABSOLUTE_MAX_OBJECT_SCAN_DEPTH = 200;
 
 	/**
 	 * Rejection reason: the value is, or contains, a PHP object.
@@ -365,23 +376,7 @@ class Draft_Mode {
 	private function copy_post_meta( $source_id, $target_id ) {
 		$meta = get_post_meta( $source_id );
 
-		$excluded_keys = array(
-			'_edit_lock',
-			'_edit_last',
-			self::META_DRAFT_OF,
-			self::META_HAS_DRAFT,
-			self::META_DRAFT_CREATED,
-			'_wp_old_slug',
-			'_wp_old_date',
-		);
-
-		/**
-		 * Filter the meta keys to copy when creating a draft.
-		 *
-		 * @param array $excluded_keys Keys to exclude from copying.
-		 * @param int   $source_id     Source post ID.
-		 */
-		$excluded_keys = apply_filters( 'designsetgo_draft_excluded_meta_keys', $excluded_keys, $source_id );
+		$excluded_keys = self::get_excluded_meta_keys( $source_id );
 
 		foreach ( $meta as $key => $values ) {
 			if ( in_array( $key, $excluded_keys, true ) ) {
@@ -432,6 +427,7 @@ class Draft_Mode {
 
 		$draft_meta    = get_post_meta( $draft_id );
 		$original_meta = get_post_meta( $original_id );
+		$excluded_keys = self::get_excluded_meta_keys( $original_id );
 
 		foreach ( array_keys( $original_meta ) as $key ) {
 			if ( in_array( $key, $preserve_keys, true ) ) {
@@ -444,10 +440,15 @@ class Draft_Mode {
 
 			// The key is on the original but not on the draft. Normally that
 			// means the author removed it, and the deletion should be synced.
-			// But copy_post_meta() may simply have refused to copy it — in
-			// which case the author never saw it, let alone removed it, and
-			// deleting here would destroy meta they never touched. Only sync
-			// the deletion when the value was actually copyable.
+			// But it may never have been copied in the first place — either
+			// because an integrator excluded it, or because the scanner refused
+			// it — in which case the author never saw the key, let alone removed
+			// it, and deleting here would destroy meta they never touched. Only
+			// sync the deletion when the key really was copyable.
+			if ( in_array( $key, $excluded_keys, true ) ) {
+				continue;
+			}
+
 			$reason = self::values_rejection_reason( $original_meta[ $key ] );
 
 			if ( '' !== $reason ) {
@@ -519,6 +520,67 @@ class Draft_Mode {
 	}
 
 	/**
+	 * Meta keys that are never copied from a post to its draft.
+	 *
+	 * Shared by copy_post_meta() and sync_post_meta(): the copy step uses it to
+	 * decide what to leave behind, and the publish step uses it to recognise
+	 * that such a key's absence from the draft means "never copied" rather than
+	 * "the author deleted it". Reading it from one place is what keeps those two
+	 * answers in agreement.
+	 *
+	 * @param int $post_id Post the meta is read from.
+	 * @return array Meta keys to exclude from copying.
+	 */
+	private static function get_excluded_meta_keys( $post_id ) {
+		$excluded_keys = array(
+			'_edit_lock',
+			'_edit_last',
+			self::META_DRAFT_OF,
+			self::META_HAS_DRAFT,
+			self::META_DRAFT_CREATED,
+			'_wp_old_slug',
+			'_wp_old_date',
+		);
+
+		/**
+		 * Filter the meta keys to copy when creating a draft.
+		 *
+		 * @param array $excluded_keys Keys to exclude from copying.
+		 * @param int   $post_id       Source post ID.
+		 */
+		return apply_filters( 'designsetgo_draft_excluded_meta_keys', $excluded_keys, $post_id );
+	}
+
+	/**
+	 * Maximum nesting depth the object scanner will descend.
+	 *
+	 * Filterable so a site with legitimately deep but object-free data (some
+	 * ACF repeater / flexible-content and page-builder configurations nest well
+	 * past the default) can opt into copying it, rather than having it withheld
+	 * from every draft with no recourse.
+	 *
+	 * The result is clamped to ABSOLUTE_MAX_OBJECT_SCAN_DEPTH. The cap exists to
+	 * bound recursion, and a filter must not be able to hand that guarantee back
+	 * to an attacker — so raising it is allowed, but only within a range that is
+	 * still nowhere near a stack overflow.
+	 *
+	 * @return int Depth to scan, at least 1 and at most ABSOLUTE_MAX_OBJECT_SCAN_DEPTH.
+	 */
+	private static function get_max_object_scan_depth() {
+		/**
+		 * Filter the maximum nesting depth scanned when vetting meta for objects.
+		 *
+		 * Anything deeper is rejected (fail closed) and withheld from the draft.
+		 * Values are clamped to the range 1..ABSOLUTE_MAX_OBJECT_SCAN_DEPTH.
+		 *
+		 * @param int $depth Default self::MAX_OBJECT_SCAN_DEPTH.
+		 */
+		$depth = (int) apply_filters( 'designsetgo_draft_max_object_scan_depth', self::MAX_OBJECT_SCAN_DEPTH );
+
+		return max( 1, min( $depth, self::ABSOLUTE_MAX_OBJECT_SCAN_DEPTH ) );
+	}
+
+	/**
 	 * Reason a meta value must not be copied, or '' when it is safe to copy.
 	 *
 	 * A plain is_object() check misses objects nested inside arrays (e.g. a
@@ -532,22 +594,29 @@ class Draft_Mode {
 	 * payload, while REJECT_DEPTH may be perfectly legitimate data that is
 	 * simply too deep to vet, and so must be preserved rather than destroyed.
 	 *
-	 * @param mixed $value Value to inspect (already passed through maybe_unserialize()).
-	 * @param int   $depth Current recursion depth (internal).
+	 * @param mixed    $value     Value to inspect (already passed through maybe_unserialize()).
+	 * @param int      $depth     Current recursion depth (internal).
+	 * @param int|null $max_depth Resolved depth cap; looked up once on entry and
+	 *                            passed down, so the filter runs once per scan
+	 *                            rather than once per nested element.
 	 * @return string self::REJECT_OBJECT, self::REJECT_DEPTH, or '' when safe.
 	 */
-	private static function meta_rejection_reason( $value, $depth = 0 ) {
+	private static function meta_rejection_reason( $value, $depth = 0, $max_depth = null ) {
+		if ( null === $max_depth ) {
+			$max_depth = self::get_max_object_scan_depth();
+		}
+
 		if ( is_object( $value ) ) {
 			return self::REJECT_OBJECT;
 		}
 
 		if ( is_array( $value ) ) {
-			if ( $depth >= self::MAX_OBJECT_SCAN_DEPTH ) {
+			if ( $depth >= $max_depth ) {
 				return self::REJECT_DEPTH;
 			}
 
 			foreach ( $value as $item ) {
-				$reason = self::meta_rejection_reason( $item, $depth + 1 );
+				$reason = self::meta_rejection_reason( $item, $depth + 1, $max_depth );
 
 				if ( '' !== $reason ) {
 					return $reason;
@@ -606,7 +675,10 @@ class Draft_Mode {
 		}
 
 		$because = self::REJECT_DEPTH === $reason
-			? sprintf( 'it nests deeper than the %d-level scan cap', self::MAX_OBJECT_SCAN_DEPTH )
+			? sprintf(
+				'it nests deeper than the %d-level scan cap (raise it with the designsetgo_draft_max_object_scan_depth filter)',
+				self::get_max_object_scan_depth()
+			)
 			: 'it contains a PHP object';
 
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Debug-only diagnostic; the alternative is a silent skip that is impossible to support.

--- a/includes/admin/class-draft-mode.php
+++ b/includes/admin/class-draft-mode.php
@@ -545,6 +545,16 @@ class Draft_Mode {
 		/**
 		 * Filter the meta keys to copy when creating a draft.
 		 *
+		 * The callback must be a pure function of $post_id: it has to return the
+		 * same list for a given post when the draft is created and again when it
+		 * is published. copy_post_meta() consults it to decide what to leave off
+		 * the draft, and sync_post_meta() consults it again on publish to tell an
+		 * excluded key's absence from the draft ("never copied") apart from a key
+		 * the author deleted. A callback that varies with mutable state (an
+		 * option, a transient, the clock) can excise a key at copy time and admit
+		 * it at publish time, at which point the deletion sync destroys it — the
+		 * same meta loss this exclusion is meant to prevent.
+		 *
 		 * @param array $excluded_keys Keys to exclude from copying.
 		 * @param int   $post_id       Source post ID.
 		 */
@@ -572,6 +582,14 @@ class Draft_Mode {
 		 *
 		 * Anything deeper is rejected (fail closed) and withheld from the draft.
 		 * Values are clamped to the range 1..ABSOLUTE_MAX_OBJECT_SCAN_DEPTH.
+		 *
+		 * Like designsetgo_draft_excluded_meta_keys, this must be stable across a
+		 * draft's create->publish lifetime: a key withheld as too deep at copy
+		 * time is recognised as "never copied" on publish by re-vetting it at the
+		 * current cap. Raising the cap between the two calls (for example a deploy
+		 * that changes the value while a draft is open) makes that key vet as
+		 * copyable on publish, and the deletion sync then destroys it. Prefer a
+		 * constant over reading mutable state here.
 		 *
 		 * @param int $depth Default self::MAX_OBJECT_SCAN_DEPTH.
 		 */

--- a/includes/admin/class-draft-mode.php
+++ b/includes/admin/class-draft-mode.php
@@ -376,7 +376,9 @@ class Draft_Mode {
 	private function copy_post_meta( $source_id, $target_id ) {
 		$meta = get_post_meta( $source_id );
 
+		// Resolve both filters once for the whole copy, not per key or per value.
 		$excluded_keys = self::get_excluded_meta_keys( $source_id );
+		$max_depth     = self::get_max_object_scan_depth();
 
 		foreach ( $meta as $key => $values ) {
 			if ( in_array( $key, $excluded_keys, true ) ) {
@@ -387,10 +389,10 @@ class Draft_Mode {
 				$unserialized = maybe_unserialize( $value );
 				// Reject PHP objects (including objects nested inside arrays)
 				// to prevent object injection, and anything too deep to vet.
-				$reason = self::meta_rejection_reason( $unserialized );
+				$reason = self::meta_rejection_reason( $unserialized, 0, $max_depth );
 
 				if ( '' !== $reason ) {
-					self::log_skipped_meta( $key, $reason, $source_id, 'the draft will not carry this key' );
+					self::log_skipped_meta( $key, $reason, $source_id, 'the draft will not carry this key', $max_depth );
 					continue;
 				}
 
@@ -427,7 +429,10 @@ class Draft_Mode {
 
 		$draft_meta    = get_post_meta( $draft_id );
 		$original_meta = get_post_meta( $original_id );
+
+		// Resolve both filters once for the whole publish, not per key or per value.
 		$excluded_keys = self::get_excluded_meta_keys( $original_id );
+		$max_depth     = self::get_max_object_scan_depth();
 
 		foreach ( array_keys( $original_meta ) as $key ) {
 			if ( in_array( $key, $preserve_keys, true ) ) {
@@ -449,10 +454,10 @@ class Draft_Mode {
 				continue;
 			}
 
-			$reason = self::values_rejection_reason( $original_meta[ $key ] );
+			$reason = self::values_rejection_reason( $original_meta[ $key ], $max_depth );
 
 			if ( '' !== $reason ) {
-				self::log_skipped_meta( $key, $reason, $original_id, 'it was left untouched on the original rather than deleted' );
+				self::log_skipped_meta( $key, $reason, $original_id, 'it was left untouched on the original rather than deleted', $max_depth );
 				continue;
 			}
 
@@ -471,10 +476,10 @@ class Draft_Mode {
 			// original already had. Reject PHP objects (including objects
 			// nested inside arrays) to prevent object injection, and anything
 			// too deep to vet.
-			$reason = self::values_rejection_reason( $values );
+			$reason = self::values_rejection_reason( $values, $max_depth );
 
 			if ( '' !== $reason ) {
-				self::log_skipped_meta( $key, $reason, $draft_id, 'the original keeps its existing value' );
+				self::log_skipped_meta( $key, $reason, $draft_id, 'the original keeps its existing value', $max_depth );
 				continue;
 			}
 
@@ -648,12 +653,19 @@ class Draft_Mode {
 	/**
 	 * Reason none of a meta key's stored values may be copied, or '' when safe.
 	 *
-	 * @param array $values Raw values as returned by get_post_meta( $id ) (still serialized).
+	 * @param array    $values    Raw values as returned by get_post_meta( $id ) (still serialized).
+	 * @param int|null $max_depth Resolved depth cap. Pass the value already
+	 *                            resolved for the surrounding loop so the filter
+	 *                            is not re-run per key; null resolves it once here.
 	 * @return string self::REJECT_OBJECT, self::REJECT_DEPTH, or '' when safe.
 	 */
-	private static function values_rejection_reason( $values ) {
+	private static function values_rejection_reason( $values, $max_depth = null ) {
+		if ( null === $max_depth ) {
+			$max_depth = self::get_max_object_scan_depth();
+		}
+
 		foreach ( (array) $values as $value ) {
-			$reason = self::meta_rejection_reason( maybe_unserialize( $value ) );
+			$reason = self::meta_rejection_reason( maybe_unserialize( $value ), 0, $max_depth );
 
 			if ( '' !== $reason ) {
 				return $reason;
@@ -671,12 +683,13 @@ class Draft_Mode {
 	 * decision is observable, and under WP_DEBUG emit a notice naming the key
 	 * and the reason. The value itself is never logged — it may hold a secret.
 	 *
-	 * @param string $key      Meta key that was skipped.
-	 * @param string $reason   self::REJECT_OBJECT or self::REJECT_DEPTH.
-	 * @param int    $post_id  Post the meta was read from.
-	 * @param string $outcome  Human-readable description of what was done instead.
+	 * @param string   $key       Meta key that was skipped.
+	 * @param string   $reason    self::REJECT_OBJECT or self::REJECT_DEPTH.
+	 * @param int      $post_id   Post the meta was read from.
+	 * @param string   $outcome   Human-readable description of what was done instead.
+	 * @param int|null $max_depth Resolved depth cap for the message; null resolves it once here.
 	 */
-	private static function log_skipped_meta( $key, $reason, $post_id, $outcome ) {
+	private static function log_skipped_meta( $key, $reason, $post_id, $outcome, $max_depth = null ) {
 		/**
 		 * Fires when the object scanner refuses to copy a meta key.
 		 *
@@ -692,10 +705,14 @@ class Draft_Mode {
 			return;
 		}
 
+		if ( null === $max_depth ) {
+			$max_depth = self::get_max_object_scan_depth();
+		}
+
 		$because = self::REJECT_DEPTH === $reason
 			? sprintf(
 				'it nests deeper than the %d-level scan cap (raise it with the designsetgo_draft_max_object_scan_depth filter)',
-				self::get_max_object_scan_depth()
+				$max_depth
 			)
 			: 'it contains a PHP object';
 

--- a/includes/admin/class-draft-mode.php
+++ b/includes/admin/class-draft-mode.php
@@ -62,12 +62,14 @@ class Draft_Mode {
 	const REJECT_OBJECT = 'object';
 
 	/**
-	 * Rejection reason: the value nests deeper than MAX_OBJECT_SCAN_DEPTH.
+	 * Rejection reason: the value nests deeper than the resolved scan cap.
 	 *
+	 * The cap defaults to MAX_OBJECT_SCAN_DEPTH but is filterable, so the bound
+	 * that actually applies is whatever get_max_object_scan_depth() resolves.
 	 * Unlike REJECT_OBJECT this says nothing about whether the value is
-	 * hostile — only that it is too deep to vet within the recursion cap. It
-	 * may well be legitimate data (deeply nested page-builder or ACF
-	 * configuration), so such a key is left untouched rather than deleted.
+	 * hostile — only that it is too deep to vet within that cap. It may well be
+	 * legitimate data (deeply nested page-builder or ACF configuration), so such
+	 * a key is left untouched rather than deleted.
 	 */
 	const REJECT_DEPTH = 'depth';
 
@@ -610,9 +612,10 @@ class Draft_Mode {
 	 * serialized payload like `a:1:{i:0;O:8:"stdClass":0:{}}`), which would
 	 * still trigger object injection when stored and later unserialized.
 	 *
-	 * Recursion is bounded by self::MAX_OBJECT_SCAN_DEPTH. A structure deeper
-	 * than that is rejected (fail closed), eliminating any stack-overflow risk
-	 * from a maliciously deep payload. The two rejection reasons are reported
+	 * Recursion is bounded by the resolved depth cap ($max_depth, which defaults
+	 * to self::MAX_OBJECT_SCAN_DEPTH but is filterable). A structure deeper than
+	 * that is rejected (fail closed), eliminating any stack-overflow risk from a
+	 * maliciously deep payload. The two rejection reasons are reported
 	 * separately because they mean different things: REJECT_OBJECT is a hostile
 	 * payload, while REJECT_DEPTH may be perfectly legitimate data that is
 	 * simply too deep to vet, and so must be preserved rather than destroyed.
@@ -695,7 +698,7 @@ class Draft_Mode {
 		 *
 		 * @param string $key     Meta key that was skipped.
 		 * @param string $reason  'object' (PHP object rejected) or 'depth'
-		 *                        (nests deeper than MAX_OBJECT_SCAN_DEPTH).
+		 *                        (nests deeper than the resolved scan cap).
 		 * @param int    $post_id Post the meta was read from.
 		 * @param string $outcome What happened to the key instead.
 		 */

--- a/tests/phpunit/draft-mode-test.php
+++ b/tests/phpunit/draft-mode-test.php
@@ -248,6 +248,97 @@ class Test_Draft_Mode extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that publishing does not delete meta an integrator excluded from copying.
+	 *
+	 * designsetgo_draft_excluded_meta_keys keeps a key off the draft on purpose.
+	 * That key's absence from the draft is therefore not the author deleting it,
+	 * and publishing must not sync a deletion the author never made. The value is
+	 * perfectly copyable, so the object/depth guard alone does not catch this.
+	 */
+	public function test_publish_draft_preserves_excluded_meta_keys() {
+		add_filter(
+			'designsetgo_draft_excluded_meta_keys',
+			function ( $keys ) {
+				$keys[] = 'thirdparty_bookkeeping';
+				return $keys;
+			}
+		);
+
+		update_post_meta( $this->page_id, 'thirdparty_bookkeeping', 'do-not-lose-me' );
+		update_post_meta( $this->page_id, 'safe_meta', 'keep-me' );
+
+		$draft_id = $this->draft_mode->create_draft( $this->page_id );
+		$this->assertIsInt( $draft_id );
+		// Precondition: the exclusion really did keep the key off the draft.
+		$this->assertSame( '', get_post_meta( $draft_id, 'thirdparty_bookkeeping', true ) );
+
+		$this->draft_mode->publish_draft( $draft_id );
+
+		// The original keeps the key the integrator deliberately withheld.
+		$this->assertSame( 'do-not-lose-me', get_post_meta( $this->page_id, 'thirdparty_bookkeeping', true ) );
+		$this->assertSame( 'keep-me', get_post_meta( $this->page_id, 'safe_meta', true ) );
+	}
+
+	/**
+	 * Test that the depth cap can be raised for legitimately deep data.
+	 *
+	 * Without an escape hatch, a site whose data genuinely nests past the default
+	 * would have that meta withheld from every draft with no recourse.
+	 */
+	public function test_scan_depth_filter_allows_deeper_meta() {
+		add_filter(
+			'designsetgo_draft_max_object_scan_depth',
+			function () {
+				return 40;
+			}
+		);
+
+		$deep = 'leaf';
+		for ( $i = 0; $i < 25; $i++ ) {
+			$deep = array( $deep );
+		}
+		// 25 levels: over the default cap of 20, under the filtered cap of 40.
+		update_post_meta( $this->page_id, 'deep_but_allowed', $deep );
+
+		$draft_id = $this->draft_mode->create_draft( $this->page_id );
+		$this->assertIsInt( $draft_id );
+
+		$this->assertSame( $deep, get_post_meta( $draft_id, 'deep_but_allowed', true ) );
+	}
+
+	/**
+	 * Test that the depth filter cannot remove the recursion bound.
+	 *
+	 * The cap exists to stop a hostile payload overflowing the stack, so a filter
+	 * may relax it but must not be able to hand that guarantee away. A value past
+	 * the absolute ceiling stays rejected however high the filter reaches.
+	 */
+	public function test_scan_depth_filter_is_clamped_to_absolute_max() {
+		add_filter(
+			'designsetgo_draft_max_object_scan_depth',
+			function () {
+				return PHP_INT_MAX;
+			}
+		);
+
+		$absolute = \DesignSetGo\Admin\Draft_Mode::ABSOLUTE_MAX_OBJECT_SCAN_DEPTH;
+
+		$deep = 'leaf';
+		for ( $i = 0; $i < $absolute + 10; $i++ ) {
+			$deep = array( $deep );
+		}
+		update_post_meta( $this->page_id, 'absurdly_deep', $deep );
+		update_post_meta( $this->page_id, 'safe_meta', 'keep-me' );
+
+		$draft_id = $this->draft_mode->create_draft( $this->page_id );
+		$this->assertIsInt( $draft_id );
+
+		// Still rejected: the clamp holds even against PHP_INT_MAX.
+		$this->assertSame( '', get_post_meta( $draft_id, 'absurdly_deep', true ) );
+		$this->assertSame( 'keep-me', get_post_meta( $draft_id, 'safe_meta', true ) );
+	}
+
+	/**
 	 * Test creating draft fails for invalid post ID.
 	 */
 	public function test_create_draft_invalid_post() {


### PR DESCRIPTION
Follow-up to #467, addressing the two review comments left on it. Both were flagged Low/non-blocking, but the first is confirmed data loss.

## 1. Excluded meta was destroyed on publish (data loss)

`copy_post_meta()` skips keys in `designsetgo_draft_excluded_meta_keys`, but `sync_post_meta()` never consulted that filter. So a key an integrator deliberately kept off the draft was present on the original yet absent from the draft at publish time — which the publish step read as *"the author deleted it"* and synced the deletion:

```php
if ( ! isset( $draft_meta[ $key ] ) ) {
    delete_post_meta( $original_id, $key );   // excluded, never copied — not deleted by the author
}
```

A third-party integration keeping its own bookkeeping meta off the draft therefore lost that key on **every** publish. This is the same shape as the depth-cap bug fixed in #467, reached by a different route: the value is perfectly copyable, so the object/depth guard doesn't catch it.

I confirmed it with a probe (an excluded key, seeded on a page, gone from the original after a create-draft → publish cycle) before fixing.

**Fix:** both functions now read the excluded-keys list from one shared `get_excluded_meta_keys()` helper, so the publish step recognises an excluded key's absence from the draft as "never copied" rather than "removed."

## 2. Depth cap is now filterable (reviewer request)

`MAX_OBJECT_SCAN_DEPTH` was a hardcoded 20 with no escape hatch, so a site with legitimately deep but object-free data (deep ACF repeater / flexible-content or page-builder configs) had it withheld from every draft with no recourse.

Added `designsetgo_draft_max_object_scan_depth`, mirroring the existing `designsetgo_draft_excluded_meta_keys` filter. The result is **clamped to `ABSOLUTE_MAX_OBJECT_SCAN_DEPTH` (200)** — the cap exists to bound recursion against a hostile payload, so the filter may relax it but must not be able to hand that guarantee away. The filter runs once per scan (resolved on entry, threaded down the recursion), not once per nested element.

## Not changed

The pre-existing split between `designsetgo_draft_excluded_meta_keys` (copy) and `designsetgo_draft_preserve_meta_keys` (publish) is left as-is — unifying them would change public filter semantics. This PR only stops the copy-side exclusion from causing deletion, which is the actual bug.

## Verification

- Full PHPUnit suite: **914 tests, 4222 assertions, green** (three new tests)
- `npm run lint:php`: clean, 117/117
- All three new tests mutation-checked:
  - `test_publish_draft_preserves_excluded_meta_keys` — fails if the shared-exclusion guard is removed
  - `test_scan_depth_filter_allows_deeper_meta` — 25-level value copies when the filter raises the cap to 40
  - `test_scan_depth_filter_is_clamped_to_absolute_max` — a value past the ceiling stays rejected even when the filter returns `PHP_INT_MAX`