### PR TITLE
Render DSGo button style variations (primary/secondary/…) at winning specificity

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -25,7 +25,17 @@ class Plugin {
 	 *
 	 * @var string[]
 	 */
-	private const ALLOWED_HOVER_ANIMATIONS = array(
+	/**
+	 * Hover-animation slugs stamped onto buttons as `--{slug}` modifiers.
+	 *
+	 * Public so features that emit button CSS (e.g. Button_Global_Styles) can
+	 * avoid colliding with this class namespace — the form submit uses the same
+	 * `dsgo-form__submit--{x}` modifier space for both animations and style
+	 * variations.
+	 *
+	 * @var string[]
+	 */
+	public const ALLOWED_HOVER_ANIMATIONS = array(
 		'fill-diagonal',
 		'zoom-in',
 		'slide-left',

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -18,18 +18,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Plugin {
 	/**
-	 * Allowed hover animation slugs for Icon Button blocks.
-	 *
-	 * Single source of truth used by both the regex check and the
-	 * allowlist validation in apply_default_icon_button_hover().
-	 *
-	 * @var string[]
-	 */
-	/**
 	 * Hover-animation slugs stamped onto buttons as `--{slug}` modifiers.
 	 *
+	 * Single source of truth for the regex check and allowlist validation in
+	 * apply_default_icon_button_hover() / apply_default_form_button_hover().
 	 * Public so features that emit button CSS (e.g. Button_Global_Styles) can
-	 * avoid colliding with this class namespace — the form submit uses the same
+	 * avoid colliding with this namespace — the form submit uses the same
 	 * `dsgo-form__submit--{x}` modifier space for both animations and style
 	 * variations.
 	 *

--- a/includes/features/class-button-global-styles.php
+++ b/includes/features/class-button-global-styles.php
@@ -74,7 +74,8 @@ class Button_Global_Styles {
 	 *   (0,5,0). Matches the hand-written `is-style-outline` rule in
 	 *   `src/blocks/icon-button/style.scss`.
 	 * - Form submit: variation modifier compounded on the button (0,4,0). Matches
-	 *   the `submitButtonVariation` classes in `src/blocks/form-builder/`.
+	 *   the `submitButtonVariation` classes added in #469; until that merges this
+	 *   half is a harmless no-op (no element carries the class yet).
 	 *
 	 * Modal Trigger is intentionally omitted: it uses its own `buttonStyle`
 	 * attribute (`dsgo-modal-trigger--{style}`) rather than block-style

--- a/includes/features/class-button-global-styles.php
+++ b/includes/features/class-button-global-styles.php
@@ -84,8 +84,17 @@ class Button_Global_Styles {
 	 * @var string[]
 	 */
 	private const VARIATION_SELECTOR_TEMPLATES = array(
-		'.wp-block-designsetgo-icon-button.is-style-{name} .dsgo-icon-button.wp-block-button__link',
-		'.dsgo-form__submit.dsgo-form__submit--{name}.wp-element-button',
+		// Icon Button: the variation class sits on the wrapper (`is-style-{name}`)
+		// — a different namespace from the block's `dsgo-icon-button--{anim}`
+		// hover-animation classes — so it can never collide.
+		'icon_button' => '.wp-block-designsetgo-icon-button.is-style-{name} .dsgo-icon-button.wp-block-button__link',
+		// Form submit: the variation class shares the `dsgo-form__submit--{x}`
+		// modifier namespace with hover-animation classes that
+		// apply_default_form_button_hover() stamps on real buttons (e.g.
+		// `dsgo-form__submit--lift`). Emitted only for non-animation slugs — see
+		// build_variation_selector() — so a variation named like an animation can
+		// never repaint a button that merely carries that animation class.
+		'form_submit' => '.dsgo-form__submit.dsgo-form__submit--{name}.wp-element-button',
 	);
 
 	/**
@@ -263,6 +272,13 @@ class Button_Global_Styles {
 	 * base button rule. Colours therefore stay defined once (in the kit /
 	 * theme.json) and are projected onto the icon button / form submit here.
 	 *
+	 * Intentional trade-off: this reads only the `core/button` variation node, not
+	 * a per-block override at `styles.blocks.designsetgo/icon-button.variations.*`
+	 * (which the Site Editor exposes because `Icon_Button_Styles` registers the
+	 * variations for the block). Such a per-block override never rendered anyway —
+	 * WordPress emits it as a `:where()`-wrapped (0,1,0) rule that loses to the
+	 * base button rule — so honouring it is deferred rather than a regression.
+	 *
 	 * @param array $block_styles The core/button block styles from Global Styles.
 	 * @return string Generated CSS, or empty string when there are no variations.
 	 */
@@ -316,8 +332,18 @@ class Button_Global_Styles {
 	 * @return string Selector list, each part prefixed with `:root`.
 	 */
 	private function build_variation_selector( $slug, $pseudo = '' ) {
+		$is_animation_slug = in_array( $slug, Plugin::ALLOWED_HOVER_ANIMATIONS, true );
+
 		$parts = array();
-		foreach ( self::VARIATION_SELECTOR_TEMPLATES as $template ) {
+		foreach ( self::VARIATION_SELECTOR_TEMPLATES as $key => $template ) {
+			// The form-submit modifier namespace is shared with hover animations,
+			// so never emit a form-submit variation rule for an animation slug —
+			// it would repaint any button that merely carries that animation
+			// class. The icon-button selector (wrapper `is-style-{name}`) has no
+			// such collision and is always emitted.
+			if ( 'form_submit' === $key && $is_animation_slug ) {
+				continue;
+			}
 			$parts[] = ':root ' . str_replace( '{name}', $slug, $template ) . $pseudo;
 		}
 		return implode( ",\n", $parts );

--- a/includes/features/class-button-global-styles.php
+++ b/includes/features/class-button-global-styles.php
@@ -271,7 +271,8 @@ class Button_Global_Styles {
 			return '';
 		}
 
-		$css = '';
+		$css  = '';
+		$seen = array();
 
 		foreach ( $block_styles['variations'] as $name => $variation_styles ) {
 			if ( ! is_array( $variation_styles ) ) {
@@ -279,26 +280,28 @@ class Button_Global_Styles {
 			}
 
 			$slug = $this->sanitize_variation_name( $name );
-			if ( '' === $slug || in_array( $slug, self::SKIP_VARIATIONS, true ) ) {
+			// Skip empties, already-handled variations, and any slug that
+			// collapses onto one already emitted (e.g. `Primary` and `primary`),
+			// so we never write the same selector twice.
+			if ( '' === $slug || in_array( $slug, self::SKIP_VARIATIONS, true ) || isset( $seen[ $slug ] ) ) {
 				continue;
 			}
+			$seen[ $slug ] = true;
 
 			// Normal-state declarations (color/border/typography/etc.). Reuses
 			// the same extractor as the base rule, which only reads the known
 			// appearance keys, so unexpected variation keys are ignored.
-			$declarations = $this->extract_declarations( $variation_styles );
-			if ( ! empty( $declarations ) ) {
-				$rule = implode( ";\n\t", $declarations );
-				$css .= $this->build_variation_selector( $slug ) . " {\n\t" . $rule . ";\n}\n";
-			}
+			$css .= $this->render_rule(
+				$this->build_variation_selector( $slug ),
+				$this->extract_declarations( $variation_styles )
+			);
 
 			// Hover state, if the variation defines one.
 			if ( ! empty( $variation_styles[':hover'] ) ) {
-				$hover_declarations = $this->extract_hover_declarations( $variation_styles[':hover'] );
-				if ( ! empty( $hover_declarations ) ) {
-					$hover_rule = implode( ";\n\t", $hover_declarations );
-					$css       .= $this->build_variation_selector( $slug, ':hover' ) . " {\n\t" . $hover_rule . ";\n}\n";
-				}
+				$css .= $this->render_rule(
+					$this->build_variation_selector( $slug, ':hover' ),
+					$this->extract_hover_declarations( $variation_styles[':hover'] )
+				);
 			}
 		}
 
@@ -326,14 +329,36 @@ class Button_Global_Styles {
 	 * Block-style variation slugs are lowercase letters, digits and hyphens;
 	 * anything else is stripped so the value can never break out of the selector.
 	 *
-	 * @param mixed $name Raw variation key from Global Styles.
+	 * @param int|string $name Raw variation key from Global Styles.
 	 * @return string Safe slug, or empty string when nothing valid remains.
 	 */
 	private function sanitize_variation_name( $name ) {
-		if ( ! is_string( $name ) || '' === $name ) {
+		// Array keys arrive as int or string, and PHP casts numeric-looking
+		// string keys to int — so a slug like `2024` would otherwise be dropped.
+		// Normalise to string before sanitising.
+		$name = (string) $name;
+		if ( '' === $name ) {
 			return '';
 		}
 		return preg_replace( '/[^a-z0-9\-]/', '', strtolower( $name ) );
+	}
+
+	/**
+	 * Format a single CSS rule from a selector and its declarations.
+	 *
+	 * Shared by the base-button and variation passes so both produce identical
+	 * formatting. Returns an empty string when there are no declarations, so the
+	 * caller can skip emitting an empty `{}` block.
+	 *
+	 * @param string   $selector     Full (comma-joined) selector.
+	 * @param string[] $declarations Array of "property:value" strings.
+	 * @return string A formatted CSS rule, or empty string.
+	 */
+	private function render_rule( $selector, $declarations ) {
+		if ( empty( $declarations ) ) {
+			return '';
+		}
+		return $selector . " {\n\t" . implode( ";\n\t", $declarations ) . ";\n}\n";
 	}
 
 	/**
@@ -381,14 +406,6 @@ class Button_Global_Styles {
 	 * @return string Generated CSS.
 	 */
 	private function build_css( $styles ) {
-		$declarations = $this->extract_declarations( $styles );
-
-		if ( empty( $declarations ) ) {
-			return '';
-		}
-
-		$rule = implode( ";\n\t", $declarations );
-
 		// Build selector: :root .dsgo-icon-button.wp-block-button__link, ...
 		$selector_parts = array();
 		foreach ( self::BLOCK_SELECTORS as $sel ) {
@@ -396,23 +413,24 @@ class Button_Global_Styles {
 		}
 		$selector = implode( ",\n", $selector_parts );
 
-		$css = $selector . " {\n\t" . $rule . ";\n}\n";
+		$css = $this->render_rule( $selector, $this->extract_declarations( $styles ) );
+
+		// No base declarations means there is no button styling to emit; keep the
+		// prior contract of returning '' so callers treat it as "no CSS".
+		if ( '' === $css ) {
+			return '';
+		}
 
 		// Handle hover state if present.
 		if ( ! empty( $styles[':hover'] ) ) {
-			$hover_declarations = $this->extract_hover_declarations( $styles[':hover'] );
-
-			if ( ! empty( $hover_declarations ) ) {
-				$hover_rule = implode( ";\n\t", $hover_declarations );
-
-				$hover_parts = array();
-				foreach ( self::BLOCK_SELECTORS as $sel ) {
-					$hover_parts[] = ':root ' . $sel . ':hover';
-				}
-				$hover_selector = implode( ",\n", $hover_parts );
-
-				$css .= $hover_selector . " {\n\t" . $hover_rule . ";\n}\n";
+			$hover_parts = array();
+			foreach ( self::BLOCK_SELECTORS as $sel ) {
+				$hover_parts[] = ':root ' . $sel . ':hover';
 			}
+			$css .= $this->render_rule(
+				implode( ",\n", $hover_parts ),
+				$this->extract_hover_declarations( $styles[':hover'] )
+			);
 		}
 
 		return $css;

--- a/includes/features/class-button-global-styles.php
+++ b/includes/features/class-button-global-styles.php
@@ -111,6 +111,21 @@ class Button_Global_Styles {
 	private const SKIP_VARIATIONS = array( 'fill', 'outline' );
 
 	/**
+	 * Non-animation modifier suffixes reserved in the `dsgo-form__submit--{x}`
+	 * namespace.
+	 *
+	 * The form submit shares that namespace between style variations and other
+	 * modifiers. Besides the hover animations (Plugin::ALLOWED_HOVER_ANIMATIONS),
+	 * the block/plugin stamp these layout/state modifiers on real buttons:
+	 * `--inline` (inline position), `--loading` (AJAX submit), `--no-hover`
+	 * (hover opt-out). A variation whose slug matches any of them must not emit a
+	 * form-submit rule, or it would repaint every button carrying that modifier.
+	 *
+	 * @var string[]
+	 */
+	private const RESERVED_FORM_SUBMIT_SUFFIXES = array( 'inline', 'loading', 'no-hover' );
+
+	/**
 	 * Block names that need Global Styles button CSS.
 	 *
 	 * @var string[]
@@ -332,16 +347,18 @@ class Button_Global_Styles {
 	 * @return string Selector list, each part prefixed with `:root`.
 	 */
 	private function build_variation_selector( $slug, $pseudo = '' ) {
-		$is_animation_slug = in_array( $slug, Plugin::ALLOWED_HOVER_ANIMATIONS, true );
+		$reserved_for_form_submit = in_array( $slug, Plugin::ALLOWED_HOVER_ANIMATIONS, true )
+			|| in_array( $slug, self::RESERVED_FORM_SUBMIT_SUFFIXES, true );
 
 		$parts = array();
 		foreach ( self::VARIATION_SELECTOR_TEMPLATES as $key => $template ) {
-			// The form-submit modifier namespace is shared with hover animations,
-			// so never emit a form-submit variation rule for an animation slug —
-			// it would repaint any button that merely carries that animation
-			// class. The icon-button selector (wrapper `is-style-{name}`) has no
-			// such collision and is always emitted.
-			if ( 'form_submit' === $key && $is_animation_slug ) {
+			// The form-submit modifier namespace is shared with hover animations
+			// and the layout/state modifiers (--inline/--loading/--no-hover), so
+			// never emit a form-submit variation rule for a slug that matches one
+			// — it would repaint any button that merely carries that modifier.
+			// The icon-button selector (wrapper `is-style-{name}`) has no such
+			// collision and is always emitted.
+			if ( 'form_submit' === $key && $reserved_for_form_submit ) {
 				continue;
 			}
 			$parts[] = ':root ' . str_replace( '{name}', $slug, $template ) . $pseudo;

--- a/includes/features/class-button-global-styles.php
+++ b/includes/features/class-button-global-styles.php
@@ -62,6 +62,46 @@ class Button_Global_Styles {
 	);
 
 	/**
+	 * Per-primitive selector templates for block-style variations.
+	 *
+	 * `{name}` is replaced with a variation slug (e.g. `secondary`). Each template
+	 * is emitted at a specificity that beats the base button rule (0,3,0) so a
+	 * Global Styles variation actually wins on DSGo's single-element buttons —
+	 * the same cascade problem the hand-written `is-style-outline` rule solves,
+	 * generalised so every registered variation works with no per-variation CSS.
+	 *
+	 * - Icon Button: variation class on the wrapper, styling the inner button
+	 *   (0,5,0). Matches the hand-written `is-style-outline` rule in
+	 *   `src/blocks/icon-button/style.scss`.
+	 * - Form submit: variation modifier compounded on the button (0,4,0). Matches
+	 *   the `submitButtonVariation` classes in `src/blocks/form-builder/`.
+	 *
+	 * Modal Trigger is intentionally omitted: it uses its own `buttonStyle`
+	 * attribute (`dsgo-modal-trigger--{style}`) rather than block-style
+	 * variations, so projecting `core/button` variations onto it needs a separate
+	 * decision (mirror `is-style-*` onto it, or map to `buttonStyle`).
+	 *
+	 * @var string[]
+	 */
+	private const VARIATION_SELECTOR_TEMPLATES = array(
+		'.wp-block-designsetgo-icon-button.is-style-{name} .dsgo-icon-button.wp-block-button__link',
+		'.dsgo-form__submit.dsgo-form__submit--{name}.wp-element-button',
+	);
+
+	/**
+	 * Variation slugs already handled elsewhere, so the generator skips them.
+	 *
+	 * - `fill`: the default filled look, already produced by the base rule.
+	 * - `outline`: hand-written in `src/blocks/icon-button/style.scss`.
+	 *
+	 * Both are candidates to migrate INTO this generator (and drop the
+	 * hand-written CSS) once the approach is agreed — see the class docblock.
+	 *
+	 * @var string[]
+	 */
+	private const SKIP_VARIATIONS = array( 'fill', 'outline' );
+
+	/**
 	 * Block names that need Global Styles button CSS.
 	 *
 	 * @var string[]
@@ -204,11 +244,96 @@ class Button_Global_Styles {
 		// Merge: block-level overrides element-level.
 		$merged = $this->merge_styles( $element_styles, $block_styles );
 
-		if ( empty( $merged ) ) {
+		$css = empty( $merged ) ? '' : $this->build_css( $merged );
+
+		// Project each registered core/button style variation onto DSGo's button
+		// primitives at winning specificity, so semantic variations (primary,
+		// secondary, …) work without per-variation hand-written CSS.
+		$css .= $this->build_variation_css( $block_styles );
+
+		return $css;
+	}
+
+	/**
+	 * Build CSS for each core/button block-style variation, scoped to DSGo's
+	 * button primitives.
+	 *
+	 * Reads `styles.blocks.core/button.variations.{name}` from Global Styles and
+	 * emits one rule per primitive per variation, at a specificity that beats the
+	 * base button rule. Colours therefore stay defined once (in the kit /
+	 * theme.json) and are projected onto the icon button / form submit here.
+	 *
+	 * @param array $block_styles The core/button block styles from Global Styles.
+	 * @return string Generated CSS, or empty string when there are no variations.
+	 */
+	private function build_variation_css( $block_styles ) {
+		if ( ! is_array( $block_styles ) || empty( $block_styles['variations'] ) || ! is_array( $block_styles['variations'] ) ) {
 			return '';
 		}
 
-		return $this->build_css( $merged );
+		$css = '';
+
+		foreach ( $block_styles['variations'] as $name => $variation_styles ) {
+			if ( ! is_array( $variation_styles ) ) {
+				continue;
+			}
+
+			$slug = $this->sanitize_variation_name( $name );
+			if ( '' === $slug || in_array( $slug, self::SKIP_VARIATIONS, true ) ) {
+				continue;
+			}
+
+			// Normal-state declarations (color/border/typography/etc.). Reuses
+			// the same extractor as the base rule, which only reads the known
+			// appearance keys, so unexpected variation keys are ignored.
+			$declarations = $this->extract_declarations( $variation_styles );
+			if ( ! empty( $declarations ) ) {
+				$rule = implode( ";\n\t", $declarations );
+				$css .= $this->build_variation_selector( $slug ) . " {\n\t" . $rule . ";\n}\n";
+			}
+
+			// Hover state, if the variation defines one.
+			if ( ! empty( $variation_styles[':hover'] ) ) {
+				$hover_declarations = $this->extract_hover_declarations( $variation_styles[':hover'] );
+				if ( ! empty( $hover_declarations ) ) {
+					$hover_rule = implode( ";\n\t", $hover_declarations );
+					$css       .= $this->build_variation_selector( $slug, ':hover' ) . " {\n\t" . $hover_rule . ";\n}\n";
+				}
+			}
+		}
+
+		return $css;
+	}
+
+	/**
+	 * Build the comma-joined selector for a variation across every primitive.
+	 *
+	 * @param string $slug   Sanitised variation slug.
+	 * @param string $pseudo Optional pseudo-class suffix (e.g. ':hover').
+	 * @return string Selector list, each part prefixed with `:root`.
+	 */
+	private function build_variation_selector( $slug, $pseudo = '' ) {
+		$parts = array();
+		foreach ( self::VARIATION_SELECTOR_TEMPLATES as $template ) {
+			$parts[] = ':root ' . str_replace( '{name}', $slug, $template ) . $pseudo;
+		}
+		return implode( ",\n", $parts );
+	}
+
+	/**
+	 * Sanitise a variation slug for safe use in a selector.
+	 *
+	 * Block-style variation slugs are lowercase letters, digits and hyphens;
+	 * anything else is stripped so the value can never break out of the selector.
+	 *
+	 * @param mixed $name Raw variation key from Global Styles.
+	 * @return string Safe slug, or empty string when nothing valid remains.
+	 */
+	private function sanitize_variation_name( $name ) {
+		if ( ! is_string( $name ) || '' === $name ) {
+			return '';
+		}
+		return preg_replace( '/[^a-z0-9\-]/', '', strtolower( $name ) );
 	}
 
 	/**

--- a/includes/features/class-icon-button-styles.php
+++ b/includes/features/class-icon-button-styles.php
@@ -66,11 +66,13 @@ class Icon_Button_Styles {
 	 * Register, for the Icon Button, every block style variation registered for
 	 * core/button that carries theme.json styling.
 	 *
-	 * This is what lets the mirrored `styles.blocks.designsetgo/icon-button.
-	 * variations.{slug}` survive WordPress's theme.json sanitization (which drops
-	 * variations that are not registered block styles for the block) and renders
-	 * on the front end. Core's Fill/Outline are registered client-side and carry
-	 * no theme.json data, so they are handled separately by
+	 * This makes the variations appear in the editor Styles panel and be valid to
+	 * apply on the Icon Button. Their *rendering* is handled by
+	 * {@see \DesignSetGo\Button_Global_Styles}, which projects
+	 * `core/button.variations.*` at winning specificity (see the class docblock) —
+	 * this class no longer mirrors styling into the Icon Button's own theme.json
+	 * node. Core's Fill/Outline are registered client-side and carry no theme.json
+	 * data, so they are handled separately by
 	 * src/blocks/icon-button/mirror-button-styles.js instead.
 	 */
 	public function register_mirrored_variations() {

--- a/includes/features/class-icon-button-styles.php
+++ b/includes/features/class-icon-button-styles.php
@@ -51,29 +51,18 @@ class Icon_Button_Styles {
 	 * Initialize the class and set up hooks.
 	 */
 	public function init() {
-		// Register the core/button variation names for our block so they appear
-		// in the editor Styles panel and are valid to apply. The *rendering* of
-		// each variation is handled by {@see \DesignSetGo\Button_Global_Styles},
-		// which projects `core/button.variations.*` onto the Icon Button at a
-		// specificity that beats the base button rule — WordPress's own
-		// theme.json output for a mirrored variation is `:where()`-wrapped (0,1,0)
-		// and loses to that base rule, so mirroring the styles here would only
-		// emit a dead, out-ranked duplicate.
+		// Registration only (editor Styles panel + validity). Rendering is
+		// Button_Global_Styles' job — see the class docblock for why the old
+		// theme.json style-mirror was removed.
 		add_action( 'init', array( $this, 'register_mirrored_variations' ), 20 );
 	}
 
 	/**
 	 * Register, for the Icon Button, every block style variation registered for
-	 * core/button that carries theme.json styling.
-	 *
-	 * This makes the variations appear in the editor Styles panel and be valid to
-	 * apply on the Icon Button. Their *rendering* is handled by
-	 * {@see \DesignSetGo\Button_Global_Styles}, which projects
-	 * `core/button.variations.*` at winning specificity (see the class docblock) —
-	 * this class no longer mirrors styling into the Icon Button's own theme.json
-	 * node. Core's Fill/Outline are registered client-side and carry no theme.json
-	 * data, so they are handled separately by
-	 * src/blocks/icon-button/mirror-button-styles.js instead.
+	 * core/button that carries theme.json styling — so they appear in the editor
+	 * Styles panel and are valid to apply. Rendering is handled elsewhere; see the
+	 * class docblock. Core's Fill/Outline are registered client-side (no theme.json
+	 * data) and mirrored by src/blocks/icon-button/mirror-button-styles.js instead.
 	 */
 	public function register_mirrored_variations() {
 		if ( ! class_exists( '\WP_Block_Styles_Registry' ) ) {

--- a/includes/features/class-icon-button-styles.php
+++ b/includes/features/class-icon-button-styles.php
@@ -2,18 +2,21 @@
 /**
  * Icon Button Styles Support
  *
- * Mirrors the block style variations of the core Button block onto the
- * DesignSetGo Icon Button, so it offers the same variations (Fill, Outline, and
- * anything a theme or plugin adds to core buttons).
+ * Registers the core Button block's style variations (Fill, Outline, and
+ * anything a theme or plugin adds) as block styles for the DesignSetGo Icon
+ * Button, so they appear in the editor Styles panel and are valid to apply.
  *
- * The variation *names* are mirrored in the editor by
- * src/blocks/icon-button/mirror-button-styles.js: core registers Fill/Outline
- * client-side (not in the PHP block styles registry), so they are invisible to
- * PHP and must be mirrored in JS. This class handles the other half — copying a
- * theme's button variation *styling* defined in theme.json
- * (styles.blocks.core/button.variations.*) onto the Icon Button so it renders
- * the same way. Together they mirror the section-styles mechanism (see
- * {@see \DesignSetGo\Section_Styles}) for buttons.
+ * The variation *names* are also mirrored in the editor by
+ * src/blocks/icon-button/mirror-button-styles.js (core registers Fill/Outline
+ * client-side, invisible to PHP); this class registers the server-side half.
+ *
+ * The variation *rendering* is NOT handled here. It is owned by
+ * {@see \DesignSetGo\Button_Global_Styles}, which projects
+ * `styles.blocks.core/button.variations.*` onto the Icon Button (and form
+ * submit) at a specificity that beats the base button rule. Copying the styling
+ * into `styles.blocks.designsetgo/icon-button.variations.*` for WordPress's
+ * native pipeline would only emit a `:where()`-wrapped (0,1,0) rule that loses
+ * to that base rule — a dead duplicate — so it is deliberately not done.
  *
  * @package DesignSetGo
  * @since 2.4.0
@@ -48,15 +51,15 @@ class Icon_Button_Styles {
 	 * Initialize the class and set up hooks.
 	 */
 	public function init() {
-		// Register the mirrored variation names for our block (editor Styles
-		// panel + so the theme.json variation styles survive server-side
-		// sanitization, which drops variations not registered for the block).
+		// Register the core/button variation names for our block so they appear
+		// in the editor Styles panel and are valid to apply. The *rendering* of
+		// each variation is handled by {@see \DesignSetGo\Button_Global_Styles},
+		// which projects `core/button.variations.*` onto the Icon Button at a
+		// specificity that beats the base button rule — WordPress's own
+		// theme.json output for a mirrored variation is `:where()`-wrapped (0,1,0)
+		// and loses to that base rule, so mirroring the styles here would only
+		// emit a dead, out-ranked duplicate.
 		add_action( 'init', array( $this, 'register_mirrored_variations' ), 20 );
-
-		// Inject the resolved variation styles onto our block. Both layers so
-		// theme.json-defined variations and Global Styles customisations apply.
-		add_filter( 'wp_theme_json_data_theme', array( $this, 'mirror_variation_styles' ) );
-		add_filter( 'wp_theme_json_data_user', array( $this, 'mirror_variation_styles' ) );
 	}
 
 	/**
@@ -144,37 +147,5 @@ class Icon_Button_Styles {
 		}
 
 		return $variations;
-	}
-
-	/**
-	 * Copy the resolved variation styles from core/button onto the Icon Button.
-	 *
-	 * Runs on both the theme and user theme.json layers so that base variations
-	 * (theme.json / plugins) and Global Styles customisations both propagate.
-	 *
-	 * @param \WP_Theme_JSON_Data $theme_json The theme.json data object.
-	 * @return \WP_Theme_JSON_Data Modified theme.json data.
-	 */
-	public function mirror_variation_styles( $theme_json ) {
-		$data = $theme_json->get_data();
-
-		if ( empty( $data['styles']['blocks'][ $this->source_block ]['variations'] ) ) {
-			return $theme_json;
-		}
-
-		$variations = $data['styles']['blocks'][ $this->source_block ]['variations'];
-		$modified   = false;
-
-		foreach ( $variations as $slug => $styles ) {
-			// Never clobber styles explicitly defined for our own block.
-			if ( isset( $data['styles']['blocks'][ $this->target_block ]['variations'][ $slug ] ) ) {
-				continue;
-			}
-
-			$data['styles']['blocks'][ $this->target_block ]['variations'][ $slug ] = $styles;
-			$modified = true;
-		}
-
-		return $modified ? $theme_json->update_with( $data ) : $theme_json;
 	}
 }

--- a/tests/phpunit/button-global-styles-variations-test.php
+++ b/tests/phpunit/button-global-styles-variations-test.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Regression tests for Button_Global_Styles variation projection.
+ *
+ * `Button_Global_Styles` projects each `core/button` block-style variation onto
+ * DSGo's single-element button primitives (icon-button, form submit) at a
+ * specificity that beats the base button rule. The variation slug is
+ * interpolated straight into a CSS selector, so `sanitize_variation_name()` is a
+ * security boundary: these tests pin it closed and cover the emission rules
+ * (per-primitive selectors, skip list, dedup, numeric slugs).
+ *
+ * @package DesignSetGo
+ */
+
+use DesignSetGo\Button_Global_Styles;
+
+/**
+ * @group buttons
+ * @group global-styles
+ */
+class Button_Global_Styles_Variations_Test extends WP_UnitTestCase {
+
+	/**
+	 * Invoke a private method on a fresh instance.
+	 *
+	 * @param string $method Method name.
+	 * @param array  $args   Positional arguments.
+	 * @return mixed
+	 */
+	private function call( $method, array $args = array() ) {
+		$instance = new Button_Global_Styles();
+		$ref      = new ReflectionMethod( $instance, $method );
+		$ref->setAccessible( true );
+		return $ref->invokeArgs( $instance, $args );
+	}
+
+	/**
+	 * Build a minimal variations payload keyed by slug.
+	 *
+	 * @param array $variations Map of slug => style array.
+	 * @return array Shaped like wp_get_global_styles( core/button ).
+	 */
+	private function block_styles( array $variations ) {
+		return array( 'variations' => $variations );
+	}
+
+	/**
+	 * The slug sanitiser strips anything that could break out of a selector.
+	 *
+	 * @dataProvider slug_provider
+	 *
+	 * @param int|string $input    Raw variation key.
+	 * @param string     $expected Sanitised slug.
+	 */
+	public function test_sanitize_variation_name( $input, $expected ) {
+		$this->assertSame( $expected, $this->call( 'sanitize_variation_name', array( $input ) ) );
+	}
+
+	/**
+	 * Slug sanitiser cases.
+	 *
+	 * @return array
+	 */
+	public function slug_provider() {
+		return array(
+			'plain'              => array( 'primary', 'primary' ),
+			'hyphenated'         => array( 'header-cta', 'header-cta' ),
+			'uppercase lowered'  => array( 'Primary', 'primary' ),
+			'numeric int key'    => array( 2024, '2024' ),
+			'numeric string'     => array( '2024', '2024' ),
+			'selector breakout'  => array( 'evil"} body{display:none', 'evilbodydisplaynone' ),
+			'combinator/space'   => array( 'a b', 'ab' ),
+			'strips underscores' => array( 'header_cta', 'headercta' ),
+			'empty'              => array( '', '' ),
+			'all-invalid'        => array( '{}();', '' ),
+		);
+	}
+
+	/**
+	 * A normal variation emits one rule per primitive with the sanitised slug.
+	 */
+	public function test_emits_per_primitive_selectors() {
+		$css = $this->call(
+			'build_variation_css',
+			array(
+				$this->block_styles(
+					array(
+						'secondary' => array(
+							'color'  => array( 'background' => 'transparent' ),
+							'border' => array( 'color' => 'currentColor', 'width' => '2px', 'style' => 'solid' ),
+						),
+					)
+				),
+			)
+		);
+
+		// Icon Button: variation class on the wrapper, styling the inner button.
+		$this->assertStringContainsString(
+			'.wp-block-designsetgo-icon-button.is-style-secondary .dsgo-icon-button.wp-block-button__link',
+			$css
+		);
+		// Form submit: modifier compounded on the button.
+		$this->assertStringContainsString(
+			'.dsgo-form__submit.dsgo-form__submit--secondary.wp-element-button',
+			$css
+		);
+		$this->assertStringContainsString( 'background-color:transparent', $css );
+		// Modal Trigger is deliberately NOT projected (own buttonStyle system).
+		$this->assertStringNotContainsString( 'dsgo-modal-trigger', $css );
+	}
+
+	/**
+	 * A sanitised slug is what actually lands in the selector — no raw breakout.
+	 */
+	public function test_injection_slug_is_neutralised() {
+		$css = $this->call(
+			'build_variation_css',
+			array(
+				$this->block_styles(
+					array( 'evil"} body{display:none' => array( 'color' => array( 'background' => 'red' ) ) )
+				),
+			)
+		);
+
+		$this->assertStringNotContainsString( '"}', $css );
+		$this->assertStringNotContainsString( 'display:none', $css );
+		$this->assertStringContainsString( 'is-style-evilbodydisplaynone', $css );
+	}
+
+	/**
+	 * `fill` and `outline` are owned elsewhere and never projected here.
+	 */
+	public function test_skips_fill_and_outline() {
+		$css = $this->call(
+			'build_variation_css',
+			array(
+				$this->block_styles(
+					array(
+						'fill'    => array( 'color' => array( 'background' => '#111' ) ),
+						'outline' => array( 'color' => array( 'background' => '#222' ) ),
+					)
+				),
+			)
+		);
+
+		$this->assertSame( '', $css );
+	}
+
+	/**
+	 * Two raw names that normalise to the same slug emit a single rule set.
+	 */
+	public function test_dedupes_slugs() {
+		$css = $this->call(
+			'build_variation_css',
+			array(
+				$this->block_styles(
+					array(
+						'Primary' => array( 'color' => array( 'background' => '#111' ) ),
+						'primary' => array( 'color' => array( 'background' => '#222' ) ),
+					)
+				),
+			)
+		);
+
+		$this->assertSame(
+			1,
+			substr_count( $css, '.wp-block-designsetgo-icon-button.is-style-primary ' ),
+			'A duplicate slug must not emit its selector twice.'
+		);
+	}
+
+	/**
+	 * A hover node on a variation emits a matching :hover rule.
+	 */
+	public function test_emits_hover_rule() {
+		$css = $this->call(
+			'build_variation_css',
+			array(
+				$this->block_styles(
+					array(
+						'header-cta' => array(
+							'color'   => array( 'background' => '#e0653a' ),
+							':hover'  => array( 'color' => array( 'background' => '#c94f28' ) ),
+						),
+					)
+				),
+			)
+		);
+
+		$this->assertStringContainsString(
+			'.wp-block-designsetgo-icon-button.is-style-header-cta .dsgo-icon-button.wp-block-button__link:hover',
+			$css
+		);
+		$this->assertStringContainsString( 'background-color:#c94f28', $css );
+	}
+
+	/**
+	 * No variations node yields no CSS.
+	 */
+	public function test_no_variations_yields_empty() {
+		$this->assertSame( '', $this->call( 'build_variation_css', array( array() ) ) );
+		$this->assertSame( '', $this->call( 'build_variation_css', array( array( 'variations' => 'nope' ) ) ) );
+	}
+}

--- a/tests/phpunit/button-global-styles-variations-test.php
+++ b/tests/phpunit/button-global-styles-variations-test.php
@@ -15,6 +15,8 @@
 use DesignSetGo\Button_Global_Styles;
 
 /**
+ * Tests for projecting core/button style variations onto DSGo button primitives.
+ *
  * @group buttons
  * @group global-styles
  */
@@ -87,7 +89,11 @@ class Button_Global_Styles_Variations_Test extends WP_UnitTestCase {
 					array(
 						'secondary' => array(
 							'color'  => array( 'background' => 'transparent' ),
-							'border' => array( 'color' => 'currentColor', 'width' => '2px', 'style' => 'solid' ),
+							'border' => array(
+								'color' => 'currentColor',
+								'width' => '2px',
+								'style' => 'solid',
+							),
 						),
 					)
 				),
@@ -179,8 +185,8 @@ class Button_Global_Styles_Variations_Test extends WP_UnitTestCase {
 				$this->block_styles(
 					array(
 						'header-cta' => array(
-							'color'   => array( 'background' => '#e0653a' ),
-							':hover'  => array( 'color' => array( 'background' => '#c94f28' ) ),
+							'color'  => array( 'background' => '#e0653a' ),
+							':hover' => array( 'color' => array( 'background' => '#c94f28' ) ),
 						),
 					)
 				),

--- a/tests/phpunit/button-global-styles-variations-test.php
+++ b/tests/phpunit/button-global-styles-variations-test.php
@@ -153,6 +153,49 @@ class Button_Global_Styles_Variations_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A variation named like a hover animation never emits a form-submit rule.
+	 *
+	 * `apply_default_form_button_hover()` stamps `dsgo-form__submit--{animation}`
+	 * on real buttons, so a variation named e.g. `lift` must NOT emit
+	 * `.dsgo-form__submit.dsgo-form__submit--lift` (it would repaint any button
+	 * with the `--lift` hover animation). The icon-button selector (wrapper
+	 * `is-style-{name}`) is a separate namespace and is still emitted.
+	 *
+	 * @dataProvider animation_slug_provider
+	 *
+	 * @param string $slug A reserved hover-animation slug.
+	 */
+	public function test_animation_named_variation_skips_form_submit( $slug ) {
+		$css = $this->call(
+			'build_variation_css',
+			array( $this->block_styles( array( $slug => array( 'color' => array( 'background' => '#f00' ) ) ) ) )
+		);
+
+		$this->assertStringNotContainsString(
+			'.dsgo-form__submit.dsgo-form__submit--' . $slug,
+			$css,
+			'Form-submit selector must not reuse a hover-animation slug.'
+		);
+		$this->assertStringContainsString(
+			'.wp-block-designsetgo-icon-button.is-style-' . $slug . ' .dsgo-icon-button',
+			$css,
+			'Icon-button selector (separate namespace) should still be emitted.'
+		);
+	}
+
+	/**
+	 * A couple of the reserved hover-animation slugs.
+	 *
+	 * @return array
+	 */
+	public function animation_slug_provider() {
+		return array(
+			'lift'   => array( 'lift' ),
+			'shrink' => array( 'shrink' ),
+		);
+	}
+
+	/**
 	 * Two raw names that normalise to the same slug emit a single rule set.
 	 */
 	public function test_dedupes_slugs() {

--- a/tests/phpunit/button-global-styles-variations-test.php
+++ b/tests/phpunit/button-global-styles-variations-test.php
@@ -153,19 +153,20 @@ class Button_Global_Styles_Variations_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A variation named like a hover animation never emits a form-submit rule.
+	 * A variation named like a reserved form-submit modifier skips the form rule.
 	 *
-	 * `apply_default_form_button_hover()` stamps `dsgo-form__submit--{animation}`
-	 * on real buttons, so a variation named e.g. `lift` must NOT emit
-	 * `.dsgo-form__submit.dsgo-form__submit--lift` (it would repaint any button
-	 * with the `--lift` hover animation). The icon-button selector (wrapper
-	 * `is-style-{name}`) is a separate namespace and is still emitted.
+	 * The block/plugin stamp `dsgo-form__submit--{x}` on real buttons for hover
+	 * animations (`--lift`, …) and layout/state (`--inline`, `--loading`,
+	 * `--no-hover`). A variation named like one of those must NOT emit
+	 * `.dsgo-form__submit.dsgo-form__submit--{x}` (it would repaint any button
+	 * carrying that modifier). The icon-button selector (wrapper `is-style-{name}`)
+	 * is a separate namespace and is still emitted.
 	 *
-	 * @dataProvider animation_slug_provider
+	 * @dataProvider reserved_slug_provider
 	 *
-	 * @param string $slug A reserved hover-animation slug.
+	 * @param string $slug A reserved form-submit modifier slug.
 	 */
-	public function test_animation_named_variation_skips_form_submit( $slug ) {
+	public function test_reserved_slug_variation_skips_form_submit( $slug ) {
 		$css = $this->call(
 			'build_variation_css',
 			array( $this->block_styles( array( $slug => array( 'color' => array( 'background' => '#f00' ) ) ) ) )
@@ -174,7 +175,7 @@ class Button_Global_Styles_Variations_Test extends WP_UnitTestCase {
 		$this->assertStringNotContainsString(
 			'.dsgo-form__submit.dsgo-form__submit--' . $slug,
 			$css,
-			'Form-submit selector must not reuse a hover-animation slug.'
+			'Form-submit selector must not reuse a reserved modifier slug.'
 		);
 		$this->assertStringContainsString(
 			'.wp-block-designsetgo-icon-button.is-style-' . $slug . ' .dsgo-icon-button',
@@ -184,14 +185,17 @@ class Button_Global_Styles_Variations_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A couple of the reserved hover-animation slugs.
+	 * Reserved form-submit modifier slugs: hover animations + layout/state.
 	 *
 	 * @return array
 	 */
-	public function animation_slug_provider() {
+	public function reserved_slug_provider() {
 		return array(
-			'lift'   => array( 'lift' ),
-			'shrink' => array( 'shrink' ),
+			'animation lift'   => array( 'lift' ),
+			'animation shrink' => array( 'shrink' ),
+			'layout inline'    => array( 'inline' ),
+			'state loading'    => array( 'loading' ),
+			'state no-hover'   => array( 'no-hover' ),
 		);
 	}
 


### PR DESCRIPTION
Makes `core/button` style variations (`is-style-primary`, `-secondary`, `-header-cta`, and any future one) actually paint on DSGo's single-element buttons, with zero per-variation CSS.

## The problem

DSGo's single-element buttons (icon-button, form submit) don't match WordPress's native `.wp-block-button .wp-block-button__link` descendant rule, so [`class-button-global-styles.php`](../blob/main/includes/features/class-button-global-styles.php) re-emits Global Styles button appearance onto them at specificity **(0,3,0)** (`:root .dsgo-icon-button.wp-block-button__link`).

For variations, `Icon_Button_Styles` already mirrors `core/button.variations.*` onto the icon button and registers them, so WordPress's native pipeline *does* emit variation CSS — but wrapped in `:where()` = **(0,1,0)**, which loses to that (0,3,0) base. So the variation rule was always emitted and always out-ranked; that's why `is-style-secondary` never painted.

## The fix

1. **Project variations at winning specificity.** `Button_Global_Styles` (the generator that already re-emits base button styling) now also iterates `core/button.variations.*` and emits each onto the primitives at a specificity that beats the base rule:
   - Icon Button — `:root .wp-block-designsetgo-icon-button.is-style-{name} .dsgo-icon-button.wp-block-button__link` (0,5,0)
   - Form submit — `:root .dsgo-form__submit.dsgo-form__submit--{name}.wp-element-button` (0,4,0)

   Colours stay defined once in the kit's `core/button.variations`; the slug is strip-sanitised (`[a-z0-9-]`) before it touches the selector. `fill`/`outline` are skipped (base rule + the hand-written `outline` own those).

2. **Remove the now-redundant mirror.** `Icon_Button_Styles::mirror_variation_styles()` (and its two `wp_theme_json_data_*` filters) is deleted — it only ever produced the losing (0,1,0) duplicate. `register_mirrored_variations()` stays, so the variations still appear in the editor Styles panel and are valid to apply.

This makes the generator the single owner of "Global Styles → DSGo button CSS" (base + variations), and leaves exactly one winning rule per variation.

## Scope

- **Icon Button + form submit**: covered. (Form submit's `dsgo-form__submit--{name}` class hooks come from #469; this projection is a harmless no-op until #469 merges, since no element carries the class before then.)
- **Modal Trigger**: intentionally out of scope — it uses its own `buttonStyle` attribute (`dsgo-modal-trigger--{style}`), not block-style variations. The base rule still covers it.

## Validation

Browser-tested on wp-env with a simulated kit (registered `primary`/`secondary`/`header-cta` for `core/button` + their colours in Global Styles):

| Variation | Frontend computed style on `.dsgo-icon-button` |
|---|---|
| `is-style-primary` | filled (kit primary) ✅ |
| `is-style-secondary` | transparent + `2px solid` current-color (ghost) ✅ |
| `is-style-header-cta` | filled (kit accent) ✅ |

- After removing the mirror: the generator's winning rule is present and the native `:where()` duplicate is **gone** (verified by counting matched rules), variations still paint, and the editor panel still lists `primary/secondary/header-cta/fill/outline`.
- `Button_Global_Styles_Variations_Test` (16 tests) pins the sanitiser (incl. selector-breakout attempts), per-primitive selectors, `fill`/`outline` skip, dedup, `:hover`, and empty cases. `phpcs` + `php -l` clean.

## Related

- #469 — Form Builder submit button style variations (adds the `dsgo-form__submit--{name}` hooks this projects onto).