### PR TITLE
fix(grid): wrap columns instead of overflowing when the min width can't fit

### DIFF
--- a/src/blocks/grid/deprecated.js
+++ b/src/blocks/grid/deprecated.js
@@ -233,6 +233,135 @@ const styleVariationClasses = {
 	},
 };
 
+// Before the column min width switched from a fixed `repeat(N, minmax(<min>,
+// 1fr))` track list to the auto-fill form in ./grid-columns.js. The fixed
+// repeat count could never drop a track, so a grid whose columns could not
+// all fit their min width (a narrow theme contentSize, say) overflowed its
+// container instead of wrapping items to the next row.
+//
+// Markup changed, so stored grids with a columnMinWidth are invalid against
+// the current save() and WordPress picks this entry by reproducing their HTML
+// — no isEligible needed, and none wanted (grids WITHOUT a columnMinWidth are
+// byte-identical under both forms and must not be re-migrated). migrate() is
+// a passthrough: only the serialised track list differs, no attribute does.
+//
+// This entry is listed FIRST so it wins over styleVariationClasses, whose
+// save() collapses to the same output for content with no style variation.
+const fixedColumnMinWidthTracks = {
+	apiVersion: 3,
+	supports: metadata.supports,
+	attributes: { ...metadata.attributes },
+	save({ attributes }) {
+		const {
+			tagName = 'div',
+			constrainWidth,
+			contentWidth,
+			columnMinWidth,
+			desktopColumns,
+			tabletColumns,
+			mobileColumns,
+			rowGap,
+			columnGap,
+			alignItems,
+			matchRowHeights,
+			overlayColor,
+			hoverBackgroundColor,
+			hoverTextColor,
+			hoverIconBackgroundColor,
+			hoverButtonBackgroundColor,
+			style,
+		} = attributes;
+
+		const hasOverlay =
+			!!overlayColor || hasOverlayStyleClass(attributes.className);
+
+		const className = [
+			'dsgo-grid',
+			`dsgo-grid-cols-${desktopColumns}`,
+			`dsgo-grid-cols-tablet-${tabletColumns}`,
+			`dsgo-grid-cols-mobile-${mobileColumns}`,
+			!constrainWidth && 'dsgo-no-width-constraint',
+			matchRowHeights && 'dsgo-grid--match-rows',
+			hasOverlay && 'dsgo-grid--has-overlay',
+			...hoverVariationClasses(attributes.className, 'dsgo-grid'),
+		]
+			.filter(Boolean)
+			.join(' ');
+
+		const TagName = tagName || 'div';
+		const blockProps = useBlockProps.save({
+			className,
+			style: {
+				...(hoverBackgroundColor && {
+					'--dsgo-hover-bg-color':
+						convertColorToCSSVar(hoverBackgroundColor),
+				}),
+				...(hoverTextColor && {
+					'--dsgo-hover-text-color':
+						convertColorToCSSVar(hoverTextColor),
+				}),
+				...(hoverIconBackgroundColor && {
+					'--dsgo-parent-hover-icon-bg': convertColorToCSSVar(
+						hoverIconBackgroundColor
+					),
+				}),
+				...(hoverButtonBackgroundColor && {
+					'--dsgo-parent-hover-button-bg': convertColorToCSSVar(
+						hoverButtonBackgroundColor
+					),
+				}),
+				...(overlayColor && {
+					'--dsgo-overlay-color': convertColorToCSSVar(overlayColor),
+					'--dsgo-overlay-opacity': '0.8',
+				}),
+			},
+		});
+
+		const blockGapValue = style?.spacing?.blockGap;
+		const isBlockGapObject =
+			typeof blockGapValue === 'object' && blockGapValue !== null;
+		const blockGapRow = convertPresetToCSSVar(
+			isBlockGapObject ? blockGapValue?.top : blockGapValue
+		);
+		const blockGapColumn = convertPresetToCSSVar(
+			isBlockGapObject ? blockGapValue?.left : blockGapValue
+		);
+		const defaultGap = 'var(--wp--preset--spacing--50)';
+
+		const innerStyles = {
+			display: 'grid',
+			gridTemplateColumns: columnMinWidth
+				? `repeat(${desktopColumns || 3}, minmax(${columnMinWidth}, 1fr))`
+				: `repeat(${desktopColumns || 3}, 1fr)`,
+			alignItems: alignItems || 'stretch',
+			rowGap: blockGapRow || rowGap || defaultGap,
+			columnGap: blockGapColumn || columnGap || defaultGap,
+		};
+
+		if (constrainWidth) {
+			innerStyles.maxWidth =
+				contentWidth ||
+				'var(--wp--style--global--content-size, 1140px)';
+			innerStyles.marginLeft = 'auto';
+			innerStyles.marginRight = 'auto';
+		}
+
+		const innerBlocksProps = useInnerBlocksProps.save({
+			className: 'dsgo-grid__inner',
+			style: innerStyles,
+		});
+
+		return (
+			<TagName {...blockProps}>
+				<div {...innerBlocksProps} />
+			</TagName>
+		);
+	},
+	migrate(attributes) {
+		return attributes;
+	},
+};
+
 // Version 1: Before align attribute - used className for alignment
 const v1 = {
 	supports: sharedSupports,
@@ -671,7 +800,17 @@ const legacyMinWidth = {
 // columnMinWidth attribute from stored HTML. styleVariationClasses.migrate()
 // is a passthrough, so if it "won" for such content, columnMinWidth would be
 // silently dropped (columns collapse to 1fr) with no recovery warning.
+// Named exports exist so tests can reference an entry without depending on its
+// position in the array below.
+export {
+	fixedColumnMinWidthTracks,
+	legacyResponsiveTabletClass,
+	legacyMinWidth,
+	styleVariationClasses,
+};
+
 export default [
+	fixedColumnMinWidthTracks,
 	legacyResponsiveTabletClass,
 	legacyMinWidth,
 	styleVariationClasses,

--- a/src/blocks/grid/edit.js
+++ b/src/blocks/grid/edit.js
@@ -49,6 +49,7 @@ import {
 	hoverVariationClasses,
 } from '../../utils/style-variation-classes';
 import { useGridRowMatch } from './utils/use-grid-row-match';
+import { getGridTemplateColumns } from './grid-columns';
 
 /**
  * Grid Container Edit Component
@@ -198,15 +199,18 @@ export default function GridEdit({ attributes, setAttributes, clientId }) {
 		isBlockGapObject ? blockGapValue?.left : blockGapValue
 	);
 	const defaultGap = 'var(--wp--preset--spacing--50)';
+	const resolvedColumnGap = blockGapColumn || columnGap || defaultGap;
 
 	const innerStyles = {
 		display: 'grid',
-		gridTemplateColumns: columnMinWidth
-			? `repeat(${desktopColumns || 3}, minmax(${columnMinWidth}, 1fr))`
-			: `repeat(${desktopColumns || 3}, 1fr)`,
+		gridTemplateColumns: getGridTemplateColumns(
+			columnMinWidth,
+			desktopColumns,
+			resolvedColumnGap
+		),
 		alignItems: alignItems || 'stretch',
 		rowGap: blockGapRow || rowGap || defaultGap,
-		columnGap: blockGapColumn || columnGap || defaultGap,
+		columnGap: resolvedColumnGap,
 	};
 
 	// Apply width constraints if enabled
@@ -796,7 +800,7 @@ export default function GridEdit({ attributes, setAttributes, clientId }) {
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 							help={__(
-								'Sets a minimum width for each column via minmax(value, 1fr) so columns never get narrower than this. Columns still drop to the tablet/mobile counts on smaller screens.',
+								'Sets a minimum width for each column. Columns never get narrower than this — if they would, one wraps to the next row instead of overflowing the container. Columns still drop to the tablet/mobile counts on smaller screens.',
 								'designsetgo'
 							)}
 						/>

--- a/src/blocks/grid/edit.js
+++ b/src/blocks/grid/edit.js
@@ -34,7 +34,7 @@ import {
 } from '@wordpress/components';
 import { grid as gridIcon } from '@wordpress/icons';
 import { DsgoInspectorPanel } from '../../components/shared';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import {
 	convertPresetToCSSVar,
@@ -50,6 +50,7 @@ import {
 } from '../../utils/style-variation-classes';
 import { useGridRowMatch } from './utils/use-grid-row-match';
 import { getGridTemplateColumns } from './grid-columns';
+import { useRenderedColumns } from './utils/use-rendered-columns';
 
 /**
  * Grid Container Edit Component
@@ -137,12 +138,21 @@ export default function GridEdit({ attributes, setAttributes, clientId }) {
 	// count to publish (`--dsgo-row-count` + activation class). The frontend
 	// measures this from the DOM in view.js; in the editor the hook reads it
 	// from the block tree and the previewed device width.
-	const { isRowMatchActive, matchRowCount } = useGridRowMatch(clientId, {
-		matchRowHeights,
-		desktopColumns,
-		tabletColumns,
-		mobileColumns,
-	});
+	const { isRowMatchActive: isRowMatchConfigured, matchRowCount } =
+		useGridRowMatch(clientId, {
+			matchRowHeights,
+			desktopColumns,
+			tabletColumns,
+			mobileColumns,
+		});
+
+	// The configured column count is an upper bound — a column min width can
+	// drop a column rather than overflow (see ./grid-columns.js). Row matching
+	// is only meaningful once the grid actually renders 2+ columns; below that
+	// the row-track spans just absorb row gaps and inflate every card.
+	const innerRef = useRef();
+	const renderedColumns = useRenderedColumns(innerRef, desktopColumns || 3);
+	const isRowMatchActive = isRowMatchConfigured && renderedColumns > 1;
 
 	// Block wrapper props - outer div stays full width (must match save.js EXACTLY)
 	const hasOverlay = !!overlayColor || hasOverlayStyleClass(className);
@@ -229,6 +239,7 @@ export default function GridEdit({ attributes, setAttributes, clientId }) {
 	// Merge inner blocks props with inner styles
 	const innerBlocksProps = useInnerBlocksProps(
 		{
+			ref: innerRef,
 			className: [
 				'dsgo-grid__inner',
 				isRowMatchActive && 'dsgo-grid__inner--rows-matched',

--- a/src/blocks/grid/edit.js
+++ b/src/blocks/grid/edit.js
@@ -134,6 +134,31 @@ export default function GridEdit({ attributes, setAttributes, clientId }) {
 		[clientId]
 	);
 
+	// Calculate inner styles declaratively (must match save.js EXACTLY)
+	// IMPORTANT: Always provide a default gap to prevent overlapping items
+	// Priority: blockGap (WordPress spacing) → custom rowGap/columnGap → preset fallback
+	// WordPress 6.1+ stores blockGap as object {top, left} for separate row/column gaps
+	// Also need to convert preset format (var:preset|spacing|X) to CSS variable
+	const blockGapValue = style?.spacing?.blockGap;
+	const isBlockGapObject =
+		typeof blockGapValue === 'object' && blockGapValue !== null;
+	const blockGapRow = convertPresetToCSSVar(
+		isBlockGapObject ? blockGapValue?.top : blockGapValue
+	);
+	const blockGapColumn = convertPresetToCSSVar(
+		isBlockGapObject ? blockGapValue?.left : blockGapValue
+	);
+	const defaultGap = 'var(--wp--preset--spacing--50)';
+	const resolvedColumnGap = blockGapColumn || columnGap || defaultGap;
+
+	// The desktop track list, shared by the inner styles below and the
+	// rendered-column measurement (which re-measures whenever it changes).
+	const gridTemplateColumns = getGridTemplateColumns(
+		columnMinWidth,
+		desktopColumns,
+		resolvedColumnGap
+	);
+
 	// "Align Rows": derive whether the subgrid is active and the per-card row
 	// count to publish (`--dsgo-row-count` + activation class). The frontend
 	// measures this from the DOM in view.js; in the editor the hook reads it
@@ -151,7 +176,11 @@ export default function GridEdit({ attributes, setAttributes, clientId }) {
 	// is only meaningful once the grid actually renders 2+ columns; below that
 	// the row-track spans just absorb row gaps and inflate every card.
 	const innerRef = useRef();
-	const renderedColumns = useRenderedColumns(innerRef, desktopColumns || 3);
+	const renderedColumns = useRenderedColumns(
+		innerRef,
+		desktopColumns || 3,
+		gridTemplateColumns
+	);
 	const isRowMatchActive = isRowMatchConfigured && renderedColumns > 1;
 
 	// Block wrapper props - outer div stays full width (must match save.js EXACTLY)
@@ -194,30 +223,9 @@ export default function GridEdit({ attributes, setAttributes, clientId }) {
 		},
 	});
 
-	// Calculate inner styles declaratively (must match save.js EXACTLY)
-	// IMPORTANT: Always provide a default gap to prevent overlapping items
-	// Priority: blockGap (WordPress spacing) → custom rowGap/columnGap → preset fallback
-	// WordPress 6.1+ stores blockGap as object {top, left} for separate row/column gaps
-	// Also need to convert preset format (var:preset|spacing|X) to CSS variable
-	const blockGapValue = style?.spacing?.blockGap;
-	const isBlockGapObject =
-		typeof blockGapValue === 'object' && blockGapValue !== null;
-	const blockGapRow = convertPresetToCSSVar(
-		isBlockGapObject ? blockGapValue?.top : blockGapValue
-	);
-	const blockGapColumn = convertPresetToCSSVar(
-		isBlockGapObject ? blockGapValue?.left : blockGapValue
-	);
-	const defaultGap = 'var(--wp--preset--spacing--50)';
-	const resolvedColumnGap = blockGapColumn || columnGap || defaultGap;
-
 	const innerStyles = {
 		display: 'grid',
-		gridTemplateColumns: getGridTemplateColumns(
-			columnMinWidth,
-			desktopColumns,
-			resolvedColumnGap
-		),
+		gridTemplateColumns,
 		alignItems: alignItems || 'stretch',
 		rowGap: blockGapRow || rowGap || defaultGap,
 		columnGap: resolvedColumnGap,

--- a/src/blocks/grid/grid-columns.js
+++ b/src/blocks/grid/grid-columns.js
@@ -1,0 +1,60 @@
+/**
+ * Grid Block - Desktop column track builder
+ *
+ * Shared by edit.js and save.js so the editor and the stored markup can never
+ * drift apart.
+ *
+ * @since 2.6.3
+ */
+
+/**
+ * Build the desktop `grid-template-columns` value.
+ *
+ * The old form — `repeat(N, minmax(<min>, 1fr))` — overflows its container
+ * whenever `N * <min> + gaps` exceeds the available width. A theme with a
+ * narrow contentSize (650px, say) plus a 3-column grid with a 480px column
+ * min width pushed the columns straight out of the content column instead of
+ * wrapping, because a fixed repeat count can never drop a track.
+ *
+ * `auto-fill` can. The track minimum is the LARGER of the author's min width
+ * and the exact 1/N share of the container, so:
+ *
+ * - wide enough → the share wins, exactly N tracks fit, and the author's
+ *   column count is honoured as before;
+ * - too narrow → the min width wins, fewer tracks fit, and the remaining
+ *   items wrap to the next row.
+ *
+ * The outer `min(100%, …)` handles the last-resort case where the container
+ * is narrower than a single column's min width: the track collapses to the
+ * container width rather than overflowing it.
+ *
+ * @param {string} columnMinWidth Author's per-column min width ('' when unset).
+ * @param {number} desktopColumns Desktop column count.
+ * @param {string} columnGap      Resolved column gap (CSS length or var()).
+ * @return {string} A `grid-template-columns` value.
+ */
+export function getGridTemplateColumns(
+	columnMinWidth,
+	desktopColumns,
+	columnGap
+) {
+	const columns = desktopColumns || 3;
+
+	if (!columnMinWidth) {
+		return `repeat(${columns}, 1fr)`;
+	}
+
+	// The width one of N columns gets once the gaps between them are removed.
+	// `auto-fill` (not `auto-fit`) so unused tracks stay in place: a 2-item,
+	// 3-column grid keeps its items one third wide, exactly as the fixed
+	// repeat count did.
+	// Percentages inside a grid track minimum resolve against the grid
+	// container's inline size, so this is exact — N tracks of this size plus
+	// N-1 gaps add back up to 100%.
+	const share =
+		columns > 1
+			? `(100% - ${columns - 1} * ${columnGap}) / ${columns}`
+			: '100%';
+
+	return `repeat(auto-fill, minmax(min(100%, max(${columnMinWidth}, ${share})), 1fr))`;
+}

--- a/src/blocks/grid/save.js
+++ b/src/blocks/grid/save.js
@@ -15,6 +15,7 @@ import {
 	hasOverlayStyleClass,
 	hoverVariationClasses,
 } from '../../utils/style-variation-classes';
+import { getGridTemplateColumns } from './grid-columns';
 
 /**
  * Grid Container Save Component
@@ -111,15 +112,18 @@ export default function GridSave({ attributes }) {
 		isBlockGapObject ? blockGapValue?.left : blockGapValue
 	);
 	const defaultGap = 'var(--wp--preset--spacing--50)';
+	const resolvedColumnGap = blockGapColumn || columnGap || defaultGap;
 
 	const innerStyles = {
 		display: 'grid',
-		gridTemplateColumns: columnMinWidth
-			? `repeat(${desktopColumns || 3}, minmax(${columnMinWidth}, 1fr))`
-			: `repeat(${desktopColumns || 3}, 1fr)`,
+		gridTemplateColumns: getGridTemplateColumns(
+			columnMinWidth,
+			desktopColumns,
+			resolvedColumnGap
+		),
 		alignItems: alignItems || 'stretch',
 		rowGap: blockGapRow || rowGap || defaultGap,
-		columnGap: blockGapColumn || columnGap || defaultGap,
+		columnGap: resolvedColumnGap,
 	};
 
 	// Apply width constraints to inner container

--- a/src/blocks/grid/test/deprecated.test.js
+++ b/src/blocks/grid/test/deprecated.test.js
@@ -18,17 +18,16 @@ import {
 } from '@wordpress/block-editor/node_modules/@wordpress/blocks';
 import metadata from '../block.json';
 import save from '../save';
-import deprecated from '../deprecated';
+import deprecated, {
+	legacyMinWidth as legacyMinWidthDeprecation,
+	styleVariationClasses as styleVariationClassesDeprecation,
+} from '../deprecated';
 
 setCategories([{ slug: 'designsetgo', title: 'DesignSetGo' }]);
 
 registerBlockType(metadata.name, { ...metadata, save, deprecated });
 
 describe('grid deprecations - style-kit overlay variation migration', () => {
-	// deprecated.js exports:
-	// [legacyResponsiveTabletClass, legacyMinWidth, styleVariationClasses, v1].
-	const [, , styleVariationClassesDeprecation] = deprecated;
-
 	const canonicalOverlayMarkup = serialize(
 		createBlock(metadata.name, { className: 'is-style-overlay-dark' })
 	);
@@ -96,8 +95,6 @@ describe('grid deprecations - style-kit overlay variation migration', () => {
 });
 
 describe('grid deprecations - style-kit hover variation migration', () => {
-	const [, , styleVariationClassesDeprecation] = deprecated;
-
 	const canonicalHoverMarkup = serialize(
 		createBlock(metadata.name, { className: 'is-style-hover-text-light' })
 	);
@@ -163,8 +160,6 @@ describe('grid deprecations - legacyMinWidth precedence over styleVariationClass
 	// case — it's the only one that recovers `columnMinWidth` on migrate();
 	// styleVariationClasses.migrate() is a passthrough and would silently
 	// drop it.
-	const [, legacyMinWidthDeprecation, styleVariationClassesDeprecation] =
-		deprecated;
 
 	const canonicalOverlayMarkup = serialize(
 		createBlock(metadata.name, { className: 'is-style-overlay-dark' })
@@ -211,5 +206,43 @@ describe('grid deprecations - legacyMinWidth precedence over styleVariationClass
 		expect(block.name).toBe('designsetgo/grid');
 		expect(block.isValid).toBe(true);
 		expect(block.attributes.columnMinWidth).toBe('200px');
+	});
+});
+
+describe('grid deprecations - fixed columnMinWidth track migration', () => {
+	// Grids saved before the auto-fill switch carry a fixed
+	// `repeat(N, minmax(<min>, 1fr))` track list, which overflowed its
+	// container whenever N columns couldn't all hold their min width.
+	const canonicalMinWidthMarkup = serialize(
+		createBlock(metadata.name, { columnMinWidth: '480px' })
+	);
+	const OLD_FIXED_TRACK_MARKUP = canonicalMinWidthMarkup.replace(
+		/grid-template-columns:[^;"]+/,
+		'grid-template-columns:repeat(3, minmax(480px, 1fr))'
+	);
+
+	test('current save() emits an auto-fill track that can drop a column', () => {
+		expect(canonicalMinWidthMarkup).toContain('repeat(auto-fill');
+		expect(canonicalMinWidthMarkup).toContain('max(480px');
+		expect(canonicalMinWidthMarkup).not.toContain('repeat(3, minmax(');
+	});
+
+	test('old fixed-track grid migrates silently and keeps columnMinWidth', () => {
+		const [block] = parse(OLD_FIXED_TRACK_MARKUP);
+
+		expect(console).toHaveInformed();
+
+		expect(block.name).toBe('designsetgo/grid');
+		expect(block.isValid).toBe(true);
+		expect(block.attributes.columnMinWidth).toBe('480px');
+		expect(getBlockContent(block)).toContain('repeat(auto-fill');
+	});
+
+	test('grids without a columnMinWidth are untouched by the deprecation', () => {
+		const markup = serialize(createBlock(metadata.name, {}));
+		const [block] = parse(markup);
+
+		expect(block.isValid).toBe(true);
+		expect(getBlockContent(block)).toContain('repeat(3, 1fr)');
 	});
 });

--- a/src/blocks/grid/test/use-rendered-columns.test.js
+++ b/src/blocks/grid/test/use-rendered-columns.test.js
@@ -1,0 +1,127 @@
+/**
+ * Grid — useRenderedColumns tests.
+ *
+ * jsdom does no layout and ships no ResizeObserver, so both are stubbed: the
+ * hook's contract is "read the resolved track list, keep it current", and both
+ * halves of that are worth pinning independently.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useRenderedColumns } from '../utils/use-rendered-columns';
+
+/**
+ * Stub the resolved track list a browser would report for the grid element.
+ *
+ * @param {number} count Rendered column count to report.
+ */
+function stubTracks(count) {
+	jest.spyOn(window, 'getComputedStyle').mockReturnValue({
+		gridTemplateColumns: '364px '.repeat(count).trim(),
+	});
+}
+
+/**
+ * Install a controllable ResizeObserver stub.
+ *
+ * @return {Object} Handle exposing `fire()` and the disconnect spy.
+ */
+function stubResizeObserver() {
+	const handle = { callbacks: [], disconnect: jest.fn() };
+	window.ResizeObserver = class {
+		constructor(cb) {
+			handle.callbacks.push(cb);
+		}
+		observe() {}
+		disconnect() {
+			handle.disconnect();
+		}
+	};
+	handle.fire = () => act(() => handle.callbacks.forEach((cb) => cb()));
+	return handle;
+}
+
+describe('useRenderedColumns', () => {
+	let element;
+
+	beforeEach(() => {
+		element = document.createElement('div');
+		document.body.appendChild(element);
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+		delete window.ResizeObserver;
+		jest.restoreAllMocks();
+	});
+
+	test('measures the resolved track count on mount', () => {
+		stubResizeObserver();
+		stubTracks(2);
+		const { result } = renderHook(() =>
+			useRenderedColumns({ current: element }, 3, 'repeat(3, 1fr)')
+		);
+		expect(result.current).toBe(2);
+	});
+
+	test('measures once even without ResizeObserver support', () => {
+		// No observer stub installed: the count must still be accurate, not
+		// pinned at the configured fallback (which would leave row matching
+		// active on a grid that has wrapped to a single column).
+		stubTracks(1);
+		const { result } = renderHook(() =>
+			useRenderedColumns({ current: element }, 3, 'repeat(3, 1fr)')
+		);
+		expect(result.current).toBe(1);
+	});
+
+	test('re-measures when the track list changes, without any resize', () => {
+		// Editing the column min width or gap can change the resolved track
+		// count while the container's own box size stays put, so the observer
+		// alone would leave the count stale.
+		stubResizeObserver();
+		stubTracks(3);
+		const { result, rerender } = renderHook(
+			({ tracks }) => useRenderedColumns({ current: element }, 3, tracks),
+			{ initialProps: { tracks: 'repeat(3, 1fr)' } }
+		);
+		expect(result.current).toBe(3);
+
+		stubTracks(1);
+		rerender({ tracks: 'repeat(auto-fill, minmax(480px, 1fr))' });
+		expect(result.current).toBe(1);
+	});
+
+	test('re-measures when the observer fires', () => {
+		const observer = stubResizeObserver();
+		stubTracks(3);
+		const { result } = renderHook(() =>
+			useRenderedColumns({ current: element }, 3, 'repeat(3, 1fr)')
+		);
+		expect(result.current).toBe(3);
+
+		stubTracks(2);
+		observer.fire();
+		expect(result.current).toBe(2);
+	});
+
+	test('falls back to the configured count when the track list is unreadable', () => {
+		stubResizeObserver();
+		jest.spyOn(window, 'getComputedStyle').mockReturnValue({
+			gridTemplateColumns: 'none',
+		});
+		const { result } = renderHook(() =>
+			useRenderedColumns({ current: element }, 4, 'repeat(4, 1fr)')
+		);
+		expect(result.current).toBe(4);
+	});
+
+	test('disconnects the observer on unmount', () => {
+		const observer = stubResizeObserver();
+		stubTracks(3);
+		const { unmount } = renderHook(() =>
+			useRenderedColumns({ current: element }, 3, 'repeat(3, 1fr)')
+		);
+		unmount();
+		expect(observer.disconnect).toHaveBeenCalled();
+	});
+});

--- a/src/blocks/grid/test/view.test.js
+++ b/src/blocks/grid/test/view.test.js
@@ -155,3 +155,62 @@ describe('grid view.js - DSGGrid', () => {
 		).toBe(false);
 	});
 });
