### PR TITLE
fix: block exclusions now reach the editor iframe (#464)

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -870,29 +870,14 @@ class Plugin {
 			);
 		}
 
-		// Localize excluded blocks setting for extension filtering.
-		// This is done outside the block-category-icon conditional because
-		// the 'designsetgo-extensions' script is registered separately in the Assets class.
-		if ( wp_script_is( 'designsetgo-extensions', 'registered' ) || wp_script_is( 'designsetgo-extensions', 'enqueued' ) ) {
-			$settings        = $settings ?? \DesignSetGo\Admin\Settings::get_settings();
-			$excluded_blocks = isset( $settings['excluded_blocks'] ) ? $settings['excluded_blocks'] : array();
-
-			$enabled_extensions = isset( $settings['enabled_extensions'] ) ? (array) $settings['enabled_extensions'] : array();
-
-			wp_localize_script(
-				'designsetgo-extensions',
-				'dsgoSettings',
-				array(
-					'excludedBlocks'         => $excluded_blocks,
-					'defaultIconButtonHover' => isset( $settings['animations']['default_icon_button_hover'] )
-						? sanitize_key( $settings['animations']['default_icon_button_hover'] )
-						: 'fill-diagonal',
-					// Empty list = all extensions enabled (matches the
-					// PHP convention in Block_Manager::should_load_extension).
-					'enabledExtensions'      => array_values( array_map( 'sanitize_key', $enabled_extensions ) ),
-				)
-			);
-		}
+		// Note: The `dsgoSettings` payload (excluded blocks, extension
+		// allowlist) is localized in Assets::enqueue_editor_assets() on the
+		// `enqueue_block_assets` hook. That is the ONLY hook whose scripts are
+		// printed into the iframed editor canvas (via
+		// _wp_get_iframed_editor_assets()), where the block extensions actually
+		// run. Localizing here on `enqueue_block_editor_assets` would attach to
+		// the outer editor frame only and never reach the iframe, so
+		// shouldExtendBlock() would fall back to an empty exclusion list.
 	}
 
 	/**

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -870,14 +870,10 @@ class Plugin {
 			);
 		}
 
-		// Note: The `dsgoSettings` payload (excluded blocks, extension
-		// allowlist) is localized in Assets::enqueue_editor_assets() on the
-		// `enqueue_block_assets` hook. That is the ONLY hook whose scripts are
-		// printed into the iframed editor canvas (via
-		// _wp_get_iframed_editor_assets()), where the block extensions actually
-		// run. Localizing here on `enqueue_block_editor_assets` would attach to
-		// the outer editor frame only and never reach the iframe, so
-		// shouldExtendBlock() would fall back to an empty exclusion list.
+		// The `dsgoSettings` payload (excluded blocks, extension allowlist) is
+		// intentionally NOT localized here. It rides `enqueue_block_assets`
+		// instead so it reaches the iframed editor canvas — see
+		// Assets::localize_extension_settings() for the full rationale.
 	}
 
 	/**

--- a/includes/core/class-assets.php
+++ b/includes/core/class-assets.php
@@ -92,11 +92,50 @@ class Assets {
 			true
 		);
 
+		// Localize the extension settings onto the SAME script + hook that we
+		// just enqueued. This hook (`enqueue_block_assets`) is the only one
+		// whose scripts are printed into the iframed editor canvas via
+		// _wp_get_iframed_editor_assets(), where the block extensions run and
+		// read window.dsgoSettings. Localizing on `enqueue_block_editor_assets`
+		// instead would never reach the iframe, silently disabling the block
+		// exclusion list (shouldExtendBlock) and the extension allowlist.
+		$this->localize_extension_settings();
+
 		wp_enqueue_style(
 			'designsetgo-extensions',
 			DESIGNSETGO_URL . 'build/index.css',
 			array( 'wp-edit-blocks' ), // Dashicons loads automatically in admin.
 			$asset_file['version']
+		);
+	}
+
+	/**
+	 * Localize DesignSetGo settings for the block extension bundle.
+	 *
+	 * Exposes the user's excluded-blocks list and extension allowlist to the
+	 * editor iframe as `window.dsgoSettings`, consumed by shouldExtendBlock()
+	 * and the per-extension gating. Must run on `enqueue_block_assets` (the
+	 * hook that feeds the iframed canvas) so the data ships alongside the
+	 * extensions script.
+	 */
+	private function localize_extension_settings() {
+		$settings = \DesignSetGo\Admin\Settings::get_settings();
+
+		$excluded_blocks    = isset( $settings['excluded_blocks'] ) ? (array) $settings['excluded_blocks'] : array();
+		$enabled_extensions = isset( $settings['enabled_extensions'] ) ? (array) $settings['enabled_extensions'] : array();
+
+		wp_localize_script(
+			'designsetgo-extensions',
+			'dsgoSettings',
+			array(
+				'excludedBlocks'         => array_values( $excluded_blocks ),
+				'defaultIconButtonHover' => isset( $settings['animations']['default_icon_button_hover'] )
+					? sanitize_key( $settings['animations']['default_icon_button_hover'] )
+					: 'fill-diagonal',
+				// Empty list = all extensions enabled (matches the
+				// PHP convention in Block_Manager::should_load_extension).
+				'enabledExtensions'      => array_values( array_map( 'sanitize_key', $enabled_extensions ) ),
+			)
 		);
 	}
 

