### PR TITLE
feat: add keyless Google Maps embed provider to the map block

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -317,3 +317,62 @@ function designsetgo_resolve_preset_color( $color, $fallback = null ) {
 	// Preset reference that could not be resolved to a palette color.
 	return null === $fallback ? $color : $fallback;
 }
+
+/**
+ * Builds a keyless Google Maps embed URL for the Map block.
+ *
+ * Uses the long-standing `output=embed` share URL rather than the official
+ * Maps Embed API (`google.com/maps/embed/v1/*`), because the latter still
+ * requires a Cloud API key even though it is free and unmetered. This form
+ * needs no key at all, which is the whole point of the `googlemaps-embed`
+ * provider. It is undocumented, so the keyed Maps JavaScript API path stays
+ * in place as the supported option.
+ *
+ * Google geocodes the `q` parameter itself, so an address is passed through
+ * verbatim and the block's Nominatim lookup is skipped entirely.
+ *
+ * @since 2.6.0
+ *
+ * @param string $address   Street address. Preferred over coordinates when set.
+ * @param float  $latitude  Latitude, used when $address is empty.
+ * @param float  $longitude Longitude, used when $address is empty.
+ * @param int    $zoom      Zoom level; clamped to Google's 1–20 range.
+ * @return string Fully-formed embed URL (not escaped — escape at output).
+ */
+function designsetgo_map_embed_url( $address, $latitude, $longitude, $zoom ) {
+	// Flatten multi-line addresses the way the block's geocoder does, so the
+	// two providers resolve the same author input to the same place.
+	$address = preg_replace( '/[\r\n]+/', ', ', (string) $address );
+	$address = trim( preg_replace( '/\s+/', ' ', $address ) );
+
+	if ( '' !== $address ) {
+		$query = $address;
+	} else {
+		$query = designsetgo_format_coordinate( $latitude ) . ',' . designsetgo_format_coordinate( $longitude );
+	}
+
+	$args = array(
+		'q'      => $query,
+		'z'      => (string) max( 1, min( 20, (int) $zoom ) ),
+		'output' => 'embed',
+	);
+
+	return 'https://maps.google.com/maps?' . http_build_query( $args );
+}
+
+/**
+ * Formats a coordinate for a map URL without exponent or trailing-zero noise.
+ *
+ * @since 2.6.0
+ *
+ * @param float $value Coordinate value.
+ * @return string Plain decimal representation.
+ */
+function designsetgo_format_coordinate( $value ) {
+	$formatted = number_format( (float) $value, 6, '.', '' );
+
+	// Trim trailing zeros, then a bare trailing separator ("0.000000" → "0").
+	$formatted = rtrim( $formatted, '0' );
+
+	return rtrim( $formatted, '.' );
+}

--- a/src/blocks/map/block.json
+++ b/src/blocks/map/block.json
@@ -22,7 +22,8 @@
 			"default": "openstreetmap",
 			"enum": [
 				"openstreetmap",
-				"googlemaps"
+				"googlemaps",
+				"googlemaps-embed"
 			]
 		},
 		"dsgoLatitude": {

--- a/src/blocks/map/components/inspector/MapSettingsPanel.js
+++ b/src/blocks/map/components/inspector/MapSettingsPanel.js
@@ -25,6 +25,27 @@ import { geocodeAddress } from '../../utils/geocoding';
 const DEFAULT_PRIVACY_NOTICE =
 	'This map will load content from external services. Click to load and view the map.';
 
+/**
+ * Help text describing what each provider costs the author.
+ *
+ * @param {string} provider - Current dsgoProvider value.
+ * @return {string} Help text.
+ */
+function providerHelp(provider) {
+	if (provider === 'googlemaps') {
+		return __('Requires a Google Maps API key.', 'designsetgo');
+	}
+
+	if (provider === 'googlemaps-embed') {
+		return __(
+			'No API key needed. Google renders the map in an embedded frame, so the marker icon, marker color, and map style settings do not apply.',
+			'designsetgo'
+		);
+	}
+
+	return __('Privacy-friendly and free to use.', 'designsetgo');
+}
+
 export default function MapSettingsPanel({ attributes, setAttributes }) {
 	const {
 		dsgoProvider,
@@ -39,6 +60,10 @@ export default function MapSettingsPanel({ attributes, setAttributes }) {
 		dsgoPrivacyMode,
 		dsgoPrivacyNotice,
 	} = attributes;
+
+	// Google owns the rendering in embed mode, so the marker and style controls
+	// would be dead UI — hide them rather than let them silently do nothing.
+	const isEmbedProvider = dsgoProvider === 'googlemaps-embed';
 
 	const [isSearching, setIsSearching] = useState(false);
 	const [searchError, setSearchError] = useState('');
@@ -115,19 +140,16 @@ export default function MapSettingsPanel({ attributes, setAttributes }) {
 							),
 							value: 'googlemaps',
 						},
+						{
+							label: __(
+								'Google Maps (No API key)',
+								'designsetgo'
+							),
+							value: 'googlemaps-embed',
+						},
 					]}
 					onChange={(value) => setAttributes({ dsgoProvider: value })}
-					help={
-						dsgoProvider === 'openstreetmap'
-							? __(
-									'Privacy-friendly and free to use.',
-									'designsetgo'
-								)
-							: __(
-									'Requires a Google Maps API key.',
-									'designsetgo'
-								)
-					}
+					help={providerHelp(dsgoProvider)}
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
 				/>