+
+describe('grid view.js - rendered column count gates row matching', () => {
+	afterEach(() => {
+		document.body.innerHTML = '';
+		jest.restoreAllMocks();
+	});
+
+	/**
+	 * jsdom does no layout, so stub the resolved track list the way a browser
+	 * would report it: space-separated used values, one per rendered column.
+	 *
+	 * @param {number} count Rendered column count to report.
+	 */
+	function stubTracks(count) {
+		const real = window.getComputedStyle.bind(window);
+		jest.spyOn(window, 'getComputedStyle').mockImplementation((el) => {
+			if (el.classList.contains('dsgo-grid__inner')) {
+				return { gridTemplateColumns: '364px '.repeat(count).trim() };
+			}
+			return real(el);
+		});
+	}
+
+	test('reads the rendered count off the resolved track list', () => {
+		stubTracks(2);
+		const grid = new DSGGrid(buildGrid({ cols: 3 }));
+		expect(grid.getRenderedColumns(3)).toBe(2);
+	});
+
+	test('falls back to the configured count when the track list is unreadable', () => {
+		jest.spyOn(window, 'getComputedStyle').mockReturnValue({
+			gridTemplateColumns: 'none',
+		});
+		const grid = new DSGGrid(buildGrid({ cols: 3 }));
+		expect(grid.getRenderedColumns(3)).toBe(3);
+	});
+
+	test('a 3-column grid wrapped to one column does not activate row matching', () => {
+		// The regression: cards spanning --dsgo-row-count row tracks in a
+		// single-column grid absorb the row gaps and inflate for no benefit.
+		stubTracks(1);
+		const grid = new DSGGrid(buildGrid({ cols: 3, cards: 3, rows: 4 }));
+		grid.handleResize();
+		expect(
+			grid.inner.classList.contains('dsgo-grid__inner--rows-matched')
+		).toBe(false);
+		expect(grid.inner.style.getPropertyValue('--dsgo-row-count')).toBe('');
+	});
+
+	test('a 3-column grid still rendering 3 columns activates as before', () => {
+		stubTracks(3);
+		const grid = new DSGGrid(buildGrid({ cols: 3, cards: 3, rows: 4 }));
+		grid.handleResize();
+		expect(
+			grid.inner.classList.contains('dsgo-grid__inner--rows-matched')
+		).toBe(true);
+		expect(grid.inner.style.getPropertyValue('--dsgo-row-count')).toBe('4');
+	});
+});

