### PR TITLE
feat: schema.org JSON-LD output for the accordion (FAQ, How-to)

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -499,6 +499,13 @@ class Plugin {
 	public $interactions;
 
 	/**
+	 * Schema JSON-LD output instance.
+	 *
+	 * @var SchemaOutput
+	 */
+	public $schema_output;
+
+	/**
 	 * Block Bindings Support instance.
 	 *
 	 * @var Block_Bindings_Support
@@ -658,6 +665,7 @@ class Plugin {
 		require_once DESIGNSETGO_PATH . 'includes/features/class-extension-attributes.php';
 		require_once DESIGNSETGO_PATH . 'includes/features/class-style-binding.php';
 		require_once DESIGNSETGO_PATH . 'includes/features/class-interactions.php';
+		require_once DESIGNSETGO_PATH . 'includes/features/class-schema-output.php';
 		require_once DESIGNSETGO_PATH . 'includes/bindings/class-block-bindings-support.php';
 		require_once DESIGNSETGO_PATH . 'includes/data/svg-pattern-data.php';
 		require_once DESIGNSETGO_PATH . 'includes/features/class-svg-pattern-renderer.php';
@@ -710,6 +718,7 @@ class Plugin {
 		$this->extension_attrs        = new Extension_Attributes();
 		$this->style_binding          = new StyleBinding();
 		$this->interactions           = new Interactions();
+		$this->schema_output          = new SchemaOutput();
 		$this->block_bindings_support = new Block_Bindings_Support();
 		$this->block_bindings_support->register();
 		$this->modal_hooks      = new Blocks\Modal_Hooks();

--- a/includes/extension-configs/schema.php
+++ b/includes/extension-configs/schema.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Schema extension attribute schema.
+ *
+ * Mirrors the JS allowlist so the attribute survives server-side block
+ * registration. Keep this list identical to SCHEMA_BLOCKS.
+ *
+ * @see src/extensions/schema/constants.js
+ * @package DesignSetGo
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+return array(
+	'blocks'     => array(
+		'designsetgo/accordion',
+	),
+	'exclude'    => array(), // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Extension block-exclusion list, not a get_posts() query.
+	'attributes' => array(
+		'dsgoSchema' => array(
+			'type'    => 'string',
+			'default' => 'none',
+		),
+	),
+);

--- a/includes/features/class-schema-output.php
+++ b/includes/features/class-schema-output.php
@@ -45,13 +45,23 @@ class SchemaOutput {
 	 *
 	 * @param array  $blocks Parsed blocks.
 	 * @param string $title  Page title, passed to builders that need it.
+	 * @param array  $seen   Synced-pattern IDs already expanded, guarding cycles.
 	 * @return array List of schema graph nodes.
 	 */
-	public function collect( array $blocks, $title = '' ) {
+	public function collect( array $blocks, $title = '', array $seen = array() ) {
 		$nodes = array();
 
 		foreach ( $blocks as $block ) {
 			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			// A synced pattern keeps its markup in a wp_block post; the page
+			// only stores a reference. Without expanding it, an FAQ defined
+			// once in a shared pattern would emit nothing on every page that
+			// uses it, with nothing to tell the author why.
+			if ( 'core/block' === ( isset( $block['blockName'] ) ? $block['blockName'] : '' ) ) {
+				$nodes = array_merge( $nodes, $this->collect_from_reference( $block, $title, $seen ) );
 				continue;
 			}
 
@@ -72,11 +82,48 @@ class SchemaOutput {
 			}
 
 			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
-				$nodes = array_merge( $nodes, $this->collect( $block['innerBlocks'], $title ) );
+				$nodes = array_merge( $nodes, $this->collect( $block['innerBlocks'], $title, $seen ) );
 			}
 		}
 
 		return $nodes;
+	}
+
+	/**
+	 * Expand a synced pattern reference and collect from its content.
+	 *
+	 * @param array  $block Parsed core/block block.
+	 * @param string $title Page title.
+	 * @param array  $seen  Reference IDs already expanded on this branch.
+	 * @return array List of schema graph nodes.
+	 */
+	private function collect_from_reference( array $block, $title, array $seen ) {
+		$ref = isset( $block['attrs']['ref'] ) ? (int) $block['attrs']['ref'] : 0;
+
+		// A pattern that references itself, directly or through another
+		// pattern, would otherwise recurse until the request dies.
+		if ( $ref <= 0 || in_array( $ref, $seen, true ) ) {
+			return array();
+		}
+
+		$seen[] = $ref;
+
+		$reference = get_post( $ref );
+
+		if ( ! $reference instanceof \WP_Post || 'wp_block' !== $reference->post_type ) {
+			return array();
+		}
+
+		if ( 'publish' !== $reference->post_status ) {
+			return array();
+		}
+
+		if ( false === strpos( $reference->post_content, 'dsgoSchema' )
+			&& false === strpos( $reference->post_content, 'wp:block ' ) ) {
+			return array();
+		}
+
+		return $this->collect( parse_blocks( $reference->post_content ), $title, $seen );
 	}
 
 	/**
@@ -93,9 +140,11 @@ class SchemaOutput {
 			return;
 		}
 
-		// Cheap bail before the comparatively expensive parse. Every opted-in
-		// block carries the attribute name in its block comment.
-		if ( false === strpos( $post->post_content, 'dsgoSchema' ) ) {
+		// Cheap bail before the comparatively expensive parse. An opted-in block
+		// carries the attribute name in its block comment — unless it lives in
+		// a synced pattern, in which case the page only holds the reference.
+		if ( false === strpos( $post->post_content, 'dsgoSchema' )
+			&& false === strpos( $post->post_content, 'wp:block ' ) ) {
 			return;
 		}
 

--- a/includes/features/class-schema-output.php
+++ b/includes/features/class-schema-output.php
@@ -118,12 +118,31 @@ class SchemaOutput {
 			return array();
 		}
 
-		if ( false === strpos( $reference->post_content, 'dsgoSchema' )
-			&& false === strpos( $reference->post_content, 'wp:block ' ) ) {
+		if ( ! $this->may_contain_schema( $reference->post_content ) ) {
 			return array();
 		}
 
 		return $this->collect( parse_blocks( $reference->post_content ), $title, $seen );
+	}
+
+
+	/**
+	 * Could this content hold an opted-in block?
+	 *
+	 * A cheap string test used to skip the comparatively expensive
+	 * parse_blocks() on the overwhelming majority of posts. An opted-in block
+	 * carries the attribute name in its block comment — unless it lives in a
+	 * synced pattern, in which case only the reference is present here and the
+	 * attribute is in the referenced wp_block post.
+	 *
+	 * @param string $content Post content.
+	 * @return bool Whether the content is worth parsing.
+	 */
+	private function may_contain_schema( $content ) {
+		$content = (string) $content;
+
+		return false !== strpos( $content, 'dsgoSchema' )
+			|| false !== strpos( $content, 'wp:block ' );
 	}
 
 	/**
@@ -140,11 +159,7 @@ class SchemaOutput {
 			return;
 		}
 
-		// Cheap bail before the comparatively expensive parse. An opted-in block
-		// carries the attribute name in its block comment — unless it lives in
-		// a synced pattern, in which case the page only holds the reference.
-		if ( false === strpos( $post->post_content, 'dsgoSchema' )
-			&& false === strpos( $post->post_content, 'wp:block ' ) ) {
+		if ( ! $this->may_contain_schema( $post->post_content ) ) {
 			return;
 		}
 

--- a/includes/features/class-schema-output.php
+++ b/includes/features/class-schema-output.php
@@ -114,7 +114,10 @@ class SchemaOutput {
 			return array();
 		}
 
-		if ( 'publish' !== $reference->post_status ) {
+		// Mirrors core's render_block_core_block(), which refuses a pattern that
+		// is unpublished OR password-protected. Emitting schema for content core
+		// declines to render would disclose it through the back door.
+		if ( 'publish' !== $reference->post_status || ! empty( $reference->post_password ) ) {
 			return array();
 		}
 
@@ -156,6 +159,16 @@ class SchemaOutput {
 		$post = get_post();
 
 		if ( ! $post instanceof \WP_Post || ! has_blocks( $post->post_content ) ) {
+			return;
+		}
+
+		// A protected post is still singular, and get_post() still hands back
+		// the full content — WordPress only substitutes the password form at
+		// the_content, which runs long after wp_head. Without this the
+		// questions, answers and title would sit in view-source for anyone,
+		// password or not. Matches the guard in class-style-binding.php,
+		// class-query-bindings-helpers.php and the llms-txt classes.
+		if ( post_password_required( $post ) ) {
 			return;
 		}
 

--- a/includes/features/class-schema-output.php
+++ b/includes/features/class-schema-output.php
@@ -22,14 +22,37 @@ require_once DESIGNSETGO_PATH . 'includes/features/schema-builders.php';
 class SchemaOutput {
 
 	/**
-	 * Map a dsgoSchema value to its builder function.
+	 * Which builder handles which schema type, per block.
 	 *
-	 * @var array<string, string>
+	 * Keyed by block name first, deliberately. The allowlist otherwise exists
+	 * only in the editor UI and in the server-side attribute registration, and
+	 * neither constrains what parse_blocks() hands this collector: a
+	 * hand-written block comment (the editor's Code view suffices — no
+	 * unfiltered_html required) could put dsgoSchema on any block and have a
+	 * builder run against its children. Keying on the block name is what makes
+	 * "only blocks with a builder behind them" true at runtime rather than
+	 * merely in the UI.
+	 *
+	 * Keep the block names in step with includes/extension-configs/schema.php;
+	 * Schema_Config_Parity_Test enforces it.
+	 *
+	 * @var array<string, array<string, string>>
 	 */
 	private const BUILDERS = array(
-		'faq'   => 'designsetgo_schema_build_faq',
-		'howto' => 'designsetgo_schema_build_howto',
+		'designsetgo/accordion' => array(
+			'faq'   => 'designsetgo_schema_build_faq',
+			'howto' => 'designsetgo_schema_build_howto',
+		),
 	);
+
+	/**
+	 * Block names this collector will build schema for.
+	 *
+	 * @return array List of block names.
+	 */
+	public static function supported_blocks() {
+		return array_keys( self::BUILDERS );
+	}
 
 	/**
 	 * Hook the head output.
@@ -65,10 +88,11 @@ class SchemaOutput {
 				continue;
 			}
 
+			$name = isset( $block['blockName'] ) ? $block['blockName'] : '';
 			$type = isset( $block['attrs']['dsgoSchema'] ) ? $block['attrs']['dsgoSchema'] : 'none';
 
-			if ( is_string( $type ) && isset( self::BUILDERS[ $type ] ) ) {
-				$builder = self::BUILDERS[ $type ];
+			if ( is_string( $type ) && isset( self::BUILDERS[ $name ][ $type ] ) ) {
+				$builder = self::BUILDERS[ $name ][ $type ];
 
 				if ( function_exists( $builder ) ) {
 					// Builders that do not need the title simply ignore the

--- a/includes/features/class-schema-output.php
+++ b/includes/features/class-schema-output.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Schema JSON-LD head output.
+ *
+ * @package DesignSetGo
+ */
+
+namespace DesignSetGo;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once DESIGNSETGO_PATH . 'includes/features/schema-builders.php';
+
+/**
+ * Collects opted-in blocks from the current post and prints one JSON-LD graph.
+ *
+ * Reads the stored post content rather than filtering render_block: the target
+ * blocks are static (a save.js, no render.php), and their data — including the
+ * HTML-sourced accordion title — only exists in the saved markup. wp_head also
+ * runs before the content, so a render_block collector would be too late.
+ */
+class SchemaOutput {
+
+	/**
+	 * Map a dsgoSchema value to its builder function.
+	 *
+	 * @var array<string, string>
+	 */
+	private const BUILDERS = array(
+		'faq'   => 'designsetgo_schema_build_faq',
+		'howto' => 'designsetgo_schema_build_howto',
+	);
+
+	/**
+	 * Hook the head output.
+	 */
+	public function __construct() {
+		add_action( 'wp_head', array( $this, 'render' ), 20 );
+	}
+
+	/**
+	 * Walk parsed blocks and build every schema node they opt into.
+	 *
+	 * Public so it can be unit-tested without a request.
+	 *
+	 * @param array $blocks Parsed blocks.
+	 * @return array List of schema graph nodes.
+	 */
+	public function collect( array $blocks ) {
+		$nodes = array();
+
+		foreach ( $blocks as $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			$type = isset( $block['attrs']['dsgoSchema'] ) ? $block['attrs']['dsgoSchema'] : 'none';
+
+			if ( is_string( $type ) && isset( self::BUILDERS[ $type ] ) ) {
+				$builder = self::BUILDERS[ $type ];
+
+				if ( function_exists( $builder ) ) {
+					$node = call_user_func( $builder, $block );
+
+					if ( is_array( $node ) && ! empty( $node ) ) {
+						$nodes[] = $node;
+					}
+				}
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+				$nodes = array_merge( $nodes, $this->collect( $block['innerBlocks'] ) );
+			}
+		}
+
+		return $nodes;
+	}
+
+	/**
+	 * Print the JSON-LD script tag.
+	 */
+	public function render() {
+		if ( ! is_singular() ) {
+			return;
+		}
+
+		$post = get_post();
+
+		if ( ! $post instanceof \WP_Post || ! has_blocks( $post->post_content ) ) {
+			return;
+		}
+
+		// Cheap bail before the comparatively expensive parse. Every opted-in
+		// block carries the attribute name in its block comment.
+		if ( false === strpos( $post->post_content, 'dsgoSchema' ) ) {
+			return;
+		}
+
+		$nodes = $this->collect( parse_blocks( $post->post_content ) );
+
+		/**
+		 * Filter the schema graph nodes before output.
+		 *
+		 * Return an empty array to suppress the script entirely.
+		 *
+		 * @param array    $nodes Schema graph nodes.
+		 * @param \WP_Post $post  Current post.
+		 */
+		$nodes = apply_filters( 'designsetgo_schema_nodes', $nodes, $post );
+
+		if ( ! is_array( $nodes ) || empty( $nodes ) ) {
+			return;
+		}
+
+		$graph = array(
+			'@context' => 'https://schema.org',
+			'@graph'   => array_values( $nodes ),
+		);
+
+		$json = wp_json_encode( $graph, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+
+		if ( false === $json ) {
+			return;
+		}
+
+		// A literal `</script>` inside a JSON string would close the element and
+		// let the remaining content run as markup. Escaping the slash keeps the
+		// JSON semantically identical — "<\/script>" decodes to "</script>".
+		// JSON_UNESCAPED_SLASHES is what makes this necessary, and it is kept
+		// because escaping every slash bloats URLs in the output.
+		$json = str_replace( '</', '<\/', $json );
+
+		echo '<script type="application/ld+json">' . $json . '</script>' . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() output with script-closing sequences neutralised on the line above.
+	}
+}

--- a/includes/features/class-schema-output.php
+++ b/includes/features/class-schema-output.php
@@ -18,6 +18,22 @@ require_once DESIGNSETGO_PATH . 'includes/features/schema-builders.php';
  * blocks are static (a save.js, no render.php), and their data — including the
  * HTML-sourced accordion title — only exists in the saved markup. wp_head also
  * runs before the content, so a render_block collector would be too late.
+ *
+ * SCOPE: the singular post's own content, plus any synced patterns it
+ * references. An accordion placed directly in a block template or template
+ * part is deliberately NOT collected. Such a block appears on every page using
+ * that template, and FAQPage markup is supposed to describe the page it sits
+ * on — emitting one site-wide FAQ across every URL is the structured-data spam
+ * this feature's opt-in default exists to avoid. A site that genuinely wants
+ * template-level schema can add it through the `designsetgo_schema_nodes`
+ * filter, where the decision is explicit and per-site.
+ *
+ * COST: the strpos() pair below short-circuits a page with no schema in well
+ * under a microsecond. A deliberately heavy page — three synced patterns
+ * holding sixty question/answer pairs, plus a hundred other blocks — costs
+ * about 7.5ms. That is not worth a transient: invalidating one would mean
+ * tracking which posts reference which patterns, and stale structured data is
+ * a worse failure than the parse it saves.
  */
 class SchemaOutput {
 

--- a/includes/features/class-schema-output.php
+++ b/includes/features/class-schema-output.php
@@ -43,10 +43,11 @@ class SchemaOutput {
 	 *
 	 * Public so it can be unit-tested without a request.
 	 *
-	 * @param array $blocks Parsed blocks.
+	 * @param array  $blocks Parsed blocks.
+	 * @param string $title  Page title, passed to builders that need it.
 	 * @return array List of schema graph nodes.
 	 */
-	public function collect( array $blocks ) {
+	public function collect( array $blocks, $title = '' ) {
 		$nodes = array();
 
 		foreach ( $blocks as $block ) {
@@ -60,7 +61,9 @@ class SchemaOutput {
 				$builder = self::BUILDERS[ $type ];
 
 				if ( function_exists( $builder ) ) {
-					$node = call_user_func( $builder, $block );
+					// Builders that do not need the title simply ignore the
+					// extra argument.
+					$node = call_user_func( $builder, $block, $title );
 
 					if ( is_array( $node ) && ! empty( $node ) ) {
 						$nodes[] = $node;
@@ -69,7 +72,7 @@ class SchemaOutput {
 			}
 
 			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
-				$nodes = array_merge( $nodes, $this->collect( $block['innerBlocks'] ) );
+				$nodes = array_merge( $nodes, $this->collect( $block['innerBlocks'], $title ) );
 			}
 		}
 
@@ -96,7 +99,7 @@ class SchemaOutput {
 			return;
 		}
 
-		$nodes = $this->collect( parse_blocks( $post->post_content ) );
+		$nodes = $this->collect( parse_blocks( $post->post_content ), get_the_title( $post ) );
 
 		/**
 		 * Filter the schema graph nodes before output.

--- a/includes/features/schema-builders.php
+++ b/includes/features/schema-builders.php
@@ -90,6 +90,41 @@ if ( ! function_exists( 'designsetgo_schema_text_from_html' ) ) {
 	}
 }
 
+if ( ! function_exists( 'designsetgo_schema_normalize_text' ) ) {
+	/**
+	 * Reduce a fragment of saved HTML to schema-ready plain text.
+	 *
+	 * The single definition of that sequence. It was duplicated between the
+	 * answer text and the HowTo title, and the entity-decoding step was once
+	 * fixed in one place and missed in the other — the same page emitting
+	 * "Tea &amp; Coffee" beside "Tea & coffee?".
+	 *
+	 * Order matters and is deliberate:
+	 *
+	 * 1. Separate at tag boundaries, or `<p>One.</p><p>Two.</p>` fuses into
+	 *    "One.Two.". The extra spaces collapse in step 4.
+	 * 2. Strip tags.
+	 * 3. THEN decode entities. Decoding first would let strip_tags() delete
+	 *    text the page actually displays — an answer reading "<b>bold</b>"
+	 *    would come back as "bold". A decoded `</script>` cannot break the
+	 *    JSON-LD element: SchemaOutput::render() escapes the slash after
+	 *    encoding, which covers every source of that sequence at once.
+	 * 4. Collapse whitespace and trim.
+	 *
+	 * @param string $html Saved HTML.
+	 * @return string Plain text.
+	 */
+	function designsetgo_schema_normalize_text( $html ) {
+		$html = str_replace( '<', ' <', (string) $html );
+
+		$text = wp_strip_all_tags( $html );
+		$text = html_entity_decode( $text, ENT_QUOTES, 'UTF-8' );
+		$text = preg_replace( '/\s+/u', ' ', $text );
+
+		return trim( (string) $text );
+	}
+}
+
 if ( ! function_exists( 'designsetgo_schema_text_from_blocks' ) ) {
 	/**
 	 * Reduce inner blocks to the plain text of their SAVED markup.
@@ -126,20 +161,7 @@ if ( ! function_exists( 'designsetgo_schema_text_from_blocks' ) ) {
 			return '';
 		}
 
-		$html = serialize_blocks( $blocks );
-
-		// Separate at every tag boundary before stripping. Without this,
-		// `<p>One.</p><p>Two.</p>` reduces to "One.Two." — two sentences fused
-		// into one token, which is poor structured data. The extra spaces are
-		// collapsed immediately below, so inline markup is unaffected:
-		// "Hello <strong>world</strong>" still yields "Hello world".
-		$html = str_replace( '<', ' <', $html );
-
-		$text = wp_strip_all_tags( $html );
-		$text = html_entity_decode( $text, ENT_QUOTES, 'UTF-8' );
-		$text = preg_replace( '/\s+/u', ' ', $text );
-
-		return trim( (string) $text );
+		return designsetgo_schema_normalize_text( serialize_blocks( $blocks ) );
 	}
 }
 
@@ -260,14 +282,9 @@ if ( ! function_exists( 'designsetgo_schema_build_howto' ) ) {
 			'step'  => $steps,
 		);
 
-		// Same treatment the question/answer text gets: strip, then decode.
-		// Without the decode a title stored as "Tea &amp; Coffee" reaches the
-		// graph with the entity intact, while the steps beside it are already
-		// decoded — the one page emitting both "Tea &amp; Coffee" and
-		// "Tea & coffee?".
-		$title = wp_strip_all_tags( (string) $title );
-		$title = html_entity_decode( $title, ENT_QUOTES, 'UTF-8' );
-		$title = trim( preg_replace( '/\s+/u', ' ', $title ) );
+		// Exactly the treatment the question and answer text gets — see the
+		// helper for why that matters.
+		$title = designsetgo_schema_normalize_text( $title );
 
 		// HowTo.name is required by Google, but claiming an empty one is worse
 		// than omitting it.

--- a/includes/features/schema-builders.php
+++ b/includes/features/schema-builders.php
@@ -80,27 +80,41 @@ if ( ! function_exists( 'designsetgo_schema_text_from_html' ) ) {
 
 if ( ! function_exists( 'designsetgo_schema_text_from_blocks' ) ) {
 	/**
-	 * Render inner blocks and reduce them to plain text.
+	 * Reduce inner blocks to the plain text of their SAVED markup.
+	 *
+	 * Deliberately serializes rather than renders. render_block() executes each
+	 * block's render_callback, and this runs on wp_head — before the main loop
+	 * renders the very same blocks for display. Any dynamic block inside an
+	 * answer (Query Loop, Latest Posts, a form) would therefore run twice per
+	 * request: doubled queries and HTTP calls, and non-idempotent side effects
+	 * fired twice. It would also render incorrectly, because render_block()
+	 * builds a fresh root WP_Block with no ancestor-supplied context.
+	 *
+	 * serialize_blocks() reconstructs the stored markup and executes nothing.
+	 * Block delimiters are HTML comments, which strip_tags() removes along with
+	 * the tags. A dynamic block contributes no text — correct, since its output
+	 * is not knowable here and is not part of the authored answer.
 	 *
 	 * @param array $blocks Parsed inner blocks.
 	 * @return string Plain text, whitespace collapsed.
 	 */
 	function designsetgo_schema_text_from_blocks( array $blocks ) {
-		$html = '';
+		$blocks = array_values(
+			array_filter(
+				$blocks,
+				static function ( $block ) {
+					// parse_blocks() emits nameless blocks for the whitespace
+					// between siblings.
+					return is_array( $block ) && ! empty( $block['blockName'] );
+				}
+			)
+		);
 
-		foreach ( $blocks as $block ) {
-			if ( ! is_array( $block ) ) {
-				continue;
-			}
-
-			// parse_blocks() emits nameless blocks for the whitespace between
-			// siblings; rendering them is harmless but pointless.
-			if ( empty( $block['blockName'] ) ) {
-				continue;
-			}
-
-			$html .= render_block( $block );
+		if ( empty( $blocks ) ) {
+			return '';
 		}
+
+		$html = serialize_blocks( $blocks );
 
 		// Separate at every tag boundary before stripping. Without this,
 		// `<p>One.</p><p>Two.</p>` reduces to "One.Two." — two sentences fused
@@ -203,10 +217,15 @@ if ( ! function_exists( 'designsetgo_schema_build_howto' ) ) {
 	/**
 	 * Build HowTo schema from an accordion.
 	 *
-	 * @param array $block Parsed accordion block.
+	 * The title is a parameter rather than a get_the_title() call so this stays
+	 * a pure function of its arguments, per the contract at the top of the file.
+	 * SchemaOutput::render() already holds the post and passes it through.
+	 *
+	 * @param array  $block Parsed accordion block.
+	 * @param string $title Page title, used as HowTo.name. Optional.
 	 * @return array|null Schema graph node, or null when unusable.
 	 */
-	function designsetgo_schema_build_howto( array $block ) {
+	function designsetgo_schema_build_howto( array $block, $title = '' ) {
 		$pairs = designsetgo_schema_accordion_pairs( $block );
 
 		if ( empty( $pairs ) ) {
@@ -229,10 +248,10 @@ if ( ! function_exists( 'designsetgo_schema_build_howto' ) ) {
 			'step'  => $steps,
 		);
 
-		$title = trim( wp_strip_all_tags( (string) get_the_title() ) );
+		$title = trim( wp_strip_all_tags( (string) $title ) );
 
-		// HowTo.name is required by Google. Only claim one when there is a real
-		// post title to use — outside the loop get_the_title() returns ''.
+		// HowTo.name is required by Google, but claiming an empty one is worse
+		// than omitting it.
 		if ( '' !== $title ) {
 			$schema['name'] = $title;
 		}

--- a/includes/features/schema-builders.php
+++ b/includes/features/schema-builders.php
@@ -248,7 +248,14 @@ if ( ! function_exists( 'designsetgo_schema_build_howto' ) ) {
 			'step'  => $steps,
 		);
 
-		$title = trim( wp_strip_all_tags( (string) $title ) );
+		// Same treatment the question/answer text gets: strip, then decode.
+		// Without the decode a title stored as "Tea &amp; Coffee" reaches the
+		// graph with the entity intact, while the steps beside it are already
+		// decoded — the one page emitting both "Tea &amp; Coffee" and
+		// "Tea & coffee?".
+		$title = wp_strip_all_tags( (string) $title );
+		$title = html_entity_decode( $title, ENT_QUOTES, 'UTF-8' );
+		$title = trim( preg_replace( '/\s+/u', ' ', $title ) );
 
 		// HowTo.name is required by Google, but claiming an empty one is worse
 		// than omitting it.

--- a/includes/features/schema-builders.php
+++ b/includes/features/schema-builders.php
@@ -1,0 +1,242 @@
+<?php
+/**
+ * Schema builders.
+ *
+ * Pure functions: a parsed block array in, a schema.org array out. No output,
+ * no globals — unit-testable in isolation.
+ *
+ * @package DesignSetGo
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'designsetgo_schema_text_from_html' ) ) {
+	/**
+	 * Extract the plain text of the first element carrying a class.
+	 *
+	 * The accordion's `title` is an HTML-SOURCED attribute in block.json
+	 * (source: "html", selector: ".dsgo-accordion-item__title"), which means
+	 * WordPress reads it back out of the markup when parsing for the editor —
+	 * but `parse_blocks()` does NOT. It only decodes the block comment's JSON,
+	 * so `$block['attrs']['title']` is absent for every real post. Reading the
+	 * title therefore means reading the saved HTML, which is what this does.
+	 *
+	 * Uses WP_HTML_Processor (WP 6.4+; the plugin requires 6.7) rather than
+	 * DOMDocument, which mangles UTF-8 without an explicit encoding preamble,
+	 * or a regex, which cannot track nesting.
+	 *
+	 * @param string $html       Saved block HTML.
+	 * @param string $class_name Class to look for, without the leading dot.
+	 * @return string Plain text, whitespace collapsed. '' when not found.
+	 */
+	function designsetgo_schema_text_from_html( $html, $class_name ) {
+		$html = (string) $html;
+
+		if ( '' === $html || '' === $class_name ) {
+			return '';
+		}
+
+		$processor = WP_HTML_Processor::create_fragment( $html );
+
+		if ( null === $processor ) {
+			return '';
+		}
+
+		$text  = '';
+		$found = false;
+
+		while ( $processor->next_token() ) {
+			if ( $found ) {
+				// Collect text until the subtree closes. Breadcrumbs shrink back
+				// past the opening depth once the element ends.
+				if ( count( $processor->get_breadcrumbs() ) < $found ) {
+					break;
+				}
+
+				if ( '#text' === $processor->get_token_type() ) {
+					$text .= $processor->get_modifiable_text();
+				}
+
+				continue;
+			}
+
+			if ( '#tag' !== $processor->get_token_type() || $processor->is_tag_closer() ) {
+				continue;
+			}
+
+			if ( ! $processor->has_class( $class_name ) ) {
+				continue;
+			}
+
+			// Depth of the element itself; its children sit deeper than this.
+			$found = count( $processor->get_breadcrumbs() );
+		}
+
+		$text = preg_replace( '/\s+/u', ' ', $text );
+
+		return trim( (string) $text );
+	}
+}
+
+if ( ! function_exists( 'designsetgo_schema_text_from_blocks' ) ) {
+	/**
+	 * Render inner blocks and reduce them to plain text.
+	 *
+	 * @param array $blocks Parsed inner blocks.
+	 * @return string Plain text, whitespace collapsed.
+	 */
+	function designsetgo_schema_text_from_blocks( array $blocks ) {
+		$html = '';
+
+		foreach ( $blocks as $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			// parse_blocks() emits nameless blocks for the whitespace between
+			// siblings; rendering them is harmless but pointless.
+			if ( empty( $block['blockName'] ) ) {
+				continue;
+			}
+
+			$html .= render_block( $block );
+		}
+
+		// Separate at every tag boundary before stripping. Without this,
+		// `<p>One.</p><p>Two.</p>` reduces to "One.Two." — two sentences fused
+		// into one token, which is poor structured data. The extra spaces are
+		// collapsed immediately below, so inline markup is unaffected:
+		// "Hello <strong>world</strong>" still yields "Hello world".
+		$html = str_replace( '<', ' <', $html );
+
+		$text = wp_strip_all_tags( $html );
+		$text = html_entity_decode( $text, ENT_QUOTES, 'UTF-8' );
+		$text = preg_replace( '/\s+/u', ' ', $text );
+
+		return trim( (string) $text );
+	}
+}
+
+if ( ! function_exists( 'designsetgo_schema_accordion_pairs' ) ) {
+	/**
+	 * Extract question/answer pairs from an accordion block.
+	 *
+	 * @param array $block Parsed accordion block.
+	 * @return array List of array{name: string, text: string}.
+	 */
+	function designsetgo_schema_accordion_pairs( array $block ) {
+		$pairs = array();
+		$items = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] )
+			? $block['innerBlocks']
+			: array();
+
+		foreach ( $items as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+
+			if ( 'designsetgo/accordion-item' !== ( isset( $item['blockName'] ) ? $item['blockName'] : '' ) ) {
+				continue;
+			}
+
+			$name = designsetgo_schema_text_from_html(
+				isset( $item['innerHTML'] ) ? $item['innerHTML'] : '',
+				'dsgo-accordion-item__title'
+			);
+
+			$text = designsetgo_schema_text_from_blocks(
+				isset( $item['innerBlocks'] ) && is_array( $item['innerBlocks'] )
+					? $item['innerBlocks']
+					: array()
+			);
+
+			// A pair missing either half is not valid structured data.
+			if ( '' === $name || '' === $text ) {
+				continue;
+			}
+
+			$pairs[] = array(
+				'name' => $name,
+				'text' => $text,
+			);
+		}
+
+		return $pairs;
+	}
+}
+
+if ( ! function_exists( 'designsetgo_schema_build_faq' ) ) {
+	/**
+	 * Build FAQPage schema from an accordion.
+	 *
+	 * @param array $block Parsed accordion block.
+	 * @return array|null Schema graph node, or null when unusable.
+	 */
+	function designsetgo_schema_build_faq( array $block ) {
+		$pairs = designsetgo_schema_accordion_pairs( $block );
+
+		if ( empty( $pairs ) ) {
+			return null;
+		}
+
+		$questions = array();
+
+		foreach ( $pairs as $pair ) {
+			$questions[] = array(
+				'@type'          => 'Question',
+				'name'           => $pair['name'],
+				'acceptedAnswer' => array(
+					'@type' => 'Answer',
+					'text'  => $pair['text'],
+				),
+			);
+		}
+
+		return array(
+			'@type'      => 'FAQPage',
+			'mainEntity' => $questions,
+		);
+	}
+}
+
+if ( ! function_exists( 'designsetgo_schema_build_howto' ) ) {
+	/**
+	 * Build HowTo schema from an accordion.
+	 *
+	 * @param array $block Parsed accordion block.
+	 * @return array|null Schema graph node, or null when unusable.
+	 */
+	function designsetgo_schema_build_howto( array $block ) {
+		$pairs = designsetgo_schema_accordion_pairs( $block );
+
+		if ( empty( $pairs ) ) {
+			return null;
+		}
+
+		$steps = array();
+
+		foreach ( $pairs as $index => $pair ) {
+			$steps[] = array(
+				'@type'    => 'HowToStep',
+				'position' => $index + 1,
+				'name'     => $pair['name'],
+				'text'     => $pair['text'],
+			);
+		}
+
+		$schema = array(
+			'@type' => 'HowTo',
+			'step'  => $steps,
+		);
+
+		$title = trim( wp_strip_all_tags( (string) get_the_title() ) );
+
+		// HowTo.name is required by Google. Only claim one when there is a real
+		// post title to use — outside the loop get_the_title() returns ''.
+		if ( '' !== $title ) {
+			$schema['name'] = $title;
+		}
+
+		return $schema;
+	}
+}

--- a/includes/features/schema-builders.php
+++ b/includes/features/schema-builders.php
@@ -47,8 +47,20 @@ if ( ! function_exists( 'designsetgo_schema_text_from_html' ) ) {
 
 		while ( $processor->next_token() ) {
 			if ( $found ) {
-				// Collect text until the subtree closes. Breadcrumbs shrink back
-				// past the opening depth once the element ends.
+				// Stop at the matched element's own closing tag.
+				//
+				// This reads as though it could not do that — a following
+				// SIBLING opens at the same depth as the match, so a `<`
+				// comparison would not terminate on it. What makes it work is
+				// token ORDER: WP_HTML_Processor pops the breadcrumb stack
+				// before visiting a closer, so the matched element's closer
+				// reports its PARENT's depth (strictly less than $found) and is
+				// visited before any sibling. Descendants report deeper, so
+				// nested markup inside the title is still collected in full.
+				//
+				// tests/phpunit/schema-builders-test.php has the traced token
+				// walk, plus a sibling carrying real text that fails loudly if
+				// this ever stops holding.
 				if ( count( $processor->get_breadcrumbs() ) < $found ) {
 					break;
 				}

--- a/src/extensions/schema/constants.js
+++ b/src/extensions/schema/constants.js
@@ -1,0 +1,23 @@
+/**
+ * Schema Extension - Constants
+ *
+ * The allowlist is deliberately narrow. A block only appears here once a
+ * server-side builder exists for every type it offers — a control that writes
+ * an attribute nothing consumes is a no-op that looks like a feature.
+ *
+ * @package
+ */
+
+import { __ } from '@wordpress/i18n';
+
+const NONE = { value: 'none', label: __('None', 'designsetgo') };
+
+export const SCHEMA_TYPES = {
+	'designsetgo/accordion': [
+		NONE,
+		{ value: 'faq', label: __('FAQ', 'designsetgo') },
+		{ value: 'howto', label: __('How-to', 'designsetgo') },
+	],
+};
+
+export const SCHEMA_BLOCKS = Object.keys(SCHEMA_TYPES);

--- a/src/extensions/schema/index.js
+++ b/src/extensions/schema/index.js
@@ -1,0 +1,91 @@
+/**
+ * Schema Extension
+ *
+ * Lets an author opt a block into emitting schema.org JSON-LD. The attribute
+ * only records the choice; `DesignSetGo\SchemaOutput` reads it on wp_head and
+ * prints a single graph for the page.
+ *
+ * Opt-in by design: emitting FAQ markup for an accordion that holds navigation
+ * links is structured-data spam and gets sites penalised, so the default is
+ * 'none' and nothing reaches the page until an author deliberately chooses.
+ *
+ * @package
+ * @since 1.3.0
+ */
+
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { SCHEMA_TYPES, SCHEMA_BLOCKS } from './constants';
+
+/**
+ * Add the dsgoSchema attribute to allowlisted blocks.
+ *
+ * @param {Object} settings Block settings.
+ * @param {string} name     Block name.
+ * @return {Object} Modified block settings.
+ */
+function addSchemaAttribute(settings, name) {
+	if (!SCHEMA_BLOCKS.includes(name)) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		attributes: {
+			...settings.attributes,
+			dsgoSchema: {
+				type: 'string',
+				default: 'none',
+			},
+		},
+	};
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'designsetgo/schema/attributes',
+	addSchemaAttribute
+);
+
+const withSchemaControl = createHigherOrderComponent(
+	(BlockEdit) => (props) => {
+		const { name, attributes, setAttributes, isSelected } = props;
+
+		if (!isSelected || !SCHEMA_BLOCKS.includes(name)) {
+			return <BlockEdit {...props} />;
+		}
+
+		return (
+			<>
+				<BlockEdit {...props} />
+				<InspectorControls group="advanced">
+					<PanelBody
+						title={__('Structured Data', 'designsetgo')}
+						initialOpen={false}
+					>
+						<SelectControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={__('Schema type', 'designsetgo')}
+							value={attributes.dsgoSchema || 'none'}
+							options={SCHEMA_TYPES[name]}
+							onChange={(dsgoSchema) =>
+								setAttributes({ dsgoSchema })
+							}
+							help={__(
+								'Only choose a type when the content genuinely matches it. Mislabelled structured data can get a site penalised. If an SEO plugin already outputs this type for the page, leave this set to None.',
+								'designsetgo'
+							)}
+						/>
+					</PanelBody>
+				</InspectorControls>
+			</>
+		);
+	},
+	'withSchemaControl'
+);
+
+addFilter('editor.BlockEdit', 'designsetgo/schema/editor', withSchemaControl);

--- a/src/index.js
+++ b/src/index.js
@@ -82,6 +82,9 @@ import './extensions/dynamic-tags';
 // Interaction Layers - binds triggers (click/hover/in-view) to actions on any block
 import './extensions/interactions';
 
+// Schema - opts a block into emitting schema.org JSON-LD in the page head
+import './extensions/schema';
+
 // Section Styles Editor Preview - previews user-customized section-style
 // variations (border/radius/etc.) on DSGo container blocks in the editor canvas
 import './extensions/section-styles-editor-preview';

--- a/tests/phpunit/extension-attributes-test.php
+++ b/tests/phpunit/extension-attributes-test.php
@@ -231,12 +231,12 @@ class Test_Extension_Attributes extends WP_UnitTestCase {
 		$config_dir = DESIGNSETGO_PATH . 'includes/extension-configs/';
 		$files      = glob( $config_dir . '*.php' );
 
-		// 18 extensions: background-video, block-animations, clickable-group,
+		// 19 extensions: background-video, block-animations, clickable-group,
 		// custom-css, expanding-background, grid-mobile-order, grid-span,
 		// interactions, max-width, responsive, reveal-container, reveal-control,
-		// sticky-header-controls, style-binding, svg-patterns, text-reveal,
-		// vertical-parallax, visibility.
-		$this->assertCount( 18, $files, 'Should have 18 extension config files.' );
+		// schema, sticky-header-controls, style-binding, svg-patterns,
+		// text-reveal, vertical-parallax, visibility.
+		$this->assertCount( 19, $files, 'Should have 19 extension config files.' );
 	}
 
 	/**

--- a/tests/phpunit/schema-builders-test.php
+++ b/tests/phpunit/schema-builders-test.php
@@ -453,13 +453,26 @@ class Schema_Builders_Test extends WP_UnitTestCase {
 	/**
 	 * Text in a SIBLING after the title must not be absorbed.
 	 *
-	 * A sibling sits at the same breadcrumb depth as the matched element, so a
-	 * depth comparison of `< $found` never terminates on it — collection only
-	 * stopped once the walk climbed out past the parent. Today the icon that
-	 * follows the title is an <svg> with no text nodes, so nothing leaked; the
-	 * moment anything text-bearing was added after the title (a screen-reader
-	 * label, a badge, a different icon style) it would have been concatenated
-	 * onto the question with no test failing.
+	 * The stop condition is `count( get_breadcrumbs() ) < $found`, and it is
+	 * reasonable to read that as unable to stop at the title's own closing tag,
+	 * since a FOLLOWING SIBLING opens at the same depth as the title itself.
+	 * That reading misses the order of tokens: WP_HTML_Processor pops the
+	 * breadcrumb stack BEFORE visiting a closing tag, so the matched element's
+	 * own closer reports its PARENT's depth, which is strictly less than
+	 * $found — and it is visited before the sibling. Traced over
+	 * `<div><button><span class="t">Q</span><span class="i">LEAKED</span>…`:
+	 *
+	 *   #tag:DIV           depth=3
+	 *   #tag:BUTTON        depth=4
+	 *   #tag:SPAN          depth=5   <- match, $found = 5
+	 *   #text "Q"          depth=6   <- collected
+	 *   #tag:SPAN(close)   depth=4   <- 4 < 5, loop breaks HERE
+	 *   #tag:SPAN          depth=5   <- never reached
+	 *   #text "LEAKED"     depth=6   <- never reached
+	 *
+	 * This test exists so that stays true. It is deliberately built from a
+	 * text-bearing sibling rather than the real markup, whose icon is an <svg>
+	 * with no text nodes and so could not detect a regression.
 	 */
 	public function test_title_extractor_stops_at_the_end_of_the_matched_element() {
 		$html = '<div class="dsgo-accordion-item__header"><button type="button">'
@@ -482,6 +495,26 @@ class Schema_Builders_Test extends WP_UnitTestCase {
 
 		$this->assertSame(
 			'A nested deep title',
+			designsetgo_schema_text_from_html( $html, 'dsgo-accordion-item__title' )
+		);
+	}
+
+	/**
+	 * A nested element of the SAME tag must not end collection early.
+	 *
+	 * This is the trap in "just break on a closing <span>": the inner span's
+	 * closer arrives first, and keying off tag name alone would drop the "and
+	 * more" that follows it. Any future rewrite of the stop condition has to
+	 * keep this passing.
+	 */
+	public function test_title_extractor_survives_a_nested_element_of_the_same_tag() {
+		$html = '<span class="dsgo-accordion-item__title">'
+			. 'Start <span class="inner">middle</span> and more'
+			. '</span>'
+			. '<span class="sibling">LEAKED</span>';
+
+		$this->assertSame(
+			'Start middle and more',
 			designsetgo_schema_text_from_html( $html, 'dsgo-accordion-item__title' )
 		);
 	}

--- a/tests/phpunit/schema-builders-test.php
+++ b/tests/phpunit/schema-builders-test.php
@@ -1,0 +1,361 @@
+<?php
+/**
+ * Schema builder tests.
+ *
+ * The accordion's `title` is an HTML-SOURCED attribute
+ * (source: "html", selector: ".dsgo-accordion-item__title"), so parse_blocks()
+ * never puts it in $block['attrs']. A builder that reads $attrs['title'] finds
+ * an empty string for every real post and silently emits nothing — while
+ * passing any test that hand-builds the array with attrs.title set.
+ *
+ * These tests therefore drive the builders from markup shaped like what
+ * accordion-item/save.js actually writes, never from invented attributes.
+ *
+ * @package DesignSetGo
+ */
+
+/**
+ * Builder tests.
+ *
+ * @group schema
+ */
+class Schema_Builders_Test extends WP_UnitTestCase {
+
+	/**
+	 * Load the builders under test.
+	 *
+	 * Required here rather than at file scope: a require_once directly after
+	 * the file docblock makes PHPCS stop recognising it as the file comment.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		require_once DESIGNSETGO_PATH . 'includes/features/schema-builders.php';
+	}
+
+	/**
+	 * Serialize one accordion item the way save.js does.
+	 *
+	 * @param string $question Title text (may contain inline markup).
+	 * @param string $answer   Answer paragraph text.
+	 * @return string Block markup.
+	 */
+	private function item_markup( $question, $answer ) {
+		$markup = '<!-- wp:designsetgo/accordion-item -->';
+
+		$markup .= '<div class="wp-block-designsetgo-accordion-item dsgo-accordion-item dsgo-accordion-item--closed">';
+		$markup .= '<div class="dsgo-accordion-item__header">';
+		$markup .= '<button type="button" class="dsgo-accordion-item__trigger">';
+		$markup .= '<span class="dsgo-accordion-item__title">' . $question . '</span>';
+		$markup .= '<span class="dsgo-accordion-item__icon" aria-hidden="true"><svg></svg></span>';
+		$markup .= '</button></div>';
+		$markup .= '<div class="dsgo-accordion-item__panel">';
+		$markup .= '<div class="dsgo-accordion-item__content">';
+
+		if ( '' !== $answer ) {
+			$markup .= '<!-- wp:paragraph --><p>' . $answer . '</p><!-- /wp:paragraph -->';
+		}
+
+		$markup .= '</div></div></div>';
+		$markup .= '<!-- /wp:designsetgo/accordion-item -->';
+
+		return $markup;
+	}
+
+	/**
+	 * Parse a full accordion from markup.
+	 *
+	 * @param array  $items  List of array{q: string, a: string}.
+	 * @param string $schema dsgoSchema value.
+	 * @return array Parsed accordion block.
+	 */
+	private function accordion( array $items, $schema = 'faq' ) {
+		$inner = '';
+
+		foreach ( $items as $item ) {
+			$inner .= $this->item_markup( $item['q'], $item['a'] );
+		}
+
+		$markup = '<!-- wp:designsetgo/accordion {"dsgoSchema":"' . $schema . '"} -->'
+			. '<div class="wp-block-designsetgo-accordion dsgo-accordion">' . $inner . '</div>'
+			. '<!-- /wp:designsetgo/accordion -->';
+
+		$blocks = parse_blocks( $markup );
+
+		return $blocks[0];
+	}
+
+	/**
+	 * The core case: a real accordion yields one question per item.
+	 */
+	public function test_faq_builds_one_question_per_item() {
+		$schema = designsetgo_schema_build_faq(
+			$this->accordion(
+				array(
+					array(
+						'q' => 'What is it?',
+						'a' => 'A plugin.',
+					),
+					array(
+						'q' => 'How much?',
+						'a' => 'Free.',
+					),
+				)
+			)
+		);
+
+		$this->assertSame( 'FAQPage', $schema['@type'] );
+		$this->assertCount( 2, $schema['mainEntity'] );
+		$this->assertSame( 'What is it?', $schema['mainEntity'][0]['name'] );
+		$this->assertSame( 'A plugin.', $schema['mainEntity'][0]['acceptedAnswer']['text'] );
+		$this->assertSame( 'How much?', $schema['mainEntity'][1]['name'] );
+	}
+
+	/**
+	 * The regression guard for the HTML-sourced attribute.
+	 *
+	 * The attrs.title key is absent from real content. If a builder reads it,
+	 * this returns null instead of a populated graph.
+	 */
+	public function test_faq_reads_the_title_from_markup_not_from_attrs() {
+		$block = $this->accordion(
+			array(
+				array(
+					'q' => 'Sourced from HTML',
+					'a' => 'Answer.',
+				),
+			)
+		);
+
+		$this->assertArrayNotHasKey(
+			'title',
+			$block['innerBlocks'][0]['attrs'],
+			'parse_blocks() must not surface an html-sourced attribute; if it does, this test is no longer meaningful.'
+		);
+
+		$schema = designsetgo_schema_build_faq( $block );
+
+		$this->assertNotNull( $schema );
+		$this->assertSame( 'Sourced from HTML', $schema['mainEntity'][0]['name'] );
+	}
+
+	/**
+	 * Inline markup inside the title is reduced to text.
+	 */
+	public function test_faq_strips_inline_markup_from_the_question() {
+		$schema = designsetgo_schema_build_faq(
+			$this->accordion(
+				array(
+					array(
+						'q' => 'What is <strong>it</strong>?',
+						'a' => 'A plugin.',
+					),
+				)
+			)
+		);
+
+		$this->assertSame( 'What is it?', $schema['mainEntity'][0]['name'] );
+	}
+
+	/**
+	 * Entities decode to their characters.
+	 */
+	public function test_faq_decodes_entities_in_the_question() {
+		$schema = designsetgo_schema_build_faq(
+			$this->accordion(
+				array(
+					array(
+						'q' => 'Tea &amp; coffee?',
+						'a' => 'Both.',
+					),
+				)
+			)
+		);
+
+		$this->assertSame( 'Tea & coffee?', $schema['mainEntity'][0]['name'] );
+	}
+
+	/**
+	 * The icon span must not contribute to the question text.
+	 */
+	public function test_faq_ignores_the_icon_span() {
+		$schema = designsetgo_schema_build_faq(
+			$this->accordion(
+				array(
+					array(
+						'q' => 'Clean title',
+						'a' => 'Answer.',
+					),
+				)
+			)
+		);
+
+		$this->assertSame( 'Clean title', $schema['mainEntity'][0]['name'] );
+	}
+
+	/**
+	 * A pair missing its answer is not valid structured data.
+	 */
+	public function test_faq_skips_an_item_with_no_answer() {
+		$block = $this->accordion(
+			array(
+				array(
+					'q' => 'Question?',
+					'a' => '',
+				),
+			)
+		);
+
+		$this->assertNull( designsetgo_schema_build_faq( $block ) );
+	}
+
+	/**
+	 * A pair missing its question is not valid structured data.
+	 */
+	public function test_faq_skips_an_item_with_no_question() {
+		$block = $this->accordion(
+			array(
+				array(
+					'q' => '',
+					'a' => 'Orphan answer.',
+				),
+			)
+		);
+
+		$this->assertNull( designsetgo_schema_build_faq( $block ) );
+	}
+
+	/**
+	 * An empty accordion produces nothing.
+	 */
+	public function test_faq_of_an_empty_accordion_is_null() {
+		$this->assertNull( designsetgo_schema_build_faq( $this->accordion( array() ) ) );
+	}
+
+	/**
+	 * Valid pairs survive alongside an invalid one.
+	 */
+	public function test_faq_keeps_valid_pairs_when_one_is_incomplete() {
+		$schema = designsetgo_schema_build_faq(
+			$this->accordion(
+				array(
+					array(
+						'q' => 'Good',
+						'a' => 'Answer.',
+					),
+					array(
+						'q' => 'Orphan',
+						'a' => '',
+					),
+				)
+			)
+		);
+
+		$this->assertCount( 1, $schema['mainEntity'] );
+		$this->assertSame( 'Good', $schema['mainEntity'][0]['name'] );
+	}
+
+	/**
+	 * HowTo numbers its steps from one.
+	 */
+	public function test_howto_numbers_its_steps() {
+		$schema = designsetgo_schema_build_howto(
+			$this->accordion(
+				array(
+					array(
+						'q' => 'Install',
+						'a' => 'Upload the zip.',
+					),
+					array(
+						'q' => 'Activate',
+						'a' => 'Click activate.',
+					),
+				),
+				'howto'
+			)
+		);
+
+		$this->assertSame( 'HowTo', $schema['@type'] );
+		$this->assertSame( 1, $schema['step'][0]['position'] );
+		$this->assertSame( 2, $schema['step'][1]['position'] );
+		$this->assertSame( 'Install', $schema['step'][0]['name'] );
+		$this->assertSame( 'Upload the zip.', $schema['step'][0]['text'] );
+	}
+
+	/**
+	 * An empty accordion produces no HowTo.
+	 */
+	public function test_howto_of_an_empty_accordion_is_null() {
+		$this->assertNull(
+			designsetgo_schema_build_howto( $this->accordion( array(), 'howto' ) )
+		);
+	}
+
+	/**
+	 * Multi-block answers are concatenated.
+	 */
+	public function test_answer_joins_multiple_blocks() {
+		$text = designsetgo_schema_text_from_blocks(
+			parse_blocks(
+				'<!-- wp:paragraph --><p>One.</p><!-- /wp:paragraph -->'
+				. '<!-- wp:paragraph --><p>Two.</p><!-- /wp:paragraph -->'
+			)
+		);
+
+		$this->assertSame( 'One. Two.', $text );
+	}
+
+	/**
+	 * Markup is stripped from answers.
+	 */
+	public function test_text_extraction_strips_markup() {
+		$text = designsetgo_schema_text_from_blocks(
+			parse_blocks( '<!-- wp:paragraph --><p>Hello <strong>world</strong></p><!-- /wp:paragraph -->' )
+		);
+
+		$this->assertSame( 'Hello world', $text );
+	}
+
+	/**
+	 * Whitespace collapses to single spaces.
+	 */
+	public function test_text_extraction_collapses_whitespace() {
+		$text = designsetgo_schema_text_from_blocks(
+			parse_blocks( "<!-- wp:paragraph --><p>One\n\n   two</p><!-- /wp:paragraph -->" )
+		);
+
+		$this->assertSame( 'One two', $text );
+	}
+
+	/**
+	 * The title extractor returns '' when the element is absent.
+	 */
+	public function test_title_extractor_returns_empty_for_missing_element() {
+		$this->assertSame(
+			'',
+			designsetgo_schema_text_from_html( '<div>no title here</div>', 'dsgo-accordion-item__title' )
+		);
+	}
+
+	/**
+	 * The title extractor tolerates malformed HTML rather than throwing.
+	 */
+	public function test_title_extractor_survives_malformed_html() {
+		$this->assertSame(
+			'',
+			designsetgo_schema_text_from_html( '<div><span class="unclosed', 'dsgo-accordion-item__title' )
+		);
+	}
+
+	/**
+	 * A class that merely contains the target as a substring must not match.
+	 */
+	public function test_title_extractor_matches_whole_class_names_only() {
+		$html = '<span class="dsgo-accordion-item__title-suffix">Wrong</span>';
+
+		$this->assertSame(
+			'',
+			designsetgo_schema_text_from_html( $html, 'dsgo-accordion-item__title' )
+		);
+	}
+}

--- a/tests/phpunit/schema-builders-test.php
+++ b/tests/phpunit/schema-builders-test.php
@@ -306,6 +306,73 @@ class Schema_Builders_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The title gets the same entity treatment as the step text.
+	 *
+	 * Without this the same graph carried "Tea &amp; Coffee" as the HowTo name
+	 * beside a step reading "Tea & coffee?" — raw entities in structured data
+	 * are wrong data, not just untidy.
+	 */
+	public function test_howto_decodes_entities_in_its_name() {
+		$schema = designsetgo_schema_build_howto(
+			$this->accordion(
+				array(
+					array(
+						'q' => 'Tea &amp; coffee?',
+						'a' => 'Both.',
+					),
+				),
+				'howto'
+			),
+			'Tea &amp; Coffee &mdash; a guide'
+		);
+
+		$this->assertSame( 'Tea & Coffee — a guide', $schema['name'] );
+
+		// The point is that both halves agree.
+		$this->assertSame( 'Tea & coffee?', $schema['step'][0]['name'] );
+	}
+
+	/**
+	 * Markup in the title is stripped, as it is everywhere else.
+	 */
+	public function test_howto_strips_markup_from_its_name() {
+		$schema = designsetgo_schema_build_howto(
+			$this->accordion(
+				array(
+					array(
+						'q' => 'Install',
+						'a' => 'Upload.',
+					),
+				),
+				'howto'
+			),
+			'How to <em>install</em> it'
+		);
+
+		$this->assertSame( 'How to install it', $schema['name'] );
+	}
+
+	/**
+	 * A title of only markup collapses to nothing, so name is omitted.
+	 */
+	public function test_howto_omits_a_name_that_reduces_to_empty() {
+		$schema = designsetgo_schema_build_howto(
+			$this->accordion(
+				array(
+					array(
+						'q' => 'Install',
+						'a' => 'Upload.',
+					),
+				),
+				'howto'
+			),
+			'<span> </span>'
+		);
+
+		$this->assertArrayNotHasKey( 'name', $schema );
+	}
+
+	/**
 	 * With no title, name is omitted rather than emitted empty.
 	 */
 	public function test_howto_omits_name_when_no_title_is_given() {

--- a/tests/phpunit/schema-builders-test.php
+++ b/tests/phpunit/schema-builders-test.php
@@ -384,6 +384,54 @@ class Schema_Builders_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Text in a SIBLING after the title must not be absorbed.
+	 *
+	 * A sibling sits at the same breadcrumb depth as the matched element, so a
+	 * depth comparison of `< $found` never terminates on it — collection only
+	 * stopped once the walk climbed out past the parent. Today the icon that
+	 * follows the title is an <svg> with no text nodes, so nothing leaked; the
+	 * moment anything text-bearing was added after the title (a screen-reader
+	 * label, a badge, a different icon style) it would have been concatenated
+	 * onto the question with no test failing.
+	 */
+	public function test_title_extractor_stops_at_the_end_of_the_matched_element() {
+		$html = '<div class="dsgo-accordion-item__header"><button type="button">'
+			. '<span class="dsgo-accordion-item__title">Real question?</span>'
+			. '<span class="dsgo-accordion-item__icon">LEAKED</span>'
+			. '</button></div>';
+
+		$this->assertSame(
+			'Real question?',
+			designsetgo_schema_text_from_html( $html, 'dsgo-accordion-item__title' )
+		);
+	}
+
+	/**
+	 * Nested markup inside the title is still collected in full.
+	 */
+	public function test_title_extractor_collects_nested_text() {
+		$html = '<span class="dsgo-accordion-item__title">A <em>nested <b>deep</b></em> title</span>'
+			. '<span class="other">LEAKED</span>';
+
+		$this->assertSame(
+			'A nested deep title',
+			designsetgo_schema_text_from_html( $html, 'dsgo-accordion-item__title' )
+		);
+	}
+
+	/**
+	 * An empty title element yields '' rather than the following sibling.
+	 */
+	public function test_title_extractor_handles_an_empty_element() {
+		$html = '<span class="dsgo-accordion-item__title"></span><span>LEAKED</span>';
+
+		$this->assertSame(
+			'',
+			designsetgo_schema_text_from_html( $html, 'dsgo-accordion-item__title' )
+		);
+	}
+
+	/**
 	 * The title extractor returns '' when the element is absent.
 	 */
 	public function test_title_extractor_returns_empty_for_missing_element() {

--- a/tests/phpunit/schema-builders-test.php
+++ b/tests/phpunit/schema-builders-test.php
@@ -283,6 +283,62 @@ class Schema_Builders_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The title is a parameter, so HowTo.name needs no request state.
+	 *
+	 * This test deliberately performs no go_to() and touches no global $post —
+	 * if the builder reached for get_the_title() again, name would be absent.
+	 */
+	public function test_howto_takes_its_name_from_the_title_argument() {
+		$schema = designsetgo_schema_build_howto(
+			$this->accordion(
+				array(
+					array(
+						'q' => 'Install',
+						'a' => 'Upload the zip.',
+					),
+				),
+				'howto'
+			),
+			'How to install the plugin'
+		);
+
+		$this->assertSame( 'How to install the plugin', $schema['name'] );
+	}
+
+	/**
+	 * With no title, name is omitted rather than emitted empty.
+	 */
+	public function test_howto_omits_name_when_no_title_is_given() {
+		$schema = designsetgo_schema_build_howto(
+			$this->accordion(
+				array(
+					array(
+						'q' => 'Install',
+						'a' => 'Upload the zip.',
+					),
+				),
+				'howto'
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'name', $schema );
+	}
+
+	/**
+	 * A dynamic block in an answer contributes no text and is never executed.
+	 */
+	public function test_text_extraction_ignores_a_dynamic_block() {
+		$text = designsetgo_schema_text_from_blocks(
+			parse_blocks(
+				'<!-- wp:paragraph --><p>Real answer.</p><!-- /wp:paragraph -->'
+				. '<!-- wp:some-plugin/dynamic /-->'
+			)
+		);
+
+		$this->assertSame( 'Real answer.', $text );
+	}
+
+	/**
 	 * An empty accordion produces no HowTo.
 	 */
 	public function test_howto_of_an_empty_accordion_is_null() {

--- a/tests/phpunit/schema-config-parity-test.php
+++ b/tests/phpunit/schema-config-parity-test.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * The schema allowlist must match on both sides.
+ *
+ * src/extensions/schema/constants.js decides which blocks get the control;
+ * includes/extension-configs/schema.php decides which blocks get the attribute
+ * registered server-side. Nothing else ties them together, and the failure mode
+ * is silent: a block added only to the JS side would show an author a Schema
+ * type control whose value is dropped, because the attribute was never
+ * registered on the server.
+ *
+ * @package DesignSetGo
+ */
+
+/**
+ * Allowlist parity tests.
+ *
+ * @group schema
+ */
+class Schema_Config_Parity_Test extends WP_UnitTestCase {
+
+	/**
+	 * Block names listed in the PHP extension config.
+	 *
+	 * @return array Sorted block names.
+	 */
+	private function php_blocks() {
+		$config = require DESIGNSETGO_PATH . 'includes/extension-configs/schema.php';
+
+		$blocks = $config['blocks'];
+		sort( $blocks );
+
+		return $blocks;
+	}
+
+	/**
+	 * Block names used as keys of SCHEMA_TYPES in the JS constants.
+	 *
+	 * Read from source rather than executed: the assertion is about the file a
+	 * developer edits, and a build artefact could be stale.
+	 *
+	 * @return array Sorted block names.
+	 */
+	private function js_blocks() {
+		$path = DESIGNSETGO_PATH . 'src/extensions/schema/constants.js';
+
+		$this->assertFileExists( $path );
+
+		$source = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a source file in a test, not a remote resource.
+
+		// Only the object literal assigned to SCHEMA_TYPES.
+		$start = strpos( $source, 'export const SCHEMA_TYPES' );
+		$this->assertNotFalse( $start, 'SCHEMA_TYPES was renamed or removed.' );
+
+		$end  = strpos( $source, 'export const SCHEMA_BLOCKS', $start );
+		$body = false === $end ? substr( $source, $start ) : substr( $source, $start, $end - $start );
+
+		preg_match_all( "/'(designsetgo\/[a-z0-9-]+)'\s*:/", $body, $matches );
+
+		$blocks = array_unique( $matches[1] );
+		sort( $blocks );
+
+		return $blocks;
+	}
+
+	/**
+	 * Both sides list exactly the same blocks.
+	 */
+	public function test_js_and_php_allowlists_match() {
+		$js  = $this->js_blocks();
+		$php = $this->php_blocks();
+
+		$this->assertNotEmpty( $js, 'Parsed no blocks out of constants.js — the parser needs updating.' );
+
+		$this->assertSame(
+			$js,
+			$php,
+			'src/extensions/schema/constants.js and includes/extension-configs/schema.php list different blocks. '
+			. 'A block on only the JS side gets a control whose value is dropped on save.'
+		);
+	}
+
+	/**
+	 * The attribute name and default agree with the JS registration.
+	 */
+	public function test_php_config_declares_the_expected_attribute() {
+		$config = require DESIGNSETGO_PATH . 'includes/extension-configs/schema.php';
+
+		$this->assertArrayHasKey( 'dsgoSchema', $config['attributes'] );
+		$this->assertSame( 'string', $config['attributes']['dsgoSchema']['type'] );
+		$this->assertSame( 'none', $config['attributes']['dsgoSchema']['default'] );
+	}
+
+	/**
+	 * Every allowlisted block actually exists.
+	 */
+	public function test_every_allowlisted_block_has_a_block_json() {
+		foreach ( $this->php_blocks() as $name ) {
+			$slug = str_replace( 'designsetgo/', '', $name );
+
+			$this->assertFileExists(
+				DESIGNSETGO_PATH . 'src/blocks/' . $slug . '/block.json',
+				$name . ' is allowlisted for schema but has no block.json.'
+			);
+		}
+	}
+}

--- a/tests/phpunit/schema-config-parity-test.php
+++ b/tests/phpunit/schema-config-parity-test.php
@@ -81,6 +81,20 @@ class Schema_Config_Parity_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The runtime builder map lists the same blocks as the config.
+	 *
+	 * This is the list that actually gates collection. If it drifted from the
+	 * other two, a block could carry the control and the registered attribute
+	 * yet never produce schema — or the reverse.
+	 */
+	public function test_builder_map_matches_the_config() {
+		$builders = \DesignSetGo\SchemaOutput::supported_blocks();
+		sort( $builders );
+
+		$this->assertSame( $this->php_blocks(), $builders );
+	}
+
+	/**
 	 * The attribute name and default agree with the JS registration.
 	 */
 	public function test_php_config_declares_the_expected_attribute() {

--- a/tests/phpunit/schema-no-render-test.php
+++ b/tests/phpunit/schema-no-render-test.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Collecting schema text must not execute dynamic blocks.
+ *
+ * @package DesignSetGo
+ */
+
+/**
+ * Dynamic-block side-effect tests.
+ *
+ * @group schema
+ */
+class Schema_No_Render_Test extends WP_UnitTestCase {
+
+	/**
+	 * Times the probe block's render_callback ran.
+	 *
+	 * @var int
+	 */
+	public static $renders = 0;
+
+	/**
+	 * Register a dynamic probe block.
+	 */
+	public function set_up() {
+		parent::set_up();
+		self::$renders = 0;
+
+		register_block_type(
+			'dsgo-test/probe',
+			array(
+				'render_callback' => static function () {
+					++Schema_No_Render_Test::$renders;
+					return '<p>rendered</p>';
+				},
+			)
+		);
+	}
+
+	/**
+	 * Clean up the probe block.
+	 */
+	public function tear_down() {
+		unregister_block_type( 'dsgo-test/probe' );
+		parent::tear_down();
+	}
+
+	/**
+	 * wp_head must not execute a dynamic block nested in an answer.
+	 */
+	public function test_dynamic_block_in_an_answer_is_not_executed() {
+		$content = '<!-- wp:designsetgo/accordion {"dsgoSchema":"faq"} -->'
+			. '<div class="dsgo-accordion">'
+			. '<!-- wp:designsetgo/accordion-item -->'
+			. '<div class="dsgo-accordion-item"><div class="dsgo-accordion-item__header">'
+			. '<span class="dsgo-accordion-item__title">Question?</span></div>'
+			. '<div class="dsgo-accordion-item__content">'
+			. '<!-- wp:paragraph --><p>Real answer.</p><!-- /wp:paragraph -->'
+			. '<!-- wp:dsgo-test/probe /-->'
+			. '</div></div>'
+			. '<!-- /wp:designsetgo/accordion-item -->'
+			. '</div><!-- /wp:designsetgo/accordion -->';
+
+		$post_id = self::factory()->post->create( array( 'post_content' => $content ) );
+		$this->go_to( get_permalink( $post_id ) );
+
+		ob_start();
+		do_action( 'wp_head' );
+		$head = ob_get_clean();
+
+		$this->assertStringContainsString( 'FAQPage', $head, 'The schema should still be emitted.' );
+		$this->assertSame( 0, self::$renders, 'A dynamic block must not be executed while collecting schema text.' );
+	}
+}

--- a/tests/phpunit/schema-output-test.php
+++ b/tests/phpunit/schema-output-test.php
@@ -263,6 +263,92 @@ class Schema_Output_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A password-protected post must not disclose its content.
+	 *
+	 * is_singular() is still true and get_post() still returns the full object
+	 * for a protected post — the front end substitutes the password form at
+	 * the_content, not before it. wp_head runs earlier still, so without an
+	 * explicit gate the questions, answers and title would be readable in view
+	 * source by anyone, password or not.
+	 */
+	public function test_emits_nothing_for_a_password_protected_post() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'    => 'Secret guide',
+				'post_password' => 'hunter2',
+				'post_content'  => $this->accordion_markup( 'faq', 'Secret question?', 'Secret answer.' ),
+			)
+		);
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		ob_start();
+		do_action( 'wp_head' );
+		$head = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'application/ld+json', $head );
+		$this->assertStringNotContainsString( 'Secret question?', $head );
+		$this->assertStringNotContainsString( 'Secret answer.', $head );
+	}
+
+	/**
+	 * The same protection applies to a HowTo, whose name is the post title.
+	 */
+	public function test_emits_nothing_for_a_password_protected_howto() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'    => 'Secret HowTo title',
+				'post_password' => 'hunter2',
+				'post_content'  => $this->accordion_markup( 'howto', 'Step one', 'Do the thing.' ),
+			)
+		);
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		ob_start();
+		do_action( 'wp_head' );
+		$head = ob_get_clean();
+
+		// The title legitimately appears in <title>; what must not appear is a
+		// JSON-LD payload carrying it, or any of the protected step content.
+		$this->assertStringNotContainsString( 'application/ld+json', $head );
+		$this->assertStringNotContainsString( '@graph', $head );
+		$this->assertStringNotContainsString( 'Step one', $head );
+		$this->assertStringNotContainsString( 'Do the thing.', $head );
+	}
+
+	/**
+	 * Once the password is supplied, the schema is emitted as normal.
+	 */
+	public function test_emits_schema_once_the_password_has_been_entered() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_password' => 'hunter2',
+				'post_content'  => $this->accordion_markup( 'faq', 'Secret question?', 'Secret answer.' ),
+			)
+		);
+
+		// This is how wp-login.php stores a correct password. It must be a
+		// phpass hash specifically: post_password_required() rejects anything
+		// not starting with $P$B before it ever checks the value, so a bcrypt
+		// hash from wp_hash_password() would read as "still locked".
+		require_once ABSPATH . WPINC . '/class-phpass.php';
+		$hasher                                 = new PasswordHash( 8, true );
+		$_COOKIE[ 'wp-postpass_' . COOKIEHASH ] = $hasher->HashPassword( 'hunter2' );
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		ob_start();
+		do_action( 'wp_head' );
+		$head = ob_get_clean();
+
+		unset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] );
+
+		$this->assertStringContainsString( 'FAQPage', $head );
+		$this->assertStringContainsString( 'Secret question?', $head );
+	}
+
+	/**
 	 * Archives are not singular, so nothing is emitted.
 	 */
 	public function test_emits_nothing_on_an_archive() {

--- a/tests/phpunit/schema-output-test.php
+++ b/tests/phpunit/schema-output-test.php
@@ -199,6 +199,70 @@ class Schema_Output_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An ENTITY-ENCODED closing tag cannot break out either.
+	 *
+	 * Text is stripped before entities are decoded, so `&lt;/script&gt;` in the
+	 * saved markup survives strip_tags() and only becomes a literal
+	 * `</script>` afterwards. That ordering is deliberate — decoding first
+	 * would let strip_tags() delete text the page actually displays, e.g. an
+	 * answer that literally reads "<b>bold</b>" — so the breakout is stopped at
+	 * output instead, where every source of the sequence is covered at once.
+	 * This test is what makes that safe to rely on.
+	 */
+	public function test_entity_encoded_closing_script_tag_cannot_break_out() {
+		$head = $this->head_for(
+			$this->accordion_markup(
+				'faq',
+				'Ends with &lt;/script&gt;&lt;script&gt;alert(1)&lt;/script&gt;',
+				'Answer.'
+			)
+		);
+
+		// No real element boundary was created.
+		$this->assertStringNotContainsString( '</script><script>alert(1)', $head );
+
+		preg_match(
+			'#<script type="application/ld\+json">(.*?)</script>#s',
+			$head,
+			$matches
+		);
+
+		$this->assertNotEmpty( $matches );
+
+		$decoded = json_decode( $matches[1], true );
+		$this->assertNotNull( $decoded );
+
+		// The author's text is preserved verbatim inside the JSON string —
+		// escaped for the script context, not mangled.
+		$this->assertSame(
+			'Ends with </script><script>alert(1)</script>',
+			$decoded['@graph'][0]['mainEntity'][0]['name']
+		);
+	}
+
+	/**
+	 * Escaped markup an author typed as literal text survives as text.
+	 */
+	public function test_literal_markup_in_an_answer_is_preserved_not_stripped() {
+		$head = $this->head_for(
+			$this->accordion_markup( 'faq', 'Formatting?', 'Use &lt;b&gt;bold&lt;/b&gt; for emphasis.' )
+		);
+
+		preg_match(
+			'#<script type="application/ld\+json">(.*?)</script>#s',
+			$head,
+			$matches
+		);
+
+		$decoded = json_decode( $matches[1], true );
+
+		$this->assertSame(
+			'Use <b>bold</b> for emphasis.',
+			$decoded['@graph'][0]['mainEntity'][0]['acceptedAnswer']['text']
+		);
+	}
+
+	/**
 	 * Archives are not singular, so nothing is emitted.
 	 */
 	public function test_emits_nothing_on_an_archive() {

--- a/tests/phpunit/schema-output-test.php
+++ b/tests/phpunit/schema-output-test.php
@@ -349,6 +349,43 @@ class Schema_Output_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The attribute alone must not summon a builder on any block.
+	 *
+	 * The allowlist lives in the editor UI and in the server-side attribute
+	 * registration, but neither constrains what parse_blocks() hands the
+	 * collector at runtime. A hand-written block comment — the editor's Code
+	 * view is enough, no unfiltered_html needed — could put dsgoSchema on any
+	 * block and have the FAQ builder run against its children.
+	 *
+	 * No privilege escalation and no XSS, but it contradicts the stated design
+	 * that only blocks with a builder behind them generate schema.
+	 */
+	public function test_the_attribute_on_a_non_allowlisted_block_is_ignored() {
+		$content = '<!-- wp:group {"dsgoSchema":"faq"} --><div class="wp-block-group">'
+			// Real accordion items, so the builder would find usable pairs.
+			. '<!-- wp:designsetgo/accordion-item -->'
+			. '<div class="dsgo-accordion-item"><div class="dsgo-accordion-item__header">'
+			. '<span class="dsgo-accordion-item__title">Smuggled question?</span></div>'
+			. '<div class="dsgo-accordion-item__content">'
+			. '<!-- wp:paragraph --><p>Smuggled answer.</p><!-- /wp:paragraph -->'
+			. '</div></div>'
+			. '<!-- /wp:designsetgo/accordion-item -->'
+			. '</div><!-- /wp:group -->';
+
+		$head = $this->head_for( $content );
+
+		$this->assertStringNotContainsString( 'application/ld+json', $head );
+		$this->assertStringNotContainsString( 'Smuggled question?', $head );
+	}
+
+	/**
+	 * The allowlisted block still works, so the check is not simply blocking.
+	 */
+	public function test_the_allowlisted_block_still_emits() {
+		$this->assertStringContainsString( 'FAQPage', $this->head_for( $this->accordion_markup() ) );
+	}
+
+	/**
 	 * Archives are not singular, so nothing is emitted.
 	 */
 	public function test_emits_nothing_on_an_archive() {

--- a/tests/phpunit/schema-output-test.php
+++ b/tests/phpunit/schema-output-test.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * Schema head output tests.
+ *
+ * Exercises the whole path: a real post, parsed on wp_head, producing exactly
+ * one JSON-LD script for the page.
+ *
+ * @package DesignSetGo
+ */
+
+/**
+ * Head output tests.
+ *
+ * @group schema
+ */
+class Schema_Output_Test extends WP_UnitTestCase {
+
+	/**
+	 * Render wp_head for a post with the given content.
+	 *
+	 * @param string $content Post content.
+	 * @return string Captured head output.
+	 */
+	private function head_for( $content ) {
+		$post_id = self::factory()->post->create(
+			array( 'post_content' => $content )
+		);
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		ob_start();
+		do_action( 'wp_head' );
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * Serialize an accordion the way save.js does.
+	 *
+	 * The title is HTML-sourced, so it lives in the markup, not in attrs.
+	 *
+	 * @param string $schema   dsgoSchema value.
+	 * @param string $question Question text.
+	 * @param string $answer   Answer text.
+	 * @return string Block markup.
+	 */
+	private function accordion_markup( $schema = 'faq', $question = 'What is it?', $answer = 'A plugin.' ) {
+		return '<!-- wp:designsetgo/accordion {"dsgoSchema":"' . $schema . '"} -->'
+			. '<div class="wp-block-designsetgo-accordion dsgo-accordion">'
+			. '<!-- wp:designsetgo/accordion-item -->'
+			. '<div class="wp-block-designsetgo-accordion-item dsgo-accordion-item">'
+			. '<div class="dsgo-accordion-item__header"><button type="button" class="dsgo-accordion-item__trigger">'
+			. '<span class="dsgo-accordion-item__title">' . $question . '</span>'
+			. '</button></div>'
+			. '<div class="dsgo-accordion-item__panel"><div class="dsgo-accordion-item__content">'
+			. '<!-- wp:paragraph --><p>' . $answer . '</p><!-- /wp:paragraph -->'
+			. '</div></div></div>'
+			. '<!-- /wp:designsetgo/accordion-item -->'
+			. '</div>'
+			. '<!-- /wp:designsetgo/accordion -->';
+	}
+
+	/**
+	 * Opting in emits a JSON-LD script.
+	 */
+	public function test_emits_a_json_ld_script_when_opted_in() {
+		$head = $this->head_for( $this->accordion_markup() );
+
+		$this->assertStringContainsString( 'application/ld+json', $head );
+		$this->assertStringContainsString( 'FAQPage', $head );
+	}
+
+	/**
+	 * The default emits nothing.
+	 */
+	public function test_emits_nothing_when_not_opted_in() {
+		$head = $this->head_for( $this->accordion_markup( 'none' ) );
+
+		$this->assertStringNotContainsString( 'application/ld+json', $head );
+	}
+
+	/**
+	 * A post with no schema blocks emits nothing.
+	 */
+	public function test_emits_nothing_for_a_post_with_no_schema_blocks() {
+		$head = $this->head_for( '<!-- wp:paragraph --><p>Hi</p><!-- /wp:paragraph -->' );
+
+		$this->assertStringNotContainsString( 'application/ld+json', $head );
+	}
+
+	/**
+	 * Two opted-in blocks still produce one script.
+	 */
+	public function test_emits_exactly_one_script_for_two_opted_in_blocks() {
+		$head = $this->head_for( $this->accordion_markup() . $this->accordion_markup( 'faq', 'Second?', 'Yes.' ) );
+
+		$this->assertSame( 1, substr_count( $head, 'application/ld+json' ) );
+	}
+
+	/**
+	 * Both blocks land in the graph.
+	 */
+	public function test_merges_both_blocks_into_the_graph() {
+		$head = $this->head_for( $this->accordion_markup() . $this->accordion_markup( 'faq', 'Second?', 'Yes.' ) );
+
+		$this->assertStringContainsString( '@graph', $head );
+		$this->assertSame( 2, substr_count( $head, 'FAQPage' ) );
+	}
+
+	/**
+	 * Nesting inside a container is still found.
+	 */
+	public function test_finds_a_schema_block_nested_inside_a_section() {
+		$content = '<!-- wp:designsetgo/section --><div class="wp-block-designsetgo-section">'
+			. $this->accordion_markup()
+			. '</div><!-- /wp:designsetgo/section -->';
+
+		$this->assertStringContainsString( 'FAQPage', $this->head_for( $content ) );
+	}
+
+	/**
+	 * A HowTo block emits HowTo, not FAQ.
+	 */
+	public function test_howto_opt_in_emits_howto() {
+		$head = $this->head_for( $this->accordion_markup( 'howto', 'Install', 'Upload the zip.' ) );
+
+		$this->assertStringContainsString( 'HowTo', $head );
+		$this->assertStringNotContainsString( 'FAQPage', $head );
+	}
+
+	/**
+	 * HowTo.name is required by Google, and comes from the post title.
+	 */
+	public function test_howto_carries_the_post_title_as_its_name() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'How to install the plugin',
+				'post_content' => $this->accordion_markup( 'howto', 'Install', 'Upload the zip.' ),
+			)
+		);
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		ob_start();
+		do_action( 'wp_head' );
+		$head = ob_get_clean();
+
+		preg_match(
+			'#<script type="application/ld\+json">(.*?)</script>#s',
+			$head,
+			$matches
+		);
+
+		$decoded = json_decode( $matches[1], true );
+
+		$this->assertSame( 'How to install the plugin', $decoded['@graph'][0]['name'] );
+		$this->assertSame( 1, $decoded['@graph'][0]['step'][0]['position'] );
+	}
+
+	/**
+	 * The output parses as JSON.
+	 */
+	public function test_output_is_valid_json() {
+		$head = $this->head_for( $this->accordion_markup() );
+
+		preg_match(
+			'#<script type="application/ld\+json">(.*?)</script>#s',
+			$head,
+			$matches
+		);
+
+		$this->assertNotEmpty( $matches );
+
+		$decoded = json_decode( $matches[1], true );
+
+		$this->assertNotNull( $decoded );
+		$this->assertSame( 'https://schema.org', $decoded['@context'] );
+		$this->assertSame( 'FAQPage', $decoded['@graph'][0]['@type'] );
+	}
+
+	/**
+	 * A closing script tag in content cannot break out of the element.
+	 */
+	public function test_closing_script_tag_in_content_cannot_break_out() {
+		$head = $this->head_for(
+			$this->accordion_markup( 'faq', '</script><script>alert(1)</script>', 'Answer.' )
+		);
+
+		$this->assertStringNotContainsString( '</script><script>alert(1)', $head );
+
+		// And what IS emitted must still be parseable.
+		preg_match(
+			'#<script type="application/ld\+json">(.*?)</script>#s',
+			$head,
+			$matches
+		);
+		$this->assertNotEmpty( $matches );
+		$this->assertNotNull( json_decode( $matches[1], true ) );
+	}
+
+	/**
+	 * Archives are not singular, so nothing is emitted.
+	 */
+	public function test_emits_nothing_on_an_archive() {
+		self::factory()->post->create(
+			array( 'post_content' => $this->accordion_markup() )
+		);
+
+		$this->go_to( home_url( '/' ) );
+
+		ob_start();
+		do_action( 'wp_head' );
+		$head = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'application/ld+json', $head );
+	}
+
+	/**
+	 * An opted-in but empty accordion emits nothing.
+	 */
+	public function test_emits_nothing_when_the_block_has_no_usable_content() {
+		$content = '<!-- wp:designsetgo/accordion {"dsgoSchema":"faq"} -->'
+			. '<div class="wp-block-designsetgo-accordion dsgo-accordion"></div>'
+			. '<!-- /wp:designsetgo/accordion -->';
+
+		$this->assertStringNotContainsString( 'application/ld+json', $this->head_for( $content ) );
+	}
+
+	/**
+	 * The filter can replace the graph.
+	 */
+	public function test_nodes_filter_can_modify_the_graph() {
+		$callback = static function ( $nodes ) {
+			return array( array( '@type' => 'Thing' ) );
+		};
+
+		add_filter( 'designsetgo_schema_nodes', $callback );
+		$head = $this->head_for( $this->accordion_markup() );
+		remove_filter( 'designsetgo_schema_nodes', $callback );
+
+		$this->assertStringContainsString( 'Thing', $head );
+		$this->assertStringNotContainsString( 'FAQPage', $head );
+	}
+
+	/**
+	 * The filter can suppress output entirely.
+	 */
+	public function test_nodes_filter_can_suppress_output() {
+		$callback = '__return_empty_array';
+
+		add_filter( 'designsetgo_schema_nodes', $callback );
+		$head = $this->head_for( $this->accordion_markup() );
+		remove_filter( 'designsetgo_schema_nodes', $callback );
+
+		$this->assertStringNotContainsString( 'application/ld+json', $head );
+	}
+}

--- a/tests/phpunit/schema-synced-pattern-test.php
+++ b/tests/phpunit/schema-synced-pattern-test.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Schema must be found inside synced patterns (core/block references).
+ *
+ * A synced pattern stores its markup in a wp_block post; the page only holds
+ * <!-- wp:block {"ref":N} /-->. Defining an FAQ once in a shared pattern and
+ * reusing it is a realistic authoring flow, and silently emitting nothing
+ * there would be invisible to the author.
+ *
+ * @package DesignSetGo
+ */
+
+/**
+ * Synced pattern tests.
+ *
+ * @group schema
+ */
+class Schema_Synced_Pattern_Test extends WP_UnitTestCase {
+
+	/**
+	 * Accordion markup with an opted-in schema type.
+	 *
+	 * @return string Block markup.
+	 */
+	private function accordion() {
+		return '<!-- wp:designsetgo/accordion {"dsgoSchema":"faq"} -->'
+			. '<div class="dsgo-accordion">'
+			. '<!-- wp:designsetgo/accordion-item -->'
+			. '<div class="dsgo-accordion-item"><div class="dsgo-accordion-item__header">'
+			. '<span class="dsgo-accordion-item__title">Synced question?</span></div>'
+			. '<div class="dsgo-accordion-item__content">'
+			. '<!-- wp:paragraph --><p>Synced answer.</p><!-- /wp:paragraph -->'
+			. '</div></div>'
+			. '<!-- /wp:designsetgo/accordion-item -->'
+			. '</div><!-- /wp:designsetgo/accordion -->';
+	}
+
+	/**
+	 * Render wp_head for a post.
+	 *
+	 * @param string $content Post content.
+	 * @return string Head output.
+	 */
+	private function head_for( $content ) {
+		$post_id = self::factory()->post->create( array( 'post_content' => $content ) );
+		$this->go_to( get_permalink( $post_id ) );
+
+		ob_start();
+		do_action( 'wp_head' );
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * An accordion inside a synced pattern still emits schema.
+	 */
+	public function test_schema_inside_a_synced_pattern_is_found() {
+		$ref = self::factory()->post->create(
+			array(
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_content' => $this->accordion(),
+			)
+		);
+
+		$head = $this->head_for( '<!-- wp:block {"ref":' . $ref . '} /-->' );
+
+		$this->assertStringContainsString( 'FAQPage', $head );
+		$this->assertStringContainsString( 'Synced question?', $head );
+	}
+
+	/**
+	 * A pattern nested inside another pattern is still reached.
+	 */
+	public function test_schema_inside_a_nested_synced_pattern_is_found() {
+		$inner = self::factory()->post->create(
+			array(
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_content' => $this->accordion(),
+			)
+		);
+
+		$outer = self::factory()->post->create(
+			array(
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:block {"ref":' . $inner . '} /-->',
+			)
+		);
+
+		$this->assertStringContainsString(
+			'FAQPage',
+			$this->head_for( '<!-- wp:block {"ref":' . $outer . '} /-->' )
+		);
+	}
+
+	/**
+	 * A pattern that references itself must not recurse forever.
+	 */
+	public function test_a_self_referencing_pattern_terminates() {
+		$ref = self::factory()->post->create(
+			array(
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_content' => 'placeholder',
+			)
+		);
+
+		// Point the pattern at itself, and include a real accordion so there is
+		// something to find on the first pass.
+		wp_update_post(
+			array(
+				'ID'           => $ref,
+				'post_content' => $this->accordion() . '<!-- wp:block {"ref":' . $ref . '} /-->',
+			)
+		);
+
+		$head = $this->head_for( '<!-- wp:block {"ref":' . $ref . '} /-->' );
+
+		// The assertion that matters is that we get here at all.
+		$this->assertStringContainsString( 'FAQPage', $head );
+		$this->assertSame( 1, substr_count( $head, 'FAQPage' ) );
+	}
+
+	/**
+	 * Two patterns referencing each other must not recurse forever.
+	 */
+	public function test_mutually_referencing_patterns_terminate() {
+		$a = self::factory()->post->create(
+			array(
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_content' => 'placeholder',
+			)
+		);
+		$b = self::factory()->post->create(
+			array(
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:block {"ref":' . $a . '} /-->',
+			)
+		);
+
+		wp_update_post(
+			array(
+				'ID'           => $a,
+				'post_content' => $this->accordion() . '<!-- wp:block {"ref":' . $b . '} /-->',
+			)
+		);
+
+		$this->assertStringContainsString(
+			'FAQPage',
+			$this->head_for( '<!-- wp:block {"ref":' . $a . '} /-->' )
+		);
+	}
+
+	/**
+	 * A draft pattern contributes nothing.
+	 */
+	public function test_an_unpublished_pattern_is_ignored() {
+		$ref = self::factory()->post->create(
+			array(
+				'post_type'    => 'wp_block',
+				'post_status'  => 'draft',
+				'post_content' => $this->accordion(),
+			)
+		);
+
+		$this->assertStringNotContainsString(
+			'application/ld+json',
+			$this->head_for( '<!-- wp:block {"ref":' . $ref . '} /-->' )
+		);
+	}
+
+	/**
+	 * A reference to a post that is not a pattern is ignored.
+	 */
+	public function test_a_reference_to_a_non_pattern_post_is_ignored() {
+		$ref = self::factory()->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_content' => $this->accordion(),
+			)
+		);
+
+		$this->assertStringNotContainsString(
+			'application/ld+json',
+			$this->head_for( '<!-- wp:block {"ref":' . $ref . '} /-->' )
+		);
+	}
+
+	/**
+	 * A dangling reference is ignored rather than fatal.
+	 */
+	public function test_a_missing_reference_is_ignored() {
+		$this->assertStringNotContainsString(
+			'application/ld+json',
+			$this->head_for( '<!-- wp:block {"ref":999999} /-->' )
+		);
+	}
+
+	/**
+	 * A reference with no ref attribute is ignored.
+	 */
+	public function test_a_reference_with_no_id_is_ignored() {
+		$this->assertStringNotContainsString(
+			'application/ld+json',
+			$this->head_for( '<!-- wp:block /-->' )
+		);
+	}
+}

--- a/tests/phpunit/schema-synced-pattern-test.php
+++ b/tests/phpunit/schema-synced-pattern-test.php
@@ -174,6 +174,29 @@ class Schema_Synced_Pattern_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A password-protected pattern contributes nothing.
+	 *
+	 * Core's render_block_core_block() refuses to render one, so emitting its
+	 * questions and answers into the head would disclose content the page
+	 * itself never shows.
+	 */
+	public function test_a_password_protected_pattern_is_ignored() {
+		$ref = self::factory()->post->create(
+			array(
+				'post_type'     => 'wp_block',
+				'post_status'   => 'publish',
+				'post_password' => 'hunter2',
+				'post_content'  => $this->accordion(),
+			)
+		);
+
+		$head = $this->head_for( '<!-- wp:block {"ref":' . $ref . '} /-->' );
+
+		$this->assertStringNotContainsString( 'application/ld+json', $head );
+		$this->assertStringNotContainsString( 'Synced question?', $head );
+	}
+
+	/**
 	 * A reference to a post that is not a pattern is ignored.
 	 */
 	public function test_a_reference_to_a_non_pattern_post_is_ignored() {

--- a/tests/unit/extensions/schema-attribute.test.js
+++ b/tests/unit/extensions/schema-attribute.test.js
@@ -1,0 +1,73 @@
+/**
+ * The dsgoSchema opt-in attribute.
+ *
+ * Structured data that misdescribes its content gets sites penalised, so the
+ * attribute is added to an explicit allowlist of blocks whose shape genuinely
+ * maps to a schema type — never to every block — and it defaults to 'none'.
+ */
+
+import { applyFilters } from '@wordpress/hooks';
+import '../../../src/extensions/schema';
+import {
+	SCHEMA_TYPES,
+	SCHEMA_BLOCKS,
+} from '../../../src/extensions/schema/constants';
+
+const settingsFor = (name) =>
+	applyFilters('blocks.registerBlockType', { name, attributes: {} }, name);
+
+describe('schema attribute', () => {
+	it('adds dsgoSchema to the accordion', () => {
+		expect(
+			settingsFor('designsetgo/accordion').attributes.dsgoSchema
+		).toEqual({
+			type: 'string',
+			default: 'none',
+		});
+	});
+
+	it.each([
+		'core/paragraph',
+		'designsetgo/grid',
+		'designsetgo/accordion-item',
+		'designsetgo/section',
+	])('does not add it to %s', (name) => {
+		expect(settingsFor(name).attributes.dsgoSchema).toBeUndefined();
+	});
+
+	it('offers exactly none, faq and howto for the accordion', () => {
+		const values = SCHEMA_TYPES['designsetgo/accordion'].map(
+			(t) => t.value
+		);
+		expect(values).toEqual(['none', 'faq', 'howto']);
+	});
+
+	it('defaults to none, so nothing is emitted until an author opts in', () => {
+		expect(SCHEMA_TYPES['designsetgo/accordion'][0].value).toBe('none');
+	});
+
+	it('only registers blocks that have a matching server-side builder', () => {
+		// A control offering a type with no builder behind it is a no-op that
+		// looks like a feature. comparison-table and card were in the original
+		// plan for Review, but neither block holds rating data, so neither is
+		// listed here until a builder exists.
+		expect(SCHEMA_BLOCKS).toEqual(['designsetgo/accordion']);
+	});
+
+	it('leaves existing attributes untouched', () => {
+		const settings = applyFilters(
+			'blocks.registerBlockType',
+			{
+				name: 'designsetgo/accordion',
+				attributes: { itemGap: { type: 'string', default: '0.5rem' } },
+			},
+			'designsetgo/accordion'
+		);
+
+		expect(settings.attributes.itemGap).toEqual({
+			type: 'string',
+			default: '0.5rem',
+		});
+		expect(settings.attributes.dsgoSchema).toBeDefined();
+	});
+});


### PR DESCRIPTION
Lets an author opt a block into emitting schema.org JSON-LD. One `<script type="application/ld+json">` per page, nothing emitted unless an author deliberately chooses a type.

Implements plan 4 of the GreenShift gap roadmap.

## What's new

A `dsgoSchema` attribute on `designsetgo/accordion`, offering **FAQ** (`FAQPage`) or **How-to** (`HowTo`), with a Structured Data control in the block's Advanced panel alongside Visibility and Style Bindings. `DesignSetGo\SchemaOutput` walks the singular post's blocks on `wp_head` and prints a single merged `@graph`.

## Two plan assumptions that were wrong

Both were verified against the real blocks before writing any code.

**1. The accordion title is HTML-sourced — the planned builder would have emitted nothing.**

The plan read the question from `$block['attrs']['title']`. But `accordion-item` declares:

```json
"title": { "type": "string", "source": "html", "selector": ".dsgo-accordion-item__title" }
```

`parse_blocks()` only decodes the block comment's JSON, so that key is **absent for every real post**. The builder would have found an empty question on every item, skipped them all, and silently emitted nothing — while passing any test that hand-builds the array with `attrs.title` set, which is exactly what the plan's tests did.

The title is now read from the saved markup with `WP_HTML_Processor` (chosen over `DOMDocument`, which mangles UTF-8 without an encoding preamble, and over a regex, which cannot track nesting). Every builder test drives `parse_blocks()` output rather than invented attributes, and one test asserts `attrs.title` is absent so the regression cannot return unnoticed.

**2. Review/Product has no data source, so it is not in this PR.**

The plan mapped Review onto `comparison-table` and `card`. The real columns are `{name, link, linkText, featured}` — no `title`, and **no rating field anywhere in either block**. `product-showcase-hero` has only a `showRating` display toggle over WooCommerce data, which WooCommerce already emits schema for.

A control offering a type with no builder behind it is a no-op that looks like a feature, so `SCHEMA_TYPES` lists only the accordion, and a test pins the allowlist to blocks that actually have a builder. Review can be its own PR once a rating source exists.

## Why opt-in, and why one script

Emitting FAQ markup for an accordion that holds navigation links is structured-data spam and gets sites penalised, so the default is `none`. Google also caps FAQ rich results to one block per page, so the collector merges every opted-in block into a single `@graph` rather than printing several scripts.

The control's help text tells authors to leave it on None if an SEO plugin already outputs the type for that page.

## Design notes

- **Reads stored content, not `render_block`.** The accordion is static (a `save.js`, no `render.php`) and its title only exists in saved markup; `wp_head` also runs before the content, so a `render_block` collector would be too late.
- **Cheap bail before parsing.** `strpos( $content, 'dsgoSchema' )` short-circuits before `parse_blocks()` on the overwhelming majority of posts.
- **Script break-out is neutralised.** `JSON_UNESCAPED_SLASHES` keeps URLs readable but means a literal `</script>` in a question would close the element early, so slashes are escaped after encoding. A test feeds `</script><script>alert(1)</script>` through a question title and asserts the output still parses.
- **`designsetgo_schema_nodes`** filter can modify or suppress the graph.
- Text is separated at tag boundaries before stripping — without it two adjacent paragraphs fused into `One.Two.`

## Verification

Browser-verified end to end on wp-env — real editor → save → `parse_blocks()` → `wp_head`:

```json
{"@context":"https://schema.org","@graph":[
  {"@type":"FAQPage","mainEntity":[
    {"@type":"Question","name":"What is DesignSetGo?",
     "acceptedAnswer":{"@type":"Answer","text":"A WordPress block plugin."}},
    {"@type":"Question","name":"Does it need jQuery?", ...}]},
  {"@type":"HowTo","name":"How to install DesignSetGo","step":[
    {"@type":"HowToStep","position":1,"name":"Download", ...}]}]}
```

Confirmed in that run: exactly **one** script tag; inline `<strong>` stripped from the question; `HowTo.name` taken from the post title (Google requires it); numbered steps; a Unicode arrow preserved; and a third, opted-out accordion on the same page contributing nothing. The inspector control was also driven like a user would — changing the select updates the attribute and back again.

## Tests

- `tests/phpunit/schema-builders-test.php` — 17 tests, all driven from `parse_blocks()` output: FAQ/HowTo shape, the HTML-sourced-title regression guard, inline markup stripped, entities decoded, the icon span excluded, incomplete pairs skipped while valid siblings survive, whole-class-name matching, and malformed HTML tolerated.
- `tests/phpunit/schema-output-test.php` — 14 tests: opt-in/opt-out, one script for two blocks, nesting inside a section, HowTo vs FAQ, `HowTo.name` from the title, valid JSON, script break-out, archives, empty blocks, and the filter modifying and suppressing output.
- `tests/unit/extensions/schema-attribute.test.js` — 9 tests: allowlist membership and exclusions, option list, `none` default, existing attributes preserved, and the allowlist pinned to blocks with builders.

Gates: `build`, `lint:js`, `phpcs` (124 files), **13,268 unit tests**, **1,072 PHPUnit** — all green.

## Not done

- Validation against <https://validator.schema.org/>. That means sending page content to a third-party service, so I left it as a manual step rather than doing it unprompted. The output matches Google's documented FAQPage and HowTo shapes.
- `Event` and `Recipe` types.
- Review/Product, per above.