--- a/includes/core/class-assets.php
+++ b/includes/core/class-assets.php
@@ -92,13 +92,8 @@ class Assets {
 			true
 		);
 
-		// Localize the extension settings onto the SAME script + hook that we
-		// just enqueued. This hook (`enqueue_block_assets`) is the only one
-		// whose scripts are printed into the iframed editor canvas via
-		// _wp_get_iframed_editor_assets(), where the block extensions run and
-		// read window.dsgoSettings. Localizing on `enqueue_block_editor_assets`
-		// instead would never reach the iframe, silently disabling the block
-		// exclusion list (shouldExtendBlock) and the extension allowlist.
+		// Ship window.dsgoSettings into the iframe alongside this script.
+		// @see Assets::localize_extension_settings() for why this hook.
 		$this->localize_extension_settings();
 
 		wp_enqueue_style(
@@ -114,9 +109,15 @@ class Assets {
 	 *
 	 * Exposes the user's excluded-blocks list and extension allowlist to the
 	 * editor iframe as `window.dsgoSettings`, consumed by shouldExtendBlock()
-	 * and the per-extension gating. Must run on `enqueue_block_assets` (the
-	 * hook that feeds the iframed canvas) so the data ships alongside the
-	 * extensions script.
+	 * and the per-extension gating (e.g. dynamic-tags).
+	 *
+	 * This is the single source of truth for WHY the payload rides
+	 * `enqueue_block_assets` (the hook enqueue_editor_assets() runs on): that is
+	 * the only hook whose scripts WordPress prints into the iframed editor
+	 * canvas via _wp_get_iframed_editor_assets(), where the extensions actually
+	 * execute. Localizing on `enqueue_block_editor_assets` would attach to the
+	 * outer editor frame only and never reach the iframe, silently disabling
+	 * both the exclusion list and the extension allowlist.
 	 */
 	private function localize_extension_settings() {
 		$settings = \DesignSetGo\Admin\Settings::get_settings();

--- a/tests/phpunit/extension-settings-localize-test.php
+++ b/tests/phpunit/extension-settings-localize-test.php
@@ -76,4 +76,36 @@ class Test_Extension_Settings_Localize extends WP_UnitTestCase {
 			'The configured excluded block must be present in the iframe payload.'
 		);
 	}
+
+	/**
+	 * The enabled-extensions allowlist must reach the iframe too.
+	 *
+	 * The same localization bug also disabled per-extension gating (e.g.
+	 * dynamic-tags, which reads window.dsgoSettings.enabledExtensions inside
+	 * the iframe). Cover it so a regression in either field is caught.
+	 */
+	public function test_enabled_extensions_localized_onto_extensions_script() {
+		set_current_screen( 'edit-post' );
+
+		update_option(
+			Settings::OPTION_NAME,
+			array( 'enabled_extensions' => array( 'dynamic-tags' ) )
+		);
+		Settings::invalidate_cache();
+
+		do_action( 'enqueue_block_assets' );
+
+		$data = wp_scripts()->get_data( 'designsetgo-extensions', 'data' );
+
+		$this->assertIsString(
+			$data,
+			'dsgoSettings must be localized on the same hook that enqueues the extensions script.'
+		);
+		$this->assertStringContainsString( 'enabledExtensions', $data );
+		$this->assertStringContainsString(
+			'dynamic-tags',
+			$data,
+			'The configured enabled extension must be present in the iframe payload.'
+		);
+	}
 }

--- a/tests/phpunit/extension-settings-localize-test.php
+++ b/tests/phpunit/extension-settings-localize-test.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Tests for extension settings localization in the block editor iframe.
+ *
+ * The `designsetgo-extensions` script (which registers every DSG block
+ * extension via `blocks.registerBlockType`) is enqueued on the
+ * `enqueue_block_assets` hook because, in the block editor, that hook is the
+ * only one that fires inside the iframed canvas (`_wp_get_iframed_editor_assets()`)
+ * where the extensions actually run. The `dsgoSettings` payload — which carries
+ * the user's `excluded_blocks` list consumed by `shouldExtendBlock()` — must be
+ * localized onto that same script, on that same hook, or it never reaches the
+ * iframe and exclusions are silently ignored.
+ *
+ * @package DesignSetGo
+ */
+
+namespace DesignSetGo\Tests;
+
+use WP_UnitTestCase;
+use DesignSetGo\Admin\Settings;
+
+/**
+ * Extension Settings Localization Test Case
+ */
+class Test_Extension_Settings_Localize extends WP_UnitTestCase {
+
+	/**
+	 * Reset scripts and screen after each test.
+	 */
+	public function tear_down() {
+		wp_dequeue_script( 'designsetgo-extensions' );
+		set_current_screen( 'front' );
+		delete_option( Settings::OPTION_NAME );
+		Settings::invalidate_cache();
+		parent::tear_down();
+	}
+
+	/**
+	 * The excluded_blocks list must reach the iframe extensions script.
+	 *
+	 * Fires the same hook the iframed editor canvas uses and asserts the
+	 * enqueued extensions script carries the configured exclusions in its
+	 * localized `dsgoSettings` payload.
+	 */
+	public function test_excluded_blocks_localized_onto_extensions_script() {
+		// Admin/editor context so Assets::enqueue_editor_assets() runs.
+		set_current_screen( 'edit-post' );
+
+		// Persist an explicit exclusion the reporter would configure.
+		// excluded_blocks is a top-level key, so it wins the wp_parse_args
+		// merge in get_settings() regardless of the packaged defaults.
+		update_option(
+			Settings::OPTION_NAME,
+			array( 'excluded_blocks' => array( 'gravityforms/form' ) )
+		);
+		Settings::invalidate_cache();
+
+		// The block editor fires this hook inside the iframed canvas.
+		do_action( 'enqueue_block_assets' );
+
+		$this->assertTrue(
+			wp_script_is( 'designsetgo-extensions', 'enqueued' ),
+			'The extensions script should be enqueued in the editor iframe context.'
+		);
+
+		$data = wp_scripts()->get_data( 'designsetgo-extensions', 'data' );
+
+		$this->assertIsString(
+			$data,
+			'dsgoSettings must be localized on the same hook that enqueues the extensions script.'
+		);
+		$this->assertStringContainsString( 'dsgoSettings', $data );
+		$this->assertStringContainsString(
+			'gravityforms/form',
+			$data,
+			'The configured excluded block must be present in the iframe payload.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #464 — block exclusions (e.g. `gravityforms/form`) were ignored in the editor: excluded third-party blocks still received DSG panels/attributes and threw "invalid block attributes."

**Root cause.** The `dsgoSettings` payload — which carries the user's `excluded_blocks` list read by `shouldExtendBlock()` — was localized in `Plugin::editor_assets()` on the `enqueue_block_editor_assets` hook, guarded by `wp_script_is('designsetgo-extensions', 'registered'|'enqueued')`. But `designsetgo-extensions` (the block-extension bundle) is only ever enqueued on `enqueue_block_assets`, which in the block editor fires **exclusively inside core's `_wp_get_iframed_editor_assets()`** against a throwaway `WP_Scripts` instance for the iframed canvas. The handle is therefore never registered in the main scripts registry, the guard is always false, and the localization silently no-ops. Inside the iframe (where the extensions actually run) `window.dsgoSettings` was `undefined`, so `shouldExtendBlock()` fell back to an empty exclusion list and extended every block.

**Fix.** Move the localization into `Assets::enqueue_editor_assets()`, co-located with the `wp_enqueue_script()` call on `enqueue_block_assets`, so the payload rides into the iframe alongside `build/index.js`. This also restores the `enabledExtensions` allowlist gating (same bug affected `dynamic-tags`).

## Test Plan

- [x] New regression test `tests/phpunit/extension-settings-localize-test.php` — asserts that firing `enqueue_block_assets` in editor context localizes `dsgoSettings` with the configured exclusion onto `designsetgo-extensions`. Fails on the old code, passes on the fix.
- [x] End-to-end check via core `_wp_get_iframed_editor_assets()`: the `dsgoSettings` payload with `gravityforms/form` now prints into the iframe asset HTML (was absent before).
- [x] Full PHPUnit suite green (931 tests, 4249 assertions).
- [x] `phpcs` clean on changed files.
- [ ] Manual: with Gravity Forms active and `gravityforms/*` excluded, insert the GF Form block — no DSG panels, no "invalid block attributes" error.