### PR TITLE
fix(tests): decode the dsgoSettings payload instead of substring-matching it

### DIFF
--- a/tests/phpunit/extension-settings-localize-test.php
+++ b/tests/phpunit/extension-settings-localize-test.php
@@ -25,6 +25,47 @@ use DesignSetGo\Admin\Settings;
 class Test_Extension_Settings_Localize extends WP_UnitTestCase {
 
 	/**
+	 * Decode the JSON object out of a `var dsgoSettings = {...};` payload.
+	 *
+	 * Assert against the decoded array rather than searching the raw string:
+	 * `wp_localize_script()` runs the payload through `wp_json_encode()`, and
+	 * whether that escapes a forward slash (`gravityforms\/form`) or leaves it
+	 * bare varies by WordPress version. A substring search for a value
+	 * containing `/` therefore passes on some versions of WP and fails on
+	 * others for reasons that have nothing to do with the behaviour under test.
+	 *
+	 * WP_Scripts::localize() appends rather than replaces
+	 * (`$script = "$data\n$script"`), so a handle localized more than once
+	 * carries several newline-joined `var … = {…};` statements. Decode the last
+	 * dsgoSettings one — that is the payload the current test produced.
+	 *
+	 * @param string $data Localized script data.
+	 * @return array Decoded settings payload.
+	 */
+	private function decode_localized_settings( $data ) {
+		$prefix = 'var dsgoSettings = ';
+
+		$statements = array_filter(
+			array_map( 'trim', explode( "\n", $data ) ),
+			static function ( $line ) use ( $prefix ) {
+				return 0 === strpos( $line, $prefix );
+			}
+		);
+
+		$this->assertNotEmpty(
+			$statements,
+			'Expected a dsgoSettings statement in the localized payload.'
+		);
+
+		$json    = rtrim( substr( (string) end( $statements ), strlen( $prefix ) ), ';' );
+		$decoded = json_decode( $json, true );
+
+		$this->assertIsArray( $decoded, 'The dsgoSettings payload should decode as JSON.' );
+
+		return $decoded;
+	}
+
+	/**
 	 * Reset scripts and screen after each test.
 	 */
 	public function tear_down() {
@@ -70,9 +111,13 @@ class Test_Extension_Settings_Localize extends WP_UnitTestCase {
 			'dsgoSettings must be localized on the same hook that enqueues the extensions script.'
 		);
 		$this->assertStringContainsString( 'dsgoSettings', $data );
-		$this->assertStringContainsString(
+
+		$settings = $this->decode_localized_settings( $data );
+
+		$this->assertArrayHasKey( 'excludedBlocks', $settings );
+		$this->assertContains(
 			'gravityforms/form',
-			$data,
+			$settings['excludedBlocks'],
 			'The configured excluded block must be present in the iframe payload.'
 		);
 	}
@@ -101,10 +146,12 @@ class Test_Extension_Settings_Localize extends WP_UnitTestCase {
 			$data,
 			'dsgoSettings must be localized on the same hook that enqueues the extensions script.'
 		);
-		$this->assertStringContainsString( 'enabledExtensions', $data );
-		$this->assertStringContainsString(
+		$settings = $this->decode_localized_settings( $data );
+
+		$this->assertArrayHasKey( 'enabledExtensions', $settings );
+		$this->assertContains(
 			'dynamic-tags',
-			$data,
+			$settings['enabledExtensions'],
 			'The configured enabled extension must be present in the iframe payload.'
 		);
 	}


### PR DESCRIPTION
## Problem

The WordPress 6.7 and 6.8 matrix jobs have been failing since #496 — all ten of them, on a single assertion:

```
Failed asserting that 'var dsgoSettings = {"excludedBlocks":["gravityforms\/form"],…};'
contains "gravityforms/form".
```

The suite passes locally, which is what kept this from being obvious.

## Cause

`WP_Scripts::localize()` builds the payload with `wp_json_encode()`. Newer WordPress passes `JSON_HEX_TAG | JSON_UNESCAPED_SLASHES`, so the forward slash survives literally. WordPress 6.7 and 6.8 do not, so it is escaped to `gravityforms\/form`.

`assertStringContainsString( 'gravityforms/form', $data )` therefore passes or fails purely on the WordPress version's JSON flags — nothing to do with the localization behaviour the test exists to cover. The sibling test asserting `dynamic-tags` was unaffected only because that value contains no slash.

## Change

Assert against the **decoded array** rather than the raw string, so the test says what it means and is indifferent to JSON escaping.

The helper also takes the **last** `dsgoSettings` statement. `localize()` appends rather than replaces:

```php
$data = $this->get_data( $handle, 'data' );
if ( ! empty( $data ) ) {
    $script = "$data\n$script";
}
```

so a handle localized more than once carries several newline-joined statements. Spanning from the first `{` to the last `}` straddles them and decodes to `null` — I hit exactly that on the second test before settling on the prefix-based extraction.

## Verification

Extraction checked against all three payload shapes:

| Payload | Old substring assert | New decoded assert |
|---|---|---|
| WP 6.7/6.8 (escaped) | **FAIL** | PASS |
| Newer WP (bare) | PASS | PASS |
| Accumulated (2 statements) | PASS | PASS |

The first row reproduces the CI failure exactly and confirms the fix addresses it.

- `phpunit --filter Test_Extension_Settings_Localize` — OK (2 tests, 12 assertions)
- Full suite — 998 tests, 4417 assertions, 1 pre-existing skip
- `phpcs --standard=phpcs.xml` — clean

Test-only change; no production code touched.