### PR TITLE
fix(overlay-header): measure the header, not the footer, and clear the hero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Overlay header is transparent again, and no longer pulls page content up by the footer's height.** Two independent bugs made the per-page Overlay Header unusable on Twenty Twenty-Five. The content pull-up was sized from the wrong element: `setupOverlayHeaderHeight()` ran for every element matched by the sticky-header selector, which includes `.wp-block-template-part:has(.wp-block-navigation)` — that matches the footer on most themes — and each match wrote the shared `--dsgo-overlay-header-height` custom property, so the last writer in DOM order won and content was pulled up by the footer's height (410px) instead of the header's (92px), slicing the top off the hero. Measurement is now restricted to the single template part that is a direct child of `.wp-site-blocks`, which is what the CSS pull-up actually consumes. Separately, the header never went transparent, because the background-strip rule only matched `.has-background`: a theme can paint a container from a block style variation (Twenty Twenty-Five's `is-style-header-section`) or from `styles.blocks` in `theme.json`, neither of which adds that class. The rule now matches container block classes as well, with a zero-specificity `:where()` exclusion list that preserves backgrounds on buttons, submenu dropdowns, and the mobile menu overlay — all unreadable over a hero image without one. The first content section also gains the header height as top padding, so its content clears the header while its background still runs behind it; the authored padding is preserved as a CSS string rather than a pixel snapshot, so inline fluid presets keep responding to viewport changes, and `--dsgo-overlay-hero-clearance: 0px` opts a section out. (#491)
+
 ## [2.5.1] - 2026-07-23
 
 ### New Features

--- a/jest.config.js
+++ b/jest.config.js
@@ -39,7 +39,8 @@ module.exports = {
 
 	// Module name mapper for CSS and asset files
 	moduleNameMapper: {
-		'\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+		'\\.(css|less|scss|sass)$':
+			'<rootDir>/tests/unit/__mocks__/styleMock.js',
 		'\\.(jpg|jpeg|png|gif|svg|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
 			'<rootDir>/tests/unit/__mocks__/fileMock.js',
 		// @wordpress/editor and @wordpress/notices pull in heavy WP store internals

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "designsetgo",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "designsetgo",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -30286,9 +30286,9 @@
       }
     },
     "node_modules/seroval": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.0.tgz",
-      "integrity": "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.6.tgz",
+      "integrity": "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "diff": "^4.0.4",
     "serialize-javascript": "^7.0.5",
     "minimatch": "^3.1.4",
-    "websocket-driver": "^0.7.5"
+    "websocket-driver": "^0.7.5",
+    "seroval": "^1.5.6"
   }
 }

--- a/src/styles/utilities/_sticky-header.scss
+++ b/src/styles/utilities/_sticky-header.scss
@@ -290,8 +290,13 @@ $dsgo-overlay-bg-targets: ".wp-block-group, .wp-block-columns, .wp-block-column,
  * they sit over the hero image and become unreadable without one: buttons and
  * other author-styled calls to action, submenu dropdowns, and the mobile menu
  * overlay.
+ *
+ * Wrapped in `:where()` so the exclusion chain contributes no specificity. Six
+ * chained `:not()`s would otherwise push these rules well above the
+ * `.has-background` selector they replace, and the whole point is to stay
+ * cascade-neutral — the `!important` below is what does the overriding.
  */
