### PR TITLE
feat(release): support beta/RC deploys to WordPress.org

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -33,6 +33,7 @@ package-lock.json
 webpack.config.js
 tsconfig.json
 lint-staged.config.js
+/scripts
 
 # ===================
 # Testing

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,32 +1,79 @@
+# Deploy to WordPress.org
+#
+# Fires on any pushed git tag. Two release channels, chosen by the tag name
+# (WordPress-core style — see scripts/lib/version.js):
+#
+#   X.Y.Z            → STABLE. Full release via the 10up action: writes SVN
+#                      /trunk + /tags/X.Y.Z. Because readme.txt "Stable tag"
+#                      is bumped to match, the auto-update channel ships it to
+#                      every user.
+#
+#   X.Y.Z-beta<N>    → PRE-RELEASE. Committed ONLY to SVN /tags/<version> by a
+#   X.Y.Z-rc<N>        custom step; /trunk is never touched. WordPress.org
+#                      still auto-builds a zip at
+#                      downloads.wordpress.org/plugin/designsetgo.<version>.zip
+#                      for opt-in testers, but since /trunk's "Stable tag" is
+#                      unchanged, the stable auto-update channel never sees it.
+#
+# The Stable-tag rule is the linchpin: WordPress.org serves whatever /trunk's
+# readme.txt "Stable tag" names. scripts/release-meta.js --validate enforces
+# that pre-release tags keep it pinned to the last stable version, and that
+# stable tags match everywhere. Use `npm run version:set -- <version>` to set
+# all version sites correctly before tagging.
+
 name: Deploy to WordPress.org
 
 on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version tag to (re)deploy, e.g. 2.5.0-beta1'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run (pre-release path only): stage the tag but do not commit to SVN'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
-  tag:
-    name: New tag
+  deploy:
+    name: Deploy
     runs-on: ubuntu-latest
     permissions:
-      contents: read  # Required for actions/checkout
+      contents: read # Required for actions/checkout
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
 
+      - name: Determine release type
+        id: meta
+        env:
+          TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: node scripts/release-meta.js "$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Validate version metadata
+        env:
+          TAG: ${{ steps.meta.outputs.version }}
+        run: node scripts/release-meta.js --validate "$TAG"
+
       - name: Build plugin
         run: npm run build
 
-      - name: WordPress Plugin Deploy
+      # STABLE — full release (trunk + tag + Stable tag bump → all users).
+      - name: WordPress Plugin Deploy (stable)
+        if: steps.meta.outputs.prerelease == 'false'
         uses: 10up/action-wordpress-plugin-deploy@stable
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
@@ -34,3 +81,59 @@ jobs:
           SLUG: designsetgo
         with:
           generate-zip: true
