### PR TITLE
feat(form-builder): submit button style variations (secondary/outline)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Cloudflare Turnstile no longer rejects every submission it protects.** Turnstile was unusable on any site that enabled it: the form endpoint validated `turnstile_token` against `/^[a-zA-Z0-9_-]+$/`, which has no `.` in the character class, but real Turnstile tokens are dot-delimited. The widget rendered and issued its token normally, then every submission failed REST parameter validation with `400 Invalid parameter(s): turnstile_token` before reaching the handler — so enabling Turnstile silently broke the form instead of protecting it. The token is opaque (Cloudflare guarantees only a 2048-character ceiling and does not contract its alphabet), so the validator no longer tries to parse its structure: it bounds the length and rejects only what a token can never contain — whitespace, newlines, and other non-printable bytes — before forwarding the value to `siteverify`. Non-string input is now rejected cleanly rather than reaching `preg_match()` as a PHP 8 `TypeError`. Pre-existing in the shipped 2.4.0 tag, and backed by a regression test that dispatches the real route and fails against the unpatched code. (#466)
 
+### New Features
+- **Form Builder: submit button style (Secondary / Outline)** — The submit button gains a Button Style control (`default` / `secondary` / `outline`) that emits a `dsgo-form__submit--{variation}` class, so a form placed on an alternate background can use a secondary/outline button and section/group style variations can restyle it. Ships a self-contained ghost fallback (transparent + current-color border) scoped above the theme's filled-button rule; Style Kits repaint the same class. Default output is byte-identical, so existing forms are untouched and need no migration. (#469)
+
 ## [2.4.0] - 2026-07-12
 
 ### Security

--- a/includes/abilities/class-block-inserter.php
+++ b/includes/abilities/class-block-inserter.php
@@ -1899,6 +1899,7 @@ class Block_Inserter {
 		$submit_button_text               = $attributes['submitButtonText'] ?? 'Submit';
 		$submit_button_alignment          = $attributes['submitButtonAlignment'] ?? 'left';
 		$submit_button_position           = $attributes['submitButtonPosition'] ?? 'below';
+		$submit_button_variation          = $attributes['submitButtonVariation'] ?? 'default';
 		$ajax_submit                      = $attributes['ajaxSubmit'] ?? true;
 		$success_message                  = $attributes['successMessage'] ?? 'Thank you! Your form has been submitted successfully.';
 		$error_message                    = $attributes['errorMessage'] ?? 'There was an error submitting the form. Please try again.';
@@ -1923,6 +1924,12 @@ class Block_Inserter {
 		$email_from_email                 = $attributes['emailFromEmail'] ?? '';
 		$email_reply_to                   = $attributes['emailReplyTo'] ?? '';
 		$email_body                       = $attributes['emailBody'] ?? '';
+
+		// Submit-button style variation class - must match save.js. Validated
+		// against the block.json enum so an AI-supplied value can't inject markup.
+		$submit_button_variation_class = in_array( $submit_button_variation, array( 'secondary', 'outline' ), true )
+			? ' dsgo-form__submit--' . $submit_button_variation
+			: '';
 
 		// Build classes - must match save.js.
 		$classes = $block_class;
@@ -1999,7 +2006,7 @@ class Block_Inserter {
 
 		// Inline button goes inside fields wrapper, before closing.
 		if ( 'inline' === $submit_button_position ) {
-			$closing .= '<button type="submit" class="dsgo-form__submit dsgo-form__submit--inline wp-element-button" style="' . $button_style . '">' . esc_html( $submit_button_text ) . '</button>';
+			$closing .= '<button type="submit" class="dsgo-form__submit dsgo-form__submit--inline' . $submit_button_variation_class . ' wp-element-button" style="' . $button_style . '">' . esc_html( $submit_button_text ) . '</button>';
 		}
 
 		// Close fields wrapper.
@@ -2021,7 +2028,7 @@ class Block_Inserter {
 		// Footer with button (below position).
 		if ( 'below' === $submit_button_position ) {
 			$closing .= '<div class="dsgo-form__footer">';
-			$closing .= '<button type="submit" class="dsgo-form__submit wp-element-button" style="' . $button_style . '">' . esc_html( $submit_button_text ) . '</button>';
+			$closing .= '<button type="submit" class="dsgo-form__submit' . $submit_button_variation_class . ' wp-element-button" style="' . $button_style . '">' . esc_html( $submit_button_text ) . '</button>';
 			$closing .= '</div>';
 		}
 

--- a/src/blocks/form-builder/block.json
+++ b/src/blocks/form-builder/block.json
@@ -45,6 +45,15 @@
 				"inline"
 			]
 		},
+		"submitButtonVariation": {
+			"type": "string",
+			"default": "default",
+			"enum": [
+				"default",
+				"secondary",
+				"outline"
+			]
+		},
 		"ajaxSubmit": {
 			"type": "boolean",
 			"default": true

--- a/src/blocks/form-builder/edit.js
+++ b/src/blocks/form-builder/edit.js
@@ -38,6 +38,10 @@ import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
 import { validateCSSLength } from '../../utils/css-generator';
 import FormBuilderPlaceholder from './components/FormBuilderPlaceholder';
 
+// Non-default submitButtonVariation values from block.json. Allowlisted before
+// interpolation into the class name. MUST MATCH save.js.
+const SUBMIT_BUTTON_VARIATIONS = ['secondary', 'outline'];
+
 // Blocks that Gutenberg identifies as form fields for the reply-to dropdown.
 const EMAILABLE_FIELD_BLOCKS = new Set([
 	'designsetgo/form-text-field',
@@ -131,11 +135,13 @@ export default function FormBuilderEdit({
 			? ` dsgo-form__submit--${effectiveAnimation}`
 			: '';
 
-	// Optional semantic style for the submit button - MUST MATCH save.js.
-	const submitVariationClass =
-		submitButtonVariation && submitButtonVariation !== 'default'
-			? ` dsgo-form__submit--${submitButtonVariation}`
-			: '';
+	// Optional semantic style for the submit button, allowlisted against the
+	// block.json enum before interpolation - MUST MATCH save.js.
+	const submitVariationClass = SUBMIT_BUTTON_VARIATIONS.includes(
+		submitButtonVariation
+	)
+		? ` dsgo-form__submit--${submitButtonVariation}`
+		: '';
 
 	useUniqueBlockId({
 		clientId,

--- a/src/blocks/form-builder/edit.js
+++ b/src/blocks/form-builder/edit.js
@@ -63,6 +63,7 @@ export default function FormBuilderEdit({
 		submitButtonText,
 		submitButtonAlignment,
 		submitButtonPosition,
+		submitButtonVariation,
 		ajaxSubmit,
 		successMessage,
 		errorMessage,
@@ -128,6 +129,12 @@ export default function FormBuilderEdit({
 	const submitAnimationClass =
 		effectiveAnimation && effectiveAnimation !== 'none'
 			? ` dsgo-form__submit--${effectiveAnimation}`
+			: '';
+
+	// Optional semantic style for the submit button - MUST MATCH save.js.
+	const submitVariationClass =
+		submitButtonVariation && submitButtonVariation !== 'default'
+			? ` dsgo-form__submit--${submitButtonVariation}`
 			: '';
 
 	useUniqueBlockId({
@@ -284,6 +291,7 @@ export default function FormBuilderEdit({
 							submitButtonText: 'Submit',
 							submitButtonAlignment: 'left',
 							submitButtonPosition: 'below',
+							submitButtonVariation: 'default',
 							ajaxSubmit: true,
 							successMessage:
 								'Thank you! Your form has been submitted successfully.',
@@ -381,6 +389,43 @@ export default function FormBuilderEdit({
 							}
 							help={__(
 								'Place button below all fields or inline with the last field (useful for subscribe forms)',
+								'designsetgo'
+							)}
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+					</DsgoInspectorPanel.Item>
+
+					<DsgoInspectorPanel.Item
+						label={__('Button Style', 'designsetgo')}
+						hasValue={() => submitButtonVariation !== 'default'}
+						onDeselect={() =>
+							setAttributes({ submitButtonVariation: 'default' })
+						}
+						isShownByDefault
+					>
+						<SelectControl
+							label={__('Button Style', 'designsetgo')}
+							value={submitButtonVariation}
+							options={[
+								{
+									label: __('Default', 'designsetgo'),
+									value: 'default',
+								},
+								{
+									label: __('Secondary', 'designsetgo'),
+									value: 'secondary',
+								},
+								{
+									label: __('Outline', 'designsetgo'),
+									value: 'outline',
+								},
+							]}
+							onChange={(value) =>
+								setAttributes({ submitButtonVariation: value })
+							}
+							help={__(
+								'Semantic style for the submit button. Themes and section styles can restyle these; useful for forms on alternate backgrounds.',
 								'designsetgo'
 							)}
 							__next40pxDefaultSize
@@ -1299,7 +1344,7 @@ export default function FormBuilderEdit({
 					{submitButtonPosition === 'inline' && (
 						<button
 							type="button"
-							className={`dsgo-form__submit dsgo-form__submit--inline wp-element-button${submitAnimationClass}`}
+							className={`dsgo-form__submit dsgo-form__submit--inline${submitVariationClass} wp-element-button${submitAnimationClass}`}
 							disabled
 							style={submitButtonStyle}
 						>
@@ -1312,7 +1357,7 @@ export default function FormBuilderEdit({
 					<div className="dsgo-form__footer">
 						<button
 							type="button"
-							className={`dsgo-form__submit wp-element-button${submitAnimationClass}`}
+							className={`dsgo-form__submit${submitVariationClass} wp-element-button${submitAnimationClass}`}
 							disabled
 							style={submitButtonStyle}
 						>

--- a/src/blocks/form-builder/edit.js
+++ b/src/blocks/form-builder/edit.js
@@ -425,7 +425,7 @@ export default function FormBuilderEdit({
 								setAttributes({ submitButtonVariation: value })
 							}
 							help={__(
-								'Semantic style for the submit button. Themes and section styles can restyle these; useful for forms on alternate backgrounds.',
+								'Semantic style for the submit button, useful for forms on alternate backgrounds. A custom Button Background/Text Color (in the Color panel) is applied inline and takes precedence over Secondary/Outline — clear it to use the ghost style.',
 								'designsetgo'
 							)}
 							__next40pxDefaultSize

--- a/src/blocks/form-builder/save.js
+++ b/src/blocks/form-builder/save.js
@@ -9,6 +9,10 @@ import classnames from 'classnames';
 import { convertColorToCSSVar } from '../../utils/convert-preset-to-css-var';
 import { validateCSSLength } from '../../utils/css-generator';
 
+// Non-default submitButtonVariation values from block.json. Allowlisted before
+// interpolation into the class name. MUST MATCH edit.js.
+const SUBMIT_BUTTON_VARIATIONS = ['secondary', 'outline'];
+
 export default function FormBuilderSave({ attributes }) {
 	const {
 		formId,
@@ -49,12 +53,15 @@ export default function FormBuilderSave({ attributes }) {
 	// Optional semantic style for the submit button (e.g. secondary/outline for
 	// forms placed on alternate backgrounds). The class is only appended for a
 	// non-default variation, so existing forms serialize byte-identically and
-	// need no deprecation. Kits (and section/group style variations) paint the
-	// class; style.scss ships a self-contained fallback. MUST MATCH edit.js.
-	const submitVariationClass =
-		submitButtonVariation && submitButtonVariation !== 'default'
-			? ` dsgo-form__submit--${submitButtonVariation}`
-			: '';
+	// need no deprecation. Validated against the block.json enum (like the PHP
+	// block-inserter) so a stray attribute value never reaches the class name.
+	// Kits (and section/group style variations) paint the class; style.scss ships
+	// a self-contained fallback. MUST MATCH edit.js.
+	const submitVariationClass = SUBMIT_BUTTON_VARIATIONS.includes(
+		submitButtonVariation
+	)
+		? ` dsgo-form__submit--${submitButtonVariation}`
+		: '';
 
 	// Same classes as edit.js - MUST MATCH
 	const formClasses = classnames('dsgo-form-builder', {

--- a/src/blocks/form-builder/save.js
+++ b/src/blocks/form-builder/save.js
@@ -16,6 +16,7 @@ export default function FormBuilderSave({ attributes }) {
 		submitButtonText,
 		submitButtonAlignment,
 		submitButtonPosition,
+		submitButtonVariation,
 		ajaxSubmit,
 		successMessage,
 		errorMessage,
@@ -44,6 +45,16 @@ export default function FormBuilderSave({ attributes }) {
 	if (!hasFields) {
 		return null;
 	}
+
+	// Optional semantic style for the submit button (e.g. secondary/outline for
+	// forms placed on alternate backgrounds). The class is only appended for a
+	// non-default variation, so existing forms serialize byte-identically and
+	// need no deprecation. Kits (and section/group style variations) paint the
+	// class; style.scss ships a self-contained fallback. MUST MATCH edit.js.
+	const submitVariationClass =
+		submitButtonVariation && submitButtonVariation !== 'default'
+			? ` dsgo-form__submit--${submitButtonVariation}`
+			: '';
 
 	// Same classes as edit.js - MUST MATCH
 	const formClasses = classnames('dsgo-form-builder', {
@@ -130,7 +141,7 @@ export default function FormBuilderSave({ attributes }) {
 					{submitButtonPosition === 'inline' && (
 						<button
 							type="submit"
-							className="dsgo-form__submit dsgo-form__submit--inline wp-element-button"
+							className={`dsgo-form__submit dsgo-form__submit--inline${submitVariationClass} wp-element-button`}
 							style={submitButtonStyle}
 						>
 							{submitButtonText}
@@ -172,7 +183,7 @@ export default function FormBuilderSave({ attributes }) {
 					<div className="dsgo-form__footer">
 						<button
 							type="submit"
-							className="dsgo-form__submit wp-element-button"
+							className={`dsgo-form__submit${submitVariationClass} wp-element-button`}
 							style={submitButtonStyle}
 						>
 							{submitButtonText}

--- a/src/blocks/form-builder/style.scss
+++ b/src/blocks/form-builder/style.scss
@@ -123,7 +123,6 @@
 		&.dsgo-form__submit--loading {
 			text-indent: -9999px;
 			white-space: nowrap;
-			overflow: hidden;
 			pointer-events: none;
 
 			&::after {
@@ -296,6 +295,19 @@
 
 :root .dsgo-form__submit--secondary.dsgo-form__submit.wp-element-button {
 	border-width: 1px;
+}
+
+// Keep the ghost look on :hover deterministically. The base Global-Styles hover
+// rule (`:root .dsgo-form__submit.wp-element-button:hover`, 0,4,0) would
+// otherwise fill these solid on hover — but only when a theme/Style Kit sets a
+// button hover colour, and the outcome was source-order dependent. `:hover` here
+// is 0,5,0 so the ghost stays transparent. A kit that wants a hover fill for
+// these variations defines it under `core/button.variations.{name}:hover`, which
+// Button_Global_Styles projects at matching specificity.
+:root .dsgo-form__submit--secondary.dsgo-form__submit.wp-element-button:hover,
+:root .dsgo-form__submit--outline.dsgo-form__submit.wp-element-button:hover {
+	background-color: transparent;
+	border-color: currentcolor;
 }
 
 :root .dsgo-form__submit--outline.dsgo-form__submit.wp-element-button {

--- a/src/blocks/form-builder/style.scss
+++ b/src/blocks/form-builder/style.scss
@@ -298,8 +298,25 @@
 // ============================================================================
 // Custom hover colors via CSS variables (same pattern as icon-button)
 
-// No animation — instant background transition
-.dsgo-form__submit[style*="--dsgo-button-hover-bg"]:not([class*="dsgo-form__submit--"]):hover {
+// No animation — instant background transition.
+// Excludes the hover-animation modifiers explicitly (kept in sync with
+// ALLOWED_HOVER_ANIMATIONS in class-plugin.php). This must NOT be a substring
+// match on `dsgo-form__submit--*`: the style-variation modifiers (`--secondary`,
+// `--outline`) share that prefix, so a substring `:not()` would treat them as
+// animations and silently drop the custom hover background on a variation button
+// that has no animation set.
+.dsgo-form__submit[style*="--dsgo-button-hover-bg"]:hover:not(
+	.dsgo-form__submit--fill-diagonal,
+	.dsgo-form__submit--zoom-in,
+	.dsgo-form__submit--lift,
+	.dsgo-form__submit--shrink,
+	.dsgo-form__submit--border-pulse,
+	.dsgo-form__submit--border-glow,
+	.dsgo-form__submit--slide-left,
+	.dsgo-form__submit--slide-right,
+	.dsgo-form__submit--slide-down,
+	.dsgo-form__submit--slide-up
+) {
 	background-color: var(--dsgo-button-hover-bg) !important;
 	opacity: 1;
 	transition: background-color 0.3s ease;

--- a/src/blocks/form-builder/style.scss
+++ b/src/blocks/form-builder/style.scss
@@ -297,13 +297,17 @@
 	border-width: 1px;
 }
 
-// Keep the ghost look on :hover deterministically. The base Global-Styles hover
-// rule (`:root .dsgo-form__submit.wp-element-button:hover`, 0,4,0) would
-// otherwise fill these solid on hover — but only when a theme/Style Kit sets a
-// button hover colour, and the outcome was source-order dependent. `:hover` here
-// is 0,5,0 so the ghost stays transparent. A kit that wants a hover fill for
-// these variations defines it under `core/button.variations.{name}:hover`, which
-// Button_Global_Styles projects at matching specificity.
+// Keep the ghost look on :hover against the base Global-Styles hover rule
+// (`:root .dsgo-form__submit.wp-element-button:hover`, 0,4,0), which would
+// otherwise fill these solid on hover when a theme/Style Kit sets a button hover
+// colour. `:hover` here is 0,5,0 so the ghost stays transparent.
+// NOTE: this intentionally does NOT override a per-instance custom hover
+// background — the "instant hover-bg" rule below uses
+// `background-color: var(--dsgo-button-hover-bg) !important`, which still wins.
+// That mirrors the base custom-colour precedence (a hand-picked colour beats the
+// ghost variation, as the Button Style control's help text notes). A kit that
+// wants a hover fill for these variations defines it under
+// `core/button.variations.{name}:hover`, which Button_Global_Styles projects.
 :root .dsgo-form__submit--secondary.dsgo-form__submit.wp-element-button:hover,
 :root .dsgo-form__submit--outline.dsgo-form__submit.wp-element-button:hover {
 	background-color: transparent;

--- a/src/blocks/form-builder/style.scss
+++ b/src/blocks/form-builder/style.scss
@@ -300,13 +300,14 @@
 
 // No animation — instant background transition.
 // Excludes the hover-animation modifiers explicitly (kept in sync with
-// ALLOWED_HOVER_ANIMATIONS in class-plugin.php), plus the `--loading` state.
-// This must NOT be a substring match on `dsgo-form__submit--*`: the
-// style-variation modifiers (`--secondary`, `--outline`) share that prefix, so a
-// substring `:not()` would treat them as animations and silently drop the custom
-// hover background on a variation button that has no animation set. `--loading`
-// stays excluded (as it was under the old substring guard) so the spinner state
-// never flashes the hover colour.
+// ALLOWED_HOVER_ANIMATIONS in class-plugin.php), plus the `--loading` and
+// `--no-hover` states. This must NOT be a substring match on
+// `dsgo-form__submit--*`: the style-variation modifiers (`--secondary`,
+// `--outline`) share that prefix, so a substring `:not()` would treat them as
+// animations and silently drop the custom hover background on a variation button
+// that has no animation set. `--loading` (spinner) and `--no-hover` (explicit
+// opt-out honoured by apply_default_form_button_hover()) stay excluded — as they
+// were under the old substring guard — so neither flashes the hover colour.
 .dsgo-form__submit[style*="--dsgo-button-hover-bg"]:hover:not(
 	.dsgo-form__submit--fill-diagonal,
 	.dsgo-form__submit--zoom-in,
@@ -318,7 +319,8 @@
 	.dsgo-form__submit--slide-right,
 	.dsgo-form__submit--slide-down,
 	.dsgo-form__submit--slide-up,
-	.dsgo-form__submit--loading
+	.dsgo-form__submit--loading,
+	.dsgo-form__submit--no-hover
 ) {
 	background-color: var(--dsgo-button-hover-bg) !important;
 	opacity: 1;

--- a/src/blocks/form-builder/style.scss
+++ b/src/blocks/form-builder/style.scss
@@ -112,9 +112,18 @@
 			width: auto;
 		}
 
-		// Loading state
+		// Loading state.
+		// Hide the label with text-indent, NOT `color: transparent`: the
+		// Global-Styles button rules (Button_Global_Styles, 0,3,0) and the style
+		// variations (0,4,0) out-specify a plain `color` override, so it would
+		// fail to hide the text — and forcing it would also blank the spinner
+		// below, which paints with `currentColor`. text-indent pushes the label
+		// out of view while keeping currentColor real for the spinner, and needs
+		// no specificity war because nothing else sets it.
 		&.dsgo-form__submit--loading {
-			color: transparent;
+			text-indent: -9999px;
+			white-space: nowrap;
+			overflow: hidden;
 			pointer-events: none;
 
 			&::after {

--- a/src/blocks/form-builder/style.scss
+++ b/src/blocks/form-builder/style.scss
@@ -267,6 +267,33 @@
 }
 
 // ============================================================================
+// SUBMIT BUTTON STYLE VARIATIONS (submitButtonVariation attribute)
+// ============================================================================
+// Self-contained "ghost" fallback — transparent fill + current-color border,
+// text following the surrounding color — so a secondary/outline submit button
+// reads on ANY background without a Style Kit, matching how the kit itself
+// defines `secondary`/`outline`. Themes/kits give `.dsgo-form__submit` a filled
+// primary look via a `:root … .dsgo-form__submit.wp-element-button` rule (0,3,0),
+// so these are compounded to 0,4,0 (`:root` + three element classes) to win —
+// the same approach as the icon-button `outline` style. Kits and section/group
+// style variations can repaint the same classes. MUST match save.js.
+:root .dsgo-form__submit--secondary.dsgo-form__submit.wp-element-button,
+:root .dsgo-form__submit--outline.dsgo-form__submit.wp-element-button {
+	background-color: transparent;
+	color: inherit;
+	border-style: solid;
+	border-color: currentcolor;
+}
+
+:root .dsgo-form__submit--secondary.dsgo-form__submit.wp-element-button {
+	border-width: 1px;
+}
+
+:root .dsgo-form__submit--outline.dsgo-form__submit.wp-element-button {
+	border-width: 2px;
+}
+
+// ============================================================================
 // HOVER COLORS
 // ============================================================================
 // Custom hover colors via CSS variables (same pattern as icon-button)

--- a/src/blocks/form-builder/style.scss
+++ b/src/blocks/form-builder/style.scss
@@ -300,11 +300,13 @@
 
 // No animation — instant background transition.
 // Excludes the hover-animation modifiers explicitly (kept in sync with
-// ALLOWED_HOVER_ANIMATIONS in class-plugin.php). This must NOT be a substring
-// match on `dsgo-form__submit--*`: the style-variation modifiers (`--secondary`,
-// `--outline`) share that prefix, so a substring `:not()` would treat them as
-// animations and silently drop the custom hover background on a variation button
-// that has no animation set.
+// ALLOWED_HOVER_ANIMATIONS in class-plugin.php), plus the `--loading` state.
+// This must NOT be a substring match on `dsgo-form__submit--*`: the
+// style-variation modifiers (`--secondary`, `--outline`) share that prefix, so a
+// substring `:not()` would treat them as animations and silently drop the custom
+// hover background on a variation button that has no animation set. `--loading`
+// stays excluded (as it was under the old substring guard) so the spinner state
+// never flashes the hover colour.
 .dsgo-form__submit[style*="--dsgo-button-hover-bg"]:hover:not(
 	.dsgo-form__submit--fill-diagonal,
 	.dsgo-form__submit--zoom-in,
@@ -315,7 +317,8 @@
 	.dsgo-form__submit--slide-left,
 	.dsgo-form__submit--slide-right,
 	.dsgo-form__submit--slide-down,
-	.dsgo-form__submit--slide-up
+	.dsgo-form__submit--slide-up,
+	.dsgo-form__submit--loading
 ) {
 	background-color: var(--dsgo-button-hover-bg) !important;
 	opacity: 1;

--- a/tests/phpunit/block-inserter-form-variation-test.php
+++ b/tests/phpunit/block-inserter-form-variation-test.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * AI-inserted forms must honour submitButtonVariation, matching save.js.
+ *
+ * Block_Inserter::generate_form_builder_html() hardcodes the submit-button
+ * markup, so it has to mirror the block's `submitButtonVariation` → class
+ * mapping or an AI-inserted Secondary/Outline form would be invalid content
+ * (its stored HTML would not match save()). The value is also validated against
+ * the block.json enum before it reaches the class attribute.
+ *
+ * @package DesignSetGo
+ */
+
+use DesignSetGo\Abilities\Block_Inserter;
+
+/**
+ * Tests that AI-inserted form submit buttons mirror submitButtonVariation.
+ *
+ * @group abilities
+ * @group form-builder
+ */
+class Block_Inserter_Form_Variation_Test extends WP_UnitTestCase {
+
+	/**
+	 * Invoke the private form-builder HTML generator and return the submit-button
+	 * markup (in the `closing` fragment).
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Generated closing HTML (contains the submit button).
+	 */
+	private function submit_html( array $attributes ) {
+		$method = new ReflectionMethod( Block_Inserter::class, 'generate_form_builder_html' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( null, 'wp-block-designsetgo-form-builder dsgo-form-builder', $attributes );
+
+		return $result['closing'];
+	}
+
+	/**
+	 * The default variation adds no modifier class.
+	 */
+	public function test_default_emits_no_variation_class() {
+		$html = $this->submit_html( array( 'formId' => 't' ) );
+		$this->assertStringContainsString( 'class="dsgo-form__submit wp-element-button"', $html );
+		$this->assertStringNotContainsString( 'dsgo-form__submit--secondary', $html );
+		$this->assertStringNotContainsString( 'dsgo-form__submit--outline', $html );
+	}
+
+	/**
+	 * A valid enum variation emits the matching modifier class.
+	 *
+	 * @dataProvider variation_provider
+	 *
+	 * @param string $variation submitButtonVariation value.
+	 */
+	public function test_valid_variation_emits_matching_class( $variation ) {
+		$html = $this->submit_html(
+			array(
+				'formId'                => 't',
+				'submitButtonVariation' => $variation,
+			)
+		);
+		// Order must match save.js: `dsgo-form__submit--{variation}` before `wp-element-button`.
+		$this->assertStringContainsString(
+			'class="dsgo-form__submit dsgo-form__submit--' . $variation . ' wp-element-button"',
+			$html
+		);
+	}
+
+	/**
+	 * Valid variation slugs.
+	 *
+	 * @return array
+	 */
+	public function variation_provider() {
+		return array(
+			'secondary' => array( 'secondary' ),
+			'outline'   => array( 'outline' ),
+		);
+	}
+
+	/**
+	 * Inline position keeps the variation class after the --inline modifier.
+	 */
+	public function test_inline_position_keeps_variation_after_inline_modifier() {
+		$html = $this->submit_html(
+			array(
+				'formId'                => 't',
+				'submitButtonPosition'  => 'inline',
+				'submitButtonVariation' => 'secondary',
+			)
+		);
+		$this->assertStringContainsString(
+			'class="dsgo-form__submit dsgo-form__submit--inline dsgo-form__submit--secondary wp-element-button"',
+			$html
+		);
+	}
+
+	/**
+	 * Out-of-enum or hostile values are dropped, not emitted into the class.
+	 *
+	 * @dataProvider rejected_provider
+	 *
+	 * @param string $variation An out-of-enum / hostile value.
+	 */
+	public function test_out_of_enum_values_are_dropped( $variation ) {
+		$html = $this->submit_html(
+			array(
+				'formId'                => 't',
+				'submitButtonVariation' => $variation,
+			)
+		);
+		// Falls back to the plain submit class; no variation modifier, no breakout.
+		$this->assertStringContainsString( 'class="dsgo-form__submit wp-element-button"', $html );
+		$this->assertStringNotContainsString( 'dsgo-form__submit--' . $variation, $html );
+	}
+
+	/**
+	 * Values outside the block.json enum, including a class-attribute breakout.
+	 *
+	 * @return array
+	 */
+	public function rejected_provider() {
+		return array(
+			'default explicit' => array( 'default' ),
+			'unknown slug'     => array( 'primary' ),
+			'breakout attempt' => array( 'x" onmouseover="alert(1)' ),
+		);
+	}
+}

--- a/tests/phpunit/form-builder-hover-guard-sync-test.php
+++ b/tests/phpunit/form-builder-hover-guard-sync-test.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * The submit-button hover-bg guard must list every hover animation.
+ *
+ * `src/blocks/form-builder/style.scss` has an instant-hover-background rule
+ * gated by `:hover:not( … )` that excludes the hover-animation modifier classes
+ * (they manage their own background). That exclusion list hand-duplicates
+ * `Plugin::ALLOWED_HOVER_ANIMATIONS`. If an animation is ever added to the PHP
+ * constant but not to the CSS guard, a button using that animation with a custom
+ * hover-bg would wrongly get the instant background — the bug this guard exists
+ * to prevent. This test fails if the two drift apart.
+ *
+ * @package DesignSetGo
+ */
+
+use DesignSetGo\Plugin;
+
+/**
+ * Pins the SCSS hover-bg guard against the PHP animation allowlist.
+ *
+ * @group form-builder
+ */
+class Form_Builder_Hover_Guard_Sync_Test extends WP_UnitTestCase {
+
+	/**
+	 * Every ALLOWED_HOVER_ANIMATIONS slug appears in the SCSS `:hover:not()` guard.
+	 */
+	public function test_hover_bg_guard_excludes_every_animation() {
+		$scss_path = dirname( __DIR__, 2 ) . '/src/blocks/form-builder/style.scss';
+		$this->assertFileExists( $scss_path );
+
+		$scss = file_get_contents( $scss_path );
+
+		// Isolate the exclusion list on the instant hover-bg rule.
+		$this->assertSame(
+			1,
+			preg_match( '/:hover:not\(\s*([^)]+)\)/', $scss, $matches ),
+			'Could not find the `:hover:not( … )` hover-bg guard in style.scss.'
+		);
+		$guard = $matches[1];
+
+		// getConstant() reads the value regardless of visibility.
+		$animations = ( new ReflectionClass( Plugin::class ) )->getConstant( 'ALLOWED_HOVER_ANIMATIONS' );
+		$this->assertNotEmpty( $animations );
+
+		foreach ( $animations as $slug ) {
+			$this->assertStringContainsString(
+				'.dsgo-form__submit--' . $slug,
+				$guard,
+				sprintf(
+					'Hover animation "%s" is in Plugin::ALLOWED_HOVER_ANIMATIONS but missing from the style.scss `:hover:not()` guard — add it, or a %1$s button with a custom hover background will regress.',
+					$slug
+				)
+			);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a **Button Style** control to the Form Builder submit button so a form placed on an alternate background can use a secondary/outline button, and so section/group style variations can restyle it via a class hook.

- New `submitButtonVariation` attribute (`default` | `secondary` | `outline`) emits `dsgo-form__submit--{variation}` on the submit `<button>` (both inline and below positions).
- Inspector **Button Style** select in the Settings panel, with editor-preview parity and reset support.
- Self-contained "ghost" fallback in `style.scss` (transparent + current-color border, inherited text) so secondary/outline read on any background without a Style Kit. Kits — and section/group style variations — can repaint the same classes.

## Why this is the fix

The submit button is a hardcoded `<button>` baked into `save()` with no `className` passthrough, so a block-style variation (`is-style-*`) can't attach to it and gets stripped on invalid-block recovery. A first-class attribute is the correct per-instance mechanism; the wrapper-cascade path (section/group variations) remains available too.

## Specificity note

The `designsetgo` theme styles `.dsgo-form__submit` as a filled primary button at `(0,3,0)` via `class-button-global-styles.php`. The fallback is compounded to `(0,4,0)` (`:root` + three element classes) to win — mirroring the icon-button `is-style-outline` approach.

## No deprecation required

Verified in a running editor: the default serialized output is **byte-identical** to the prior output (`class="dsgo-form__submit wp-element-button"`, and `submitButtonVariation` is omitted from the block comment at its default), so existing forms stay valid. Adding a deprecation would be dead code.

## Verification

- Default / secondary / outline all round-trip `isValid: true`; full `deprecations-isEligible` suite passes (218/218).
- Rendered on the real frontend: the secondary button computes `background: transparent`, `border: 1px solid currentColor`, inherited text (ghost button) instead of the filled default.
- `lint:js` and `lint:css` clean; `npm run build` succeeds.

## Test plan

- Insert a Form Builder block → Settings → **Button Style** → Secondary/Outline; confirm editor preview and frontend both show the ghost button.
- Confirm an existing form (no Button Style set) is unchanged and does not prompt "Attempt Recovery".