@@ -302,26 +324,28 @@ export default function MapSettingsPanel({ attributes, setAttributes }) {
 				/>
 			</DsgoInspectorPanel.Item>
 
-			<DsgoInspectorPanel.Item
-				label={__('Marker Icon', 'designsetgo')}
-				hasValue={() => dsgoMarkerIcon !== '📍'}
-				onDeselect={() => setAttributes({ dsgoMarkerIcon: '📍' })}
-				isShownByDefault
-			>
-				<TextControl
+			{!isEmbedProvider && (
+				<DsgoInspectorPanel.Item
 					label={__('Marker Icon', 'designsetgo')}
-					value={dsgoMarkerIcon}
-					onChange={(value) =>
-						setAttributes({ dsgoMarkerIcon: value || '📍' })
-					}
-					help={__(
-						'Enter an emoji or icon character.',
-						'designsetgo'
-					)}
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-				/>
-			</DsgoInspectorPanel.Item>
+					hasValue={() => dsgoMarkerIcon !== '📍'}
+					onDeselect={() => setAttributes({ dsgoMarkerIcon: '📍' })}
+					isShownByDefault
+				>
+					<TextControl
+						label={__('Marker Icon', 'designsetgo')}
+						value={dsgoMarkerIcon}
+						onChange={(value) =>
+							setAttributes({ dsgoMarkerIcon: value || '📍' })
+						}
+						help={__(
+							'Enter an emoji or icon character.',
+							'designsetgo'
+						)}
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				</DsgoInspectorPanel.Item>
+			)}
 
 			<DsgoInspectorPanel.Item
 				label={__('Aspect Ratio', 'designsetgo')}

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -22,6 +22,7 @@ import {
 } from '../../utils/encode-color-value';
 // Inspector Panel
 import MapSettingsPanel from './components/inspector/MapSettingsPanel';
+import { buildEmbedUrl } from './utils/embed-url';
 
 /**
  * Edit component for Map block.
@@ -48,6 +49,10 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
 
+	// Google draws its own pin in embed mode, so the marker colour control has
+	// nothing to act on. Mirrors the same gate in MapSettingsPanel.
+	const isEmbedProvider = dsgoProvider === 'googlemaps-embed';
+
 	// Compute block classes
 	const blockClasses = classnames('dsgo-map', {
 		'dsgo-map--privacy-mode': dsgoPrivacyMode,
@@ -69,6 +74,114 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 		className: blockClasses,
 		style: mapStyles,
 	});
+
+	// Embed mode is a real Google iframe, so the editor can show the actual
+	// map. The other providers are initialized by view.js on the front end
+	// only, which is why they get a placeholder card here instead.
+	const renderPreview = () => {
+		if (dsgoPrivacyMode) {
+			return (
+				<div className="dsgo-map__privacy-overlay">
+					<div className="dsgo-map__privacy-content">
+						<svg
+							className="dsgo-map__privacy-icon"
+							xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+						>
+							<path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
+							<circle cx="12" cy="10" r="3" />
+						</svg>
+						<p className="dsgo-map__privacy-text">
+							{dsgoPrivacyNotice ||
+								__('Click to load map', 'designsetgo')}
+						</p>
+						<button
+							className="dsgo-map__load-button"
+							type="button"
+							onClick={(e) => e.preventDefault()}
+						>
+							{__('Load Map', 'designsetgo')}
+						</button>
+						<p className="dsgo-map__preview-note">
+							{__(
+								'Preview: Privacy mode is enabled',
+								'designsetgo'
+							)}
+						</p>
+					</div>
+				</div>
+			);
+		}
+
+		if (isEmbedProvider) {
+			return (
+				<iframe
+					className="dsgo-map__iframe"
+					src={buildEmbedUrl(
+						dsgoAddress,
+						dsgoLatitude,
+						dsgoLongitude,
+						dsgoZoom
+					)}
+					title={__('Map preview', 'designsetgo')}
+					loading="lazy"
+					referrerPolicy="no-referrer-when-downgrade"
+				/>
+			);
+		}
+
+		return (
+			<div className="dsgo-map__preview-placeholder">
+				<div className="dsgo-map__preview-info">
+					<svg
+						className="dsgo-map__preview-icon"
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					>
+						<path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
+						<circle cx="12" cy="10" r="3" />
+					</svg>
+					<div className="dsgo-map__preview-details">
+						<strong>{__('Map Preview', 'designsetgo')}</strong>
+						<div className="dsgo-map__preview-coords">
+							{dsgoLatitude === 0 &&
+							dsgoLongitude === 0 &&
+							dsgoAddress ? (
+								<span>{dsgoAddress}</span>
+							) : (
+								<code>
+									{dsgoLatitude.toFixed(6)},{' '}
+									{dsgoLongitude.toFixed(6)}
+								</code>
+							)}
+						</div>
+						<div className="dsgo-map__preview-meta">
+							{dsgoProvider === 'openstreetmap'
+								? __('OpenStreetMap', 'designsetgo')
+								: __('Google Maps', 'designsetgo')}{' '}
+							• {__('Zoom:', 'designsetgo')} {dsgoZoom}
+						</div>
+					</div>
+				</div>
+				<div className="dsgo-map__preview-note">
+					{__(
+						'Interactive map will display on the frontend',
+						'designsetgo'
+					)}
+				</div>
+			</div>
+		);
+	};
 
 	return (
 		<>
@@ -101,135 +214,51 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 				</DsgoInspectorPanel>
 			</InspectorControls>
 
-			<InspectorControls group="color">
-				<ColorGradientSettingsDropdown
-					panelId={clientId}
-					title={__('Google Maps Marker Color', 'designsetgo')}
-					settings={[
-						{
-							// Only the Google Maps provider draws a recolorable
-							// pin (PinElement); the OpenStreetMap marker is the
-							// Marker Icon emoji as-is, which CSS color can't
-							// change. Label makes that scope clear in the UI.
-							label: __(
-								'Google Maps Marker Color',
-								'designsetgo'
-							),
-							colorValue: decodeColorValue(
-								dsgoMarkerColor,
-								colorGradientSettings
-							),
-							onColorChange: (color) =>
-								setAttributes({
-									// Store the preset reference for palette
-									// picks; on clear, store '' so render.php's
-									// attribute → kit setting → default fallback
-									// chain drives the color instead of baking a
-									// hex into the block.
-									dsgoMarkerColor: color
-										? encodeColorValue(
-												color,
-												colorGradientSettings
-											)
-										: '',
-								}),
-							enableAlpha: true,
-							clearable: true,
-						},
-					]}
-					{...colorGradientSettings}
-				/>
-			</InspectorControls>
+			{!isEmbedProvider && (
+				<InspectorControls group="color">
+					<ColorGradientSettingsDropdown
+						panelId={clientId}
+						title={__('Google Maps Marker Color', 'designsetgo')}
+						settings={[
+							{
+								// Only the Google Maps provider draws a recolorable
+								// pin (PinElement); the OpenStreetMap marker is the
+								// Marker Icon emoji as-is, which CSS color can't
+								// change. Label makes that scope clear in the UI.
+								label: __(
+									'Google Maps Marker Color',
+									'designsetgo'
+								),
+								colorValue: decodeColorValue(
+									dsgoMarkerColor,
+									colorGradientSettings
+								),
+								onColorChange: (color) =>
+									setAttributes({
+										// Store the preset reference for palette
+										// picks; on clear, store '' so render.php's
+										// attribute → kit setting → default fallback
+										// chain drives the color instead of baking a
+										// hex into the block.
+										dsgoMarkerColor: color
+											? encodeColorValue(
+													color,
+													colorGradientSettings
+												)
+											: '',
+									}),
+								enableAlpha: true,
+								clearable: true,
+							},
+						]}
+						{...colorGradientSettings}
+					/>
+				</InspectorControls>
+			)}
 
 			<div {...blockProps}>
 				<div className="dsgo-map__editor-preview">
-					{dsgoPrivacyMode ? (
-						<div className="dsgo-map__privacy-overlay">
-							<div className="dsgo-map__privacy-content">
-								<svg
-									className="dsgo-map__privacy-icon"
-									xmlns="http://www.w3.org/2000/svg"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-								>
-									<path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
-									<circle cx="12" cy="10" r="3" />
-								</svg>
-								<p className="dsgo-map__privacy-text">
-									{dsgoPrivacyNotice ||
-										__('Click to load map', 'designsetgo')}
-								</p>
-								<button
-									className="dsgo-map__load-button"
-									type="button"
-									onClick={(e) => e.preventDefault()}
-								>
-									{__('Load Map', 'designsetgo')}
-								</button>
-								<p className="dsgo-map__preview-note">
-									{__(
-										'Preview: Privacy mode is enabled',
-										'designsetgo'
-									)}
-								</p>
-							</div>
-						</div>
-					) : (
-						<div className="dsgo-map__preview-placeholder">
-							<div className="dsgo-map__preview-info">
-								<svg
-									className="dsgo-map__preview-icon"
-									xmlns="http://www.w3.org/2000/svg"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-								>
-									<path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
-									<circle cx="12" cy="10" r="3" />
-								</svg>
-								<div className="dsgo-map__preview-details">
-									<strong>
-										{__('Map Preview', 'designsetgo')}
-									</strong>
-									<div className="dsgo-map__preview-coords">
-										{dsgoLatitude === 0 &&
-										dsgoLongitude === 0 &&
-										dsgoAddress ? (
-											<span>{dsgoAddress}</span>
-										) : (
-											<code>
-												{dsgoLatitude.toFixed(6)},{' '}
-												{dsgoLongitude.toFixed(6)}
-											</code>
-										)}
-									</div>
-									<div className="dsgo-map__preview-meta">
-										{dsgoProvider === 'openstreetmap'
-											? __('OpenStreetMap', 'designsetgo')
-											: __(
-													'Google Maps',
-													'designsetgo'
-												)}{' '}
-										• {__('Zoom:', 'designsetgo')}{' '}
-										{dsgoZoom}
-									</div>
-								</div>
-							</div>
-							<div className="dsgo-map__preview-note">
-								{__(
-									'Interactive map will display on the frontend',
-									'designsetgo'
-								)}
-							</div>
-						</div>
-					)}
+					{renderPreview()}
 				</div>
 			</div>
 		</>

--- a/src/blocks/map/editor.scss
+++ b/src/blocks/map/editor.scss
@@ -23,6 +23,13 @@
 			justify-content: center;
 		}
 
+		// Live embed preview. Pointer events are off so clicking the map
+		// selects the block instead of being swallowed by Google's iframe —
+		// the front end keeps the map fully interactive.
+		&__iframe {
+			pointer-events: none;
+		}
+
 		// Preview placeholder (non-privacy mode)
 		&__preview-placeholder {
 			width: 100%;

--- a/src/blocks/map/handlers/DSGMap.js
+++ b/src/blocks/map/handlers/DSGMap.js
@@ -85,6 +85,14 @@ export default class DSGMap {
 	 */
 	async loadMap() {
 		try {
+			// The keyless Google provider is a server-rendered iframe. In privacy
+			// mode render.php parks the URL in data-dsgo-src so nothing reaches
+			// Google until now; there is no JS map library to initialize.
+			if (this.config.provider === 'googlemaps-embed') {
+				this.revealEmbed();
+				return;
+			}
+
 			if (
 				this.config.lat === 0 &&
 				this.config.lng === 0 &&
@@ -131,6 +139,29 @@ export default class DSGMap {
 			// eslint-disable-next-line no-console
 			console.error('Failed to load map:', error);
 			this.showError('Failed to load map. Please check your settings.');
+		}
+	}
+
+	/**
+	 * Reveal a parked iframe embed and hide the privacy overlay.
+	 */
+	revealEmbed() {
+		const iframe = this.element.querySelector('.dsgo-map__iframe');
+		if (iframe && iframe.dataset.dsgoSrc) {
+			iframe.src = iframe.dataset.dsgoSrc;
+			delete iframe.dataset.dsgoSrc;
+		}
+
+		const overlay = this.element.querySelector(
+			'.dsgo-map__privacy-overlay'
+		);
+		if (overlay) {
+			overlay.style.display = 'none';
+		}
+
+		// Move focus into the map the visitor just asked for.
+		if (iframe && this.config.privacyMode) {
+			iframe.focus();
 		}
 	}
 

--- a/src/blocks/map/render.php
+++ b/src/blocks/map/render.php
@@ -25,6 +25,30 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! function_exists( 'designsetgo_map_privacy_overlay' ) ) {
+	/**
+	 * Builds the click-to-load overlay shared by every map provider.
+	 *
+	 * @param string $notice Author-supplied notice text.
+	 * @return string Overlay markup.
+	 */
+	function designsetgo_map_privacy_overlay( $notice ) {
+		// Fallback mirrors the block.json default so render.php stays self-consistent
+		// even if it is ever invoked with attributes that weren't merged with defaults.
+		$text = '' !== $notice
+			? $notice
+			: __( 'This map will load content from external services. Click to load and view the map.', 'designsetgo' );
+
+		$html  = '<div class="dsgo-map__privacy-overlay"><div class="dsgo-map__privacy-content">';
+		$html .= '<svg class="dsgo-map__privacy-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"></path><circle cx="12" cy="10" r="3"></circle></svg>';
+		$html .= '<p class="dsgo-map__privacy-text">' . esc_html( $text ) . '</p>';
+		$html .= '<button class="dsgo-map__load-button" type="button" aria-label="' . esc_attr__( 'Load map. This will connect to external map services.', 'designsetgo' ) . '">' . esc_html__( 'Load Map', 'designsetgo' ) . '</button>';
+		$html .= '</div></div>';
+
+		return $html;
+	}
+}
+
 if ( ! function_exists( 'designsetgo_render_map' ) ) {
 	/**
 	 * Renders the Map block on the front end.
@@ -107,29 +131,46 @@ if ( ! function_exists( 'designsetgo_render_map' ) ) {
 			'data-dsgo-privacy-mode' => $privacy_mode ? 'true' : 'false',
 			'data-dsgo-map-style'    => $map_style,
 		);
-		$data_attr_html = '';
+		$data_attr_html  = '';
 		foreach ( $data_attributes as $key => $value ) {
 			$data_attr_html .= ' ' . $key . '="' . esc_attr( $value ) . '"';
 		}
 
+		$aria_label = '' !== $address
+			/* translators: %s: The address being shown on the map */
+			? sprintf( __( 'Map showing %s', 'designsetgo' ), $address )
+			: __( 'Interactive map', 'designsetgo' );
+
+		// The keyless Google provider is a plain iframe built server-side: no
+		// Maps JS API, no Leaflet, and no geocoding round-trip, so outside of
+		// privacy mode the block needs no JavaScript at all. The marker icon /
+		// colour and map style attributes have no effect here — Google owns the
+		// rendering — which is why the inspector hides those controls.
+		if ( 'googlemaps-embed' === $provider ) {
+			$embed_url = designsetgo_map_embed_url( $address, $safe_lat, $safe_lng, $safe_zoom );
+
+			// In privacy mode the URL is parked until the visitor asks for it,
+			// so no request reaches Google on page load.
+			$src_attribute = $privacy_mode
+				? 'data-dsgo-src="' . esc_url( $embed_url ) . '"'
+				: 'src="' . esc_url( $embed_url ) . '"';
+
+			$inner = '<iframe class="dsgo-map__iframe" ' . $src_attribute
+				. ' title="' . esc_attr( $aria_label ) . '"'
+				. ' loading="lazy" referrerpolicy="no-referrer-when-downgrade"'
+				. ' allowfullscreen></iframe>';
+
+			if ( $privacy_mode ) {
+				$inner .= designsetgo_map_privacy_overlay( $privacy_note );
+			}
+
+			echo '<div ' . $wrapper_attributes . $data_attr_html . '>' . $inner . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			return;
+		}
+
 		if ( $privacy_mode ) {
-			// Fallback mirrors the block.json default so render.php stays self-consistent
-			// even if it is ever invoked with attributes that weren't merged with defaults.
-			$notice = '' !== $privacy_note
-				? $privacy_note
-				: __( 'This map will load content from external services. Click to load and view the map.', 'designsetgo' );
-
-			$inner  = '<div class="dsgo-map__privacy-overlay"><div class="dsgo-map__privacy-content">';
-			$inner .= '<svg class="dsgo-map__privacy-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"></path><circle cx="12" cy="10" r="3"></circle></svg>';
-			$inner .= '<p class="dsgo-map__privacy-text">' . esc_html( $notice ) . '</p>';
-			$inner .= '<button class="dsgo-map__load-button" type="button" aria-label="' . esc_attr__( 'Load map. This will connect to external map services.', 'designsetgo' ) . '">' . esc_html__( 'Load Map', 'designsetgo' ) . '</button>';
-			$inner .= '</div></div>';
+			$inner = designsetgo_map_privacy_overlay( $privacy_note );
 		} else {
-			$aria_label = '' !== $address
-				/* translators: %s: The address being shown on the map */
-				? sprintf( __( 'Map showing %s', 'designsetgo' ), $address )
-				: __( 'Interactive map', 'designsetgo' );
-
 			$inner = '<div class="dsgo-map__container" role="region" aria-label="' . esc_attr( $aria_label ) . '"></div>';
 		}
 

--- a/src/blocks/map/style.scss
+++ b/src/blocks/map/style.scss
@@ -32,8 +32,22 @@
 		z-index: 1;
 	}
 
+	// Keyless Google embed. Positioned like &__container so the aspect-ratio
+	// padding trick above works for the iframe too.
+	&__iframe {
+		position: absolute;
+		top: 0;
+		left: 0;
+		display: block;
+		width: 100%;
+		height: 100%;
+		border: 0;
+		z-index: 1;
+	}
+
 	// Custom height (no aspect ratio)
-	&:not([class*='dsgo-map--aspect-']) &__container {
+	&:not([class*='dsgo-map--aspect-']) &__container,
+	&:not([class*='dsgo-map--aspect-']) &__iframe {
 		position: relative;
 		height: 100%;
 	}

--- a/src/blocks/map/utils/embed-url.js
+++ b/src/blocks/map/utils/embed-url.js
@@ -39,7 +39,18 @@ export function buildEmbedUrl(address, latitude, longitude, zoom) {
 		? flattened
 		: `${formatCoordinate(latitude)},${formatCoordinate(longitude)}`;
 
-	const safeZoom = Math.max(1, Math.min(20, parseInt(zoom, 10) || 13));
+	// Mirror PHP's max(1, min(20, (int) $zoom)) exactly. Two traps: `|| 13`
+	// would treat a zoom of 0 as missing and substitute the attribute default
+	// where PHP clamps to 1, and PHP's (int) cast turns any unparseable value
+	// into 0 (which then clamps to 1) rather than a default. The block UI's
+	// RangeControl has min={1}, but patterns and the API can set dsgoZoom
+	// freely, and a mismatch here shows one zoom in the editor preview and
+	// another on the front end.
+	const parsedZoom = parseInt(zoom, 10);
+	const safeZoom = Math.max(
+		1,
+		Math.min(20, Number.isFinite(parsedZoom) ? parsedZoom : 0)
+	);
 
 	const params = new URLSearchParams({
 		q: query,

--- a/src/blocks/map/utils/embed-url.js
+++ b/src/blocks/map/utils/embed-url.js
@@ -1,0 +1,51 @@
+/**
+ * Keyless Google Maps embed URL builder.
+ *
+ * Mirrors designsetgo_map_embed_url() in includes/helpers.php so the editor
+ * preview and the server-rendered front end resolve to the same URL. Keep the
+ * two in sync — the PHP side is the one that ships in the markup.
+ */
+
+/**
+ * Format a coordinate without exponent or trailing-zero noise.
+ *
+ * @param {number} value - Coordinate value.
+ * @return {string} Plain decimal representation.
+ */
+function formatCoordinate(value) {
+	const numeric = Number.isFinite(value) ? value : 0;
+
+	return numeric.toFixed(6).replace(/0+$/, '').replace(/\.$/, '');
+}
+
+/**
+ * Build the embed URL for the googlemaps-embed provider.
+ *
+ * @param {string} address   - Street address; preferred over coordinates.
+ * @param {number} latitude  - Latitude, used when address is empty.
+ * @param {number} longitude - Longitude, used when address is empty.
+ * @param {number} zoom      - Zoom level; clamped to Google's 1–20 range.
+ * @return {string} Embed URL.
+ */
+export function buildEmbedUrl(address, latitude, longitude, zoom) {
+	// Flatten multi-line addresses the way the geocoder does, so both providers
+	// resolve the same author input to the same place.
+	const flattened = String(address || '')
+		.replace(/[\r\n]+/g, ', ')
+		.replace(/\s+/g, ' ')
+		.trim();
+
+	const query = flattened
+		? flattened
+		: `${formatCoordinate(latitude)},${formatCoordinate(longitude)}`;
+
+	const safeZoom = Math.max(1, Math.min(20, parseInt(zoom, 10) || 13));
+
+	const params = new URLSearchParams({
+		q: query,
+		z: String(safeZoom),
+		output: 'embed',
+	});
+
+	return `https://maps.google.com/maps?${params.toString()}`;
+}

--- a/tests/phpunit/map-embed-render-test.php
+++ b/tests/phpunit/map-embed-render-test.php
@@ -26,6 +26,22 @@ class Map_Embed_Render_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Read one query parameter out of a built URL.
+	 *
+	 * Substring assertions are unsafe here: 'z=13' contains 'z=1', so a clamp
+	 * regression would pass unnoticed.
+	 *
+	 * @param string $url  Built embed URL.
+	 * @param string $name Parameter name.
+	 * @return string|null Decoded parameter value.
+	 */
+	private function param( $url, $name ) {
+		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $params );
+
+		return isset( $params[ $name ] ) ? $params[ $name ] : null;
+	}
+
+	/**
 	 * The block is registered, so the suite exercises real markup.
 	 */
 	public function test_the_block_is_registered() {
@@ -54,7 +70,7 @@ class Map_Embed_Render_Test extends WP_UnitTestCase {
 	public function test_url_builder_prefers_address_over_coordinates() {
 		$url = designsetgo_map_embed_url( '123 Main St, Springfield', 40.7128, -74.006, 13 );
 
-		$this->assertStringContainsString( 'q=123+Main+St%2C+Springfield', $url );
+		$this->assertSame( '123 Main St, Springfield', $this->param( $url, 'q' ) );
 		$this->assertStringNotContainsString( '40.7128', $url );
 	}
 
@@ -64,15 +80,41 @@ class Map_Embed_Render_Test extends WP_UnitTestCase {
 	public function test_url_builder_falls_back_to_coordinates() {
 		$url = designsetgo_map_embed_url( '', 40.7128, -74.006, 13 );
 
-		$this->assertStringContainsString( 'q=40.7128%2C-74.006', $url );
+		$this->assertSame( '40.7128,-74.006', $this->param( $url, 'q' ) );
 	}
 
 	/**
 	 * Zoom is clamped into Google's supported range.
 	 */
 	public function test_url_builder_clamps_zoom() {
-		$this->assertStringContainsString( 'z=20', designsetgo_map_embed_url( '', 0, 0, 99 ) );
-		$this->assertStringContainsString( 'z=1', designsetgo_map_embed_url( '', 0, 0, -5 ) );
+		$this->assertSame( '20', $this->param( designsetgo_map_embed_url( '', 0, 0, 99 ), 'z' ) );
+		$this->assertSame( '1', $this->param( designsetgo_map_embed_url( '', 0, 0, -5 ), 'z' ) );
+	}
+
+	/**
+	 * A zero zoom clamps up to 1 rather than falling back to the default.
+	 *
+	 * Pins the value the JS twin (buildEmbedUrl) must agree with; a falsy
+	 * check on that side would substitute the attribute default of 13 and
+	 * drift the editor preview away from this render.
+	 */
+	public function test_url_builder_clamps_zero_zoom_to_one() {
+		$this->assertSame( '1', $this->param( designsetgo_map_embed_url( '', 0, 0, 0 ), 'z' ) );
+	}
+
+	/**
+	 * Unparseable zoom values cast to 0, which then clamps to 1.
+	 */
+	public function test_url_builder_treats_unparseable_zoom_as_the_minimum() {
+		$this->assertSame( '1', $this->param( designsetgo_map_embed_url( '', 0, 0, 'abc' ), 'z' ) );
+		$this->assertSame( '1', $this->param( designsetgo_map_embed_url( '', 0, 0, null ), 'z' ) );
+	}
+
+	/**
+	 * A fractional zoom truncates toward zero.
+	 */
+	public function test_url_builder_truncates_fractional_zoom() {
+		$this->assertSame( '7', $this->param( designsetgo_map_embed_url( '', 0, 0, 7.9 ), 'z' ) );
 	}
 
 	/**
@@ -81,7 +123,7 @@ class Map_Embed_Render_Test extends WP_UnitTestCase {
 	public function test_url_builder_flattens_multiline_addresses() {
 		$url = designsetgo_map_embed_url( "123 Main St\nSpringfield, IL", 0, 0, 13 );
 
-		$this->assertStringContainsString( 'q=123+Main+St%2C+Springfield%2C+IL', $url );
+		$this->assertSame( '123 Main St, Springfield, IL', $this->param( $url, 'q' ) );
 		$this->assertStringNotContainsString( '%0A', $url );
 	}
 

--- a/tests/phpunit/map-embed-render-test.php
+++ b/tests/phpunit/map-embed-render-test.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Tests for the map block's keyless Google Maps embed provider.
+ *
+ * @package DesignSetGo
+ * @subpackage Tests
+ */
+
+/**
+ * Covers designsetgo_map_embed_url() and the iframe branch of render.php.
+ *
+ * @group map
+ */
+class Map_Embed_Render_Test extends WP_UnitTestCase {
+
+	/**
+	 * Render a map block from an attribute array.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Rendered markup.
+	 */
+	private function render( array $attributes ) {
+		return do_blocks(
+			'<!-- wp:designsetgo/map ' . wp_json_encode( $attributes ) . ' /-->'
+		);
+	}
+
+	/**
+	 * The block is registered, so the suite exercises real markup.
+	 */
+	public function test_the_block_is_registered() {
+		$this->assertTrue(
+			WP_Block_Type_Registry::get_instance()->is_registered( 'designsetgo/map' ),
+			'designsetgo/map is not registered — run `npm run build` first.'
+		);
+	}
+
+	/**
+	 * The new provider is a valid enum value in the built block.json.
+	 */
+	public function test_embed_provider_is_an_allowed_enum_value() {
+		$block = WP_Block_Type_Registry::get_instance()->get_registered( 'designsetgo/map' );
+
+		$this->assertContains(
+			'googlemaps-embed',
+			$block->attributes['dsgoProvider']['enum'],
+			'googlemaps-embed missing from the dsgoProvider enum.'
+		);
+	}
+
+	/**
+	 * The URL builder prefers an address over coordinates.
+	 */
+	public function test_url_builder_prefers_address_over_coordinates() {
+		$url = designsetgo_map_embed_url( '123 Main St, Springfield', 40.7128, -74.006, 13 );
+
+		$this->assertStringContainsString( 'q=123+Main+St%2C+Springfield', $url );
+		$this->assertStringNotContainsString( '40.7128', $url );
+	}
+
+	/**
+	 * With no address, the builder falls back to lat,lng.
+	 */
+	public function test_url_builder_falls_back_to_coordinates() {
+		$url = designsetgo_map_embed_url( '', 40.7128, -74.006, 13 );
+
+		$this->assertStringContainsString( 'q=40.7128%2C-74.006', $url );
+	}
+
+	/**
+	 * Zoom is clamped into Google's supported range.
+	 */
+	public function test_url_builder_clamps_zoom() {
+		$this->assertStringContainsString( 'z=20', designsetgo_map_embed_url( '', 0, 0, 99 ) );
+		$this->assertStringContainsString( 'z=1', designsetgo_map_embed_url( '', 0, 0, -5 ) );
+	}
+
+	/**
+	 * Multi-line addresses are flattened, matching the geocoding normalizer.
+	 */
+	public function test_url_builder_flattens_multiline_addresses() {
+		$url = designsetgo_map_embed_url( "123 Main St\nSpringfield, IL", 0, 0, 13 );
+
+		$this->assertStringContainsString( 'q=123+Main+St%2C+Springfield%2C+IL', $url );
+		$this->assertStringNotContainsString( '%0A', $url );
+	}
+
+	/**
+	 * The embed always asks Google for the bare embed output.
+	 */
+	public function test_url_builder_requests_embed_output() {
+		$url = designsetgo_map_embed_url( 'Paris', 0, 0, 13 );
+
+		$this->assertStringStartsWith( 'https://maps.google.com/maps?', $url );
+		$this->assertStringContainsString( 'output=embed', $url );
+	}
+
+	/**
+	 * Normal mode emits a ready-to-load iframe needing no JavaScript.
+	 */
+	public function test_embed_provider_renders_a_live_iframe() {
+		$html = $this->render(
+			array(
+				'dsgoProvider' => 'googlemaps-embed',
+				'dsgoAddress'  => 'Paris, France',
+			)
+		);
+
+		$this->assertStringContainsString( 'dsgo-map__iframe', $html );
+		$this->assertStringContainsString( 'src="https://maps.google.com/maps?', $html );
+		$this->assertStringContainsString( 'loading="lazy"', $html );
+		$this->assertStringContainsString( 'referrerpolicy="no-referrer-when-downgrade"', $html );
+		$this->assertStringNotContainsString( 'data-dsgo-src', $html );
+	}
+
+	/**
+	 * The iframe carries an accessible name derived from the address.
+	 */
+	public function test_embed_iframe_has_an_accessible_title() {
+		$html = $this->render(
+			array(
+				'dsgoProvider' => 'googlemaps-embed',
+				'dsgoAddress'  => 'Paris, France',
+			)
+		);
+
+		$this->assertStringContainsString( 'title="Map showing Paris, France"', $html );
+	}
+
+	/**
+	 * Privacy mode parks the URL until the visitor asks for it.
+	 */
+	public function test_privacy_mode_withholds_the_iframe_src() {
+		$html = $this->render(
+			array(
+				'dsgoProvider'    => 'googlemaps-embed',
+				'dsgoAddress'     => 'Paris, France',
+				'dsgoPrivacyMode' => true,
+			)
+		);
+
+		$this->assertStringContainsString( 'data-dsgo-src="https://maps.google.com/maps?', $html );
+		$this->assertStringNotContainsString( ' src="https://maps.google.com', $html );
+		$this->assertStringContainsString( 'dsgo-map__load-button', $html );
+	}
+
+	/**
+	 * Attribute values cannot break out of the src attribute.
+	 */
+	public function test_address_is_escaped_in_the_iframe_src() {
+		$html = $this->render(
+			array(
+				'dsgoProvider' => 'googlemaps-embed',
+				'dsgoAddress'  => '"><script>alert(1)</script>',
+			)
+		);
+
+		$this->assertStringNotContainsString( '<script>alert(1)</script>', $html );
+	}
+
+	/**
+	 * The keyed JavaScript providers keep their container-based markup.
+	 */
+	public function test_other_providers_still_render_the_js_container() {
+		foreach ( array( 'openstreetmap', 'googlemaps' ) as $provider ) {
+			$html = $this->render( array( 'dsgoProvider' => $provider ) );
+
+			$this->assertStringContainsString( 'dsgo-map__container', $html, $provider );
+			$this->assertStringNotContainsString( 'dsgo-map__iframe', $html, $provider );
+		}
+	}
+}

--- a/tests/unit/map-embed-url.test.js
+++ b/tests/unit/map-embed-url.test.js
@@ -1,0 +1,52 @@
+/**
+ * Tests for the keyless Google Maps embed URL builder.
+ *
+ * The PHP twin in includes/helpers.php is covered by
+ * tests/phpunit/map-embed-render-test.php; these assertions are deliberately
+ * the same shape so a drift between the two is visible.
+ */
+
+import { buildEmbedUrl } from '../../src/blocks/map/utils/embed-url';
+
+describe('buildEmbedUrl', () => {
+	it('prefers an address over coordinates', () => {
+		const url = buildEmbedUrl(
+			'123 Main St, Springfield',
+			40.7128,
+			-74.006,
+			13
+		);
+
+		expect(url).toContain('q=123+Main+St%2C+Springfield');
+		expect(url).not.toContain('40.7128');
+	});
+
+	it('falls back to coordinates when there is no address', () => {
+		expect(buildEmbedUrl('', 40.7128, -74.006, 13)).toContain(
+			'q=40.7128%2C-74.006'
+		);
+	});
+
+	it('flattens multi-line addresses', () => {
+		const url = buildEmbedUrl('123 Main St\nSpringfield, IL', 0, 0, 13);
+
+		expect(url).toContain('q=123+Main+St%2C+Springfield%2C+IL');
+		expect(url).not.toContain('%0A');
+	});
+
+	it('clamps zoom to the supported range', () => {
+		expect(buildEmbedUrl('', 0, 0, 99)).toContain('z=20');
+		expect(buildEmbedUrl('', 0, 0, -5)).toContain('z=1');
+	});
+
+	it('renders zero coordinates as a plain zero', () => {
+		expect(buildEmbedUrl('', 0, 0, 13)).toContain('q=0%2C0');
+	});
+
+	it('requests the bare embed output', () => {
+		const url = buildEmbedUrl('Paris', 0, 0, 13);
+
+		expect(url.startsWith('https://maps.google.com/maps?')).toBe(true);
+		expect(url).toContain('output=embed');
+	});
+});

--- a/tests/unit/map-embed-url.test.js
+++ b/tests/unit/map-embed-url.test.js
@@ -8,6 +8,20 @@
 
 import { buildEmbedUrl } from '../../src/blocks/map/utils/embed-url';
 
+/**
+ * Read one query parameter from a built URL.
+ *
+ * Substring assertions are unsafe here: 'z=13' contains 'z=1', so a clamp
+ * regression would pass unnoticed.
+ *
+ * @param {string} url  - Built embed URL.
+ * @param {string} name - Parameter name.
+ * @return {string|null} Parameter value.
+ */
+function param(url, name) {
+	return new URL(url).searchParams.get(name);
+}
+
 describe('buildEmbedUrl', () => {
 	it('prefers an address over coordinates', () => {
 		const url = buildEmbedUrl(
@@ -17,30 +31,47 @@ describe('buildEmbedUrl', () => {
 			13
 		);
 
-		expect(url).toContain('q=123+Main+St%2C+Springfield');
+		expect(param(url, 'q')).toBe('123 Main St, Springfield');
 		expect(url).not.toContain('40.7128');
 	});
 
 	it('falls back to coordinates when there is no address', () => {
-		expect(buildEmbedUrl('', 40.7128, -74.006, 13)).toContain(
-			'q=40.7128%2C-74.006'
+		expect(param(buildEmbedUrl('', 40.7128, -74.006, 13), 'q')).toBe(
+			'40.7128,-74.006'
 		);
 	});
 
 	it('flattens multi-line addresses', () => {
 		const url = buildEmbedUrl('123 Main St\nSpringfield, IL', 0, 0, 13);
 
-		expect(url).toContain('q=123+Main+St%2C+Springfield%2C+IL');
+		expect(param(url, 'q')).toBe('123 Main St, Springfield, IL');
 		expect(url).not.toContain('%0A');
 	});
 
 	it('clamps zoom to the supported range', () => {
-		expect(buildEmbedUrl('', 0, 0, 99)).toContain('z=20');
-		expect(buildEmbedUrl('', 0, 0, -5)).toContain('z=1');
+		expect(param(buildEmbedUrl('', 0, 0, 99), 'z')).toBe('20');
+		expect(param(buildEmbedUrl('', 0, 0, -5), 'z')).toBe('1');
+	});
+
+	it('clamps a zero zoom up to 1, matching the PHP twin', () => {
+		// PHP does max(1, min(20, (int) $zoom)), so 0 becomes 1 — not the
+		// attribute default. A falsy-check here would wrongly substitute 13.
+		expect(param(buildEmbedUrl('', 0, 0, 0), 'z')).toBe('1');
+	});
+
+	it('treats an unparseable zoom the way PHP casts it', () => {
+		// (int) 'abc' and (int) null are both 0 in PHP, which then clamps to 1.
+		expect(param(buildEmbedUrl('', 0, 0, 'abc'), 'z')).toBe('1');
+		expect(param(buildEmbedUrl('', 0, 0, null), 'z')).toBe('1');
+		expect(param(buildEmbedUrl('', 0, 0, undefined), 'z')).toBe('1');
+	});
+
+	it('truncates a fractional zoom toward zero like an int cast', () => {
+		expect(param(buildEmbedUrl('', 0, 0, 7.9), 'z')).toBe('7');
 	});
 
 	it('renders zero coordinates as a plain zero', () => {
-		expect(buildEmbedUrl('', 0, 0, 13)).toContain('q=0%2C0');
+		expect(param(buildEmbedUrl('', 0, 0, 13), 'q')).toBe('0,0');
 	});
 
 	it('requests the bare embed output', () => {


### PR DESCRIPTION
## Why

The Google Maps provider requires an API key configured in Settings, and without one the block renders nothing — just a warning notice in the inspector. This adds a third `dsgoProvider` value, `googlemaps-embed`, that needs no key at all.

## Which URL, and why it matters

Two Google iframe URLs exist and the difference is the whole point:

- `google.com/maps/embed/v1/place?key=…` — the official **Maps Embed API**. Free and unmetered, but [still requires a Cloud API key](https://developers.google.com/maps/documentation/embed/get-started). Doesn't solve the problem.
- `maps.google.com/maps?q=…&output=embed` — the old share-iframe format. **No key.** This is what the block now uses.

That second URL is undocumented and not covered by Google's ToS. It has been stable for years and much of the plugin ecosystem depends on it, but it could break without notice — which is why the keyed Maps JavaScript API path stays in place, untouched, as the supported option. Authors choose explicitly between the two rather than one silently falling back to the other.

## What it does

`render.php` emits the iframe server-side, so outside of privacy mode **the block needs no JavaScript at all** — no Maps JS API, no Leaflet, and no Nominatim geocoding round-trip, since Google geocodes the `q` parameter itself.

Privacy mode parks the URL in `data-dsgo-src` and `DSGMap.revealEmbed()` swaps it in on click, so nothing reaches Google on page load.

Google owns the rendering here, so the marker icon, marker color, and map style controls would be dead UI. The inspector hides them in this mode rather than let them silently do nothing, and the provider help text says so.

## Notes for review

- **No deprecation needed.** The block is dynamic (`save()` returns null), so there is no stored HTML to invalidate and widening an enum is backward-compatible.
- The privacy overlay is now shared by both render branches, extracted into `designsetgo_map_privacy_overlay()`.
- `designsetgo_map_embed_url()` lives in `includes/helpers.php`, not `render.php` — a block's render file is only loaded at render time, so a function defined there doesn't exist for anything that calls it first.
- Styles went into `src/blocks/map/style.scss` rather than the global entry, because the map block loads its own SCSS via `index.js` with `"style": "file:./index.css"`.
- The editor iframe gets `pointer-events: none` so clicking the map selects the block instead of being swallowed by Google's frame. The front end stays fully interactive.
- The `edit.js` diff is larger than the change warrants: the three preview branches were a ternary chain, and adding a third arm tripped `no-nested-ternary`, so they moved into a `renderPreview()` function and prettier reindented the JSX.

## Testing

- 12 new PHPUnit tests (URL builder + render branches, escaping, privacy parking, other providers unaffected) and 6 new Jest tests for the JS twin, deliberately the same shape so drift between them is visible
- Full suites green: **1257 PHP** (1 pre-existing skip), **5836 JS**
- `phpcs`, `lint-js`, `lint-style` clean; pre-commit e2e suite passed
- Manually verified in wp-env with **no API key configured**: live map renders on the front end and in the editor; privacy-mode iframe sits at `about:blank` until clicked, then loads; the iframe carries an accessible title derived from the address; no console errors; toggling back to OpenStreetMap restores the hidden controls with no block warnings
