### PR TITLE
fix(pcp): silence false-positive Offloading error on Turnstile endpoint

### DIFF
--- a/includes/blocks/forms/class-form-security.php
+++ b/includes/blocks/forms/class-form-security.php
@@ -144,6 +144,7 @@ class Form_Security {
 		// experience. On timeout, wp_remote_post() returns a WP_Error and we degrade
 		// gracefully (let the submission through) rather than punish the user.
 		$response = wp_remote_post(
+			// phpcs:ignore PluginCheck.CodeAnalysis.Offloading.OffloadedContent -- Server-side Turnstile verification API endpoint, not an offloaded asset. The sniff matches any `cloudflare.com` host in any string; no image, script, style or other content is loaded from it.
 			'https://challenges.cloudflare.com/turnstile/v0/siteverify',
 			array(
 				'timeout' => 3,


### PR DESCRIPTION
## The failure

The Plugin Check (PCP) job fails on `main` and therefore on every open PR, with a single error:

```
PluginCheck.CodeAnalysis.Offloading.OffloadedContent  ERROR
Offloading images, js, css, and other scripts to your servers or any remote service is disallowed.
includes/blocks/forms/class-form-security.php  147
```

No code changed. Plugin Check released **2.1.0**, and the workflow installs it unpinned (`wp plugin install plugin-check --activate --force`), so CI picked up the new `CodeAnalysis.Offloading` sniff. It fails on [run 32051972177](https://github.com/jnealey-godaddy/designsetgo/actions/runs/32051972177) (main) identically to the PR runs.

## Why it is a false positive

`OffloadingSniff` runs its first check against a fixed list of known CDN hosts, over **every string token in the file**, with no surrounding context taken into account. From `OffloadingServicesTrait`:

```php
'(?<!api\.)cloudflare\.com',
```

The line it flags is the Turnstile **server-side verification API**, called from PHP via `wp_remote_post()`:

```php
$response = wp_remote_post(
    'https://challenges.cloudflare.com/turnstile/v0/siteverify',
```

No image, script, style, font or other asset is loaded from that host — the request happens on the server during form submission and returns a JSON pass/fail. The sniff's own second check (the file-extension pattern) is deliberately scoped to HTML markup strings "to avoid false positives on arbitrary URLs"; the known-services list has no such guard.

The negative lookbehind exempts only `api.cloudflare.com`, so `challenges.cloudflare.com` cannot be written literally without tripping the sniff.

## The fix

A targeted `phpcs:ignore` on that one line, with the reason recorded inline. The repo already relies on PCP honouring these annotations — see the four existing `PluginCheck.Security.DirectDB.UnescapedDBParameter` ignores in `class-query-filter-index.php` and `class-block-migrator.php`.

Rejected alternatives:

- **Adding `Offloading` to the workflow's `--ignore-codes`** — suppresses the check plugin-wide, including genuine asset offloading a future change might introduce.
- **Splitting the string** (`'https://challenges.' . 'cloudflare.com/…'`) — evades the regex but obscures the URL for no stated reason.

## Verification

Reproduced and verified locally against **PCP 2.1.0** (the exact version CI installs) on wp-env with WP 6.9, running the workflow's exact command with the plugin mounted under its real `designsetgo` slug:

| | `ERROR` count | Offloading error |
|---|---|---|
| Before | 1 | present at `class-form-security.php:147` |
| After | **0** | gone |

Diffing the full before/after findings, the removed error is the **only** difference — no warning was introduced or masked. The workflow gates on `grep -c $'\tERROR\t'`, which is now 0.

`composer run-script lint` passes `--warning-severity=0`, so `Generic.Files.LineLength` (a warning) cannot fail it; the new comment is 266 chars, shorter than the existing 304- and 364-char `phpcs:ignore` lines already passing CI.

## Scope

Behaviour is unchanged — this adds one comment line. Turnstile verification, its 3s timeout and its graceful-degradation paths are untouched.

Worth considering separately: pinning `plugin-check` to a known version in the workflow, so a PCP release cannot turn CI red across every branch without a code change.