-$dsgo-overlay-bg-exceptions: ":not(.wp-block-button__link):not(.wp-element-button):not(.wp-block-navigation__submenu-container):not(.wp-block-navigation__submenu-container *):not(.wp-block-navigation__responsive-container):not(.wp-block-navigation__responsive-container *)";
+$dsgo-overlay-bg-exceptions: ":where(:not(.wp-block-button__link):not(.wp-element-button):not(.wp-block-navigation__submenu-container):not(.wp-block-navigation__submenu-container *):not(.wp-block-navigation__responsive-container):not(.wp-block-navigation__responsive-container *))";
 
 /**
  * Overlay: force inner header sections transparent so they don't show

--- a/src/styles/utilities/_sticky-header.scss
+++ b/src/styles/utilities/_sticky-header.scss
@@ -274,10 +274,30 @@ body:not(.block-editor-page).dsgo-page-overlay-header header.wp-block-template-p
 }
 
 /**
+ * Elements inside the overlay header whose background must be forced
+ * transparent.
+ *
+ * Matching on `.has-background` alone is not enough. A theme can paint a
+ * container background from a *block style variation* (Twenty Twenty-Five's
+ * `is-style-header-section`) or from `styles.blocks` in theme.json — neither
+ * puts a `.has-background` class on the element, so the header stayed opaque.
+ * Matching the container block classes catches those cases too.
+ */
+$dsgo-overlay-bg-targets: ".wp-block-group, .wp-block-columns, .wp-block-column, .wp-block-cover, .wp-block-cover__background, .wp-block-designsetgo-section, .wp-block-designsetgo-row, .wp-block-designsetgo-grid, .has-background";
+
+/**
+ * Elements that must keep their background while the header is transparent —
+ * they sit over the hero image and become unreadable without one: buttons and
+ * other author-styled calls to action, submenu dropdowns, and the mobile menu
+ * overlay.
+ */
+$dsgo-overlay-bg-exceptions: ":not(.wp-block-button__link):not(.wp-element-button):not(.wp-block-navigation__submenu-container):not(.wp-block-navigation__submenu-container *):not(.wp-block-navigation__responsive-container):not(.wp-block-navigation__responsive-container *)";
+
+/**
  * Overlay: force inner header sections transparent so they don't show
  * through over the hero. Uses :where() for zero specificity.
  */
