### PR TITLE
fix(forms): localize form script regardless of where the form renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Forms outside post content — a newsletter signup in the footer, most commonly — no longer fail every submission with "designsetgoForm is not defined."** The script that carries the form's REST URL and nonces was localized behind a `has_block( 'designsetgo/form-builder' )` guard, and that check only inspects the current post's content. A form living in a template part, a synced pattern, a block widget, or anything rendered through `do_blocks()` never matched it, so the guard returned early and the payload was never attached — while the block itself still rendered and WordPress still enqueued its `viewScript`. The form therefore looked completely fine right up until someone pressed Submit, at which point `view.js` hit an undefined `designsetgoForm` and the submission died client-side. The guard is removed rather than taught to scan template parts, which would still have missed synced patterns, widgets and `do_blocks()` while adding per-request cost. Removing it is free: `wp_localize_script()` only attaches data to a *registered* handle, and that data is printed only when the script is actually enqueued — which happens at block render time — so a page with no form still emits nothing, leaking neither nonce nor payload. (#496)
+
 ## [2.6.0] - 2026-07-29
 
 ### New Features

--- a/includes/blocks/forms/class-form-handler.php
+++ b/includes/blocks/forms/class-form-handler.php
@@ -706,14 +706,20 @@ class Form_Handler {
 	 * Localize script with nonce and REST URL.
 	 */
 	public function localize_form_script() {
-		// Only enqueue if form block is present on the page.
-		if ( ! has_block( 'designsetgo/form-builder' ) ) {
-			return;
-		}
-
-		// Get the form-builder view script handle.
-		$asset_file = include DESIGNSETGO_PATH . 'build/blocks/form-builder/view.asset.php';
-		$handle     = 'designsetgo-form-builder-view-script';
+		// Deliberately unconditional. This used to be guarded by
+		// has_block( 'designsetgo/form-builder' ), which only inspects the
+		// current post's content — so a form living in a template part
+		// (a newsletter signup in the footer), a synced pattern, a block
+		// widget, or anything rendered via do_blocks() never matched. The
+		// block still rendered and WordPress still enqueued its viewScript,
+		// so view.js ran with designsetgoForm undefined and every submission
+		// died on a ReferenceError.
+		//
+		// No guard is needed: wp_localize_script() only attaches data to a
+		// registered handle. WordPress enqueues the block's viewScript at
+		// render time, and the data is printed only if that happens — on a
+		// page with no form, this outputs nothing.
+		$handle = 'designsetgo-form-builder-view-script';
 
 		// Localize with nonce and REST URL.
 		wp_localize_script(

--- a/tests/phpunit/form-script-localize-test.php
+++ b/tests/phpunit/form-script-localize-test.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Tests that the form-builder view script is localized wherever the form renders.
+ *
+ * `Form_Handler::localize_form_script()` used to bail early behind
+ * `has_block( 'designsetgo/form-builder' )`, which only inspects the CURRENT
+ * POST'S CONTENT. A form living in a template part (a newsletter signup in the
+ * footer), a synced pattern, a block widget, or anything rendered through
+ * `do_blocks()` never matched that guard. The block still rendered and
+ * WordPress still enqueued its `viewScript`, so `view.js` ran with
+ * `designsetgoForm` undefined and every submission died on a ReferenceError.
+ *
+ * The guard was removed rather than taught about template parts: scanning
+ * template-part content would still miss synced patterns, widgets and
+ * `do_blocks()`. No guard is needed because `wp_localize_script()` only
+ * attaches data to a REGISTERED handle — the payload is printed only if that
+ * script is actually enqueued, which happens at block render time.
+ *
+ * These tests pin both halves of that reasoning so the guard cannot be
+ * reintroduced as an "optimization" without CI failing.
+ *
+ * @package DesignSetGo
+ */
+
+namespace DesignSetGo\Tests;
+
+use WP_UnitTestCase;
+use DesignSetGo\Blocks\Form_Handler;
+
+/**
+ * Form Script Localization Test Case
+ */
+class Test_Form_Script_Localize extends WP_UnitTestCase {
+
+	/**
+	 * The handle WordPress generates for the block's viewScript.
+	 *
+	 * Derived from `designsetgo/form-builder` + `viewScript` in block.json,
+	 * via WP core's generate_block_asset_handle().
+	 */
+	const HANDLE = 'designsetgo-form-builder-view-script';
+
+	/**
+	 * Form handler instance.
+	 *
+	 * @var Form_Handler
+	 */
+	private $handler;
+
+	/**
+	 * Whether this test registered a stand-in for the viewScript handle.
+	 *
+	 * @var bool
+	 */
+	private $registered_stub = false;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->handler = new Form_Handler();
+
+		// The real handle is registered by register_block_type() from
+		// build/blocks/form-builder/block.json on `init`. Stand one in when the
+		// build artifacts are absent, so these tests exercise the localization
+		// behaviour rather than whether someone ran `npm run build`.
+		if ( ! wp_script_is( self::HANDLE, 'registered' ) ) {
+			wp_register_script( self::HANDLE, 'https://example.org/view.js', array(), '1.0.0', true );
+			$this->registered_stub = true;
+		}
+
+		$this->reset_localized_data();
+		wp_dequeue_script( self::HANDLE );
+	}
+
+	/**
+	 * Reset scripts state after each test.
+	 */
+	public function tear_down() {
+		$this->reset_localized_data();
+		wp_dequeue_script( self::HANDLE );
+
+		if ( $this->registered_stub ) {
+			wp_deregister_script( self::HANDLE );
+			$this->registered_stub = false;
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Drop any previously localized payload from the handle.
+	 *
+	 * Calling wp_localize_script() APPENDS rather than replaces, and
+	 * $wp_scripts outlives an individual test, so without this a later
+	 * assertion could pass on stale data.
+	 */
+	private function reset_localized_data() {
+		$scripts = wp_scripts();
+
+		if ( isset( $scripts->registered[ self::HANDLE ] ) ) {
+			unset( $scripts->registered[ self::HANDLE ]->extra['data'] );
+		}
+	}
+
+	/**
+	 * Make $page_id the queried post so has_block() evaluates its content.
+	 *
+	 * The has_block() helper falls back to get_post(), which reads
+	 * $GLOBALS['post'] — so the global has to be set, or the guard would read
+	 * false for the wrong reason and the regression test would pass trivially.
+	 *
+	 * @param int $page_id Page to query.
+	 */
+	private function go_to_page( $page_id ) {
+		$this->go_to( get_permalink( $page_id ) );
+
+		$GLOBALS['post'] = get_post( $page_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Emulating the main query for has_block().
+		setup_postdata( $GLOBALS['post'] );
+	}
+
+	/**
+	 * Create a page whose content does NOT contain the form block.
+	 *
+	 * @return int Page ID.
+	 */
+	private function create_page_without_form() {
+		return self::factory()->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_content' => '<!-- wp:paragraph --><p>No form in this page body.</p><!-- /wp:paragraph -->',
+			)
+		);
+	}
+
+	/**
+	 * THE REGRESSION TEST: a form in a template part, not in post content.
+	 *
+	 * Reproduces the reported failure exactly — a footer newsletter signup on a
+	 * page whose own content has no form block. Reinstating the has_block()
+	 * guard makes this fail, because the guard reads the post content only.
+	 */
+	public function test_localizes_when_queried_post_has_no_form_block() {
+		$this->go_to_page( $this->create_page_without_form() );
+
+		// Precondition: this is the exact state the old guard bailed on. If
+		// this ever returns true the fixture is wrong and the test below
+		// would pass for the wrong reason.
+		$this->assertFalse(
+			has_block( 'designsetgo/form-builder' ),
+			'Fixture invalid: the queried post must NOT contain the form block.'
+		);
+
+		$this->handler->localize_form_script();
+
+		$data = wp_scripts()->get_data( self::HANDLE, 'data' );
+
+		$this->assertIsString(
+			$data,
+			'The form script must be localized even when the form lives outside post content (e.g. a footer template part).'
+		);
+		$this->assertStringContainsString(
+			'designsetgoForm',
+			$data,
+			'view.js reads window.designsetgoForm; without it every submission fails with a ReferenceError.'
+		);
+		$this->assertStringContainsString(
+			'ajaxNonce',
+			$data,
+			'The admin-ajax fallback nonce must reach the frontend.'
+		);
+		$this->assertStringContainsString(
+			'dsgoIntegrations',
+			$data,
+			'Turnstile settings ride the same handle and were lost to the same guard.'
+		);
+	}
+
+	/**
+	 * Positive control: the in-content case must keep working.
+	 *
+	 * Guards against a "fix" that merely inverts the bug.
+	 */
+	public function test_localizes_when_queried_post_does_contain_the_form_block() {
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_content' => '<!-- wp:designsetgo/form-builder {"formId":"abc123"} --><div class="wp-block-designsetgo-form-builder"></div><!-- /wp:designsetgo/form-builder -->',
+			)
+		);
+
+		$this->go_to_page( $page_id );
+
+		$this->assertTrue(
+			has_block( 'designsetgo/form-builder' ),
+			'Fixture invalid: the queried post SHOULD contain the form block.'
+		);
+
+		$this->handler->localize_form_script();
+
+		$data = wp_scripts()->get_data( self::HANDLE, 'data' );
+
+		$this->assertIsString( $data, 'The form script must still be localized for in-content forms.' );
+		$this->assertStringContainsString( 'designsetgoForm', $data );
+	}
+
+	/**
+	 * Localizing must not enqueue anything by itself.
+	 *
+	 * This is what makes the unconditional localization free: data attached to
+	 * a registered-but-not-enqueued handle is never printed. WordPress enqueues
+	 * the viewScript at block render time, so a page with no form emits nothing
+	 * — no payload, no nonce. A "fix" that unconditionally enqueued the script
+	 * instead would leak both onto every page, and fails here.
+	 */
+	public function test_localizing_does_not_enqueue_the_view_script() {
+		$this->go_to_page( $this->create_page_without_form() );
+
+		$this->handler->localize_form_script();
+
+		$this->assertFalse(
+			wp_script_is( self::HANDLE, 'enqueued' ),
+			'Localizing must not enqueue the view script; otherwise the nonce payload prints on every page.'
+		);
+	}
+}


### PR DESCRIPTION
## Description

A DesignSetGo form rendered anywhere other than the current post's content — most commonly a newsletter signup in the **footer template part** — failed on every submission with `designsetgoForm is not defined`.

`localize_form_script()` was guarded by `has_block( 'designsetgo/form-builder' )`, which only inspects the current post's content. It never sees template parts, so the guard returned early, the script was never localized, and `view.js` ran with `designsetgoForm` undefined. The block itself still rendered and WordPress still enqueued its `viewScript` — so the form looked completely fine right up until someone pressed Submit.

This affects any footer/header pattern containing the form block, plus synced patterns, block widgets, and anything rendered through `do_blocks()`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issue

None filed — reported directly with a screenshot of the failure in a footer newsletter form.

## Changes Made

- Removed the `has_block( 'designsetgo/form-builder' )` guard from `localize_form_script()`.
- Documented *why* the method is deliberately unconditional, so the guard doesn't get reintroduced as an "optimization".
- Dropped a dead `$asset_file = include ... view.asset.php` line — the result was never used, and the include emitted an `E_WARNING` (evaluating to `false`) whenever the build directory was absent. *(Corrected: an earlier revision of this description, and the commit message, said this "would fatal". That's wrong — `include` warns and continues; only `require` fatals. Thanks to review for catching it.)*

### Why remove the guard instead of teaching it about template parts

Extending the check to scan template part content was the other option, but it's the weaker fix: it patches one symptom while leaving synced patterns, block widgets, and `do_blocks()` still broken, and it adds content-scanning cost to every request.

Removing the guard is free, because the laziness it appeared to buy already exists in WordPress. `wp_localize_script()` only attaches data to a **registered** handle; the data is printed by `WP_Scripts::do_item()`, which runs only for **enqueued** scripts. The block's `viewScript` is enqueued at render time, so a page with no form emits nothing regardless of this guard. Verified below rather than assumed.

Ordering is safe: blocks register on `init` (`Blocks\Loader`), and this runs on `wp_enqueue_scripts`, so the handle always exists by the time it's referenced.

## Testing

Tested against wp-env (WordPress 6.9, PHP 8.3, Twenty Twenty-Five) using a form placed in the **footer template part**, on a page whose own content contains no form block. `has_block()` returns `false` in exactly that arrangement, confirming the trigger condition.

| Check | Guard present (before) | Guard removed (after) |
| --- | --- | --- |
| `has_block()` on the page | `false` | `false` |
| Form renders in footer | yes | yes |
| `view.js` enqueued | yes | yes |
| `designsetgoForm` defined | **no** | **yes** |
| Submit result | **"designsetgoForm is not defined"** | "Thanks!" (success) |

The original error was reproduced by temporarily restoring the guard, then the fix confirmed end to end: the submission stored server-side as a `dsgo_form_submission` post (`Form Submission - footer01`), with no console errors.

**No-regression check.** With no form anywhere on the page, the response contains no `view.js`, no `designsetgo-form-builder-view-script-js-extra` tag, and the string `designsetgoForm` appears nowhere in the HTML. Removing the guard therefore leaks no nonce and adds no payload to form-free pages.

- [ ] Tested in WordPress editor — n/a, frontend-only PHP asset change
- [x] Tested on frontend
- [x] Tested with Twenty Twenty-Five theme
- [ ] Tested responsive behavior (mobile/tablet/desktop) — n/a, no markup or CSS change
- [x] No console errors
- [x] No PHP errors (`WP_DEBUG` on; no new `debug.log` entries during testing)

### Regression test

`tests/phpunit/form-script-localize-test.php` pins this fix: the out-of-content case (the actual regression), a positive control so a fix that merely inverts the bug is caught, and an assertion that localizing does not itself enqueue the script — which is what makes unconditional localization free. Reinstating the `has_block()` guard fails the first test and leaves the other two green; verified by temporarily restoring it rather than assuming.

Full suite: 998 tests, 4,412 assertions, 0 failures (1 pre-existing documented skip).

### Per-request cost

Removing the guard means `wp_create_nonce()` (×2) and `get_option( 'designsetgo_settings' )` now run on every frontend request. Measured rather than assumed: the option stores with `autoload = auto`, so it is served from the already-loaded options cache with **no additional database query** (and when it does not exist yet, WordPress's `notoptions` cache prevents a repeat lookup). The remaining cost is two HMAC hashes. There is no clean core hook for "this script just got enqueued", so deferring the payload would mean fragile print-time ordering for no measurable gain.

## Screenshots/Videos

Not attached. The failure state is the reported screenshot — a footer newsletter form showing `designsetgoForm is not defined` in its error region; after the fix the same form returns its success message.

## Checklist

- [x] My code follows the WordPress Coding Standards (`phpcs --standard=phpcs.xml` clean on the changed file)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated documentation as needed (n/a)
- [x] My changes generate no new warnings or errors
- [x] I have tested on WordPress 6.4+ (tested on 6.9)
- [x] I have followed the patterns in CLAUDE.md
- [ ] All files are under 300 lines — `class-form-handler.php` is ~1,530 lines. Pre-existing; this PR is a net −8 lines of code in that file and does not address the file-size debt.
- [x] I have added JSDoc comments to new functions (n/a — no new functions)
- [x] Accessibility: WCAG 2.1 AA compliant (n/a — no markup change)
- [x] Security: All user input is validated and sanitized (no change to validation, capability checks, or nonce lifetime; nonces are still generated per request and, as verified above, are not emitted on pages without a form)
- [x] Internationalization: All user-facing strings use `__()` or `_e()` (n/a — no strings added)

## Additional Notes

While tracing this, I checked `Assets::has_designsetgo_blocks()` ([class-assets.php:188](../blob/main/includes/core/class-assets.php#L188)), which has the same post-content-only limitation. **It is not a bug and is intentionally left alone here.** Frontend assets load via `maybe_enqueue_frontend_on_render()` on the `render_block` filter, which does see template parts; I confirmed a `designsetgo/grid` in a footer template part renders correctly styled.

That function only gates `inline_critical_css()` / `dequeue_inlined_css()`. Worth flagging separately: on pages where it *does* fire, the plugin inlines ~12KB covering grid/row/icon/pill regardless of which are present, dequeues core's own targeted per-block inline, and still loads `build/style-index.css` containing the same CSS. Making it template-part-aware would extend that duplication to more pages, not fewer. The critical-CSS path looks like it deserves its own PR with before/after FCP numbers.
