### PR TITLE
docs: fix stale plugin version/PHP requirement in contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -791,4 +791,4 @@ Thank you for contributing to DesignSetGo! Every contribution, no matter how sma
 
 ---
 
-**License**: GPL-2.0-or-later | **Version**: 2.0.23 | **WordPress**: 6.7+ | **PHP**: 8.0+
+**License**: GPL-2.0-or-later | **Version**: 2.6.3 | **WordPress**: 6.7+ | **PHP**: 7.4+

--- a/TESTING.md
+++ b/TESTING.md
@@ -471,5 +471,5 @@ bash bin/install-wp-tests.sh wordpress_test root '' localhost latest
 ---
 
 **Last Updated**: 2026-02-13
-**Plugin Version**: 2.0.23
+**Plugin Version**: 2.6.3
 **WordPress Compatibility**: 6.7+


### PR DESCRIPTION
## Description
Fixes stale plugin-version and PHP-requirement metadata in `CONTRIBUTING.md` and `TESTING.md` so they match the actual plugin header (`designsetgo.php`) and `readme.txt`.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issue
Closes #505

## Changes Made
- `CONTRIBUTING.md` footer: `Version: 2.0.23` → `2.6.3`, `PHP: 8.0+` → `7.4+` (matches the plugin's actual `Requires PHP` header; 8.0+ was only ever the recommended local-lint version, documented separately elsewhere in the file)
- `TESTING.md`: `Plugin Version: 2.0.23` → `2.6.3`

## Testing
- [x] Cross-checked both values against `designsetgo.php` header and `readme.txt`
- [x] Markdown renders correctly (no syntax touched beyond the two value changes)
- [x] Searched `README.md`/`TESTING-QUICKSTART.md` for other stale version references — none found
- [ ] Tested in WordPress editor — n/a, docs-only change
- [x] Tested on frontend — n/a, docs-only change
- [x] No console errors
- [x] No PHP errors

## Screenshots/Videos
N/A — docs-only change.

## Checklist
- [x] My code follows the WordPress Coding Standards (n/a, no code changed)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (n/a)
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings or errors
- [x] I have tested on WordPress 6.4+ (n/a, docs-only)
- [x] All files are under 300 lines (if applicable)
- [x] Accessibility: WCAG 2.1 AA compliant (n/a)
- [x] Security: All user input is validated and sanitized (n/a)
- [x] Internationalization: All user-facing strings use `__()` or `_e()` (n/a, docs files aren't translated)

## Additional Notes
None.