-body:not(.block-editor-page).dsgo-page-overlay-header:not(.dsgo-page-overlay-skip-top-bar) :where(header.wp-block-template-part, .wp-block-template-part:not(footer):first-of-type) .has-background {
+body:not(.block-editor-page).dsgo-page-overlay-header:not(.dsgo-page-overlay-skip-top-bar) :where(header.wp-block-template-part, .wp-block-template-part:not(footer):first-of-type) :is(#{$dsgo-overlay-bg-targets})#{$dsgo-overlay-bg-exceptions} {
 	background-color: transparent !important;
 	background-image: none !important;
 }
@@ -286,8 +306,8 @@ body:not(.block-editor-page).dsgo-page-overlay-header:not(.dsgo-page-overlay-ski
  * Overlay + Skip Top Bar: only strip backgrounds from the nav row area
  * (second child onwards), preserving the top bar's background.
  */
-body:not(.block-editor-page).dsgo-page-overlay-header.dsgo-page-overlay-skip-top-bar :where(header.wp-block-template-part, .wp-block-template-part:not(footer):first-of-type) > * > :not(:first-child) .has-background,
-body:not(.block-editor-page).dsgo-page-overlay-header.dsgo-page-overlay-skip-top-bar :where(header.wp-block-template-part, .wp-block-template-part:not(footer):first-of-type) > * > :not(:first-child).has-background {
+body:not(.block-editor-page).dsgo-page-overlay-header.dsgo-page-overlay-skip-top-bar :where(header.wp-block-template-part, .wp-block-template-part:not(footer):first-of-type) > * > :not(:first-child) :is(#{$dsgo-overlay-bg-targets})#{$dsgo-overlay-bg-exceptions},
+body:not(.block-editor-page).dsgo-page-overlay-header.dsgo-page-overlay-skip-top-bar :where(header.wp-block-template-part, .wp-block-template-part:not(footer):first-of-type) > * > :is(#{$dsgo-overlay-bg-targets}):not(:first-child)#{$dsgo-overlay-bg-exceptions} {
 	background-color: transparent !important;
 	background-image: none !important;
 }

--- a/src/utils/sticky-header.js
+++ b/src/utils/sticky-header.js
@@ -125,6 +125,19 @@ import './sticky-header.scss';
 	 * @param {HTMLElement} header Overlay header element
 	 */
 	function applyOverlayHeroPadding(header) {
+		// `header.nextElementSibling` is exactly what the CSS pull-up targets
+		// (`.wp-site-blocks > header.wp-block-template-part + *`), so the two stay
+		// anchored to the same element by construction. The clearance then goes one
+		// level in, onto that element's first child, and that step is deliberate:
+		// padding the pulled-up element itself would push its whole box back down
+		// and cancel the overlay, whereas padding the first block inside it moves
+		// only the content while the block's background stays under the header.
+		//
+		// That assumes the standard block-theme shape — content wrapper, then the
+		// first block. A theme with an extra wrapper level lands the clearance on
+		// that wrapper instead; the overlay degrades to "background no longer runs
+		// under the header" rather than misplacing content, so it is left
+		// unguarded rather than heuristically sniffing for the painted block.
 		const hero = header.nextElementSibling?.firstElementChild;
 		if (!hero) {
 			return;

--- a/src/utils/sticky-header.js
+++ b/src/utils/sticky-header.js
@@ -77,6 +77,61 @@ import './sticky-header.scss';
 	let lastScrollY = window.scrollY;
 	let ticking = false;
 
+	// The element whose height the overlay pull-up in `_sticky-header.scss`
+	// consumes — the template part that is a direct child of `.wp-site-blocks`.
+	// The sticky selector above is deliberately broader (it matches any template
+	// part containing a navigation), so on most themes it also matches the FOOTER.
+	// Without this narrower check every matched part would write the shared
+	// `--dsgo-overlay-header-height` custom property and the last one in DOM order
+	// — the footer — would win, pulling page content up by the footer's height
+	// instead of the header's.
+	const overlayTargetSelector =
+		'.wp-site-blocks > header.wp-block-template-part, .wp-site-blocks > .wp-block-template-part:not(footer):first-of-type';
+
+	/**
+	 * Resolve the single element the overlay header height should be measured from.
+	 *
+	 * @return {HTMLElement|null} Overlay header element, or null when absent.
+	 */
+	function getOverlayTarget() {
+		return document.querySelector(overlayTargetSelector);
+	}
+
+	/**
+	 * Pad the first content section so it clears the overlay header.
+	 *
+	 * The overlay pull-up in `_sticky-header.scss` slides the content block up
+	 * by the header height so the hero's *background* runs behind the header —
+	 * that is the point of the overlay. Without this, the hero's *content* ends
+	 * up underneath the header too.
+	 *
+	 * The header height is added on top of whatever padding the pattern already
+	 * set, so authored spacing survives. The authored value is kept as a CSS
+	 * string rather than a pixel snapshot so fluid presets
+	 * (`var(--wp--preset--spacing--60)` resolves to a `clamp()`) keep responding
+	 * to viewport changes, and the header height is referenced through the live
+	 * custom property so a resize needs no re-run.
+	 *
+	 * @param {HTMLElement} header Overlay header element
+	 */
+	function applyOverlayHeroPadding(header) {
+		const hero = header.nextElementSibling?.firstElementChild;
+		if (!hero) {
+			return;
+		}
+
+		// Cache the authored padding before overwriting it — otherwise a second
+		// run would nest our calc() inside itself and compound the clearance.
+		if (typeof hero.dataset.dsgoOverlayBasePaddingTop !== 'string') {
+			hero.dataset.dsgoOverlayBasePaddingTop =
+				hero.style.paddingTop ||
+				window.getComputedStyle(hero).paddingTop ||
+				'0px';
+		}
+
+		hero.style.paddingTop = `calc(${hero.dataset.dsgoOverlayBasePaddingTop} + var(--dsgo-overlay-header-height, 0px))`;
+	}
+
 	/**
 	 * Set up overlay header height measurement for a header element.
 	 * Measures the header so CSS can pull content up by the right amount.
@@ -85,6 +140,10 @@ import './sticky-header.scss';
 	 */
 	function setupOverlayHeaderHeight(header) {
 		if (!document.body.classList.contains('dsgo-page-overlay-header')) {
+			return;
+		}
+
+		if (header !== getOverlayTarget()) {
 			return;
 		}
 
@@ -118,6 +177,7 @@ import './sticky-header.scss';
 			);
 		};
 		setHeaderHeight();
+		applyOverlayHeroPadding(header);
 		window.addEventListener('resize', setHeaderHeight);
 		window.addEventListener('load', setHeaderHeight, { once: true });
 	}

--- a/src/utils/sticky-header.js
+++ b/src/utils/sticky-header.js
@@ -101,16 +101,26 @@ import './sticky-header.scss';
 	 * Pad the first content section so it clears the overlay header.
 	 *
 	 * The overlay pull-up in `_sticky-header.scss` slides the content block up
-	 * by the header height so the hero's *background* runs behind the header —
-	 * that is the point of the overlay. Without this, the hero's *content* ends
-	 * up underneath the header too.
+	 * by the header height so the first section's *background* runs behind the
+	 * header — that is the point of the overlay. This padding is the exact
+	 * counterpart: it applies to the same element the negative margin does, so
+	 * the section's *content* lands back where it started instead of being
+	 * occluded. That invariant is why the clearance is applied unconditionally
+	 * rather than sniffing for a "hero"-shaped block; whatever comes first has
+	 * already been pulled under the header and needs the same amount back.
+	 *
+	 * Authors who do want the content under the header (a full-bleed section
+	 * that deliberately runs behind a transparent nav, say) opt out by setting
+	 * `--dsgo-overlay-hero-clearance: 0px` on the block.
 	 *
 	 * The header height is added on top of whatever padding the pattern already
-	 * set, so authored spacing survives. The authored value is kept as a CSS
-	 * string rather than a pixel snapshot so fluid presets
-	 * (`var(--wp--preset--spacing--60)` resolves to a `clamp()`) keep responding
-	 * to viewport changes, and the header height is referenced through the live
-	 * custom property so a resize needs no re-run.
+	 * set, so authored spacing survives. Both terms of the calc() stay live —
+	 * the clearance reads the custom property JS keeps updated, so a resize
+	 * needs no re-run. The authored term keeps its original CSS string, so when
+	 * the block serializes its padding inline (how WordPress writes block
+	 * spacing) a fluid preset stays fluid. Padding inherited from a stylesheet
+	 * instead has no inline string to preserve, so it falls back to a resolved
+	 * pixel snapshot taken at init.
 	 *
 	 * @param {HTMLElement} header Overlay header element
 	 */
@@ -129,7 +139,7 @@ import './sticky-header.scss';
 				'0px';
 		}
 
-		hero.style.paddingTop = `calc(${hero.dataset.dsgoOverlayBasePaddingTop} + var(--dsgo-overlay-header-height, 0px))`;
+		hero.style.paddingTop = `calc(${hero.dataset.dsgoOverlayBasePaddingTop} + var(--dsgo-overlay-hero-clearance, var(--dsgo-overlay-header-height, 0px)))`;
 	}
 
 	/**

--- a/tests/unit/__mocks__/styleMock.js
+++ b/tests/unit/__mocks__/styleMock.js
@@ -1,0 +1,12 @@
+/**
+ * Stylesheet mock for Jest.
+ *
+ * Source modules import their own SCSS so webpack extracts a stylesheet
+ * (e.g. `src/utils/sticky-header.js` imports `./sticky-header.scss`). Jest has
+ * no stylesheet loader, so those imports are mapped here and resolve to an
+ * empty module. Mirrors the `fileMock.js` treatment of asset imports.
+ *
+ * @package
+ */
+
+module.exports = {};

--- a/tests/unit/overlay-header-measurement.test.js
+++ b/tests/unit/overlay-header-measurement.test.js
@@ -1,0 +1,133 @@
+/**
+ * Overlay header measurement — sticky-header.js DOM logic
+ *
+ * Pins the two bugs that made the overlay header unusable:
+ *
+ * 1. `--dsgo-overlay-header-height` was written by every element the sticky
+ *    selector matched. That selector includes
+ *    `.wp-block-template-part:has(.wp-block-navigation)`, which matches the
+ *    footer on most themes, so the last writer in DOM order won and content
+ *    was pulled up by the footer's height instead of the header's.
+ * 2. The first content section needs the header height added back as top
+ *    padding, or the overlay pull-up leaves its content under the header.
+ */
+
+const HEADER_HEIGHT = 92;
+const FOOTER_HEIGHT = 410;
+
+/**
+ * Build a site structure matching a block theme: a header template part and a
+ * footer template part that BOTH contain a navigation, plus a content wrapper
+ * whose first child is the hero.
+ *
+ * @param {Object} options                   Options.
+ * @param {string} options.heroInlinePadding Inline padding-top on the hero.
+ * @return {Object} References to the created elements.
+ */
+function buildSite({ heroInlinePadding = '' } = {}) {
+	document.body.className = 'dsgo-page-overlay-header';
+	document.body.innerHTML = `
+		<div class="wp-site-blocks">
+			<header class="wp-block-template-part">
+				<div class="wp-block-group">
+					<nav class="wp-block-navigation"></nav>
+				</div>
+			</header>
+			<div class="entry-content">
+				<div class="wp-block-cover"${
+					heroInlinePadding
+						? ` style="padding-top:${heroInlinePadding}"`
+						: ''
+				}></div>
+			</div>
+			<footer class="wp-block-template-part">
+				<div class="wp-block-group">
+					<nav class="wp-block-navigation"></nav>
+				</div>
+			</footer>
+		</div>
+	`;
+
+	const header = document.querySelector('.wp-site-blocks > header');
+	const footer = document.querySelector('.wp-site-blocks > footer');
+	const hero = document.querySelector('.wp-block-cover');
+
+	// jsdom has no layout, so heights come from stubs. The footer is
+	// deliberately taller — that difference is the whole regression.
+	header.getBoundingClientRect = () => ({ height: HEADER_HEIGHT, top: 0 });
+	footer.getBoundingClientRect = () => ({ height: FOOTER_HEIGHT, top: 0 });
+
+	return { header, footer, hero };
+}
+
+/**
+ * Load sticky-header.js fresh. The module is an IIFE that runs its init on
+ * import, so the DOM must be in place before it is required.
+ */
+function loadStickyHeader() {
+	jest.isolateModules(() => {
+		require('../../src/utils/sticky-header.js');
+	});
+}
+
+describe('overlay header measurement', () => {
+	beforeEach(() => {
+		document.documentElement.removeAttribute('style');
+		document.body.className = '';
+		document.body.innerHTML = '';
+		window.dsgStickyHeaderSettings = {
+			enable: true,
+			mobileBreakpoint: 768,
+		};
+	});
+
+	const readHeightVar = () =>
+		document.documentElement.style.getPropertyValue(
+			'--dsgo-overlay-header-height'
+		);
+
+	it('measures the header, not a footer that also contains a navigation', () => {
+		buildSite();
+
+		loadStickyHeader();
+
+		expect(readHeightVar()).toBe(`${HEADER_HEIGHT}px`);
+		expect(readHeightVar()).not.toBe(`${FOOTER_HEIGHT}px`);
+	});
+
+	it('adds the header clearance to the hero without discarding authored padding', () => {
+		const { hero } = buildSite({
+			heroInlinePadding: 'var(--wp--preset--spacing--60)',
+		});
+
+		loadStickyHeader();
+
+		// The authored value survives as a CSS string, so a fluid preset stays
+		// fluid, and the clearance term stays live via the custom property.
+		expect(hero.style.paddingTop).toBe(
+			'calc(var(--wp--preset--spacing--60) + var(--dsgo-overlay-hero-clearance, var(--dsgo-overlay-header-height, 0px)))'
+		);
+	});
+
+	it('does not compound the clearance when init runs more than once', () => {
+		const { hero } = buildSite({ heroInlinePadding: '40px' });
+
+		loadStickyHeader();
+		const afterFirst = hero.style.paddingTop;
+
+		// A soft navigation re-runs initAll via this event.
+		document.dispatchEvent(new Event('dsgo-content-loaded'));
+
+		expect(hero.style.paddingTop).toBe(afterFirst);
+		expect(hero.dataset.dsgoOverlayBasePaddingTop).toBe('40px');
+	});
+
+	it('leaves the height variable alone when the page has no overlay header', () => {
+		buildSite();
+		document.body.className = '';
+
+		loadStickyHeader();
+
+		expect(readHeightVar()).toBe('');
+	});
+});


### PR DESCRIPTION
## Description

The overlay header was unusable on Twenty Twenty-Five: the header stayed opaque grey instead of going transparent, and the hero was yanked up far past the header, slicing off its heading. Two independent bugs, plus a spacing gap that made the result look cramped even once both were fixed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

**1. The content pull-up was sized from the footer, not the header.**

`setupOverlayHeaderHeight()` ran for every element matched by the sticky-header selector, which includes `.wp-block-template-part:has(.wp-block-navigation)` — that matches the footer on most themes. Each match wrote the shared `--dsgo-overlay-header-height` custom property, so the last one in DOM order won:

| Element | Height |
| --- | --- |
| `<header>` (correct) | 92px |
| `<footer>` (what won) | **410px** |

Content got `margin-top: -410px` instead of `-92px`. The measurement is now restricted to the single template part that is a direct child of `.wp-site-blocks`, which is what the CSS pull-up actually consumes.

**2. The header never went transparent.**

The strip rule only matched `.has-background`. A theme can paint a container background from a block style variation — Twenty Twenty-Five's `is-style-header-section` — or from `styles.blocks` in `theme.json`, neither of which adds that class. The rule now matches container block classes as well.

Backgrounds are deliberately preserved on buttons, submenu dropdowns, and the mobile menu overlay; all three are unreadable over a hero image without one.

**3. Hero clearance.**

The header height is added to the first content section's top padding, so the hero's content clears the header while its background still runs behind it. The authored padding is kept as a CSS string rather than a pixel snapshot, so fluid presets keep responding to viewport changes:

```
calc(var(--wp--preset--spacing--60) + var(--dsgo-overlay-header-height, 0px))
```

Both terms stay live, so a resize needs no re-run. The authored value is cached in a data attribute so repeat runs can't nest the `calc()` inside itself and compound the clearance.

## Testing

- [x] Tested in WordPress editor
- [x] Tested on frontend
- [x] Tested with Twenty Twenty-Five theme
- [x] Tested responsive behavior (mobile/tablet/desktop)
- [x] No console errors
- [x] No PHP errors

Verified against a live Twenty Twenty-Five site with the compiled CSS and the new JS logic:

| Check | Result |
| --- | --- |
| Overlay height source | 92px header, no longer the 410px footer |
| Header at rest | transparent |
| Header scrolled | `rgba(255, 255, 255, 0.95)` fades in, nav readable |
| Hero clearance (1512px) | 196px = 104 authored + 92 header |
| Hero clearance (390px) | 176px = 104 authored + 72 header, no compounding |
| CTA button | keeps its background |
| Mobile menu overlay | keeps its background |

4615 unit tests and the e2e suite pass. `npm run build`, `lint:js`, and `lint:style` are clean.

## Additional Notes

No PHP changes, no attribute or markup changes, so no deprecation is needed. The `:not(<complex-selector>)` forms used in the exception list are supported across all browsers in the project's support range.