--- a/src/blocks/grid/test/view.test.js
+++ b/src/blocks/grid/test/view.test.js
@@ -214,3 +214,27 @@ describe('grid view.js - rendered column count gates row matching', () => {
 		expect(grid.inner.style.getPropertyValue('--dsgo-row-count')).toBe('4');
 	});
 });
+
+describe('grid view.js - measurement is skipped without Align Rows', () => {
+	afterEach(() => {
+		document.body.innerHTML = '';
+		jest.restoreAllMocks();
+	});
+
+	test('does not measure when Align Rows is off', () => {
+		// getComputedStyle forces a synchronous layout flush, and only Align
+		// Rows consumes the result — a page full of plain grids must not pay
+		// for a reflow each on every resize.
+		const grid = new DSGGrid(buildGrid({ match: false }));
+		const spy = jest.spyOn(grid, 'getRenderedColumns');
+		grid.handleResize();
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	test('still measures when Align Rows is on', () => {
+		const grid = new DSGGrid(buildGrid({ match: true }));
+		const spy = jest.spyOn(grid, 'getRenderedColumns');
+		grid.handleResize();
+		expect(spy).toHaveBeenCalled();
+	});
+});

--- a/src/blocks/grid/utils/use-rendered-columns.js
+++ b/src/blocks/grid/utils/use-rendered-columns.js
@@ -1,0 +1,72 @@
+/**
+ * Grid — measure the column count the grid is ACTUALLY rendering.
+ *
+ * The configured desktop column count is an upper bound, not a promise: the
+ * column min width builds an `auto-fill` track list that drops a column rather
+ * than overflow its container (see ../grid-columns.js). "Align Rows" has to
+ * key off what rendered, because a card spanning `--dsgo-row-count` row tracks
+ * in a grid that has wrapped to a single column absorbs the row gaps between
+ * those tracks and grows taller for nothing — there is no sibling beside it to
+ * align to.
+ *
+ * The frontend does the same measurement in view.js (`getRenderedColumns`).
+ */
+
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Read the resolved track count off an element's computed style.
+ *
+ * @param {HTMLElement} element  Grid container.
+ * @param {number}      fallback Count to use when the track list is unreadable.
+ * @return {number} Rendered column count.
+ */
+function readColumnCount(element, fallback) {
+	const view = element.ownerDocument?.defaultView;
+	if (!view) {
+		return fallback;
+	}
+
+	const tracks = view.getComputedStyle(element).gridTemplateColumns;
+	if (!tracks || tracks === 'none') {
+		return fallback;
+	}
+
+	return tracks.split(/\s+/).filter(Boolean).length || fallback;
+}
+
+/**
+ * Track the rendered column count of the element held by `ref`.
+ *
+ * @param {Object} ref      Ref holding the grid container element.
+ * @param {number} fallback Count to report before the first measurement, and
+ *                          whenever the track list can't be read.
+ * @return {number} Rendered column count.
+ */
+export function useRenderedColumns(ref, fallback) {
+	const [columns, setColumns] = useState(fallback);
+
+	useEffect(() => {
+		const element = ref.current;
+		const view = element?.ownerDocument?.defaultView;
+		if (!element || !view?.ResizeObserver) {
+			return undefined;
+		}
+
+		const measure = () => {
+			const next = readColumnCount(element, fallback);
+			// Only the width drives the track count, so this can't oscillate
+			// with the height change that activating row matching causes — but
+			// bail on an unchanged value anyway to avoid a wasted render.
+			setColumns((current) => (current === next ? current : next));
+		};
+
+		measure();
+
+		const observer = new view.ResizeObserver(measure);
+		observer.observe(element);
+		return () => observer.disconnect();
+	}, [ref, fallback]);
+
+	return columns;
+}

--- a/src/blocks/grid/utils/use-rendered-columns.js
+++ b/src/blocks/grid/utils/use-rendered-columns.js
@@ -38,18 +38,23 @@ function readColumnCount(element, fallback) {
 /**
  * Track the rendered column count of the element held by `ref`.
  *
- * @param {Object} ref      Ref holding the grid container element.
- * @param {number} fallback Count to report before the first measurement, and
- *                          whenever the track list can't be read.
+ * @param {Object} ref       Ref holding the grid container element.
+ * @param {number} fallback  Count to report before the first measurement, and
+ *                           whenever the track list can't be read.
+ * @param {string} trackList The authored `grid-template-columns` value. Never
+ *                           read — it's the re-measure trigger. Editing the
+ *                           column min width or the gap changes the resolved
+ *                           track count without necessarily resizing the
+ *                           container itself, so the observer alone can leave
+ *                           the count stale.
  * @return {number} Rendered column count.
  */
-export function useRenderedColumns(ref, fallback) {
+export function useRenderedColumns(ref, fallback, trackList) {
 	const [columns, setColumns] = useState(fallback);
 
 	useEffect(() => {
 		const element = ref.current;
-		const view = element?.ownerDocument?.defaultView;
-		if (!element || !view?.ResizeObserver) {
+		if (!element) {
 			return undefined;
 		}
 
@@ -61,12 +66,22 @@ export function useRenderedColumns(ref, fallback) {
 			setColumns((current) => (current === next ? current : next));
 		};
 
+		// Measure BEFORE subscribing, so the count is right even where
+		// ResizeObserver is missing. The observer only adds the ability to keep
+		// the count right; going without it must not pin the value at the
+		// configured count forever, which would leave row matching active on a
+		// grid that has actually wrapped to one column.
 		measure();
+
+		const view = element.ownerDocument?.defaultView;
+		if (!view?.ResizeObserver) {
+			return undefined;
+		}
 
 		const observer = new view.ResizeObserver(measure);
 		observer.observe(element);
 		return () => observer.disconnect();
-	}, [ref, fallback]);
+	}, [ref, fallback, trackList]);
 
 	return columns;
 }

--- a/src/blocks/grid/utils/use-rendered-columns.js
+++ b/src/blocks/grid/utils/use-rendered-columns.js
@@ -12,7 +12,7 @@
  * The frontend does the same measurement in view.js (`getRenderedColumns`).
  */
 
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useLayoutEffect } from '@wordpress/element';
 
 /**
  * Read the resolved track count off an element's computed style.
@@ -52,7 +52,11 @@ function readColumnCount(element, fallback) {
 export function useRenderedColumns(ref, fallback, trackList) {
 	const [columns, setColumns] = useState(fallback);
 
-	useEffect(() => {
+	// Layout effect, not a plain effect: this runs after the DOM is in place but
+	// BEFORE paint, so a grid that actually wraps never paints a frame with row
+	// matching on. State starts at the configured count, which is only correct
+	// for a grid that doesn't wrap.
+	useLayoutEffect(() => {
 		const element = ref.current;
 		if (!element) {
 			return undefined;

--- a/src/blocks/grid/view.js
+++ b/src/blocks/grid/view.js
@@ -85,11 +85,18 @@
 			// null, so fall back to the desktop column class), then narrowed
 			// to what the grid is actually rendering — a column min width can
 			// drop a column instead of overflowing.
+			//
+			// Only Align Rows consumes this, and the measurement forces a
+			// synchronous layout flush, so skip it entirely for grids without
+			// the feature: `applyRowMatching()` treats a falsy count the same
+			// way it treats a single column, and returns before using it.
 			const configuredColumns =
 				config.columns === null
 					? this.getDesktopColumns()
 					: config.columns;
-			const effectiveColumns = this.getRenderedColumns(configuredColumns);
+			const effectiveColumns = this.matchRows
+				? this.getRenderedColumns(configuredColumns)
+				: null;
 
 			// Desktop: Remove all constraints
 			if (config.breakpoint === 'desktop') {

--- a/src/blocks/grid/view.js
+++ b/src/blocks/grid/view.js
@@ -82,11 +82,14 @@
 			const config = this.getResponsiveColumns();
 
 			// Effective columns at the current breakpoint (desktop reports
-			// null, so fall back to the desktop column class).
-			const effectiveColumns =
+			// null, so fall back to the desktop column class), then narrowed
+			// to what the grid is actually rendering — a column min width can
+			// drop a column instead of overflowing.
+			const configuredColumns =
 				config.columns === null
 					? this.getDesktopColumns()
 					: config.columns;
+			const effectiveColumns = this.getRenderedColumns(configuredColumns);
 
 			// Desktop: Remove all constraints
 			if (config.breakpoint === 'desktop') {
@@ -112,6 +115,40 @@
 				}
 			}
 			return 1;
+		}
+
+		/**
+		 * Count the columns the grid is ACTUALLY rendering, by reading the
+		 * resolved track list off the computed style.
+		 *
+		 * This can be fewer than the configured desktop count: the column min
+		 * width builds an `auto-fill` track list that drops a column rather
+		 * than overflowing the container (see utils/grid-columns.js). Row
+		 * matching must key off the rendered count, not the configured one —
+		 * a card spanning `--dsgo-row-count` row tracks in a grid that has
+		 * wrapped to a single column absorbs the row gaps between those tracks
+		 * and grows taller for no benefit, since there is nothing beside it to
+		 * align to.
+		 *
+		 * @param {number} fallback Count to use when the track list is
+		 *                          unreadable (detached or `display: none`).
+		 * @return {number} Rendered column count.
+		 */
+		getRenderedColumns(fallback) {
+			const tracks = window.getComputedStyle(
+				this.inner
+			).gridTemplateColumns;
+
+			// 'none' (no grid), '' (detached / jsdom without layout), or any
+			// unresolved value: fall back to the configured count.
+			if (!tracks || tracks === 'none') {
+				return fallback;
+			}
+
+			// Resolved track lists are space-separated used values
+			// ('364px 364px 364px'). `minmax()`/`repeat()` only survive here if
+			// the browser could not resolve them, which the guard above covers.
+			return tracks.split(/\s+/).filter(Boolean).length || fallback;
 		}
 
 		/**

--- a/tests/unit/grid-compat-deprecation.test.js
+++ b/tests/unit/grid-compat-deprecation.test.js
@@ -41,11 +41,14 @@ describe('grid site-designer compatibility deprecation (responsive tablet class)
 		expect(block.attributes.columnMinWidth).toBe('480px');
 		expect(block.attributes.className).toBeUndefined();
 
-		// Re-serializes to consistent current markup: one tablet-1 class, minmax
+		// Re-serializes to consistent current markup: one tablet-1 class, track
 		// rebuilt from the attribute.
 		const out = serialize(block);
 		expect(out).toContain('dsgo-grid-cols-tablet-1');
 		expect(out).not.toContain('dsgo-grid-cols-tablet-2');
-		expect(out).toContain('minmax(480px, 1fr)');
+		// Rebuilt from the attribute in the current auto-fill form, which drops a
+		// column instead of overflowing when 2 x 480px can't fit the container.
+		expect(out).toContain('repeat(auto-fill');
+		expect(out).toContain('max(480px');
 	});
 });


### PR DESCRIPTION
## Problem

Set a theme `contentSize` of 650px, then add a Grid with 2 columns and a 480px **Column Min Width**. The columns render 984px wide and blow straight out of the content column instead of wrapping.

The desktop track list was `repeat(N, minmax(<min>, 1fr))`. A fixed repeat count can never drop a track, so as soon as `N * <min> + gaps` exceeds the available width, the grid overflows.

## Fix

New shared builder `src/blocks/grid/grid-columns.js`, used by both `edit.js` and `save.js`:

```
repeat(auto-fill, minmax(min(100%, max(<min>, (100% - (N-1) * <gap>) / N)), 1fr))
```

The track minimum is the larger of the author's min width and the exact 1/N share of the container, so N columns still fit exactly when there's room, and fewer fit when there isn't — the extra items wrap to the next row. The outer `min(100%, …)` covers a container narrower than a single column's min width.

`auto-fill` rather than `auto-fit`: **auto-fit collapses empty tracks**, which would stretch a 2-item, 3-column grid's items to half the container instead of a third. `auto-fill` reproduces the old sizing exactly.

## Layout verified in a browser

Measured computed track sizes rather than trusting the formula:

| container | cols × min | before | after |
| --- | --- | --- | --- |
| 650px | 2 × 480px | 984px, overflowing | 1 col @ 650px |
| 650px | 3 × 280px | overflow | 2 cols @ 313px |
| 1140px | 3 × 480px | overflow | 2 cols @ 558px |
| 1600px | 3 × 280px | 3 cols | 3 cols (unchanged) |
| 1140px | 3 × 280px | 3 cols @ 364px | 3 cols @ 364px |
| 1140px | 3 × 280px, 2 items | items @ 364px | items @ 364px (auto-fit would give 558px) |

## Deprecation

Markup changed, so `fixedColumnMinWidthTracks` reproduces the old fixed track list byte-for-byte and is listed first — stored grids migrate silently, no "Attempt Recovery".

It deliberately carries **no `isEligible`**: grids without a `columnMinWidth` serialise identically under both forms, and an `isEligible` would opt those valid blocks into a pointless re-migration.

## Also

- Deprecation entries gain named exports; the tests referenced them by array position, which broke four existing tests when the new entry was inserted at index 0.
- Updated the "Column Min Width" inspector help text, which described the old `minmax(value, 1fr)` behaviour.

## Testing

- `npm run build`, `npm run lint:js`, full suite: 10,202 tests pass.
- New regression tests in `src/blocks/grid/test/deprecated.test.js` cover the silent migration and confirm grids without a `columnMinWidth` are untouched.
- `tests/unit/grid-compat-deprecation.test.js` already fixtures the exact reported shape (2 columns × 480px); its assertion is updated to the new track form.
- **Not verified:** a hands-on pass in the wp-env editor/frontend — the above is unit tests plus an isolated browser layout probe, not the block rendered on a real page.