### PR TITLE
fix: clear all resolvable npm run build warnings (postcss-calc + Sass @import)

### DIFF
--- a/src/blocks/form-checkbox-field/editor.scss
+++ b/src/blocks/form-checkbox-field/editor.scss
@@ -4,5 +4,5 @@
  * @since 1.0.0
  */
 
-// Import the main frontend styles
-@import './style';
+// Load the main frontend styles
+@use './style';

--- a/src/blocks/form-date-field/editor.scss
+++ b/src/blocks/form-date-field/editor.scss
@@ -4,5 +4,5 @@
  * @since 1.0.0
  */
 
-// Import the main frontend styles
-@import './style';
+// Load the main frontend styles
+@use './style';

--- a/src/blocks/form-email-field/editor.scss
+++ b/src/blocks/form-email-field/editor.scss
@@ -4,5 +4,5 @@
  * @since 1.0.0
  */
 
-// Import the main frontend styles
-@import './style';
+// Load the main frontend styles
+@use './style';

--- a/src/blocks/form-hidden-field/editor.scss
+++ b/src/blocks/form-hidden-field/editor.scss
@@ -4,8 +4,8 @@
  * @since 1.0.0
  */
 
-// Import the main frontend styles
-@import './style';
+// Load the main frontend styles
+@use './style';
 
 // Show in editor with visual indicator
 .dsgo-form-field--hidden {

--- a/src/blocks/form-number-field/editor.scss
+++ b/src/blocks/form-number-field/editor.scss
@@ -4,5 +4,5 @@
  * @since 1.0.0
  */
 
-// Import the main frontend styles
-@import './style';
+// Load the main frontend styles
+@use './style';

--- a/src/blocks/form-phone-field/editor.scss
+++ b/src/blocks/form-phone-field/editor.scss
@@ -4,5 +4,5 @@
  * @since 1.0.0
  */
 
-// Import the main frontend styles
-@import './style';
+// Load the main frontend styles
+@use './style';

--- a/src/blocks/form-select-field/editor.scss
+++ b/src/blocks/form-select-field/editor.scss
@@ -4,8 +4,8 @@
  * @since 1.0.0
  */
 
-// Import the main frontend styles
-@import './style';
+// Load the main frontend styles
+@use './style';
 
 // Editor-specific: WordPress editor styles override select width
 .editor-styles-wrapper {

--- a/src/blocks/form-text-field/editor.scss
+++ b/src/blocks/form-text-field/editor.scss
@@ -6,8 +6,8 @@
  * @since 1.0.0
  */
 
-// Import the main frontend styles for base styling
-@import './style';
+// Load the main frontend styles for base styling
+@use './style';
 
 // Editor-specific overrides
 .editor-styles-wrapper {

--- a/src/blocks/form-textarea-field/editor.scss
+++ b/src/blocks/form-textarea-field/editor.scss
@@ -4,5 +4,5 @@
  * @since 1.0.0
  */
 
-// Import the main frontend styles
-@import './style';
+// Load the main frontend styles
+@use './style';

--- a/src/blocks/form-time-field/editor.scss
+++ b/src/blocks/form-time-field/editor.scss
@@ -4,5 +4,5 @@
  * @since 1.0.0
  */
 
-// Import the main frontend styles
-@import './style';
+// Load the main frontend styles
+@use './style';

--- a/src/blocks/form-url-field/editor.scss
+++ b/src/blocks/form-url-field/editor.scss
@@ -4,5 +4,5 @@
  * @since 1.0.0
  */
 
-// Import the main frontend styles
-@import './style';
+// Load the main frontend styles
+@use './style';

--- a/src/blocks/image-accordion-item/style.scss
+++ b/src/blocks/image-accordion-item/style.scss
@@ -42,7 +42,11 @@
 				)
 			)
 		);
-		opacity: var(
+		// Resolve the four-layer opacity cascade once into a single custom
+		// property. The collapsed state below adds 0.2 to it inside calc();
+		// referencing this flat var (no nested var() fallbacks) sidesteps a
+		// postcss-calc parse bug that chokes on nested var() inside calc().
+		--dsgo-resolved-overlay-opacity: var(
 			--dsgo-overlay-opacity,
 			var(
 				--dsgo-image-accordion-overlay-opacity,
@@ -52,6 +56,7 @@
 				)
 			)
 		);
+		opacity: var(--dsgo-resolved-overlay-opacity);
 		transition: opacity 0.3s ease;
 		pointer-events: none;
 		z-index: 1;
@@ -148,19 +153,10 @@
 		flex: 1;
 
 		&.dsgo-image-accordion-item--has-overlay::before {
-			// Darker when collapsed
-			opacity: calc(
-				var(
-						--dsgo-overlay-opacity,
-						var(
-							--dsgo-image-accordion-overlay-opacity,
-							var(
-								--wp--custom--designsetgo--image-accordion--overlay-opacity,
-								0.4
-							)
-						)
-					) + 0.2
-			);
+			// Darker when collapsed. --dsgo-resolved-overlay-opacity is set on
+			// the base &--has-overlay::before rule, which always co-applies to
+			// this same pseudo-element, so the flat var resolves here.
+			opacity: calc(var(--dsgo-resolved-overlay-opacity) + 0.2);
 		}
 
 		.dsgo-image-accordion-item__content {


### PR DESCRIPTION
## Summary

`npm run build` emitted 13 warnings. This clears the 12 resolvable ones, leaving only the pre-existing (unrelated) asset-size-limit advisory. No runtime CSS changes.

### 1. postcss-calc parse error — `image-accordion-item/style.scss`

postcss-calc 9.x cannot parse **nested `var()` fallbacks inside `calc()`**, so the collapsed-overlay opacity threw a parse-error warning on every build:

```
(1:2599) postcss-calc: Parse error ... Expecting end of input, "ADD", "SUB", "MUL", "DIV", got unexpected "RPAREN"
```

Reproduced in isolation to pin the exact trigger:
- `calc(var(--a, var(--b, var(--c, 0.4))) + 0.2)` → parse error
- `calc(var(--a, 0.4) + 0.2)` (single fallback) → clean
- `calc(var(--a) + 0.2)` (flat) → clean

**Fix:** hoist the four-layer opacity cascade into a single `--dsgo-resolved-overlay-opacity` custom property and reference it flat inside `calc()`. Also de-duplicates the cascade that was repeated between the base and collapsed states.

The warning was non-fatal (postcss-calc left the value untouched, so the accordion rendered correctly), but it was noise on every build.

### 2. Sass `@import` deprecations — 11 `form-*-field/editor.scss`

Dart Sass deprecated `@import` (removed in 3.0). Each form field's `editor.scss` pulled in its sibling `style.scss` via `@import './style'`, one deprecation warning per file.

**Fix:** migrate to `@use './style'` — the correct successor for these JS-imported leaf entries (nothing consumes their Sass members; only comments precede the statement, so `@use`'s top-of-file rule is satisfied).

## Verification

- Clean builds (webpack cache cleared): **13 → 1 warning**. The remaining one is the pre-existing asset-size-limit advisory (slider/section/modal/icon-button/form-builder bundle sizes) — out of scope here.
- The 11 `@use` migrations produce **byte-identical** compiled CSS — all 22 output files (`index.css` + `index-rtl.css`) hash-match the pre-migration build, so behavior is provably unchanged.
- `stylelint` passes clean on all 12 touched files.
- e2e block smoke tests pass (modal, form builder, patterns).

## Files changed

- `src/blocks/image-accordion-item/style.scss`
- `src/blocks/form-{checkbox,date,email,hidden,number,phone,select,text,textarea,time,url}-field/editor.scss`