### PR TITLE
chore(ci): bump outdated GitHub Actions across all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20.x
           cache: 'npm'
@@ -93,7 +93,7 @@ jobs:
           fi
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-output
           path: build/
@@ -108,10 +108,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20.x
           cache: 'npm'
@@ -129,7 +129,7 @@ jobs:
         run: npm run test:unit -- --ci
 
       - name: Upload coverage reports
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           files: ./coverage/lcov.info
           flags: unittests
@@ -170,7 +170,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
@@ -212,10 +212,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20.x
 
@@ -236,10 +236,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: critical
 
@@ -276,10 +276,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20.x
           cache: 'npm'
@@ -296,7 +296,7 @@ jobs:
           composer install --no-interaction --prefer-dist
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-output
           path: build/

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -131,7 +131,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/deploy-assets.yml
+++ b/.github/workflows/deploy-assets.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Deploy assets to WordPress.org
         uses: 10up/action-wordpress-plugin-asset-update@stable
@@ -47,7 +47,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Deploy readme.txt to WordPress.org SVN
         env:
@@ -102,10 +102,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,10 @@ jobs:
     permissions:
       contents: read  # Required for actions/checkout
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Label based on files changed
-        uses: actions/labeler@v5
+        uses: actions/labeler@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20.x
           cache: 'npm'
@@ -95,7 +95,7 @@ jobs:
 
       - name: Post results to PR
         if: always() && github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: plugin-check
           path: plugin-check-results/report.md

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -20,19 +20,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: main-repo
 
       - name: Checkout wiki repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: jnealey-godaddy/designsetgo.wiki
           path: wiki-repo
           token: ${{ secrets.WIKI_PAT }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20.x
 


### PR DESCRIPTION
## Summary
- Bump every outdated pinned GitHub Action across `.github/workflows/*.yml` to its latest major release:
  - `actions/checkout`: v4 → v7
  - `actions/setup-node`: v4 → v7 (`node-version` input left at `20.x`/`'20'`, unchanged — matches `.nvmrc` and is not part of what's outdated here)
  - `actions/upload-artifact`: v4 → v7 (`ci.yml`)
  - `actions/download-artifact`: v4 → v8 (`ci.yml`)
  - `codecov/codecov-action`: v4 → v7 (`ci.yml`)
  - `actions/dependency-review-action`: v4 → v5 (`ci.yml`)
  - `actions/labeler`: v5 → v7 (`label-pr.yml`)
  - `marocchino/sticky-pull-request-comment`: v2 → v3 (`plugin-check.yml`)
- Checked the changelog for every intermediate major version bumped through, specifically for changes that could affect this repo's usage:
  - `download-artifact` v5's breaking change only affects downloads by `artifact-ids`; this repo downloads by `name`, so it doesn't apply.
  - `codecov-action` v5 deprecated the `file`/`plugin` inputs in favor of `files`/`plugins`; this repo's workflow already uses `files`/`flags`/`name`, not the deprecated form.
  - All other majors bumped (`checkout`, `setup-node`, `upload-artifact`, `labeler`, `dependency-review-action`, `sticky-pull-request-comment`) were Node 24 runtime updates or additive features with no input/behavior changes relevant here.
- No `dependabot.yml` exists in this repo, so there's no separate Dependabot config to update.
- Left unchanged (already tracking their latest release via a moving major tag, nothing newer to bump to): `shivammathur/setup-php@v2`, `codelytv/pr-size-labeler@v1`, `anthropics/claude-code-action@v1`, and both `10up/action-wordpress-plugin-*@stable` actions.

## Context
Spotted while looking into run [31773714055](https://github.com/jnealey-godaddy/designsetgo/actions/runs/31773714055) on PR #504. That run's actual Plugin Check scan passed with 0 errors — the job only showed red because the separate "Post results to PR" step failed with `Resource not accessible by integration`. That's unrelated to this PR: GitHub forces the `GITHUB_TOKEN` to read-only for `pull_request`-triggered workflows from forked repos, regardless of the `permissions:` block declared in the workflow file. This PR doesn't attempt to fix that (would need `pull_request_target` or skipping the comment step for fork PRs — a tradeoff for you to decide) — it only clears the Node 20 deprecation warnings that were also visible in that run's annotations, and extends the same cleanup to every other workflow in the repo that had the same issue.

## Test plan
- [ ] CI runs on this PR (`ci.yml`, `plugin-check.yml`, `label-pr.yml`) and completes without Node 20 deprecation annotations
- [ ] `ci.yml`'s build/upload/download-artifact round trip still works end to end
- [ ] `codecov` coverage upload still succeeds
- [ ] `deploy.yml` / `deploy-assets.yml` are unchanged in behavior (only checkout/setup-node bumped) — worth a dry run or close look before merging since these push to WordPress.org