+
+      # PRE-RELEASE — tag-only SVN commit; /trunk and its Stable tag untouched.
+      - name: WordPress Plugin Deploy (pre-release, tag only)
+        if: steps.meta.outputs.prerelease == 'true'
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SLUG: designsetgo
+          VERSION: ${{ steps.meta.outputs.version }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update
+          sudo apt-get install -y subversion rsync
+
+          SVN_URL="https://plugins.svn.wordpress.org/${SLUG}/"
+          SVN_DIR="/tmp/svn-${SLUG}"
+
+          echo "➤ Shallow checkout of SVN root (no trunk)..."
+          svn checkout --depth=empty "$SVN_URL" "$SVN_DIR" \
+            --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive
+
+          cd "$SVN_DIR"
+
+          echo "➤ Fetching tag names only..."
+          svn update --set-depth=immediates tags --non-interactive
+
+          if [ -d "tags/$VERSION" ]; then
+            echo "ℹ︎ Version $VERSION already published to SVN tags — nothing to do."
+            exit 0
+          fi
+
+          echo "➤ Staging build into tags/$VERSION (trunk is never touched)..."
+          mkdir -p "tags/$VERSION"
+          rsync -rc --exclude='.svn' \
+            --exclude-from="$GITHUB_WORKSPACE/.distignore" \
+            "$GITHUB_WORKSPACE/" "tags/$VERSION/"
+
+          svn add "tags/$VERSION" --force --auto-props --parents --depth infinity -q
+
+          echo "➤ Staged changes:"
+          svn status
+
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            echo "➤ DRY RUN: not committing. Summary of what would be added:"
+            svn diff --summarize
+            exit 0
+          fi
+
+          echo "➤ Committing pre-release tag $VERSION..."
+          svn commit -m "Release pre-release $VERSION (tag only; stable channel untouched)" \
+            --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive
+
+          echo "✓ Pre-release $VERSION deployed to tags only."
+          echo "  Testers: https://downloads.wordpress.org/plugin/${SLUG}.${VERSION}.zip"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "scripts": {
     "start": "wp-scripts start",
+    "version:set": "node scripts/set-version.js",
     "start:fast": "cross-env DISABLE_ESLINT_PLUGIN=true wp-scripts start",
     "build": "wp-scripts build",
     "build:dev": "cross-env NODE_ENV=development wp-scripts build",

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,14 @@ Yes to both. All blocks work in the Site Editor, templates, and template parts. 
 
 [Documentation](https://designsetgoblocks.com/docs/), the [support forum](https://wordpress.org/support/plugin/designsetgo/), or [GitHub](https://github.com/jnealey-godaddy/designsetgo).
 
+= Can I test beta / release-candidate versions? =
+
+Yes. Ahead of a stable release we publish beta and release-candidate builds to WordPress.org without pushing them to the normal auto-update channel, so regular installs are never affected. To try one, download the versioned zip and install it over your current copy:
+
+`https://downloads.wordpress.org/plugin/designsetgo.VERSION.zip`
+
+Replace `VERSION` with the pre-release you want, e.g. `2.5.0-beta1` or `2.5.0-rc1`. To return to the stable channel, reinstall the latest stable version the same way (or from the plugin directory). Please report beta feedback on [GitHub](https://github.com/jnealey-godaddy/designsetgo).
+
 == Screenshots ==
 
 1. Container block with responsive grid layout and video background support

--- a/scripts/lib/version.js
+++ b/scripts/lib/version.js
@@ -1,0 +1,175 @@
+/*
+ * Pure release-version logic shared by the release CLIs and the deploy
+ * workflow's CI guard.
+ *
+ * Everything here is a pure string/object transform — no `fs`, no `process`,
+ * no side effects — so it can be unit-tested with inline fixtures (see
+ * tests/unit/release-version.test.js) and reused verbatim by
+ * scripts/set-version.js and scripts/release-meta.js.
+ *
+ * Version grammar (WordPress-core style):
+ *   X.Y.Z            → stable release
+ *   X.Y.Z-beta<N>    → beta pre-release   (e.g. 2.5.0-beta1)
+ *   X.Y.Z-rc<N>      → release candidate  (e.g. 2.5.0-rc1)
+ *
+ * A pre-release is any version containing a `-` suffix. The single most
+ * important rule this module enforces: for a pre-release, the readme.txt
+ * "Stable tag" is LEFT UNTOUCHED so WordPress.org keeps serving the last
+ * stable version to the auto-update channel.
+ */
+
+'use strict';
+
+const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)(?:-(beta|rc)(\d+))?$/;
+
+// Targeted rewrite regexes — each captures (prefix)(value)(suffix?) so we can
+// swap only the value and leave surrounding formatting untouched.
+const PKG_VERSION_RE = /("version"\s*:\s*")([^"]+)(")/;
+const PHP_HEADER_RE = /^(\s*\*\s*Version:\s*)(.+)$/m;
+const PHP_DEFINE_RE = /(define\(\s*'DESIGNSETGO_VERSION',\s*')([^']+)('\s*\))/;
+const README_STABLE_RE = /^(Stable tag:\s*)(.+?)\s*$/im;
+
+/**
+ * Parse and validate a version or git-tag string.
+ *
+ * @param {string} input Version or tag (an optional leading `v` is stripped).
+ * @return {{version: string, isPrerelease: boolean, channel: 'stable'|'beta'|'rc'}} Parsed version metadata.
+ * @throws {Error} When the input is not a valid stable/beta/rc version.
+ */
+function parseVersion(input) {
+	if (typeof input !== 'string') {
+		throw new Error('Version must be a string.');
+	}
+
+	const version = input.trim().replace(/^v/, '');
+	const match = VERSION_RE.exec(version);
+
+	if (!match) {
+		throw new Error(
+			`Invalid version "${input}". Expected X.Y.Z, X.Y.Z-beta<N> or X.Y.Z-rc<N> (e.g. 2.5.0, 2.5.0-beta1, 2.5.0-rc1).`
+		);
+	}
+
+	const channel = match[4] || 'stable';
+
+	return {
+		version,
+		isPrerelease: channel !== 'stable',
+		channel,
+	};
+}
+
+/**
+ * Rewrite the top-level "version" field in package.json text.
+ *
+ * @param {string} text    Raw package.json contents.
+ * @param {string} version New version.
+ * @return {string} Updated contents.
+ */
+function updatePackageJson(text, version) {
+	return text.replace(PKG_VERSION_RE, `$1${version}$3`);
+}
+
+/**
+ * Rewrite both the plugin-header "Version:" line and the
+ * DESIGNSETGO_VERSION define in designsetgo.php text.
+ *
+ * @param {string} text    Raw designsetgo.php contents.
+ * @param {string} version New version.
+ * @return {string} Updated contents.
+ */
+function updatePluginPhp(text, version) {
+	return text
+		.replace(PHP_HEADER_RE, `$1${version}`)
+		.replace(PHP_DEFINE_RE, `$1${version}$3`);
+}
+
+/**
+ * Rewrite the "Stable tag:" line in readme.txt text.
+ *
+ * @param {string} text    Raw readme.txt contents.
+ * @param {string} version New stable tag value.
+ * @return {string} Updated contents.
+ */
+function updateReadmeStableTag(text, version) {
+	return text.replace(README_STABLE_RE, `$1${version}`);
+}
+
+/**
+ * Read the DESIGNSETGO_VERSION define (the canonical runtime version).
+ *
+ * @param {string} text Raw designsetgo.php contents.
+ * @return {string|null} The version, or null when not found.
+ */
+function readPluginPhpVersion(text) {
+	const match = PHP_DEFINE_RE.exec(text);
+	return match ? match[2] : null;
+}
+
+/**
+ * Read the top-level package.json "version".
+ *
+ * @param {string} text Raw package.json contents.
+ * @return {string|null} The version, or null when not found.
+ */
+function readPackageVersion(text) {
+	const match = PKG_VERSION_RE.exec(text);
+	return match ? match[2] : null;
+}
+
+/**
+ * Read the readme.txt "Stable tag" value.
+ *
+ * @param {string} text Raw readme.txt contents.
+ * @return {string|null} The stable tag, or null when not found.
+ */
+function readReadmeStableTag(text) {
+	const match = README_STABLE_RE.exec(text);
+	return match ? match[2].trim() : null;
+}
+
+/**
+ * Compute the new file contents for a version change.
+ *
+ * For a STABLE version all three files are updated. For a PRE-RELEASE the
+ * readme.txt is deliberately left as-is (Stable tag stays at the last stable
+ * release), so the beta/rc never reaches the auto-update channel.
+ *
+ * @param {{pkg: string, php: string, readme: string}} files   Raw file contents.
+ * @param {string}                                     version New version.
+ * @return {{pkg: string, php: string, readme: string, changed: string[]}} New file contents and the list of files that changed.
+ */
+function planFileUpdates(files, version) {
+	const { isPrerelease } = parseVersion(version);
+
+	const pkg = updatePackageJson(files.pkg, version);
+	const php = updatePluginPhp(files.php, version);
+	const readme = isPrerelease
+		? files.readme
+		: updateReadmeStableTag(files.readme, version);
+
+	const changed = [];
+	if (pkg !== files.pkg) {
+		changed.push('package.json');
+	}
+	if (php !== files.php) {
+		changed.push('designsetgo.php');
+	}
+	if (readme !== files.readme) {
+		changed.push('readme.txt');
+	}
+
+	return { pkg, php, readme, changed };
+}
+
+module.exports = {
+	VERSION_RE,
+	parseVersion,
+	updatePackageJson,
+	updatePluginPhp,
+	updateReadmeStableTag,
+	readPluginPhpVersion,
+	readPackageVersion,
+	readReadmeStableTag,
+	planFileUpdates,
+};

--- a/scripts/release-meta.js
+++ b/scripts/release-meta.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/*
+ * Release metadata + CI guard for the deploy workflow.
+ *
+ * Two modes, both driven by scripts/lib/version.js so CI trusts exactly the
+ * same logic the unit tests cover:
+ *
+ *   node scripts/release-meta.js <tag>
+ *     Prints GitHub-Actions outputs for a pushed tag:
+ *       version=2.5.0-beta1
+ *       prerelease=true
+ *       channel=beta
+ *     The workflow appends these to $GITHUB_OUTPUT.
+ *
+ *   node scripts/release-meta.js --validate <tag>
+ *     Fails (non-zero + ::error::) unless the working tree matches the tag:
+ *       - always: DESIGNSETGO_VERSION and package.json "version" == tag version
+ *       - stable tag:      readme.txt "Stable tag" == tag version
+ *       - pre-release tag: readme.txt "Stable tag" != tag version
+ *                          (must still point at the last stable release)
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+	parseVersion,
+	readPluginPhpVersion,
+	readPackageVersion,
+	readReadmeStableTag,
+} = require('./lib/version');
+
+const ROOT = path.resolve(__dirname, '..');
+
+function ghError(message) {
+	// Emits a GitHub Actions error annotation; harmless as plain text locally.
+	process.stdout.write(`::error::${message}\n`);
+}
+
+function readFile(relative) {
+	return fs.readFileSync(path.join(ROOT, relative), 'utf8');
+}
+
+function printOutputs(meta) {
+	process.stdout.write(`version=${meta.version}\n`);
+	process.stdout.write(
+		`prerelease=${meta.isPrerelease ? 'true' : 'false'}\n`
+	);
+	process.stdout.write(`channel=${meta.channel}\n`);
+}
+
+function validate(meta) {
+	const { version, isPrerelease } = meta;
+	const errors = [];
+
+	const phpVersion = readPluginPhpVersion(readFile('designsetgo.php'));
+	const pkgVersion = readPackageVersion(readFile('package.json'));
+	const stableTag = readReadmeStableTag(readFile('readme.txt'));
+
+	if (phpVersion !== version) {
+		errors.push(
+			`designsetgo.php DESIGNSETGO_VERSION is "${phpVersion}" but the tag is "${version}". Run: npm run version:set -- ${version}`
+		);
+	}
+
+	if (pkgVersion !== version) {
+		errors.push(
+			`package.json version is "${pkgVersion}" but the tag is "${version}". Run: npm run version:set -- ${version}`
+		);
+	}
+
+	if (isPrerelease) {
+		if (stableTag === version) {
+			errors.push(
+				`readme.txt "Stable tag" is "${stableTag}", which equals this pre-release. It must stay at the last STABLE version so pre-releases never reach the auto-update channel.`
+			);
+		}
+	} else if (stableTag !== version) {
+		errors.push(
+			`readme.txt "Stable tag" is "${stableTag}" but this stable release is "${version}". Run: npm run version:set -- ${version}`
+		);
+	}
+
+	if (errors.length) {
+		errors.forEach(ghError);
+		process.exit(1);
+	}
+
+	process.stdout.write(
+		`✔ Version metadata is consistent for ${version} (${meta.channel}).\n`
+	);
+}
+
+function main() {
+	const args = process.argv.slice(2);
+	const isValidate = args[0] === '--validate';
+	const tag = isValidate ? args[1] : args[0];
+
+	if (!tag) {
+		ghError(
+			'Missing tag argument. Usage: release-meta.js [--validate] <tag>'
+		);
+		process.exit(1);
+	}
+
+	let meta;
+	try {
+		meta = parseVersion(tag);
+	} catch (error) {
+		ghError(error.message);
+		process.exit(1);
+	}
+
+	if (isValidate) {
+		validate(meta);
+	} else {
+		printOutputs(meta);
+	}
+}
+
+main();

--- a/scripts/set-version.js
+++ b/scripts/set-version.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/*
+ * Sync the plugin version across every file that declares it, in one shot.
+ *
+ * Usage:
+ *   node scripts/set-version.js <version>
+ *   npm run version:set -- <version>
+ *
+ * Examples:
+ *   node scripts/set-version.js 2.5.0          # stable release
+ *   node scripts/set-version.js 2.5.0-beta1    # beta pre-release
+ *   node scripts/set-version.js 2.5.0-rc1      # release candidate
+ *
+ * Files touched:
+ *   - package.json              "version"
+ *   - designsetgo.php           header "Version:" + DESIGNSETGO_VERSION define
+ *   - readme.txt                "Stable tag:"  (STABLE releases only)
+ *
+ * For a pre-release the readme.txt "Stable tag" is intentionally left at the
+ * last stable version so WordPress.org keeps serving stable to auto-update
+ * users. See scripts/lib/version.js for the shared logic.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+	parseVersion,
+	planFileUpdates,
+	readReadmeStableTag,
+} = require('./lib/version');
+
+const ROOT = path.resolve(__dirname, '..');
+const FILES = {
+	pkg: path.join(ROOT, 'package.json'),
+	php: path.join(ROOT, 'designsetgo.php'),
+	readme: path.join(ROOT, 'readme.txt'),
+};
+
+function fail(message) {
+	process.stderr.write(`✖ ${message}\n`);
+	process.exit(1);
+}
+
+function main() {
+	const input = process.argv[2];
+
+	if (!input || input === '--help' || input === '-h') {
+		process.stdout.write(
+			'Usage: node scripts/set-version.js <version>\n' +
+				'  e.g. 2.5.0 | 2.5.0-beta1 | 2.5.0-rc1\n'
+		);
+		process.exit(input ? 0 : 1);
+	}
+
+	let meta;
+	try {
+		meta = parseVersion(input);
+	} catch (error) {
+		fail(error.message);
+	}
+
+	const raw = {
+		pkg: fs.readFileSync(FILES.pkg, 'utf8'),
+		php: fs.readFileSync(FILES.php, 'utf8'),
+		readme: fs.readFileSync(FILES.readme, 'utf8'),
+	};
+
+	const result = planFileUpdates(raw, meta.version);
+
+	fs.writeFileSync(FILES.pkg, result.pkg);
+	fs.writeFileSync(FILES.php, result.php);
+	fs.writeFileSync(FILES.readme, result.readme);
+
+	process.stdout.write(
+		`\n✔ Set version to ${meta.version} (${meta.channel})\n`
+	);
+	result.changed.forEach((file) => {
+		process.stdout.write(`  • updated ${file}\n`);
+	});
+
+	if (meta.isPrerelease) {
+		const stableTag = readReadmeStableTag(result.readme);
+		process.stdout.write(
+			`  • readme.txt "Stable tag" left at ${stableTag} — stable channel unaffected\n`
+		);
+	}
+
+	process.stdout.write(
+		`\nNext:\n` +
+			`  git commit -am "chore: bump version to ${meta.version}"\n` +
+			`  git tag ${meta.version} && git push origin ${meta.version}\n\n`
+	);
+}
+
+main();

--- a/tests/unit/release-version.test.js
+++ b/tests/unit/release-version.test.js
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for scripts/lib/version.js — the shared release-version logic
+ * used by scripts/set-version.js and scripts/release-meta.js (the CI guard).
+ */
+
+const {
+	parseVersion,
+	updatePackageJson,
+	updatePluginPhp,
+	updateReadmeStableTag,
+	readPluginPhpVersion,
+	readPackageVersion,
+	readReadmeStableTag,
+	planFileUpdates,
+} = require('../../scripts/lib/version');
+
+// Minimal fixtures mirroring the real files' relevant lines.
+const PKG = `{
+  "name": "designsetgo",
+  "version": "2.4.0",
+  "description": "Blocks."
+}
+`;
+
+const PHP = `<?php
+/**
+ * Plugin Name:       DesignSetGo
+ * Version:           2.4.0
+ * Requires PHP:      7.4
+ */
+define( 'DESIGNSETGO_VERSION', '2.4.0' );
+define( 'DESIGNSETGO_FILE', __FILE__ );
+`;
+
+const README = `=== DesignSetGo ===
+Requires at least: 6.7
+Tested up to: 7.0
+Stable tag: 2.4.0
+License: GPLv2 or later
+`;
+
+describe('parseVersion', () => {
+	it('parses a stable version', () => {
+		expect(parseVersion('2.5.0')).toEqual({
+			version: '2.5.0',
+			isPrerelease: false,
+			channel: 'stable',
+		});
+	});
+
+	it('parses a beta pre-release', () => {
+		expect(parseVersion('2.5.0-beta1')).toEqual({
+			version: '2.5.0-beta1',
+			isPrerelease: true,
+			channel: 'beta',
+		});
+	});
+
+	it('parses a release candidate', () => {
+		expect(parseVersion('2.5.0-rc1')).toEqual({
+			version: '2.5.0-rc1',
+			isPrerelease: true,
+			channel: 'rc',
+		});
+	});
+
+	it('strips a leading v', () => {
+		expect(parseVersion('v2.5.0-beta2')).toMatchObject({
+			version: '2.5.0-beta2',
+			channel: 'beta',
+		});
+	});
+
+	it.each([
+		'2.5',
+		'2.5.0.1',
+		'2.5.0-alpha1',
+		'2.5.0-beta',
+		'2.5.0-rc',
+		'foo',
+		'',
+	])('throws on malformed input %p', (bad) => {
+		expect(() => parseVersion(bad)).toThrow();
+	});
+
+	it('throws on non-string input', () => {
+		expect(() => parseVersion(250)).toThrow();
+	});
+});
+
+describe('updatePluginPhp', () => {
+	it('updates both the header line and the DESIGNSETGO_VERSION define', () => {
+		const out = updatePluginPhp(PHP, '2.5.0-beta1');
+		expect(out).toContain('* Version:           2.5.0-beta1');
+		expect(out).toContain(
+			"define( 'DESIGNSETGO_VERSION', '2.5.0-beta1' );"
+		);
+		// Unrelated lines/defines untouched.
+		expect(out).toContain('* Requires PHP:      7.4');
+		expect(out).toContain("define( 'DESIGNSETGO_FILE', __FILE__ );");
+	});
+
+	it('round-trips with readPluginPhpVersion', () => {
+		expect(readPluginPhpVersion(updatePluginPhp(PHP, '3.0.0'))).toBe(
+			'3.0.0'
+		);
+	});
+});
+
+describe('updateReadmeStableTag', () => {
+	it('rewrites the Stable tag line', () => {
+		const out = updateReadmeStableTag(README, '2.5.0');
+		expect(out).toContain('Stable tag: 2.5.0');
+		expect(out).toContain('Tested up to: 7.0');
+	});
+
+	it('is case-insensitive on the label', () => {
+		const lower = README.replace('Stable tag:', 'Stable Tag:');
+		expect(updateReadmeStableTag(lower, '9.9.9')).toContain('9.9.9');
+	});
+
+	it('round-trips with readReadmeStableTag', () => {
+		expect(
+			readReadmeStableTag(updateReadmeStableTag(README, '2.6.0'))
+		).toBe('2.6.0');
+	});
+});
+
+describe('updatePackageJson', () => {
+	it('changes only the version and preserves other keys/formatting', () => {
+		const out = updatePackageJson(PKG, '2.5.0-rc1');
+		expect(readPackageVersion(out)).toBe('2.5.0-rc1');
+		expect(out).toContain('"name": "designsetgo"');
+		expect(out).toContain('"description": "Blocks."');
+	});
+});
+
+describe('planFileUpdates', () => {
+	const files = { pkg: PKG, php: PHP, readme: README };
+
+	it('updates all three files for a stable version', () => {
+		const result = planFileUpdates(files, '2.5.0');
+		expect(result.changed.sort()).toEqual(
+			['designsetgo.php', 'package.json', 'readme.txt'].sort()
+		);
+		expect(readReadmeStableTag(result.readme)).toBe('2.5.0');
+		expect(readPluginPhpVersion(result.php)).toBe('2.5.0');
+		expect(readPackageVersion(result.pkg)).toBe('2.5.0');
+	});
+
+	it('leaves readme.txt untouched for a pre-release (the footgun guard)', () => {
+		const result = planFileUpdates(files, '2.5.0-beta1');
+		expect(result.changed).not.toContain('readme.txt');
+		expect(result.readme).toBe(README);
+		expect(readReadmeStableTag(result.readme)).toBe('2.4.0');
+		// php + package.json still bumped to the beta.
+		expect(readPluginPhpVersion(result.php)).toBe('2.5.0-beta1');
+		expect(readPackageVersion(result.pkg)).toBe('2.5.0-beta1');
+	});
+
+	it('throws on an invalid version', () => {
+		expect(() => planFileUpdates(files, '2.5')).toThrow();
+	});
+});


### PR DESCRIPTION
## What

Extends the tag-triggered `.github/workflows/deploy.yml` so **beta and release-candidate builds ship to the WordPress.org repo** without reaching the stable auto-update channel — the plugin analog of how WordPress core offers beta/RC.

Naming (WP-core style): `X.Y.Z` = stable, `X.Y.Z-beta<N>` / `X.Y.Z-rc<N>` = pre-release.

## How it stays safe

WordPress.org serves whatever `trunk/readme.txt` **"Stable tag"** names; every other committed SVN tag still gets an auto-built zip at `downloads.wordpress.org/plugin/designsetgo.<version>.zip`. So:

- **Stable tag** → existing `10up/action-wordpress-plugin-deploy` (writes trunk + tag + bumps Stable tag → all users update).
- **Pre-release tag** → a **custom tag-only SVN step**: commits only to `/tags/<version>`, never touches `/trunk`. Stable users are provably unaffected. (No off-the-shelf action does tag-only — the 10up maintainers closed the "trunk-only" PR in Dec 2025.)

The **footgun guard**: a pre-release must keep readme "Stable tag" pinned to the last stable version. `scripts/set-version.js` enforces this when bumping, and `scripts/release-meta.js --validate` fails the deploy if the tree and tag disagree.

## Changes

- **`.github/workflows/deploy.yml`** — branch on tag type; adds `workflow_dispatch` + `dry_run`; bumps Node 20 → 24; documents the model in a header comment.
- **`scripts/lib/version.js`** — pure, unit-tested version logic shared by the CLIs and the CI guard.
- **`scripts/set-version.js`** (`npm run version:set -- <version>`) — syncs all four version sites in one shot.
- **`scripts/release-meta.js`** — emits workflow outputs; `--validate` is the CI guard.
- **`tests/unit/release-version.test.js`** — 21 tests over the shared logic (incl. the pre-release readme guard).
- **`readme.txt`** — beta-testing FAQ with the tester zip-URL pattern.
- **`.distignore`** — stop shipping dev-only `/scripts` to end users (also covers the pre-existing `patch-wp-env-composer-audit.js` leak).

## Testing

- `npm run test:unit` → 21/21 pass.
- Ran the CLIs against the real tree: pre-release leaves `readme.txt` Stable tag at `2.4.0` while bumping `package.json` + `designsetgo.php`; guard passes for a consistent pre-release and fails (non-zero, `::error::`) on mismatch. Tree reset to `2.4.0` afterward.
- `wp-scripts lint-js` clean on all new files.

## Release flow (for reviewers)

```
npm run version:set -- 2.5.0-beta1   # bumps php+pkg, leaves Stable tag at last stable
git commit -am "chore: bump to 2.5.0-beta1" && git tag 2.5.0-beta1 && git push origin 2.5.0-beta1
# → deploys to /tags/2.5.0-beta1 only; testers grab designsetgo.2.5.0-beta1.zip
npm run version:set -- 2.5.0         # bumps all four incl. Stable tag
git commit -am "chore: 2.5.0" && git tag 2.5.0 && git push origin 2.5.0
# → normal stable release to all users
```

_(Supersedes #480, which auto-closed when its branch was renamed.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)