### PR TITLE
fix(sticky-header): cascade scroll background through theme presets

### DIFF
--- a/src/styles/utilities/_sticky-header.scss
+++ b/src/styles/utilities/_sticky-header.scss
@@ -118,8 +118,15 @@ body:not(.block-editor-page).admin-bar .wp-block-template-part.dsgo-sticky-heade
 		color var(--dsgo-sticky-header-transition-speed, 300ms) ease-in-out;
 }
 
+/**
+ * Prefer the theme's secondary surface preset; themes without a `base-2`
+ * slug (Twenty Twenty-*) resolve to the historical near-white.
+ */
 .dsgo-sticky-bg-on-scroll.wp-block-template-part.dsgo-scrolled {
-	background-color: var(--dsgo-sticky-scroll-bg-color, rgba(255, 255, 255, 0.95));
+	background-color: var(
+		--dsgo-sticky-scroll-bg-color,
+		color-mix(in srgb, var(--wp--preset--color--base-2, #fff) 95%, transparent)
+	);
 	color: var(--dsgo-sticky-scroll-text-color, inherit);
 
 	/* Apply text color to navigation elements only — excludes buttons with user-set colors */
@@ -207,9 +214,21 @@ body:not(.block-editor-page).admin-bar .wp-block-template-part.dsgo-sticky-heade
 		box-shadow: 0 10px 15px rgba(0, 0, 0, 0.5);
 	}
 
+	/**
+	 * `contrast`/`base` rather than `base-2` here: this rule hardcodes a light
+	 * foreground, and those two slugs are guaranteed to oppose each other in
+	 * any palette, so the pairing stays readable in light *and* dark themes.
+	 * Themes with neither slug resolve to black-on-white, as before.
+	 */
 	.dsgo-sticky-bg-on-scroll.wp-block-template-part.dsgo-scrolled {
-		background-color: var(--dsgo-sticky-scroll-bg-color, rgba(0, 0, 0, 0.95));
-		color: var(--dsgo-sticky-scroll-text-color, rgba(255, 255, 255, 0.95));
+		background-color: var(
+			--dsgo-sticky-scroll-bg-color,
+			color-mix(in srgb, var(--wp--preset--color--contrast, #000) 95%, transparent)
+		);
+		color: var(
+			--dsgo-sticky-scroll-text-color,
+			color-mix(in srgb, var(--wp--preset--color--base, #fff) 95%, transparent)
+		);
 
 		.wp-block-navigation a,
 		.wp-block-navigation a:hover,
@@ -226,12 +245,18 @@ body:not(.block-editor-page).admin-bar .wp-block-template-part.dsgo-sticky-heade
 		.wp-block-site-title a:focus-visible,
 		.wp-block-site-title a:visited,
 		.wp-block-site-title a:active {
-			color: var(--dsgo-sticky-scroll-text-color, rgba(255, 255, 255, 0.95));
+			color: var(
+				--dsgo-sticky-scroll-text-color,
+				color-mix(in srgb, var(--wp--preset--color--base, #fff) 95%, transparent)
+			);
 		}
 
 		.wp-block-navigation__submenu-icon svg,
 		.wp-block-navigation__responsive-container-open svg {
-			fill: var(--dsgo-sticky-scroll-text-color, rgba(255, 255, 255, 0.95));
+			fill: var(
+				--dsgo-sticky-scroll-text-color,
+				color-mix(in srgb, var(--wp--preset--color--base, #fff) 95%, transparent)
+			);
 		}
 	}
 }
@@ -348,10 +373,18 @@ body:not(.block-editor-page).admin-bar.dsgo-page-overlay-header header.wp-block-
  * Overlay Scroll Background
  * When scrolled past threshold, fade in the solid background.
  * Position stays fixed — only background-color transitions.
+ *
+ * Overlay headers never enter the JS branch that sets
+ * --dsgo-sticky-scroll-bg-color (see utils/sticky-header.js), so this fallback
+ * is the value that actually renders. Prefer the theme's secondary surface;
+ * themes without a `base-2` slug keep the historical near-white.
  */
 body:not(.block-editor-page).dsgo-page-overlay-header .wp-block-template-part.dsgo-scrolled:not(footer):first-of-type,
 body:not(.block-editor-page).dsgo-page-overlay-header header.wp-block-template-part.dsgo-scrolled {
-	background-color: var(--dsgo-sticky-scroll-bg-color, rgba(255, 255, 255, 0.95));
+	background-color: var(
+		--dsgo-sticky-scroll-bg-color,
+		color-mix(in srgb, var(--wp--preset--color--base-2, #fff) 95%, transparent)
+	);
 }
 
 /**

--- a/src/styles/utilities/_sticky-header.scss
+++ b/src/styles/utilities/_sticky-header.scss
@@ -119,16 +119,23 @@ body:not(.block-editor-page).admin-bar .wp-block-template-part.dsgo-sticky-heade
 }
 
 /**
+ * Every theme-preset cascade below is gated on this feature query, and the
+ * gating is load-bearing rather than defensive.
+ *
+ * A declaration containing var() is only syntax-checked after substitution, so
+ * a color-mix() the browser doesn't understand makes the declaration "invalid
+ * at computed-value time" — which resets background-color to its initial value
+ * (transparent), *not* to any earlier declaration in the cascade. Declaring the
+ * literal first and the color-mix() second therefore does not degrade
+ * gracefully; the second declaration parses cleanly, wins, and only then fails.
+ * @supports is the only construct that keeps a color-mix()-less browser on the
+ * literal.
+ */
+$dsgo-color-mix-support: "(background-color: color-mix(in srgb, red 95%, transparent))";
+
+/**
  * Prefer the theme's secondary surface preset; themes without a `base-2`
  * slug (Twenty Twenty-*) resolve to the historical near-white.
- *
- * The preset cascade is applied by redefining --dsgo-sticky-scrolled-bg inside
- * @supports rather than by putting color-mix() straight into the var()
- * fallback. A declaration containing var() is only syntax-checked after
- * substitution, and a result that fails to parse is "invalid at computed-value
- * time" — which resets background-color to its initial value (transparent),
- * *not* to any earlier declaration. @supports is the only construct that keeps
- * a color-mix()-less browser on the literal below.
  */
 .dsgo-sticky-bg-on-scroll.wp-block-template-part.dsgo-scrolled {
 	--dsgo-sticky-scrolled-bg: rgba(255, 255, 255, 0.95);
@@ -136,7 +143,7 @@ body:not(.block-editor-page).admin-bar .wp-block-template-part.dsgo-sticky-heade
 	background-color: var(--dsgo-sticky-scroll-bg-color, var(--dsgo-sticky-scrolled-bg));
 	color: var(--dsgo-sticky-scroll-text-color, inherit);
 
-	@supports (background-color: color-mix(in srgb, red 95%, transparent)) {
+	@supports #{$dsgo-color-mix-support} {
 		--dsgo-sticky-scrolled-bg: color-mix(in srgb, var(--wp--preset--color--base-2, #fff) 95%, transparent);
 	}
 
@@ -232,8 +239,8 @@ body:not(.block-editor-page).admin-bar .wp-block-template-part.dsgo-sticky-heade
 	 * Themes with neither slug resolve to black-on-white, as before.
 	 *
 	 * --dsgo-sticky-dark-fg is hoisted because the foreground is read from
-	 * three places below; see the @supports note on the light rule for why the
-	 * preset cascade lives in a feature query.
+	 * three places below; see $dsgo-color-mix-support for why the preset
+	 * cascade lives in a feature query.
 	 */
 	.dsgo-sticky-bg-on-scroll.wp-block-template-part.dsgo-scrolled {
 		--dsgo-sticky-scrolled-bg: rgba(0, 0, 0, 0.95);
@@ -242,7 +249,7 @@ body:not(.block-editor-page).admin-bar .wp-block-template-part.dsgo-sticky-heade
 		background-color: var(--dsgo-sticky-scroll-bg-color, var(--dsgo-sticky-scrolled-bg));
 		color: var(--dsgo-sticky-scroll-text-color, var(--dsgo-sticky-dark-fg));
 
-		@supports (background-color: color-mix(in srgb, red 95%, transparent)) {
+		@supports #{$dsgo-color-mix-support} {
 			--dsgo-sticky-scrolled-bg: color-mix(in srgb, var(--wp--preset--color--contrast, #000) 95%, transparent);
 			--dsgo-sticky-dark-fg: color-mix(in srgb, var(--wp--preset--color--base, #fff) 95%, transparent);
 		}
@@ -396,7 +403,7 @@ body:not(.block-editor-page).dsgo-page-overlay-header header.wp-block-template-p
 
 	background-color: var(--dsgo-sticky-scroll-bg-color, var(--dsgo-sticky-scrolled-bg));
 
-	@supports (background-color: color-mix(in srgb, red 95%, transparent)) {
+	@supports #{$dsgo-color-mix-support} {
 		--dsgo-sticky-scrolled-bg: color-mix(in srgb, var(--wp--preset--color--base-2, #fff) 95%, transparent);
 	}
 }

--- a/src/styles/utilities/_sticky-header.scss
+++ b/src/styles/utilities/_sticky-header.scss
@@ -121,13 +121,24 @@ body:not(.block-editor-page).admin-bar .wp-block-template-part.dsgo-sticky-heade
 /**
  * Prefer the theme's secondary surface preset; themes without a `base-2`
  * slug (Twenty Twenty-*) resolve to the historical near-white.
+ *
+ * The preset cascade is applied by redefining --dsgo-sticky-scrolled-bg inside
+ * @supports rather than by putting color-mix() straight into the var()
+ * fallback. A declaration containing var() is only syntax-checked after
+ * substitution, and a result that fails to parse is "invalid at computed-value
+ * time" — which resets background-color to its initial value (transparent),
+ * *not* to any earlier declaration. @supports is the only construct that keeps
+ * a color-mix()-less browser on the literal below.
  */
 .dsgo-sticky-bg-on-scroll.wp-block-template-part.dsgo-scrolled {
-	background-color: var(
-		--dsgo-sticky-scroll-bg-color,
-		color-mix(in srgb, var(--wp--preset--color--base-2, #fff) 95%, transparent)
-	);
+	--dsgo-sticky-scrolled-bg: rgba(255, 255, 255, 0.95);
+
+	background-color: var(--dsgo-sticky-scroll-bg-color, var(--dsgo-sticky-scrolled-bg));
 	color: var(--dsgo-sticky-scroll-text-color, inherit);
+
+	@supports (background-color: color-mix(in srgb, red 95%, transparent)) {
+		--dsgo-sticky-scrolled-bg: color-mix(in srgb, var(--wp--preset--color--base-2, #fff) 95%, transparent);
+	}
 
 	/* Apply text color to navigation elements only — excludes buttons with user-set colors */
 	.wp-block-navigation a,
@@ -219,16 +230,22 @@ body:not(.block-editor-page).admin-bar .wp-block-template-part.dsgo-sticky-heade
 	 * foreground, and those two slugs are guaranteed to oppose each other in
 	 * any palette, so the pairing stays readable in light *and* dark themes.
 	 * Themes with neither slug resolve to black-on-white, as before.
+	 *
+	 * --dsgo-sticky-dark-fg is hoisted because the foreground is read from
+	 * three places below; see the @supports note on the light rule for why the
+	 * preset cascade lives in a feature query.
 	 */
 	.dsgo-sticky-bg-on-scroll.wp-block-template-part.dsgo-scrolled {
-		background-color: var(
-			--dsgo-sticky-scroll-bg-color,
-			color-mix(in srgb, var(--wp--preset--color--contrast, #000) 95%, transparent)
-		);
-		color: var(
-			--dsgo-sticky-scroll-text-color,
-			color-mix(in srgb, var(--wp--preset--color--base, #fff) 95%, transparent)
-		);
+		--dsgo-sticky-scrolled-bg: rgba(0, 0, 0, 0.95);
+		--dsgo-sticky-dark-fg: rgba(255, 255, 255, 0.95);
+
+		background-color: var(--dsgo-sticky-scroll-bg-color, var(--dsgo-sticky-scrolled-bg));
+		color: var(--dsgo-sticky-scroll-text-color, var(--dsgo-sticky-dark-fg));
+
+		@supports (background-color: color-mix(in srgb, red 95%, transparent)) {
+			--dsgo-sticky-scrolled-bg: color-mix(in srgb, var(--wp--preset--color--contrast, #000) 95%, transparent);
+			--dsgo-sticky-dark-fg: color-mix(in srgb, var(--wp--preset--color--base, #fff) 95%, transparent);
+		}
 
 		.wp-block-navigation a,
 		.wp-block-navigation a:hover,
@@ -245,18 +262,12 @@ body:not(.block-editor-page).admin-bar .wp-block-template-part.dsgo-sticky-heade
 		.wp-block-site-title a:focus-visible,
 		.wp-block-site-title a:visited,
 		.wp-block-site-title a:active {
-			color: var(
-				--dsgo-sticky-scroll-text-color,
-				color-mix(in srgb, var(--wp--preset--color--base, #fff) 95%, transparent)
-			);
+			color: var(--dsgo-sticky-scroll-text-color, var(--dsgo-sticky-dark-fg));
 		}
 
 		.wp-block-navigation__submenu-icon svg,
 		.wp-block-navigation__responsive-container-open svg {
-			fill: var(
-				--dsgo-sticky-scroll-text-color,
-				color-mix(in srgb, var(--wp--preset--color--base, #fff) 95%, transparent)
-			);
+			fill: var(--dsgo-sticky-scroll-text-color, var(--dsgo-sticky-dark-fg));
 		}
 	}
 }
@@ -381,10 +392,13 @@ body:not(.block-editor-page).admin-bar.dsgo-page-overlay-header header.wp-block-
  */
 body:not(.block-editor-page).dsgo-page-overlay-header .wp-block-template-part.dsgo-scrolled:not(footer):first-of-type,
 body:not(.block-editor-page).dsgo-page-overlay-header header.wp-block-template-part.dsgo-scrolled {
-	background-color: var(
-		--dsgo-sticky-scroll-bg-color,
-		color-mix(in srgb, var(--wp--preset--color--base-2, #fff) 95%, transparent)
-	);
+	--dsgo-sticky-scrolled-bg: rgba(255, 255, 255, 0.95);
+
+	background-color: var(--dsgo-sticky-scroll-bg-color, var(--dsgo-sticky-scrolled-bg));
+
+	@supports (background-color: color-mix(in srgb, red 95%, transparent)) {
+		--dsgo-sticky-scrolled-bg: color-mix(in srgb, var(--wp--preset--color--base-2, #fff) 95%, transparent);
+	}
 }
 
 /**


### PR DESCRIPTION
## Problem

Reported by Julia: on a page with `dsgo_overlay_header` enabled, the scrolled header background renders as a hardcoded near-white regardless of the theme's palette.

Her diagnosis is correct. `--dsgo-sticky-scroll-bg-color` is only written by [`utils/sticky-header.js`](https://github.com/jnealey-godaddy/designsetgo/blob/main/src/utils/sticky-header.js#L335-L360) when `backgroundOnScroll` is enabled **or** the block carries `dsgo-sticky-bg-on-scroll`. Overlay-only pages enter neither branch, so the CSS fallback in `_sticky-header.scss` is the value that actually renders.

## Change

All three fallback sites now cascade through a theme preset before the hardcoded literal, wrapped in `color-mix()` so the 95% alpha survives:

| Rule | Before | After |
|---|---|---|
| `.dsgo-sticky-bg-on-scroll` (light) | `rgba(255,255,255,.95)` | `base-2` → near-white |
| `.dsgo-sticky-bg-on-scroll` (dark) | bg `rgba(0,0,0,.95)`, fg `rgba(255,255,255,.95)` | bg `contrast` → black, fg `base` → white |
| Overlay scrolled | `rgba(255,255,255,.95)` | `base-2` → near-white |

Preferring `--wp--preset--color--base-2` for a secondary surface is already the house pattern — `accordion-item`, `timeline-item` and `query-results` all do it.

### Why the dark-mode rule uses different slugs

That rule hardcodes a **light foreground** in three places (`color`, nested nav `color`, and SVG `fill`). Using `base-2` there would put white text on an off-white background for any theme that defines `base-2` as a light surface. `contrast` and `base` are guaranteed to oppose each other in any `theme.json` palette, so the pairing stays readable in light themes, dark themes, and no-preset themes alike.

### Why the cascade lives in `@supports`

The preset cascade is applied by redefining a `--dsgo-sticky-scrolled-bg` custom property inside a feature query, rather than by putting `color-mix()` straight into the `var()` fallback.

A declaration containing `var()` isn't syntax-checked until after substitution, so a `color-mix()` a browser doesn't understand makes the declaration *invalid at computed-value time* — which resets `background-color` to its initial value, `transparent`, leaving the scrolled header with no background at all. Declaring the literal first and the `color-mix()` second doesn't help, because IACVT doesn't fall back to an earlier declaration; the second declaration parses cleanly, overrides the first, and only then fails. `@supports` is the only construct that keeps a non-supporting browser on the literal.

## Compatibility

The whole point of the cascade is that an undefined custom property falls through:

- **No `base-2` / `contrast` / `base` presets** → resolves to exactly the previous literals. `color-mix(in srgb, #fff 95%, transparent)` is `rgba(255,255,255,0.95)`.
- **No `color-mix()` support** (pre-2023 browsers) → the feature query never applies and the literal declaration stands, so behavior is unchanged rather than failing shut.
- **Twenty Twenty-Five** → defines `contrast` and `base` but not `base-2`, so the overlay path is byte-identical to before; only the dark-mode rule shifts from pure black to the theme's own near-black.
- **`--dsgo-sticky-scroll-bg-color` set** → the fallback never evaluates; the JS still wins, including its explicit `transparent`.

## Verification

- `npm run lint:css` — clean
- `npm run build` — succeeds
- Compiled `build/utils/sticky-header.css` (this partial ships via the JS-linked entry, not `style-index.css`) contains all three cascades, and a brace-balance check confirms both dark-mode `@supports` overrides stay nested inside the `prefers-color-scheme: dark` media query

**Not yet verified in a browser.** Two things worth an eyeball before merge: an Airo overlay page at scroll, and the TT5 dark-mode shift from `#000` to `contrast`.