### PR TITLE
fix: correct the Abilities API discovery surface and document all 20 abilities

### DIFF
--- a/.claude/claude-memory.md
+++ b/.claude/claude-memory.md
@@ -347,3 +347,42 @@ project repo, so `composer install` cannot fetch phpcs/WPCS or PHPUnit. PHP was 
 `php -l` on every touched file plus a standalone harness that stubs the WP functions and
 renders the block end-to-end (including colour-injection and script-in-template attempts,
 both neutralised); `tests/phpunit/star-rating-test.php` is written but unrun.
+
+---
+
+## Session: abilities-audit-2026-08-24 (agent id: abilities-verify-01)
+
+Ran `wp-abilities-verify` over the 20 registered abilities, static then runtime
+(wp-env, WP 7.1 + Woo, Abilities API present). Report: `docs/audits/ABILITIES-VERIFICATION.md`.
+
+Things worth remembering about this tree:
+
+- **`grep 'wp_register_ability('` finds ONE call site, not 20.** Registration goes through
+  `Abstract_Ability::register()`, which calls the function *indirectly*
+  (`$fn = 'wp_register_ability'; $fn(...)`) so Plugin Check's static "requires WP 6.9" scan
+  doesn't flag it. Enumerate by reflecting over concrete `Abstract_Ability` subclasses, or at
+  runtime via `wp_get_abilities()`. Same trick for `wp_register_ability_category()`.
+- Abilities are auto-discovered by glob over
+  `includes/abilities/{info,inserters,configurators,settings}/class-*.php` — no list to update
+  when adding one. `generators/` is wired but empty.
+- **Three discovery abilities were lying about their own taxonomy** (all now fixed):
+  `list-abilities` inferred a category from the name prefix instead of reading the registered
+  one; `list-blocks` remapped every block through a dead `designsetgo-*` slug table so the
+  filter only ever returned one bucket; `list-dynamic-tag-sources` hardcoded a `group` enum
+  that omitted `woocommerce`, and with `additionalProperties:false` that made Woo sources
+  unfilterable. Lesson: hardcoded enums mirroring a live registry are the drift hotspot here.
+- `list-blocks` now sources its `group` from `includes/admin/blocks-registry.json`.
+  **That file lists only 48 of 68 blocks** — the other 20 report `group: "uncategorized"`.
+  Same file drives the Blocks & Extensions admin screen, so those 20 have no enable/disable
+  control there. Open product decision, deliberately not guessed at.
+- Ability error codes are now prefixed `designsetgo_*` (incl. the status map in
+  `Abstract_Ability::get_default_status_for_error()` and ~25 test assertions).
+  `rest_forbidden` deliberately keeps its core-conventional unprefixed name.
+- The `read` gate on `list-abilities`/`list-blocks`/`list-extensions` is INTENTIONAL —
+  `abilities-security-test.php` asserts subscribers can call them. Don't "tighten" it.
+- Per-post `edit_post` checks live inside `Block_Inserter` / `Block_Configurator`, not in the
+  ability permission callbacks. `configure-custom-css` and `configure-shape-divider` have no
+  `edit_post` call of their own and are covered entirely by the helper — verified, not a gap.
+- Env note: `docker` is at `/Applications/Docker.app/Contents/Resources/bin/docker`, not on
+  PATH by default; `php` needs `/opt/homebrew/bin`. `Map_Embed_Render_Test` has **4 failures
+  on a clean tree** — pre-existing, unrelated to abilities work.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,8 +110,15 @@ designsetgo/
 │   │   └── class-block-styles.php
 │   ├── patterns/             # Pattern registration
 │   │   └── class-pattern-registry.php
-│   ├── abilities/            # WordPress Abilities API
-│   │   └── class-abilities-provider.php
+│   ├── abilities/            # WordPress Abilities API (20 abilities)
+│   │   ├── class-abilities-registry.php   # Auto-discovery + registration
+│   │   ├── class-abstract-ability.php     # Base class for every ability
+│   │   ├── class-block-inserter.php       # Shared insert helper (caps + save)
+│   │   ├── class-block-configurator.php   # Shared update helper (caps + save)
+│   │   ├── info/             # 6 read-only discovery abilities
+│   │   ├── inserters/        # 5 block-insertion abilities
+│   │   ├── configurators/    # 5 block-modification abilities
+│   │   └── settings/         # 4 settings / global-CSS abilities
 │   ├── class-plugin.php      # Main plugin class
 │   ├── class-assets.php      # Asset management
 │   └── class-i18n.php        # Internationalization
@@ -790,36 +797,56 @@ describe('Icon Block Edit', () => {
 **Location:** `includes/abilities/`
 
 The Abilities API allows AI agents to programmatically interact with blocks.
+DesignSetGo registers 20 abilities in three categories — `info`, `blocks`,
+and `settings`.
+
+Abilities are **auto-discovered**: `Abilities_Registry` globs
+`includes/abilities/{info,inserters,configurators,settings}/class-*.php`,
+instantiates every concrete `Abstract_Ability` subclass, and registers each
+on the `wp_abilities_api_init` hook. Adding a file to one of those
+directories is all that is required — there is no list to update.
 
 ```php
-// includes/abilities/class-abilities-provider.php
-class Abilities_Provider {
-  public function register_abilities() {
-    register_ability('designsetgo/list-blocks', [
-      'callback' => [$this, 'list_blocks'],
-      'schema' => [...],
-    ]);
+// includes/abilities/info/class-list-blocks.php
+class List_Blocks extends Abstract_Ability {
 
-    register_ability('designsetgo/add-block', [
-      'callback' => [$this, 'add_block'],
-      'schema' => [...],
-    ]);
+  public function get_name(): string {
+    return 'designsetgo/list-blocks';
   }
 
-  public function list_blocks($params) {
-    // Return block information
-    return [
-      'blocks' => $this->get_all_blocks(),
-    ];
+  public function get_config(): array {
+    return array(
+      'label'               => __( 'List DesignSetGo Blocks', 'designsetgo' ),
+      'description'         => __( '...', 'designsetgo' ),
+      'category'            => 'info',
+      'input_schema'        => $this->get_input_schema(),
+      'output_schema'       => $this->get_output_schema(),
+      'permission_callback' => array( $this, 'check_permission_callback' ),
+      'annotations'         => array(
+        'readonly'    => true,
+        'destructive' => false,
+        'idempotent'  => true,
+      ),
+    );
+  }
+
+  public function execute( array $input ): array {
+    return array( 'blocks' => ..., 'total' => ... );
   }
 }
 ```
 
+`Abstract_Ability::register()` normalises the config (moving
+`show_in_rest`, `public`, `annotations`, and `keywords` under `meta`, which
+is where `WP_Ability` expects them) and then calls `wp_register_ability()`.
+The call is made indirectly so Plugin Check's static "requires WP 6.9" scan
+does not flag a function that is already runtime-gated.
+
 **Usage by AI:**
 ```bash
-curl -X GET http://site.com/wp-json/wp-abilities/v1/designsetgo/list-blocks/run \
-  -u "user:pass" \
-  -d '{"category": "all"}'
+# readonly abilities route to GET
+curl -X GET "http://site.com/wp-json/wp-abilities/v1/designsetgo/list-blocks/run?group=containers" \
+  -u "user:pass"
 ```
 
 See [ABILITIES-API.md](ABILITIES-API.md) for complete documentation.

--- a/docs/api/ABILITIES-API.md
+++ b/docs/api/ABILITIES-API.md
@@ -20,13 +20,22 @@ The WordPress Abilities API is a new core initiative that creates a structured w
 
 ## Available Abilities
 
-DesignSetGo provides a focused set of abilities across 3 categories:
+DesignSetGo registers **20 abilities** in 3 registered categories. The
+category an ability is registered in — `info`, `blocks`, or `settings` — is
+what `/wp-json/wp-abilities/v1/categories` reports and what the `category`
+filter on `list-abilities` accepts.
 
-- **Info** - Discover abilities, list blocks, list extensions, inspect post content, find blocks across posts (`list-abilities`, `list-blocks`, `list-extensions`, `get-post-blocks`, `find-blocks`)
-- **Inserters** - `add-block` (generic top-level), `add-child-block` (nested), plus child-block inserters (`add-accordion-item`, `add-tab`, `add-timeline-item`)
-- **Configurators** - `update-block` (generic), block-specific configurators with custom logic, and operations (`batch-update`, `delete-block`)
+| Registered category | Count | Contents |
+|---|---|---|
+| `info` | 6 | `list-abilities`, `list-blocks`, `list-extensions`, `list-dynamic-tag-sources`, `get-post-blocks`, `find-blocks` |
+| `blocks` | 10 | `add-block`, `add-child-block`, `add-accordion-item`, `add-tab`, `add-timeline-item`, `update-block`, `batch-update`, `configure-custom-css`, `configure-shape-divider`, `delete-block` |
+| `settings` | 4 | `get-settings`, `update-settings`, `get-global-css`, `update-global-css` |
 
-### 1. Info Abilities (5)
+The groupings used as headings below (Info / Inserters / Configurators /
+Settings) are editorial. Insertion and configuration abilities all register
+in the single `blocks` category.
+
+### 1. Info Abilities (6)
 
 #### `designsetgo/list-abilities`
 
@@ -35,7 +44,8 @@ Returns a manifest of all registered DesignSetGo abilities with their names, des
 **Input:**
 ```json
 {
-  "category": "all"  // Options: "all", "inserter", "configurator", "generator", "info"
+  "category": "all",  // Options: "all", "info", "blocks", "settings"
+  "search": ""        // Optional: match name, label, description, or keywords
 }
 ```
 
@@ -57,7 +67,7 @@ Returns a manifest of all registered DesignSetGo abilities with their names, des
 
 **REST API Example:** (readonly — uses GET)
 ```bash
-curl -X GET "http://yoursite.com/wp-json/wp-abilities/v1/designsetgo/list-abilities/run?category=inserter" \
+curl -X GET "http://yoursite.com/wp-json/wp-abilities/v1/designsetgo/list-abilities/run?category=blocks" \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
@@ -70,14 +80,25 @@ Lists all available DesignSetGo blocks with their metadata, attributes, and capa
 **Input:**
 ```json
 {
-  "category": "all",  // Options: "all", "layout", "interactive", "visual", "dynamic"
-  "detail": "summary" // Options: "summary", "full"
+  "group": "all",     // Options: "all", "containers", "ui", "interactive", "widgets", "forms", "uncategorized"
+  "detail": "summary", // Options: "summary", "full"
+  "blocks": []        // Optional: restrict to specific block names
 }
 ```
 
+Each returned block reports **both** `category` and `group`:
+
+- `category` is the block editor category from `block.json`, verbatim —
+  `"designsetgo"` for almost every block. It is not a useful filter, which
+  is why the filter input is `group`.
+- `group` is the plugin's own grouping, sourced from
+  `includes/admin/blocks-registry.json` (the same file behind the Blocks &
+  Extensions admin screen). Blocks registered but not yet listed in that
+  file report `"uncategorized"`.
+
 **REST API Example:** (readonly — uses GET)
 ```bash
-curl -X GET "http://yoursite.com/wp-json/wp-abilities/v1/designsetgo/list-blocks/run?category=layout" \
+curl -X GET "http://yoursite.com/wp-json/wp-abilities/v1/designsetgo/list-blocks/run?group=containers" \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
@@ -476,8 +497,15 @@ Adds an item to an existing timeline container.
 | `list-abilities` | Discover all registered abilities with schemas | readonly |
 | `list-blocks` | List all available DesignSetGo blocks | readonly |
 | `list-extensions` | List all extensions with attribute schemas and applicable blocks | readonly |
+| `list-dynamic-tag-sources` | List Dynamic Tag binding sources, filterable by `returns` and `group` | readonly |
 | `get-post-blocks` | Retrieve blocks from a post with blockIndex values | readonly |
 | `find-blocks` | Search for blocks across posts by type | readonly |
+
+All info abilities are annotated `readonly: true, destructive: false,
+idempotent: true`. `list-abilities`, `list-blocks`, and `list-extensions`
+gate on the `read` capability, so any logged-in user can call them;
+`list-dynamic-tag-sources`, `get-post-blocks`, and `find-blocks` require
+`edit_posts`, and the latter two additionally check `edit_post` per post.
 
 #### Inserter Abilities
 
@@ -510,8 +538,38 @@ Adds an item to an existing timeline container.
 
 | Ability | Description | Annotation |
 |---------|-------------|------------|
-| `batch-update` | Update multiple blocks in one call | -- |
+| `batch-update` | Update multiple blocks in one call | idempotent |
 | `delete-block` | Remove blocks from a post | destructive |
+
+`delete-block` is annotated `idempotent: false` deliberately: targeting is
+by block index, and indices shift after a removal, so a repeated call
+deletes a *different* block rather than being a no-op.
+
+#### Settings Abilities
+
+These read and write plugin-level and site-level configuration rather than
+post content. All four register in the `settings` category.
+
+| Ability | Description | Capability | Annotation |
+|---------|-------------|------------|------------|
+| `get-settings` | Read all DesignSetGo settings merged with defaults | `manage_options` | readonly, idempotent |
+| `update-settings` | Apply a partial update to DesignSetGo settings | `manage_options` | idempotent |
+| `get-global-css` | Read the active theme's Additional CSS | `edit_css` | readonly, idempotent |
+| `update-global-css` | Replace the active theme's Additional CSS | `edit_css` | idempotent |
+
+Notes:
+
+- `get-settings` returns integration secrets, which is why it requires
+  `manage_options` rather than a read capability.
+- `update-settings` merges field-by-field; omitted keys are untouched. List
+  fields (`enabled_blocks`, `enabled_extensions`, `excluded_blocks`) merge
+  positionally, so resubmit the full array to replace one.
+  `animations.block_animations` is the exception — always replaced wholesale.
+- `update-global-css` **replaces** the entire Additional CSS value. Call
+  `get-global-css` first and concatenate if you mean to append.
+- `edit_css` maps to `unfiltered_html`, so editors hold it on single-site
+  installs and only super-admins hold it on multisite. This mirrors the
+  Customizer's Additional CSS panel.
 
 ---
 
@@ -641,7 +699,7 @@ All abilities return standardized error responses:
 
 ```json
 {
-  "code": "invalid_post",
+  "code": "designsetgo_invalid_post",
   "message": "Post not found.",
   "data": {
     "status": 404
@@ -651,12 +709,32 @@ All abilities return standardized error responses:
 
 ### Common Error Codes
 
-- `invalid_post` - Post ID not found
-- `permission_denied` - User lacks required capability
-- `missing_post_id` - Required post_id parameter missing
-- `missing_settings` - Required settings parameter missing
-- `invalid_attributes` - Attributes failed JSON Schema validation
-- `block_not_found` - No matching blocks found to update
+Every ability-specific code is prefixed `designsetgo_` so an orchestrating
+agent can match on codes without colliding with another plugin's.
+
+| Code | Status | Meaning |
+|---|---|---|
+| `designsetgo_invalid_post` | 404 | Post ID not found |
+| `designsetgo_block_not_found` | 404 | No matching block found |
+| `designsetgo_permission_denied` | 403 | User lacks the required capability for this post |
+| `designsetgo_missing_post_id` | 400 | Required `post_id` parameter missing |
+| `designsetgo_missing_block_name` | 400 | Required `block_name` parameter missing |
+| `designsetgo_missing_attributes` | 400 | Required `attributes` parameter missing |
+| `designsetgo_missing_operations` | 400 | `batch-update` called with no operations |
+| `designsetgo_invalid_input` | 400 | Input present but semantically wrong |
+| `designsetgo_validation_failed` | 400 | Attributes failed JSON Schema validation |
+| `designsetgo_block_name_mismatch` | 400 | Block at the given index is not the expected type |
+| `designsetgo_invalid_inner_block` | 400 | A nested block entry is malformed |
+| `designsetgo_custom_css_update_failed` | 400 | WordPress rejected the Additional CSS write |
+| `rest_forbidden` | 403 | Capability check failed before the callback ran |
+| `ability_invalid_input` | 400 | Core's schema validator rejected the input first |
+
+`rest_forbidden` keeps its unprefixed name on purpose — it is the code
+WordPress core uses for the same condition, and REST clients already match
+on it. `ability_invalid_input` comes from the Abilities API itself when the
+`input_schema` rejects a call before the execute callback runs; invoking an
+ability directly in PHP bypasses that layer and surfaces the
+`designsetgo_*` equivalent instead.
 
 ---
 
@@ -664,15 +742,27 @@ All abilities return standardized error responses:
 
 Each ability has specific permission requirements:
 
-| Category | Required Capability |
-|---------|-------------------|
-| `list-abilities` | `read` |
-| `list-blocks` | `read` |
-| `list-extensions` | `read` |
-| All other info abilities | `edit_posts` |
-| All inserter abilities | `edit_posts` |
-| All configurator abilities | `edit_posts` |
-| All generator abilities | `edit_posts` |
+| Ability | Required capability | anon | subscriber | editor | admin |
+|---|---|---|---|---|---|
+| `list-abilities`, `list-blocks`, `list-extensions` | `read` | deny | **allow** | allow | allow |
+| `list-dynamic-tag-sources`, `get-post-blocks`, `find-blocks` | `edit_posts` | deny | deny | allow | allow |
+| All inserter and configurator abilities | `edit_posts` | deny | deny | allow | allow |
+| `get-settings`, `update-settings` | `manage_options` | deny | deny | deny | allow |
+| `get-global-css`, `update-global-css` | `edit_css` | deny | deny | allow¹ | allow |
+
+¹ `edit_css` maps to `unfiltered_html`: editors hold it on single-site
+installs, and only super-admins hold it on multisite.
+
+The three `read`-gated catalog abilities are deliberately reachable by any
+logged-in user — they expose only the block and extension inventory, which
+is not privileged. This is pinned by
+`tests/phpunit/abilities-security-test.php`.
+
+Capability checks are layered. Abilities that modify post content gate on
+`edit_posts` at the ability level and then re-check
+`current_user_can( 'edit_post', $post_id )` against the specific target post
+inside `Block_Inserter` / `Block_Configurator`, so holding `edit_posts` does
+not grant write access to a post the user cannot edit.
 
 ---
 

--- a/docs/audits/ABILITIES-VERIFICATION.md
+++ b/docs/audits/ABILITIES-VERIFICATION.md
@@ -1,0 +1,291 @@
+---
+Last updated: 2026-08-24
+---
+
+# DesignSetGo Abilities Verification — Runtime Mode
+
+## Status: PASS (was FAIL — 3 accuracy failures found and fixed)
+
+20 abilities registered, verified statically and then against a live
+WordPress 7.1 + WooCommerce environment (`wp-env`, Abilities API present).
+
+The audit found three accuracy failures, all in the **discovery** abilities
+— the ones an agent calls first to decide what to do next. None were
+security issues; all three made the plugin describe itself incorrectly. All
+three are fixed, along with eight lower-severity findings.
+
+Verification evidence: 1300 PHPUnit tests pass (4 pre-existing
+`Map_Embed_Render_Test` failures, confirmed identical on a clean tree, plus
+1 pre-existing skip), `phpcs` clean on all changed source, runtime
+enumeration and permission roundtrip captured below.
+
+## Inventory — static and runtime agree
+
+Static enumeration by reflection found 20 concrete `Abstract_Ability`
+subclasses; `wp_get_abilities()` on the live site returns the same 20 with
+the same names. Registration fires correctly; no source-only or
+runtime-only divergence.
+
+Abilities are auto-discovered — `Abilities_Registry` globs
+`includes/abilities/{info,inserters,configurators,settings}/class-*.php` —
+so there is no hardcoded list to drift. (`generators/` is wired but empty.)
+Registration goes through `Abstract_Ability::register()`, which calls
+`wp_register_ability()` **indirectly** to dodge Plugin Check's static
+"requires WP 6.9" scan, so the canonical `grep 'wp_register_ability('`
+enumeration finds one call site rather than 20 — worth knowing for any
+future audit of this tree.
+
+| Registered category | Count | Abilities |
+|---|---|---|
+| `info` | 6 | `list-abilities`, `list-blocks`, `list-extensions`, `list-dynamic-tag-sources`, `get-post-blocks`, `find-blocks` |
+| `blocks` | 10 | `add-block`, `add-child-block`, `add-accordion-item`, `add-tab`, `add-timeline-item`, `update-block`, `batch-update`, `configure-custom-css`, `configure-shape-divider`, `delete-block` |
+| `settings` | 4 | `get-settings`, `update-settings`, `get-global-css`, `update-global-css` |
+
+All 20 are `show_in_rest: true` and inherit `meta.public: true`.
+
+## Annotation correctness
+
+Every callback was read end-to-end and compared against its claim. **No
+`readonly: true` ability writes anywhere** — no `$wpdb` calls, no option or
+post writes, no filesystem or cron effects, no non-GET delegates. No
+`verify-ignore` suppressions were needed anywhere in the tree.
+
+| Ability | Claim | Result | Evidence |
+|---|---|---|---|
+| all 6 `info` abilities | readonly, idempotent | OK | read the block registry / post content / extension configs only |
+| `get-settings`, `get-global-css` | readonly, idempotent | OK | `Settings::get_settings()`; theme `custom_css` post read |
+| `delete-block` | destructive | OK | `wp_update_post` at `configurators/class-delete-block.php:197` |
+| 5 inserters | idempotent=false | OK | each call appends another block |
+| `update-block`, `batch-update`, `configure-*` | idempotent | OK | attribute merges / wholesale replacement; repeating is a no-op |
+| `update-settings`, `update-global-css` | idempotent | OK | field-merge and wholesale replace respectively |
+
+`delete-block` keeps `idempotent: false` on purpose, now documented in
+code: targeting is by block **index**, and indices shift after a removal,
+so a repeated call deletes a *different* block. (Declaring it idempotent
+would also flip its REST routing from POST to DELETE, since core maps
+`destructive && idempotent` → DELETE.)
+
+## Permission gates — runtime roundtrip
+
+Exercised via `WP_Ability::check_permissions()` against four real user
+contexts. Every callback is Shape A (`current_user_can( '<cap>' )`); no
+Shape B-bad (`WP_REST_Request` in a permission callback), no Shape E
+(literal `true`), no `__return_true`.
+
+| Ability | Capability | anon | subscriber | editor | admin |
+|---|---|---|---|---|---|
+| `list-abilities`, `list-blocks`, `list-extensions` | `read` | deny | **allow** | allow | allow |
+| `list-dynamic-tag-sources`, `get-post-blocks`, `find-blocks` | `edit_posts` | deny | deny | allow | allow |
+| all inserters + configurators | `edit_posts` | deny | deny | allow | allow |
+| `get-settings`, `update-settings` | `manage_options` | deny | deny | **deny** | allow |
+| `get-global-css`, `update-global-css` | `edit_css` | deny | deny | allow¹ | allow |
+
+¹ `edit_css` maps to `unfiltered_html`, which editors hold on single-site
+and only super-admins hold on multisite — the same gate as the Customizer's
+Additional CSS panel.
+
+Two things worth recording:
+
+- **The layering is right.** Content-modifying abilities gate on
+  `edit_posts` at the ability level and then re-check
+  `current_user_can( 'edit_post', $post_id )` against the specific target
+  post inside `Block_Inserter` (`class-block-inserter.php:49`) and
+  `Block_Configurator` (`:48`, `:407`, `:577`). Holding `edit_posts` does
+  not grant write access to a post the user cannot edit. This was checked
+  specifically for `configure-custom-css` and `configure-shape-divider`,
+  which have no `edit_post` call of their own and rely entirely on the
+  helper — they are covered.
+- **The three `read` gates are deliberate, not an oversight.**
+  `tests/phpunit/abilities-security-test.php` explicitly asserts that a
+  subscriber *can* list abilities and blocks. Left unchanged.
+
+## Schema lints
+
+Machine-checked across all 20. All six lints pass: `additionalProperties:
+false` declared on every object schema, every entry in every `required`
+array has a non-empty description, no empty or single-value enums, no
+`$ref`, and every `default` is a static literal (`get-settings` correctly
+uses `new \stdClass()` for its empty `properties`).
+
+Note that enum *contents* are a separate axis from enum *shape* — F2 and F3
+below were content failures on schemas that passed every structural lint.
+
+## Findings and resolutions
+
+### F1 — FAIL → fixed: `list-abilities` reported a category vocabulary that did not exist
+
+`info/class-list-abilities.php` derived each ability's category from its
+**name prefix** (`inserter` / `configurator` / `info` / `settings`) rather
+than reading the `category` it was registered with. The two vocabularies
+disagreed: no ability was ever reported as `blocks` (10 are registered
+there), `get-global-css` was reported as `info` because the name starts
+with `get-`, and `update-global-css` as `configurator`.
+
+An agent filtering `{"category": "settings"}` got 2 abilities and never
+discovered the two global-CSS ones.
+
+**Fixed:** `infer_category()` deleted; the ability now reports
+`$config['category']`, and the enum is `all | info | blocks | settings`.
+Runtime confirmation — `category=settings` now returns 4, `category=blocks`
+returns 10, unfiltered returns `{"blocks":10,"info":6,"settings":4}`.
+
+### F2 — FAIL → fixed: `list-blocks`'s category filter could only ever return one bucket
+
+`normalize_category()` mapped blocks into `layout` / `interactive` /
+`visual` / `dynamic` using legacy `designsetgo-*` slugs that no block uses
+any more. 66 of 68 blocks declare `"category": "designsetgo"` → all became
+`layout`; `flip-card-face` and `section-divider` declare `"design"` → fell
+through to the `visual` default. `interactive` and `dynamic` returned zero
+blocks, and every block's reported category was wrong.
+
+**Fixed:** the synthetic remap is gone. Blocks now report `category`
+verbatim from `block.json`, plus a `group` sourced from
+`includes/admin/blocks-registry.json` — the same file behind the Blocks &
+Extensions admin screen, so the grouping matches what site owners already
+see. The input filter is now `group`, with its enum derived from the
+registry so a new group becomes filterable without touching the ability.
+
+Runtime confirmation:
+
+```
+total=68  groups={"containers":3,"forms":12,"interactive":7,
+                  "ui":18,"uncategorized":20,"widgets":8}
+verbatim categories={"designsetgo":66,"design":2}
+```
+
+### F3 — FAIL → fixed: `list-dynamic-tag-sources` could not filter the WooCommerce group
+
+The `group` enum hardcoded five groups. A sixth, `woocommerce`, is
+registered by `class-dynamic-tags-sources-woo.php:52` whenever WooCommerce
+is active. Because the schema also sets `additionalProperties: false`,
+`{"group": "woocommerce"}` was rejected by schema validation *before* the
+callback ran — so the six Woo bindings sources could not be scoped to at
+all, which is exactly the filter an agent building a product loop reaches
+for.
+
+**Fixed:** the enum is now read from the live registry
+(`Registry::instance()->all_groups()`), guarded by `class_exists()` with a
+fallback to the built-in five. Sources register on `init` priority 6 and
+abilities at priority 9, so the registry is populated by the time
+`get_config()` runs — and the enum correctly *omits* `woocommerce` when Woo
+is inactive. Runtime confirmation: enum is `post, site, archive, user,
+custom-fields, woocommerce`, and `{"group":"woocommerce"}` returns all 6
+`designsetgo/woo-*` sources.
+
+### W1 — fixed: four writers carried no annotations at all
+
+`update-block`, `batch-update`, `configure-custom-css`, and
+`configure-shape-divider` passed no `annotations` key. Core defaults every
+flag to `false`, so nothing was actively misrepresented, but they were the
+only four abilities with no declared contract and no `instructions` string.
+All four now declare the full triple plus instructions.
+
+### W2 — fixed: `idempotent` was declared inconsistently across pure reads
+
+`get-settings` and `get-global-css` declared `readonly + idempotent`; the
+six `info` abilities — equally pure reads — declared `readonly` only. Every
+ability now declares all three flags explicitly, so `tools/list` has one
+consistent shape.
+
+### W3 — fixed: `list-extensions` metadata was stale in both directions
+
+`EXTENSION_META` had drifted from `includes/extension-configs/`:
+
+- **Shipped but undescribed** — `interactions`, `schema`, `style-binding`,
+  and `visibility` had config files but no META entry, so they were
+  returned with an auto-generated label and an **empty description**. Two
+  of them, `visibility` (`dsgoVisibility`) and `style-binding`
+  (`dsgoStyleBinding`), are among the most rule-heavy extensions in the
+  plugin — an agent got the raw attribute schema and no guidance on the
+  rule shape.
+- **Described but never emitted** — `dynamic-tags` had a full META entry
+  but no matching config file, so the loop never reached it.
+
+All four are now documented (including the JSON-LD block list for `schema`
+and the rule shapes for `visibility` / `style-binding`); the dead
+`dynamic-tags` entry is removed. META and configs now match 19/19 exactly.
+
+### W4 — fixed: `list-abilities` omitted annotations from its output
+
+The ability tells agents "call this first", but its output carried no
+`readonly` / `destructive` information, forcing a second round-trip to REST
+introspection. It now emits an `annotations` object per ability.
+
+### W5 — no change: the three `read` gates are intentional
+
+`list-abilities`, `list-blocks`, and `list-extensions` gate on `read`,
+which subscribers hold. Initially flagged as over-permissive, but
+`abilities-security-test.php` contains explicit tests asserting subscribers
+*can* call them — this is a tested design decision about a non-privileged
+block catalog, not drift. Left as-is and now documented in
+`docs/api/ABILITIES-API.md`.
+
+### W6 — fixed: error codes were not namespaced
+
+Codes were generic (`invalid_post`, `permission_denied`, `block_not_found`,
+`missing_post_id`, …) and could collide with another plugin's codes in an
+agent's error-matching logic. All ability-specific codes are now prefixed
+`designsetgo_`, including the HTTP-status map in
+`Abstract_Ability::get_default_status_for_error()` and the ~25 assertions
+in the ability test files.
+
+`rest_forbidden` deliberately keeps its unprefixed name — it is the code
+WordPress core uses for the same condition and REST clients already match
+on it.
+
+### W7 — fixed: `update-settings` group properties were undescribed
+
+The eight top-level settings groups (`performance`, `forms`, `animations`,
+`security`, `integrations`, `sticky_header`, `draft_mode`, `llms_txt`) had
+no `description`. All eight now do, including the note that
+`animations.block_animations` is replaced wholesale while other list fields
+merge positionally.
+
+### W8 — fixed: documentation drift
+
+- `docs/api/ABILITIES-API.md` documented **14 of 20** abilities — missing
+  all four settings abilities, `configure-custom-css`, and
+  `list-dynamic-tag-sources` — and labelled the info group "(5)" when there
+  are 6. Now complete, with a category table, a Settings Abilities section,
+  a runtime-verified permissions matrix, and a corrected error-code table.
+- `docs/ARCHITECTURE.md` referenced
+  `includes/abilities/class-abilities-provider.php` (no such file) and a
+  `register_ability()` function (the real one is `wp_register_ability()`).
+  Replaced with the real auto-discovery architecture and a real ability as
+  the example.
+- `docs/testing/TESTING-ABILITIES-API.md` used the dead
+  `category=layout` filter and unprefixed error codes. Updated.
+
+*(An earlier draft of this report listed `designsetgo/add-animation` as a
+nonexistent ability referenced in ARCHITECTURE.md. That was wrong — it is a
+JS filter namespace in an extension example, not an ability.)*
+
+## Open item — not an abilities bug
+
+`includes/admin/blocks-registry.json` lists **48 of 68** registered blocks.
+The 20 missing ones now surface honestly as `group: "uncategorized"` in
+`list-blocks` output:
+
+> advanced-heading, chart, comparison-table, dynamic-image, fifty-fifty,
+> flip-card-back, flip-card-front, heading-segment, product-categories-grid,
+> product-showcase-hero, query, query-filter, query-group-header,
+> query-no-results, query-pagination, query-results, section-divider,
+> sticky-sections, timeline, timeline-item
+
+This matters beyond the abilities surface: that file drives the Blocks &
+Extensions admin screen, so those 20 blocks appear to have no enable/disable
+control there. Worth a separate look — it is a product decision about which
+groups they belong to, not something this audit should guess at.
+
+## Re-verification
+
+Rerun the runtime checks after any change to the discovery abilities:
+
+```bash
+npx wp-env run cli wp eval '
+  $m = array_filter( wp_get_abilities(), fn($a) => strpos($a->get_name(),"designsetgo/")===0 );
+  echo count($m) . PHP_EOL;'
+
+npx wp-env run tests-cli --env-cwd=wp-content/plugins/designsetgo \
+  vendor/bin/phpunit --filter Abilities
+```

--- a/docs/testing/TESTING-ABILITIES-API.md
+++ b/docs/testing/TESTING-ABILITIES-API.md
@@ -188,7 +188,7 @@ curl -s -X POST \
     "name": "designsetgo/flex",
     "title": "Flex Container",
     "description": "Flexible horizontal or vertical layout container...",
-    "category": "layout",
+    "group": "containers",
     "attributes": {
       "direction": { "type": "string", "enum": ["row", "column"] },
       ...
@@ -207,7 +207,7 @@ curl -s -X POST \
   -u "$WP_USER:$WP_PASS" \
   -H "Content-Type: application/json" \
   "$WP_URL/wp-json/wp-abilities/v1/abilities/designsetgo/list-blocks/execute" \
-  -d '{"category": "layout"}' | jq '.'
+  -d '{"group": "containers"}' | jq '.'
 
 # Interactive blocks only
 curl -s -X POST \
@@ -482,7 +482,7 @@ curl -s -X POST \
 **Expected:**
 ```json
 {
-  "code": "invalid_post",
+  "code": "designsetgo_invalid_post",
   "message": "Post not found.",
   "data": {
     "status": 404
@@ -503,7 +503,7 @@ curl -s -X POST \
 **Expected:**
 ```json
 {
-  "code": "missing_post_id",
+  "code": "designsetgo_missing_post_id",
   "message": "Post ID is required.",
   ...
 }

--- a/includes/abilities/class-abstract-ability.php
+++ b/includes/abilities/class-abstract-ability.php
@@ -183,7 +183,7 @@ abstract class Abstract_Ability {
 
 		if ( ! $post ) {
 			return new WP_Error(
-				'invalid_post',
+				'designsetgo_invalid_post',
 				__( 'Post not found.', 'designsetgo' ),
 				array( 'status' => 404 )
 			);
@@ -254,25 +254,25 @@ abstract class Abstract_Ability {
 	 */
 	private function get_default_status_for_error( string $code ): int {
 		$status_map = array(
-			'invalid_post'             => 404,
-			'post_not_found'           => 404,
-			'block_not_found'          => 404,
-			'not_found'                => 404,
-			'permission_denied'        => 403,
-			'rest_forbidden'           => 403,
-			'unauthorized'             => 401,
-			'missing_post_id'          => 400,
-			'missing_block_name'       => 400,
-			'missing_settings'         => 400,
-			'missing_animation'        => 400,
-			'missing_faqs'             => 400,
-			'missing_css'              => 400,
-			'missing_operations'       => 400,
-			'missing_block_identifier' => 400,
-			'missing_attributes'       => 400,
-			'invalid_input'            => 400,
-			'validation_failed'        => 400,
-			'block_name_mismatch'      => 400,
+			'designsetgo_invalid_post'             => 404,
+			'designsetgo_post_not_found'           => 404,
+			'designsetgo_block_not_found'          => 404,
+			'designsetgo_not_found'                => 404,
+			'designsetgo_permission_denied'        => 403,
+			'rest_forbidden'                       => 403,
+			'designsetgo_unauthorized'             => 401,
+			'designsetgo_missing_post_id'          => 400,
+			'designsetgo_missing_block_name'       => 400,
+			'designsetgo_missing_settings'         => 400,
+			'designsetgo_missing_animation'        => 400,
+			'designsetgo_missing_faqs'             => 400,
+			'designsetgo_missing_css'              => 400,
+			'designsetgo_missing_operations'       => 400,
+			'designsetgo_missing_block_identifier' => 400,
+			'designsetgo_missing_attributes'       => 400,
+			'designsetgo_invalid_input'            => 400,
+			'designsetgo_validation_failed'        => 400,
+			'designsetgo_block_name_mismatch'      => 400,
 		);
 
 		return $status_map[ $code ] ?? 400; // Default to Bad Request.
@@ -341,7 +341,7 @@ abstract class Abstract_Ability {
 					$valid = rest_validate_value_from_schema( $value, $schema['properties'][ $key ], $key );
 					if ( is_wp_error( $valid ) ) {
 						return $this->error(
-							'validation_failed',
+							'designsetgo_validation_failed',
 							$valid->get_error_message(),
 							array( 'field' => $key )
 						);

--- a/includes/abilities/class-abstract-configurator-ability.php
+++ b/includes/abilities/class-abstract-configurator-ability.php
@@ -205,14 +205,14 @@ abstract class Abstract_Configurator_Ability extends Abstract_Ability {
 		// Validate required parameters.
 		if ( ! $post_id ) {
 			return $this->error(
-				'missing_post_id',
+				'designsetgo_missing_post_id',
 				__( 'Post ID is required.', 'designsetgo' )
 			);
 		}
 
 		if ( '' === $block_name ) {
 			return $this->error(
-				'missing_block_name',
+				'designsetgo_missing_block_name',
 				__( 'Block name is required.', 'designsetgo' )
 			);
 		}
@@ -230,7 +230,7 @@ abstract class Abstract_Configurator_Ability extends Abstract_Ability {
 		// Use count() instead of empty() to allow legitimate falsy values (0, false).
 		if ( ! is_array( $new_attributes ) || 0 === count( $new_attributes ) ) {
 			return $this->error(
-				'missing_attributes',
+				'designsetgo_missing_attributes',
 				__( 'No attributes provided to configure.', 'designsetgo' )
 			);
 		}

--- a/includes/abilities/class-block-configurator.php
+++ b/includes/abilities/class-block-configurator.php
@@ -38,7 +38,7 @@ class Block_Configurator {
 		$post = get_post( $post_id );
 		if ( ! $post ) {
 			return new WP_Error(
-				'invalid_post',
+				'designsetgo_invalid_post',
 				__( 'Post not found.', 'designsetgo' ),
 				array( 'status' => 404 )
 			);
@@ -47,7 +47,7 @@ class Block_Configurator {
 		// Check permissions.
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return new WP_Error(
-				'permission_denied',
+				'designsetgo_permission_denied',
 				__( 'You do not have permission to edit this post.', 'designsetgo' ),
 				array( 'status' => 403 )
 			);
@@ -95,7 +95,7 @@ class Block_Configurator {
 
 		if ( 0 === $updated_count ) {
 			return new WP_Error(
-				'block_not_found',
+				'designsetgo_block_not_found',
 				__( 'No matching blocks found to update.', 'designsetgo' ),
 				array( 'status' => 404 )
 			);
@@ -397,7 +397,7 @@ class Block_Configurator {
 		$post = get_post( $post_id );
 		if ( ! $post ) {
 			return new WP_Error(
-				'invalid_post',
+				'designsetgo_invalid_post',
 				__( 'Post not found.', 'designsetgo' ),
 				array( 'status' => 404 )
 			);
@@ -406,7 +406,7 @@ class Block_Configurator {
 		// Check permissions.
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return new WP_Error(
-				'permission_denied',
+				'designsetgo_permission_denied',
 				__( 'You do not have permission to edit this post.', 'designsetgo' ),
 				array( 'status' => 403 )
 			);
@@ -436,7 +436,7 @@ class Block_Configurator {
 		if ( ! $updated ) {
 			if ( ! empty( $matched_name ) && '' !== $expected_block_name && $matched_name !== $expected_block_name ) {
 				return new WP_Error(
-					'block_name_mismatch',
+					'designsetgo_block_name_mismatch',
 					sprintf(
 						/* translators: 1: expected block name, 2: actual block name, 3: block index */
 						__( 'Expected block "%1$s" at index %3$d, but found "%2$s".', 'designsetgo' ),
@@ -449,7 +449,7 @@ class Block_Configurator {
 			}
 
 			return new WP_Error(
-				'block_not_found',
+				'designsetgo_block_not_found',
 				sprintf(
 					/* translators: %d: block index */
 					__( 'No block found at index %d.', 'designsetgo' ),
@@ -567,7 +567,7 @@ class Block_Configurator {
 		$post = get_post( $post_id );
 		if ( ! $post ) {
 			return new WP_Error(
-				'invalid_post',
+				'designsetgo_invalid_post',
 				__( 'Post not found.', 'designsetgo' ),
 				array( 'status' => 404 )
 			);
@@ -576,7 +576,7 @@ class Block_Configurator {
 		// Check permissions.
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return new WP_Error(
-				'permission_denied',
+				'designsetgo_permission_denied',
 				__( 'You do not have permission to edit this post.', 'designsetgo' ),
 				array( 'status' => 403 )
 			);
@@ -586,7 +586,7 @@ class Block_Configurator {
 		$block_registry = \WP_Block_Type_Registry::get_instance();
 		if ( ! $block_registry->get_registered( $block_name ) ) {
 			return new WP_Error(
-				'invalid_input',
+				'designsetgo_invalid_input',
 				sprintf(
 					/* translators: %s: block name */
 					__( 'Block type "%s" is not registered.', 'designsetgo' ),
@@ -619,7 +619,7 @@ class Block_Configurator {
 
 		if ( ! $found ) {
 			return new WP_Error(
-				'block_not_found',
+				'designsetgo_block_not_found',
 				sprintf(
 					/* translators: %d: block index */
 					__( 'No parent block found at index %d.', 'designsetgo' ),

--- a/includes/abilities/class-block-inserter.php
+++ b/includes/abilities/class-block-inserter.php
@@ -39,7 +39,7 @@ class Block_Inserter {
 		$post = get_post( $post_id );
 		if ( ! $post ) {
 			return new WP_Error(
-				'invalid_post',
+				'designsetgo_invalid_post',
 				__( 'Post not found.', 'designsetgo' ),
 				array( 'status' => 404 )
 			);
@@ -48,7 +48,7 @@ class Block_Inserter {
 		// Check permissions.
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return new WP_Error(
-				'permission_denied',
+				'designsetgo_permission_denied',
 				__( 'You do not have permission to edit this post.', 'designsetgo' ),
 				array( 'status' => 403 )
 			);
@@ -1257,7 +1257,7 @@ class Block_Inserter {
 				if ( ! in_array( $panel_edge, array( 'left', 'right', 'top', 'bottom' ), true ) ) {
 					$panel_edge = 'right';
 				}
-				$panel_size            = isset( $attributes['panelSize'] ) ? (string) $attributes['panelSize'] : '24rem';
+				$panel_size = isset( $attributes['panelSize'] ) ? (string) $attributes['panelSize'] : '24rem';
 				// Mirror save.js: allow-list a single plain CSS length. This is
 				// interpolated into `--dsgo-panel-size:<value>`, and esc_attr()
 				// stops an attribute break-out but not a `;` that appends
@@ -2577,7 +2577,7 @@ class Block_Inserter {
 		foreach ( $inner_blocks as $index => $block ) {
 			if ( ! isset( $block['name'] ) || ! is_string( $block['name'] ) ) {
 				return new WP_Error(
-					'invalid_inner_block',
+					'designsetgo_invalid_inner_block',
 					sprintf(
 						/* translators: %d: Block index */
 						__( 'Inner block at index %d is missing a valid name.', 'designsetgo' ),
@@ -2588,7 +2588,7 @@ class Block_Inserter {
 
 			if ( isset( $block['attributes'] ) && ! is_array( $block['attributes'] ) ) {
 				return new WP_Error(
-					'invalid_inner_block_attributes',
+					'designsetgo_invalid_inner_block_attributes',
 					sprintf(
 						/* translators: %d: Block index */
 						__( 'Inner block at index %d has invalid attributes (must be an array).', 'designsetgo' ),
@@ -2599,7 +2599,7 @@ class Block_Inserter {
 
 			if ( isset( $block['innerBlocks'] ) && ! is_array( $block['innerBlocks'] ) ) {
 				return new WP_Error(
-					'invalid_nested_blocks',
+					'designsetgo_invalid_nested_blocks',
 					sprintf(
 						/* translators: %d: Block index */
 						__( 'Inner block at index %d has invalid innerBlocks (must be an array).', 'designsetgo' ),

--- a/includes/abilities/configurators/class-batch-update.php
+++ b/includes/abilities/configurators/class-batch-update.php
@@ -48,6 +48,12 @@ class Batch_Update extends Abstract_Ability {
 			'output_schema'       => $this->get_output_schema(),
 			'permission_callback' => array( $this, 'check_permission_callback' ),
 			'keywords'            => array( 'bulk', 'multiple', 'mass' ),
+			'annotations'         => array(
+				'readonly'     => false,
+				'destructive'  => false,
+				'idempotent'   => true,
+				'instructions' => 'Applies several attribute updates to one post in a single save. Operations are matched by block name and applied in order; none of them insert or remove blocks. Call get-post-blocks first to confirm the targets exist — an operation that matches nothing is skipped silently rather than failing the batch.',
+			),
 		);
 	}
 
@@ -153,7 +159,7 @@ class Batch_Update extends Abstract_Ability {
 		// Validate post ID.
 		if ( ! $post_id ) {
 			return $this->error(
-				'missing_post_id',
+				'designsetgo_missing_post_id',
 				__( 'Post ID is required.', 'designsetgo' )
 			);
 		}
@@ -161,7 +167,7 @@ class Batch_Update extends Abstract_Ability {
 		// Validate operations.
 		if ( empty( $operations ) ) {
 			return $this->error(
-				'missing_operations',
+				'designsetgo_missing_operations',
 				__( 'At least one operation is required.', 'designsetgo' )
 			);
 		}
@@ -170,7 +176,7 @@ class Batch_Update extends Abstract_Ability {
 		$post = get_post( $post_id );
 		if ( ! $post ) {
 			return $this->error(
-				'invalid_post',
+				'designsetgo_invalid_post',
 				__( 'Post not found.', 'designsetgo' )
 			);
 		}

--- a/includes/abilities/configurators/class-configure-custom-css.php
+++ b/includes/abilities/configurators/class-configure-custom-css.php
@@ -49,6 +49,12 @@ class Configure_Custom_CSS extends Abstract_Ability {
 			'output_schema'       => Block_Configurator::get_default_output_schema(),
 			'permission_callback' => array( $this, 'check_permission_callback' ),
 			'keywords'            => array( 'style', 'code', 'stylesheet' ),
+			'annotations'         => array(
+				'readonly'     => false,
+				'destructive'  => false,
+				'idempotent'   => true,
+				'instructions' => 'Sets per-block custom CSS, replacing whatever was there for the targeted breakpoint. Prefer this over update-block for the custom-css extension: it sanitizes the CSS before storing it. For site-wide CSS use update-global-css instead.',
+			),
 		);
 	}
 
@@ -124,14 +130,14 @@ class Configure_Custom_CSS extends Abstract_Ability {
 		// Validate required parameters.
 		if ( ! $post_id ) {
 			return $this->error(
-				'missing_post_id',
+				'designsetgo_missing_post_id',
 				__( 'Post ID is required.', 'designsetgo' )
 			);
 		}
 
 		if ( empty( $css ) ) {
 			return $this->error(
-				'missing_css',
+				'designsetgo_missing_css',
 				__( 'CSS settings are required.', 'designsetgo' )
 			);
 		}

--- a/includes/abilities/configurators/class-configure-shape-divider.php
+++ b/includes/abilities/configurators/class-configure-shape-divider.php
@@ -86,6 +86,12 @@ class Configure_Shape_Divider extends Abstract_Ability {
 			'output_schema'       => Block_Configurator::get_default_output_schema(),
 			'permission_callback' => array( $this, 'check_permission_callback' ),
 			'keywords'            => array( 'separator', 'wave', 'decoration', 'border' ),
+			'annotations'         => array(
+				'readonly'     => false,
+				'destructive'  => false,
+				'idempotent'   => true,
+				'instructions' => 'Configures the shape divider on an existing section block. Re-sending the same shape and position is a no-op. Use list-blocks with detail "full" on designsetgo/section to see the accepted shape values.',
+			),
 		);
 	}
 
@@ -194,14 +200,14 @@ class Configure_Shape_Divider extends Abstract_Ability {
 		// Validate required parameters.
 		if ( ! $post_id ) {
 			return $this->error(
-				'missing_post_id',
+				'designsetgo_missing_post_id',
 				__( 'Post ID is required.', 'designsetgo' )
 			);
 		}
 
 		if ( empty( $shape ) ) {
 			return $this->error(
-				'missing_settings',
+				'designsetgo_missing_settings',
 				__( 'Shape type is required.', 'designsetgo' )
 			);
 		}
@@ -209,7 +215,7 @@ class Configure_Shape_Divider extends Abstract_Ability {
 		// Validate shape is one of the known values.
 		if ( ! in_array( $shape, self::VALID_SHAPES, true ) ) {
 			return $this->error(
-				'validation_failed',
+				'designsetgo_validation_failed',
 				sprintf(
 					/* translators: %s: shape name */
 					__( 'Invalid shape "%s". Use list-blocks with detail "full" to see all available shapes.', 'designsetgo' ),
@@ -221,13 +227,13 @@ class Configure_Shape_Divider extends Abstract_Ability {
 		// Validate color values.
 		if ( null !== $color && ! $this->is_valid_color( $color ) ) {
 			return $this->error(
-				'validation_failed',
+				'designsetgo_validation_failed',
 				__( 'Invalid color value. Must be a hex color (#rgb or #rrggbb), rgb/rgba function, hsl/hsla function, or CSS variable (var(--...)).', 'designsetgo' )
 			);
 		}
 		if ( null !== $bg_color && ! $this->is_valid_color( $bg_color ) ) {
 			return $this->error(
-				'validation_failed',
+				'designsetgo_validation_failed',
 				__( 'Invalid backgroundColor value. Must be a hex color (#rgb or #rrggbb), rgb/rgba function, hsl/hsla function, or CSS variable (var(--...)).', 'designsetgo' )
 			);
 		}
@@ -235,13 +241,13 @@ class Configure_Shape_Divider extends Abstract_Ability {
 		// Validate height/width ranges and return errors instead of silently clamping.
 		if ( null !== $height && ( $height < 0 || $height > 300 ) ) {
 			return $this->error(
-				'validation_failed',
+				'designsetgo_validation_failed',
 				__( 'Height must be between 0 and 300 pixels.', 'designsetgo' )
 			);
 		}
 		if ( null !== $width && ( $width < 50 || $width > 200 ) ) {
 			return $this->error(
-				'validation_failed',
+				'designsetgo_validation_failed',
 				__( 'Width must be between 50 and 200 percent.', 'designsetgo' )
 			);
 		}
@@ -249,7 +255,7 @@ class Configure_Shape_Divider extends Abstract_Ability {
 		// Validate targeting.
 		if ( null === $block_index && empty( $block_client_id ) ) {
 			return $this->error(
-				'invalid_input',
+				'designsetgo_invalid_input',
 				__( 'Either block_index or block_client_id is required.', 'designsetgo' )
 			);
 		}

--- a/includes/abilities/configurators/class-delete-block.php
+++ b/includes/abilities/configurators/class-delete-block.php
@@ -49,7 +49,11 @@ class Delete_Block extends Abstract_Ability {
 			'show_in_rest'        => true,
 			'keywords'            => array( 'remove', 'destroy', 'clear' ),
 			'annotations'         => array(
+				'readonly'     => false,
 				'destructive'  => true,
+				// Targeting is by block index, and indices shift after a removal, so
+				// a repeated call deletes a different block rather than being a no-op.
+				'idempotent'   => false,
 				'instructions' => 'Permanently removes blocks from post content. Use get-post-blocks first to identify targets. Prefer block_client_id for precise deletion.',
 			),
 		);
@@ -144,18 +148,18 @@ class Delete_Block extends Abstract_Ability {
 
 		// Validate post ID.
 		if ( ! $post_id ) {
-			return $this->error( 'missing_post_id', __( 'Post ID is required.', 'designsetgo' ) );
+			return $this->error( 'designsetgo_missing_post_id', __( 'Post ID is required.', 'designsetgo' ) );
 		}
 
 		// Need either block_name or block_client_id.
 		if ( empty( $block_name ) && empty( $block_client_id ) ) {
-			return $this->error( 'missing_block_identifier', __( 'Either block_name or block_client_id is required.', 'designsetgo' ) );
+			return $this->error( 'designsetgo_missing_block_identifier', __( 'Either block_name or block_client_id is required.', 'designsetgo' ) );
 		}
 
 		// Validate post exists.
 		$post = get_post( $post_id );
 		if ( ! $post ) {
-			return $this->error( 'invalid_post', __( 'Post not found.', 'designsetgo' ) );
+			return $this->error( 'designsetgo_invalid_post', __( 'Post not found.', 'designsetgo' ) );
 		}
 
 		// Check permission for this specific post.
@@ -190,7 +194,7 @@ class Delete_Block extends Abstract_Ability {
 
 		// Check if any blocks were deleted.
 		if ( 0 === $deleted_count ) {
-			return $this->error( 'block_not_found', __( 'No matching blocks found to delete.', 'designsetgo' ) );
+			return $this->error( 'designsetgo_block_not_found', __( 'No matching blocks found to delete.', 'designsetgo' ) );
 		}
 
 		// Serialize and update post.

--- a/includes/abilities/configurators/class-update-block.php
+++ b/includes/abilities/configurators/class-update-block.php
@@ -50,6 +50,12 @@ class Update_Block extends Abstract_Ability {
 			'output_schema'       => Block_Configurator::get_default_output_schema(),
 			'permission_callback' => array( $this, 'check_permission_callback' ),
 			'keywords'            => array( 'modify', 'change', 'edit', 'set' ),
+			'annotations'         => array(
+				'readonly'     => false,
+				'destructive'  => false,
+				'idempotent'   => true,
+				'instructions' => 'Merges the supplied attributes into a block that already exists — it never inserts one. Call get-post-blocks first to get the block index or client ID. Submitting the same attributes twice leaves the post in the same state.',
+			),
 		);
 	}
 
@@ -113,14 +119,14 @@ class Update_Block extends Abstract_Ability {
 		// Validate required parameters.
 		if ( ! $post_id ) {
 			return $this->error(
-				'missing_post_id',
+				'designsetgo_missing_post_id',
 				__( 'Post ID is required.', 'designsetgo' )
 			);
 		}
 
 		$post = get_post( $post_id );
 		if ( ! $post ) {
-			return $this->error( 'invalid_post', __( 'Post not found.', 'designsetgo' ) );
+			return $this->error( 'designsetgo_invalid_post', __( 'Post not found.', 'designsetgo' ) );
 		}
 
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
@@ -129,7 +135,7 @@ class Update_Block extends Abstract_Ability {
 
 		if ( ! is_array( $attributes ) || empty( $attributes ) ) {
 			return $this->error(
-				'missing_settings',
+				'designsetgo_missing_settings',
 				__( 'Attributes object is required and must contain at least one key-value pair to update.', 'designsetgo' )
 			);
 		}
@@ -137,7 +143,7 @@ class Update_Block extends Abstract_Ability {
 		// Validate targeting: at least one targeting method must be provided.
 		if ( null === $block_index && empty( $block_name ) && empty( $block_client_id ) ) {
 			return $this->error(
-				'invalid_input',
+				'designsetgo_invalid_input',
 				__( 'At least one targeting parameter is required: block_index, block_name, or block_client_id.', 'designsetgo' )
 			);
 		}
@@ -162,7 +168,7 @@ class Update_Block extends Abstract_Ability {
 		// Target by block name and/or client ID.
 		if ( empty( $block_name ) ) {
 			return $this->error(
-				'missing_block_name',
+				'designsetgo_missing_block_name',
 				__( 'block_name is required when block_index is not provided.', 'designsetgo' )
 			);
 		}
@@ -221,7 +227,7 @@ class Update_Block extends Abstract_Ability {
 				// For 'style', only validate it's an array/object.
 				if ( 'style' === $key && ! is_array( $value ) ) {
 					return new WP_Error(
-						'validation_failed',
+						'designsetgo_validation_failed',
 						__( 'The "style" attribute must be an object.', 'designsetgo' ),
 						array( 'status' => 400 )
 					);
@@ -233,7 +239,7 @@ class Update_Block extends Abstract_Ability {
 			// Some blocks have empty attribute schemas and accept arbitrary attributes.
 			if ( ! empty( $registered_attrs ) && ! isset( $registered_attrs[ $key ] ) ) {
 				return new WP_Error(
-					'validation_failed',
+					'designsetgo_validation_failed',
 					sprintf(
 						/* translators: 1: attribute key, 2: block name */
 						__( 'Attribute "%1$s" is not registered for block "%2$s".', 'designsetgo' ),

--- a/includes/abilities/info/class-find-blocks.php
+++ b/includes/abilities/info/class-find-blocks.php
@@ -50,6 +50,8 @@ class Find_Blocks extends Abstract_Ability {
 			'keywords'            => array( 'search', 'locate', 'query', 'filter' ),
 			'annotations'         => array(
 				'readonly'     => true,
+				'destructive'  => false,
+				'idempotent'   => true,
 				'instructions' => 'Searches for blocks across posts by block name. Useful for content audits and finding blocks before bulk operations.',
 			),
 		);
@@ -154,7 +156,7 @@ class Find_Blocks extends Abstract_Ability {
 		// Validate block name.
 		if ( empty( $block_name ) ) {
 			return $this->error(
-				'missing_block_name',
+				'designsetgo_missing_block_name',
 				__( 'Block name is required.', 'designsetgo' )
 			);
 		}

--- a/includes/abilities/info/class-get-post-blocks.php
+++ b/includes/abilities/info/class-get-post-blocks.php
@@ -50,6 +50,8 @@ class Get_Post_Blocks extends Abstract_Ability {
 			'keywords'            => array( 'content', 'inspect', 'read', 'page' ),
 			'annotations'         => array(
 				'readonly'     => true,
+				'destructive'  => false,
+				'idempotent'   => true,
 				'instructions' => 'Use this to inspect existing blocks in a post before making changes. Returns block indices needed for configurator and delete abilities.',
 			),
 		);
@@ -154,7 +156,7 @@ class Get_Post_Blocks extends Abstract_Ability {
 		// Validate post.
 		if ( ! $post_id ) {
 			return $this->error(
-				'missing_post_id',
+				'designsetgo_missing_post_id',
 				__( 'Post ID is required.', 'designsetgo' )
 			);
 		}
@@ -162,7 +164,7 @@ class Get_Post_Blocks extends Abstract_Ability {
 		$post = get_post( $post_id );
 		if ( ! $post ) {
 			return $this->error(
-				'invalid_post',
+				'designsetgo_invalid_post',
 				__( 'Post not found.', 'designsetgo' )
 			);
 		}

--- a/includes/abilities/info/class-list-abilities.php
+++ b/includes/abilities/info/class-list-abilities.php
@@ -52,7 +52,9 @@ class List_Abilities extends Abstract_Ability {
 			'keywords'            => array( 'discover', 'tools', 'capabilities', 'help' ),
 			'annotations'         => array(
 				'readonly'     => true,
-				'instructions' => 'Call this first to discover all available DesignSetGo abilities. Use category filter to narrow by type: inserter, configurator, or info.',
+				'destructive'  => false,
+				'idempotent'   => true,
+				'instructions' => 'Call this first to discover all available DesignSetGo abilities. Use the category filter to narrow by registered category: info (read-only discovery), blocks (insert/configure/delete blocks in post content), or settings (plugin settings and global CSS). Each entry carries its annotations, so you can tell readonly from destructive without a second lookup.',
 			),
 		);
 	}
@@ -68,8 +70,8 @@ class List_Abilities extends Abstract_Ability {
 			'properties'           => array(
 				'category' => array(
 					'type'        => 'string',
-					'description' => __( 'Filter by ability category', 'designsetgo' ),
-					'enum'        => array( 'all', 'inserter', 'configurator', 'info', 'settings' ),
+					'description' => __( 'Filter by the category the ability is registered in. These are the same categories exposed at /wp-json/wp-abilities/v1/categories.', 'designsetgo' ),
+					'enum'        => array( 'all', 'info', 'blocks', 'settings' ),
 					'default'     => 'all',
 				),
 				'search'   => array(
@@ -110,7 +112,11 @@ class List_Abilities extends Abstract_Ability {
 							),
 							'category'     => array(
 								'type'        => 'string',
-								'description' => __( 'Ability category: inserter, configurator, or info', 'designsetgo' ),
+								'description' => __( 'The category the ability is registered in: info, blocks, or settings', 'designsetgo' ),
+							),
+							'annotations'  => array(
+								'type'        => 'object',
+								'description' => __( 'Behavioural hints — readonly, destructive, idempotent, and instructions. Absent flags default to false.', 'designsetgo' ),
 							),
 							'input_schema' => array(
 								'type'        => 'object',
@@ -151,9 +157,9 @@ class List_Abilities extends Abstract_Ability {
 		$result    = array();
 
 		foreach ( $abilities as $ability ) {
-			$config   = $ability->get_config();
+			$config   = Abstract_Ability::normalize_config( $ability->get_config() );
 			$name     = $ability->get_name();
-			$category = $this->infer_category( $name );
+			$category = $config['category'] ?? 'info';
 
 			// Filter by category if specified.
 			if ( 'all' !== $category_filter && $category !== $category_filter ) {
@@ -174,6 +180,7 @@ class List_Abilities extends Abstract_Ability {
 				'label'        => $label,
 				'description'  => $description,
 				'category'     => $category,
+				'annotations'  => (object) ( $config['meta']['annotations'] ?? array() ),
 				'input_schema' => $config['input_schema'] ?? array(),
 			);
 		}
@@ -231,56 +238,5 @@ class List_Abilities extends Abstract_Ability {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Infer the ability category from its name.
-	 *
-	 * Uses naming conventions:
-	 * - insert-*, add-* → inserter
-	 * - configure-*, apply-*, batch-*, delete-*, update-* → configurator
-	 * - list-*, get-*, find-* → info
-	 * - *-settings → settings (takes precedence over the prefix rules)
-	 *
-	 * @param string $name Ability name (e.g., 'designsetgo/add-block').
-	 * @return string Category: inserter, configurator, info, or settings.
-	 */
-	private function infer_category( string $name ): string {
-		// Remove namespace prefix.
-		$short_name = str_replace( 'designsetgo/', '', $name );
-
-		// Suffix-based overrides run first so names like "update-settings"
-		// aren't mis-bucketed as configurators.
-		$suffix_map = array(
-			'-settings' => 'settings',
-		);
-
-		foreach ( $suffix_map as $suffix => $category ) {
-			$suffix_len = strlen( $suffix );
-			if ( strlen( $short_name ) >= $suffix_len && 0 === substr_compare( $short_name, $suffix, -$suffix_len ) ) {
-				return $category;
-			}
-		}
-
-		$prefix_map = array(
-			'insert-'    => 'inserter',
-			'add-'       => 'inserter',
-			'configure-' => 'configurator',
-			'apply-'     => 'configurator',
-			'batch-'     => 'configurator',
-			'delete-'    => 'configurator',
-			'update-'    => 'configurator',
-			'list-'      => 'info',
-			'get-'       => 'info',
-			'find-'      => 'info',
-		);
-
-		foreach ( $prefix_map as $prefix => $category ) {
-			if ( 0 === strpos( $short_name, $prefix ) ) {
-				return $category;
-			}
-		}
-
-		return 'configurator';
 	}
 }

--- a/includes/abilities/info/class-list-blocks.php
+++ b/includes/abilities/info/class-list-blocks.php
@@ -13,6 +13,7 @@
 namespace DesignSetGo\Abilities\Info;
 
 use DesignSetGo\Abilities\Abstract_Ability;
+use DesignSetGo\Admin\Settings;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -49,7 +50,9 @@ class List_Blocks extends Abstract_Ability {
 			'keywords'            => array( 'available', 'library', 'catalog', 'registry' ),
 			'annotations'         => array(
 				'readonly'     => true,
-				'instructions' => 'Returns all DesignSetGo blocks with their attributes and metadata. Use category filter to narrow results. Use detail "full" with specific block names for complete attribute definitions.',
+				'destructive'  => false,
+				'idempotent'   => true,
+				'instructions' => 'Returns all DesignSetGo blocks with their attributes and metadata. Each block reports both `category` (the block editor category it registers into, almost always "designsetgo") and `group` (the plugin\'s own grouping: containers, ui, interactive, widgets, forms, or uncategorized). Filter with `group`, not `category` — `category` is near-uniform across the library and will not narrow anything. Use detail "full" with specific block names for complete attribute definitions.',
 			),
 		);
 	}
@@ -63,19 +66,19 @@ class List_Blocks extends Abstract_Ability {
 		return array(
 			'type'                 => 'object',
 			'properties'           => array(
-				'category' => array(
+				'group'  => array(
 					'type'        => 'string',
-					'description' => __( 'Filter by category', 'designsetgo' ),
-					'enum'        => array( 'all', 'layout', 'interactive', 'visual', 'dynamic' ),
+					'description' => __( 'Filter by the plugin\'s own block grouping (the same grouping used by the Blocks & Extensions admin screen). "uncategorized" returns blocks that are registered but not yet listed in the block registry.', 'designsetgo' ),
+					'enum'        => self::get_group_enum(),
 					'default'     => 'all',
 				),
-				'detail'   => array(
+				'detail' => array(
 					'type'        => 'string',
 					'description' => __( 'Level of attribute detail. "summary" returns type/default/enum only. "full" returns complete attribute definitions including minimum, maximum, nested properties, and items for arrays.', 'designsetgo' ),
 					'enum'        => array( 'summary', 'full' ),
 					'default'     => 'summary',
 				),
-				'blocks'   => array(
+				'blocks' => array(
 					'type'        => 'array',
 					'description' => __( 'Filter to specific block names (e.g., ["designsetgo/section", "designsetgo/row"]). When combined with detail "full", limits verbose output to only the requested blocks.', 'designsetgo' ),
 					'items'       => array(
@@ -115,7 +118,11 @@ class List_Blocks extends Abstract_Ability {
 							),
 							'category'    => array(
 								'type'        => 'string',
-								'description' => __( 'Block category', 'designsetgo' ),
+								'description' => __( 'The block editor category the block registers into, verbatim from block.json (almost always "designsetgo").', 'designsetgo' ),
+							),
+							'group'       => array(
+								'type'        => 'string',
+								'description' => __( 'The plugin\'s own grouping: containers, ui, interactive, widgets, forms, or uncategorized.', 'designsetgo' ),
 							),
 							'attributes'  => array(
 								'type'        => 'object',
@@ -153,7 +160,7 @@ class List_Blocks extends Abstract_Ability {
 	 * @return array<string, mixed>
 	 */
 	public function execute( array $input ): array {
-		$category     = $input['category'] ?? 'all';
+		$group        = $input['group'] ?? 'all';
 		$detail       = $input['detail'] ?? 'summary';
 		$block_filter = $input['blocks'] ?? array();
 		$use_full     = 'full' === $detail;
@@ -171,12 +178,12 @@ class List_Blocks extends Abstract_Ability {
 			);
 		}
 
-		// Filter by category if specified.
-		if ( 'all' !== $category ) {
+		// Filter by group if specified.
+		if ( 'all' !== $group ) {
 			$all_blocks = array_filter(
 				$all_blocks,
-				function ( $block ) use ( $category ) {
-					return $block['category'] === $category;
+				function ( $block ) use ( $group ) {
+					return $block['group'] === $group;
 				}
 			);
 		}
@@ -210,7 +217,8 @@ class List_Blocks extends Abstract_Ability {
 				'name'        => $block_type->name,
 				'title'       => '' !== $block_type->title ? $block_type->title : $this->generate_title_from_name( $block_type->name ),
 				'description' => $block_type->description,
-				'category'    => $this->normalize_category( $block_type->category ?? 'designsetgo' ),
+				'category'    => $block_type->category ?? '',
+				'group'       => self::get_block_group( $block_type->name ),
 				'supports'    => $this->format_supports( $block_type->supports ?? array() ),
 				'parent'      => $block_type->parent ?? null,
 				'icon'        => is_string( $block_type->icon ) ? $block_type->icon : null,
@@ -237,44 +245,69 @@ class List_Blocks extends Abstract_Ability {
 	}
 
 	/**
-	 * Normalize block category to simplified categories for filtering.
+	 * Map a block name to the plugin's own grouping.
 	 *
-	 * Maps various block categories to four main categories:
-	 * - layout: Container and layout blocks
-	 * - interactive: Blocks with user interaction (accordions, tabs, etc.)
-	 * - visual: Display and media blocks
-	 * - dynamic: Animated and data-driven blocks
+	 * The source of truth is includes/admin/blocks-registry.json — the same
+	 * file that drives the Blocks & Extensions admin screen — so this
+	 * grouping stays in step with what site owners see there. Blocks that
+	 * are registered but not yet listed in that file report
+	 * "uncategorized" rather than being silently bucketed somewhere wrong.
 	 *
-	 * @param string $category Original block category.
-	 * @return string Normalized category.
+	 * @param string $block_name Full block name (e.g. 'designsetgo/section').
+	 * @return string Group slug.
 	 */
-	private function normalize_category( string $category ): string {
-		$category_map = array(
-			// Layout categories.
-			'designsetgo'             => 'layout',
-			'designsetgo-layout'      => 'layout',
-			'designsetgo-containers'  => 'layout',
-			'layout'                  => 'layout',
+	private static function get_block_group( string $block_name ): string {
+		$map = self::get_group_map();
 
-			// Interactive categories.
-			'designsetgo-interactive' => 'interactive',
-			'designsetgo-navigation'  => 'interactive',
-			'interactive'             => 'interactive',
+		return $map[ $block_name ] ?? 'uncategorized';
+	}
 
-			// Visual categories.
-			'designsetgo-visual'      => 'visual',
-			'designsetgo-media'       => 'visual',
-			'designsetgo-elements'    => 'visual',
-			'visual'                  => 'visual',
-			'media'                   => 'visual',
+	/**
+	 * Build the block-name => group lookup from the block registry.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function get_group_map(): array {
+		static $map = null;
 
-			// Dynamic categories.
-			'designsetgo-dynamic'     => 'dynamic',
-			'designsetgo-animated'    => 'dynamic',
-			'dynamic'                 => 'dynamic',
-		);
+		if ( null !== $map ) {
+			return $map;
+		}
 
-		return $category_map[ $category ] ?? 'visual';
+		$map = array();
+
+		if ( ! class_exists( Settings::class ) ) {
+			return $map;
+		}
+
+		foreach ( Settings::get_available_blocks() as $group_slug => $group ) {
+			if ( empty( $group['blocks'] ) || ! is_array( $group['blocks'] ) ) {
+				continue;
+			}
+
+			foreach ( $group['blocks'] as $block ) {
+				if ( isset( $block['name'] ) ) {
+					$map[ $block['name'] ] = $group_slug;
+				}
+			}
+		}
+
+		return $map;
+	}
+
+	/**
+	 * Enum of accepted values for the `group` input.
+	 *
+	 * Derived from the registry so a new group added to
+	 * blocks-registry.json becomes filterable without touching this file.
+	 *
+	 * @return array<int, string>
+	 */
+	private static function get_group_enum(): array {
+		$groups = array_values( array_unique( array_values( self::get_group_map() ) ) );
+		sort( $groups );
+
+		return array_merge( array( 'all' ), $groups, array( 'uncategorized' ) );
 	}
 
 	/**

--- a/includes/abilities/info/class-list-dynamic-tag-sources.php
+++ b/includes/abilities/info/class-list-dynamic-tag-sources.php
@@ -53,6 +53,8 @@ class List_Dynamic_Tag_Sources extends Abstract_Ability {
 			'keywords'            => array( 'binding', 'dynamic', 'token', 'tag', 'source', 'data' ),
 			'annotations'         => array(
 				'readonly'     => true,
+				'destructive'  => false,
+				'idempotent'   => true,
 				'instructions' => 'Read-only catalog. Filter by `returns` (text|image|url|number|date) to narrow to sources compatible with the bound attribute, or by `group` to scope to one family. To bind a source, write `attributes.metadata.bindings.<attr> = { source: "<slug>", args: { ... } }` via update-block.',
 			),
 		);
@@ -83,12 +85,41 @@ class List_Dynamic_Tag_Sources extends Abstract_Ability {
 				),
 				'group'   => array(
 					'type'        => 'string',
-					'enum'        => array( 'post', 'site', 'archive', 'user', 'custom-fields' ),
-					'description' => __( 'Filter to a single group.', 'designsetgo' ),
+					'enum'        => $this->get_group_enum(),
+					'description' => __( 'Filter to a single group. The accepted values are the groups actually registered on this site, so conditional families (for example "woocommerce", which only exists when WooCommerce is active) appear here only when they are available.', 'designsetgo' ),
 				),
 			),
 			'additionalProperties' => false,
 		);
+	}
+
+	/**
+	 * Enum of accepted `group` values, read from the live registry.
+	 *
+	 * Hardcoding this list is how it drifted: the WooCommerce group is
+	 * registered by WooSources on init priority 6 (abilities register at
+	 * priority 9), and it was missing from the enum, so a schema with
+	 * additionalProperties:false rejected { "group": "woocommerce" }
+	 * before the callback ever ran.
+	 *
+	 * @return array<int, string>
+	 */
+	private function get_group_enum(): array {
+		$fallback = array( 'post', 'site', 'archive', 'user', 'custom-fields' );
+
+		if ( ! class_exists( Registry::class ) ) {
+			return $fallback;
+		}
+
+		$groups = array_column( Registry::instance()->all_groups(), 'slug' );
+
+		if ( empty( $groups ) ) {
+			// Registry not yet populated — fall back to the built-in groups
+			// seeded by register_default_groups().
+			return $fallback;
+		}
+
+		return array_values( $groups );
 	}
 
 	/**

--- a/includes/abilities/info/class-list-extensions.php
+++ b/includes/abilities/info/class-list-extensions.php
@@ -104,15 +104,30 @@ class List_Extensions extends Abstract_Ability {
 			'description' => 'Decorative SVG pattern overlays for container blocks.',
 			'keywords'    => array( 'pattern', 'decoration', 'overlay', 'texture' ),
 		),
+		'interactions'           => array(
+			'label'       => 'Interactions',
+			'description' => 'Event-driven interactions on any block — a trigger (click, hover, scroll into view) paired with an action (toggle a class, show/hide a target, scroll to an anchor). Stored on the dsgoInteractions attribute as an array of rules.',
+			'keywords'    => array( 'interaction', 'trigger', 'click', 'hover', 'event', 'action' ),
+		),
+		'schema'                 => array(
+			'label'       => 'Schema Output',
+			'description' => 'Emits JSON-LD structured data for the block into the page graph, so accordions become FAQPage entries and star ratings become Review/AggregateRating. Applies only to designsetgo/accordion and designsetgo/star-rating. Set via the dsgoSchema attribute.',
+			'keywords'    => array( 'schema', 'json-ld', 'structured data', 'seo', 'rich results', 'faq', 'review' ),
+		),
+		'style-binding'          => array(
+			'label'       => 'Dynamic Style Bindings',
+			'description' => 'Binds CSS properties — including custom properties like --dsgo-progress — to a dynamic source, so a value from post meta, ACF, or a WooCommerce field drives the rendered style. Shape: dsgoStyleBinding = { "<css-property>": { "source": "<slug>", "key": "<field>" } }. Dangerous values (url(, expression(, javascript:) are rejected server-side. Use list-dynamic-tag-sources to enumerate sources.',
+			'keywords'    => array( 'style', 'binding', 'dynamic', 'css variable', 'custom property', 'data' ),
+		),
+		'visibility'             => array(
+			'label'       => 'Conditional Visibility',
+			'description' => 'Shows or hides a block based on runtime conditions, evaluated on the server and mirrored in the editor. Shape: dsgoVisibility = { "operator": "AND"|"OR", "rules": [ { "type": "meta"|"taxonomy"|"index"|"auth", "op": "...", "key": "...", "value": "..." } ] }. Custom rule types can be added via the designsetgo_visibility_rule filter.',
+			'keywords'    => array( 'visibility', 'conditional', 'hide', 'show', 'rules', 'logic' ),
+		),
 		'sticky-header-controls' => array(
 			'label'       => 'Sticky Header Controls',
 			'description' => 'Configuration for sticky/fixed header behavior.',
 			'keywords'    => array( 'sticky', 'fixed', 'header', 'navigation' ),
-		),
-		'dynamic-tags'           => array(
-			'label'       => 'Dynamic Tags',
-			'description' => 'Bind block attributes (paragraph content, heading content, image url/alt, button text/url, etc.) to post / site / archive / user data or custom fields (ACF, Meta Box, Pods, JetEngine). Authors trigger the picker from the inline toolbar (database icon) or the Inspector "Dynamic Tags" panel. Bindings are written to attributes.metadata.bindings; use designsetgo/list-dynamic-tag-sources to enumerate sources.',
-			'keywords'    => array( 'binding', 'dynamic', 'data', 'acf', 'meta', 'token' ),
 		),
 	);
 
@@ -142,6 +157,8 @@ class List_Extensions extends Abstract_Ability {
 			'keywords'            => array( 'discover', 'features', 'add-ons' ),
 			'annotations'         => array(
 				'readonly'     => true,
+				'destructive'  => false,
+				'idempotent'   => true,
 				'instructions' => 'Returns all DesignSetGo extensions with attribute schemas and applicable blocks. After discovering extensions, use update-block to apply extension attributes to any applicable block. Exception: use configure-custom-css for custom CSS (it sanitizes CSS for security).',
 			),
 		);

--- a/includes/abilities/inserters/class-add-accordion-item.php
+++ b/includes/abilities/inserters/class-add-accordion-item.php
@@ -49,7 +49,10 @@ class Add_Accordion_Item extends Abstract_Ability {
 			'show_in_rest'        => true,
 			'keywords'            => array( 'collapsible', 'expandable', 'faq', 'toggle' ),
 			'annotations'         => array(
-				'idempotent' => false,
+				'readonly'    => false,
+				'destructive' => false,
+				// Each call appends another block, so repeating it is not a no-op.
+				'idempotent'  => false,
 			),
 		);
 	}
@@ -121,7 +124,7 @@ class Add_Accordion_Item extends Abstract_Ability {
 		// Validate required parameters.
 		if ( ! $post_id ) {
 			return $this->error(
-				'missing_post_id',
+				'designsetgo_missing_post_id',
 				__( 'Post ID is required.', 'designsetgo' )
 			);
 		}
@@ -144,7 +147,7 @@ class Add_Accordion_Item extends Abstract_Ability {
 		$post = get_post( $post_id );
 		if ( ! $post ) {
 			return $this->error(
-				'invalid_post',
+				'designsetgo_invalid_post',
 				__( 'Post not found.', 'designsetgo' )
 			);
 		}

--- a/includes/abilities/inserters/class-add-block.php
+++ b/includes/abilities/inserters/class-add-block.php
@@ -52,7 +52,10 @@ class Add_Block extends Abstract_Ability {
 			'show_in_rest'        => true,
 			'keywords'            => array( 'insert', 'create', 'new' ),
 			'annotations'         => array(
-				'idempotent' => false,
+				'readonly'    => false,
+				'destructive' => false,
+				// Each call appends another block, so repeating it is not a no-op.
+				'idempotent'  => false,
 			),
 		);
 	}
@@ -137,14 +140,14 @@ class Add_Block extends Abstract_Ability {
 		// Validate required parameters.
 		if ( ! $post_id ) {
 			return $this->error(
-				'missing_post_id',
+				'designsetgo_missing_post_id',
 				__( 'Post ID is required.', 'designsetgo' )
 			);
 		}
 
 		$post = get_post( $post_id );
 		if ( ! $post ) {
-			return $this->error( 'invalid_post', __( 'Post not found.', 'designsetgo' ) );
+			return $this->error( 'designsetgo_invalid_post', __( 'Post not found.', 'designsetgo' ) );
 		}
 
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
@@ -153,7 +156,7 @@ class Add_Block extends Abstract_Ability {
 
 		if ( empty( $block_name ) ) {
 			return $this->error(
-				'missing_block_name',
+				'designsetgo_missing_block_name',
 				__( 'block_name is required.', 'designsetgo' )
 			);
 		}
@@ -162,7 +165,7 @@ class Add_Block extends Abstract_Ability {
 		$block_name = sanitize_text_field( $block_name );
 		if ( ! preg_match( '/^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/', $block_name ) ) {
 			return $this->error(
-				'invalid_input',
+				'designsetgo_invalid_input',
 				__( 'block_name must be in "namespace/block-name" format (lowercase alphanumeric and hyphens).', 'designsetgo' )
 			);
 		}

--- a/includes/abilities/inserters/class-add-child-block.php
+++ b/includes/abilities/inserters/class-add-child-block.php
@@ -54,7 +54,10 @@ class Add_Child_Block extends Abstract_Ability {
 			'show_in_rest'        => true,
 			'keywords'            => array( 'nested', 'inner', 'append' ),
 			'annotations'         => array(
-				'idempotent' => false,
+				'readonly'    => false,
+				'destructive' => false,
+				// Each call appends another block, so repeating it is not a no-op.
+				'idempotent'  => false,
 			),
 		);
 	}
@@ -182,14 +185,14 @@ class Add_Child_Block extends Abstract_Ability {
 		// Validate required parameters.
 		if ( ! $post_id ) {
 			return $this->error(
-				'missing_post_id',
+				'designsetgo_missing_post_id',
 				__( 'Post ID is required.', 'designsetgo' )
 			);
 		}
 
 		$post = get_post( $post_id );
 		if ( ! $post ) {
-			return $this->error( 'invalid_post', __( 'Post not found.', 'designsetgo' ) );
+			return $this->error( 'designsetgo_invalid_post', __( 'Post not found.', 'designsetgo' ) );
 		}
 
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
@@ -198,14 +201,14 @@ class Add_Child_Block extends Abstract_Ability {
 
 		if ( null === $parent_block_index ) {
 			return $this->error(
-				'invalid_input',
+				'designsetgo_invalid_input',
 				__( 'parent_block_index is required.', 'designsetgo' )
 			);
 		}
 
 		if ( empty( $block_name ) ) {
 			return $this->error(
-				'missing_block_name',
+				'designsetgo_missing_block_name',
 				__( 'block_name is required.', 'designsetgo' )
 			);
 		}
@@ -214,7 +217,7 @@ class Add_Child_Block extends Abstract_Ability {
 		$block_name = sanitize_text_field( $block_name );
 		if ( ! preg_match( '/^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/', $block_name ) ) {
 			return $this->error(
-				'invalid_input',
+				'designsetgo_invalid_input',
 				__( 'block_name must be in "namespace/block-name" format (lowercase alphanumeric and hyphens).', 'designsetgo' )
 			);
 		}

--- a/includes/abilities/inserters/class-add-tab.php
+++ b/includes/abilities/inserters/class-add-tab.php
@@ -49,7 +49,10 @@ class Add_Tab extends Abstract_Ability {
 			'show_in_rest'        => true,
 			'keywords'            => array( 'tabs', 'tabbed', 'panel' ),
 			'annotations'         => array(
-				'idempotent' => false,
+				'readonly'    => false,
+				'destructive' => false,
+				// Each call appends another block, so repeating it is not a no-op.
+				'idempotent'  => false,
 			),
 		);
 	}
@@ -120,7 +123,7 @@ class Add_Tab extends Abstract_Ability {
 		// Validate required parameters.
 		if ( ! $post_id ) {
 			return $this->error(
-				'missing_post_id',
+				'designsetgo_missing_post_id',
 				__( 'Post ID is required.', 'designsetgo' )
 			);
 		}
@@ -144,7 +147,7 @@ class Add_Tab extends Abstract_Ability {
 		$post = get_post( $post_id );
 		if ( ! $post ) {
 			return $this->error(
-				'invalid_post',
+				'designsetgo_invalid_post',
 				__( 'Post not found.', 'designsetgo' )
 			);
 		}

--- a/includes/abilities/inserters/class-add-timeline-item.php
+++ b/includes/abilities/inserters/class-add-timeline-item.php
@@ -49,7 +49,10 @@ class Add_Timeline_Item extends Abstract_Ability {
 			'show_in_rest'        => true,
 			'keywords'            => array( 'chronological', 'history', 'steps' ),
 			'annotations'         => array(
-				'idempotent' => false,
+				'readonly'    => false,
+				'destructive' => false,
+				// Each call appends another block, so repeating it is not a no-op.
+				'idempotent'  => false,
 			),
 		);
 	}
@@ -139,7 +142,7 @@ class Add_Timeline_Item extends Abstract_Ability {
 		// Validate required parameters.
 		if ( ! $post_id ) {
 			return $this->error(
-				'missing_post_id',
+				'designsetgo_missing_post_id',
 				__( 'Post ID is required.', 'designsetgo' )
 			);
 		}
@@ -155,7 +158,7 @@ class Add_Timeline_Item extends Abstract_Ability {
 		$post = get_post( $post_id );
 		if ( ! $post ) {
 			return $this->error(
-				'invalid_post',
+				'designsetgo_invalid_post',
 				__( 'Post not found.', 'designsetgo' )
 			);
 		}

--- a/includes/abilities/settings/class-get-global-css.php
+++ b/includes/abilities/settings/class-get-global-css.php
@@ -59,6 +59,7 @@ class Get_Global_CSS extends Abstract_Ability {
 			'keywords'            => array( 'css', 'styles', 'customizer', 'additional css', 'global', 'theme' ),
 			'annotations'         => array(
 				'readonly'     => true,
+				'destructive'  => false,
 				'idempotent'   => true,
 				'instructions' => 'Call this before update-global-css when you want to append to or modify the existing Additional CSS rather than replace it. The value is scoped to the currently active theme.',
 			),

--- a/includes/abilities/settings/class-get-settings.php
+++ b/includes/abilities/settings/class-get-settings.php
@@ -53,6 +53,7 @@ class Get_Settings extends Abstract_Ability {
 			'keywords'            => array( 'settings', 'config', 'options', 'preferences' ),
 			'annotations'         => array(
 				'readonly'     => true,
+				'destructive'  => false,
 				'idempotent'   => true,
 				'instructions' => 'Call this before update-settings to see current values. Results include secrets (API keys) since the caller has already been authorized via manage_options.',
 			),

--- a/includes/abilities/settings/class-update-global-css.php
+++ b/includes/abilities/settings/class-update-global-css.php
@@ -61,6 +61,8 @@ class Update_Global_CSS extends Abstract_Ability {
 			'show_in_rest'        => true,
 			'keywords'            => array( 'css', 'styles', 'customizer', 'additional css', 'global', 'theme' ),
 			'annotations'         => array(
+				'readonly'     => false,
+				'destructive'  => false,
 				'idempotent'   => true,
 				'instructions' => 'Submitting { "css": "..." } REPLACES the entire Additional CSS for the active theme — there is no merge. To append, call get-global-css first, concatenate, then submit. To clear, submit { "css": "" }. Sanitization is applied by WordPress core.',
 			),
@@ -127,7 +129,7 @@ class Update_Global_CSS extends Abstract_Ability {
 
 		if ( is_wp_error( $post ) ) {
 			return $this->error(
-				'custom_css_update_failed',
+				'designsetgo_custom_css_update_failed',
 				$post->get_error_message(),
 				array( 'wp_error_code' => $post->get_error_code() )
 			);

--- a/includes/abilities/settings/class-update-settings.php
+++ b/includes/abilities/settings/class-update-settings.php
@@ -56,6 +56,8 @@ class Update_Settings extends Abstract_Ability {
 			'show_in_rest'        => true,
 			'keywords'            => array( 'settings', 'config', 'configure', 'preferences', 'options' ),
 			'annotations'         => array(
+				'readonly'     => false,
+				'destructive'  => false,
 				'idempotent'   => true,
 				'instructions' => 'Call get-settings first to see current values. Submit only the keys you want to change — omitted keys remain untouched. Empty arrays for enabled_blocks or enabled_extensions mean "all enabled". To replace a list field (enabled_blocks, enabled_extensions, excluded_blocks) entirely, fetch the current value first and resubmit the full desired array — lists are merged positionally (by index), not replaced wholesale. The exception is animations.block_animations, which is always replaced wholesale with whatever you submit.',
 			),

--- a/includes/admin/class-settings-schema.php
+++ b/includes/admin/class-settings-schema.php
@@ -58,6 +58,7 @@ class Settings_Schema {
 				),
 				'performance'        => array(
 					'type'                 => 'object',
+					'description'          => __( 'Performance controls — asset loading strategy, lazy loading, and script/style deferral.', 'designsetgo' ),
 					'additionalProperties' => false,
 					'properties'           => array(
 						'conditional_loading' => array( 'type' => 'boolean' ),
@@ -69,6 +70,7 @@ class Settings_Schema {
 				),
 				'forms'              => array(
 					'type'                 => 'object',
+					'description'          => __( 'Form Builder behaviour — submission storage, retention_days, spam protection, and notification settings.', 'designsetgo' ),
 					'additionalProperties' => false,
 					'properties'           => array(
 						'enable_honeypot'      => array( 'type' => 'boolean' ),
@@ -82,6 +84,7 @@ class Settings_Schema {
 				),
 				'animations'         => array(
 					'type'                 => 'object',
+					'description'          => __( 'Animation defaults and the per-block animation registry. Note that animations.block_animations is replaced wholesale on update, unlike the other list fields.', 'designsetgo' ),
 					'additionalProperties' => false,
 					'properties'           => array(
 						'enable_animations'              => array( 'type' => 'boolean' ),
@@ -120,6 +123,7 @@ class Settings_Schema {
 				),
 				'security'           => array(
 					'type'                 => 'object',
+					'description'          => __( 'Security controls — SVG upload handling, CSS sanitization, and related hardening switches.', 'designsetgo' ),
 					'additionalProperties' => false,
 					'properties'           => array(
 						'log_ip_addresses' => array( 'type' => 'boolean' ),
@@ -129,6 +133,7 @@ class Settings_Schema {
 				),
 				'integrations'       => array(
 					'type'                 => 'object',
+					'description'          => __( 'Third-party integration credentials and endpoints. Values here include secrets, which is why reading settings requires manage_options.', 'designsetgo' ),
 					'additionalProperties' => false,
 					'properties'           => array(
 						'google_maps_api_key'  => array( 'type' => 'string' ),
@@ -138,6 +143,7 @@ class Settings_Schema {
 				),
 				'sticky_header'      => array(
 					'type'                 => 'object',
+					'description'          => __( 'Sticky header behaviour — which element sticks, the scroll offset that activates it, and shrink-on-scroll options.', 'designsetgo' ),
 					'additionalProperties' => false,
 					'properties'           => array(
 						'enable'                    => array( 'type' => 'boolean' ),
@@ -185,6 +191,7 @@ class Settings_Schema {
 				),
 				'draft_mode'         => array(
 					'type'                 => 'object',
+					'description'          => __( 'Draft Mode — lets an editor stage changes to a published page and publish them in one step.', 'designsetgo' ),
 					'additionalProperties' => false,
 					'properties'           => array(
 						'enable'                 => array( 'type' => 'boolean' ),
@@ -200,6 +207,7 @@ class Settings_Schema {
 				),
 				'llms_txt'           => array(
 					'type'                 => 'object',
+					'description'          => __( 'llms.txt generation — whether the file is served, and which post types and fields it advertises to AI crawlers.', 'designsetgo' ),
 					'additionalProperties' => false,
 					'properties'           => array(
 						'enable'            => array( 'type' => 'boolean' ),

--- a/tests/phpunit/abilities-coverage-test.php
+++ b/tests/phpunit/abilities-coverage-test.php
@@ -342,7 +342,7 @@ class Test_Validate_Input extends WP_UnitTestCase {
 			'attributes' => array( 'tagName' => 'section' ),
 		) );
 		$this->assertWPError( $result );
-		$this->assertEquals( 'missing_post_id', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_missing_post_id', $result->get_error_code() );
 	}
 
 	/**
@@ -488,7 +488,7 @@ class Test_Block_Configurator_Index extends WP_UnitTestCase {
 		);
 
 		$this->assertWPError( $result );
-		$this->assertEquals( 'block_not_found', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_block_not_found', $result->get_error_code() );
 	}
 
 	/**
@@ -503,7 +503,7 @@ class Test_Block_Configurator_Index extends WP_UnitTestCase {
 		);
 
 		$this->assertWPError( $result );
-		$this->assertEquals( 'block_name_mismatch', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_block_name_mismatch', $result->get_error_code() );
 	}
 
 	/**
@@ -517,7 +517,7 @@ class Test_Block_Configurator_Index extends WP_UnitTestCase {
 		);
 
 		$this->assertWPError( $result );
-		$this->assertEquals( 'invalid_post', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_invalid_post', $result->get_error_code() );
 	}
 
 	/**
@@ -535,7 +535,7 @@ class Test_Block_Configurator_Index extends WP_UnitTestCase {
 		);
 
 		$this->assertWPError( $result );
-		$this->assertEquals( 'permission_denied', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_permission_denied', $result->get_error_code() );
 	}
 }
 
@@ -589,7 +589,7 @@ class Test_Block_Configurator_Insert_Inner extends WP_UnitTestCase {
 		);
 
 		$this->assertWPError( $result );
-		$this->assertEquals( 'invalid_post', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_invalid_post', $result->get_error_code() );
 	}
 
 	/**
@@ -603,7 +603,7 @@ class Test_Block_Configurator_Insert_Inner extends WP_UnitTestCase {
 		);
 
 		$this->assertWPError( $result );
-		$this->assertEquals( 'invalid_input', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_invalid_input', $result->get_error_code() );
 	}
 
 	/**
@@ -617,7 +617,7 @@ class Test_Block_Configurator_Insert_Inner extends WP_UnitTestCase {
 		);
 
 		$this->assertWPError( $result );
-		$this->assertEquals( 'block_not_found', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_block_not_found', $result->get_error_code() );
 	}
 
 	/**
@@ -634,6 +634,6 @@ class Test_Block_Configurator_Insert_Inner extends WP_UnitTestCase {
 		);
 
 		$this->assertWPError( $result );
-		$this->assertEquals( 'permission_denied', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_permission_denied', $result->get_error_code() );
 	}
 }

--- a/tests/phpunit/abilities-security-test.php
+++ b/tests/phpunit/abilities-security-test.php
@@ -95,7 +95,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'validation_failed', $result );
+		$this->assert_error_code( 'designsetgo_validation_failed', $result );
 	}
 
 	/**
@@ -117,7 +117,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'validation_failed', $result );
+		$this->assert_error_code( 'designsetgo_validation_failed', $result );
 	}
 
 	/**
@@ -139,7 +139,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'validation_failed', $result );
+		$this->assert_error_code( 'designsetgo_validation_failed', $result );
 	}
 
 	/**
@@ -206,7 +206,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'invalid_input', $result );
+		$this->assert_error_code( 'designsetgo_invalid_input', $result );
 	}
 
 	/**
@@ -225,7 +225,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'invalid_input', $result );
+		$this->assert_error_code( 'designsetgo_invalid_input', $result );
 	}
 
 	/**
@@ -244,7 +244,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'invalid_input', $result );
+		$this->assert_error_code( 'designsetgo_invalid_input', $result );
 	}
 
 	// -------------------------------------------------------------------------
@@ -267,7 +267,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'block_not_found', $result );
+		$this->assert_error_code( 'designsetgo_block_not_found', $result );
 	}
 
 	/**
@@ -283,7 +283,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'invalid_post', $result );
+		$this->assert_error_code( 'designsetgo_invalid_post', $result );
 	}
 
 	/**
@@ -301,7 +301,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'invalid_input', $result );
+		$this->assert_error_code( 'designsetgo_invalid_input', $result );
 	}
 
 	/**
@@ -320,7 +320,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'missing_settings', $result );
+		$this->assert_error_code( 'designsetgo_missing_settings', $result );
 	}
 
 	/**
@@ -335,7 +335,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'missing_post_id', $result );
+		$this->assert_error_code( 'designsetgo_missing_post_id', $result );
 	}
 
 	/**
@@ -355,7 +355,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'block_name_mismatch', $result );
+		$this->assert_error_code( 'designsetgo_block_name_mismatch', $result );
 	}
 
 	// -------------------------------------------------------------------------
@@ -380,7 +380,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'validation_failed', $result );
+		$this->assert_error_code( 'designsetgo_validation_failed', $result );
 	}
 
 	/**
@@ -402,7 +402,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'validation_failed', $result );
+		$this->assert_error_code( 'designsetgo_validation_failed', $result );
 	}
 
 	/**
@@ -424,7 +424,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'validation_failed', $result );
+		$this->assert_error_code( 'designsetgo_validation_failed', $result );
 	}
 
 	/**
@@ -444,7 +444,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'invalid_input', $result );
+		$this->assert_error_code( 'designsetgo_invalid_input', $result );
 	}
 
 	/**
@@ -464,7 +464,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'missing_settings', $result );
+		$this->assert_error_code( 'designsetgo_missing_settings', $result );
 	}
 
 	/**
@@ -486,7 +486,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'validation_failed', $result );
+		$this->assert_error_code( 'designsetgo_validation_failed', $result );
 	}
 
 	// -------------------------------------------------------------------------
@@ -677,7 +677,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'validation_failed', $result );
+		$this->assert_error_code( 'designsetgo_validation_failed', $result );
 	}
 
 	// -------------------------------------------------------------------------
@@ -699,7 +699,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'invalid_input', $result );
+		$this->assert_error_code( 'designsetgo_invalid_input', $result );
 	}
 
 	/**
@@ -717,7 +717,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'missing_block_name', $result );
+		$this->assert_error_code( 'designsetgo_missing_block_name', $result );
 	}
 
 	/**
@@ -736,7 +736,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'block_not_found', $result );
+		$this->assert_error_code( 'designsetgo_block_not_found', $result );
 	}
 
 	// -------------------------------------------------------------------------
@@ -902,7 +902,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'validation_failed', $result );
+		$this->assert_error_code( 'designsetgo_validation_failed', $result );
 	}
 
 	/**
@@ -924,7 +924,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'validation_failed', $result );
+		$this->assert_error_code( 'designsetgo_validation_failed', $result );
 	}
 
 	// -------------------------------------------------------------------------
@@ -987,7 +987,7 @@ class Abilities_Security_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assert_error_code( 'block_not_found', $result );
+		$this->assert_error_code( 'designsetgo_block_not_found', $result );
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/phpunit/abilities-test.php
+++ b/tests/phpunit/abilities-test.php
@@ -227,7 +227,7 @@ class Test_Block_Inserter extends WP_UnitTestCase {
 		);
 
 		$this->assertWPError( $result );
-		$this->assertEquals( 'invalid_post', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_invalid_post', $result->get_error_code() );
 	}
 
 	/**
@@ -249,7 +249,7 @@ class Test_Block_Inserter extends WP_UnitTestCase {
 		);
 
 		$this->assertWPError( $result );
-		$this->assertEquals( 'permission_denied', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_permission_denied', $result->get_error_code() );
 	}
 
 	/**
@@ -356,7 +356,7 @@ class Test_Block_Inserter extends WP_UnitTestCase {
 		$result = Block_Inserter::validate_inner_blocks( $inner_blocks );
 
 		$this->assertWPError( $result );
-		$this->assertEquals( 'invalid_inner_block', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_invalid_inner_block', $result->get_error_code() );
 	}
 
 	/**
@@ -373,7 +373,7 @@ class Test_Block_Inserter extends WP_UnitTestCase {
 		$result = Block_Inserter::validate_inner_blocks( $inner_blocks );
 
 		$this->assertWPError( $result );
-		$this->assertEquals( 'invalid_inner_block_attributes', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_invalid_inner_block_attributes', $result->get_error_code() );
 	}
 
 	/**
@@ -501,7 +501,7 @@ class Test_Block_Configurator extends WP_UnitTestCase {
 		);
 
 		$this->assertWPError( $result );
-		$this->assertEquals( 'invalid_post', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_invalid_post', $result->get_error_code() );
 	}
 
 	/**
@@ -515,7 +515,7 @@ class Test_Block_Configurator extends WP_UnitTestCase {
 		);
 
 		$this->assertWPError( $result );
-		$this->assertEquals( 'block_not_found', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_block_not_found', $result->get_error_code() );
 	}
 
 	/**
@@ -708,19 +708,44 @@ class Test_Abilities_Execution extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test list-blocks ability with category filter.
+	 * Test list-blocks ability with the group filter.
+	 *
+	 * `group` is the plugin's own grouping, sourced from
+	 * includes/admin/blocks-registry.json. It replaced a synthetic
+	 * `category` filter whose enum (layout/interactive/visual/dynamic) no
+	 * block could ever match, because every block registers into the
+	 * "designsetgo" editor category.
 	 */
 	public function test_list_blocks_ability_filtered() {
 		$registry = Abilities_Registry::get_instance();
 		$ability = $registry->get_ability( 'designsetgo/list-blocks' );
 
-		$result = $ability->execute( array( 'category' => 'layout' ) );
+		$result = $ability->execute( array( 'group' => 'containers' ) );
 
 		$this->assertIsArray( $result );
+		$this->assertGreaterThan( 0, $result['total'], 'The containers group should not be empty.' );
 
-		// All returned blocks should be in layout category.
 		foreach ( $result['blocks'] as $block ) {
-			$this->assertEquals( 'layout', $block['category'] );
+			$this->assertEquals( 'containers', $block['group'] );
+		}
+	}
+
+	/**
+	 * Every block reports its editor category verbatim, and a group.
+	 */
+	public function test_list_blocks_reports_verbatim_category_and_group() {
+		$registry = Abilities_Registry::get_instance();
+		$ability  = $registry->get_ability( 'designsetgo/list-blocks' );
+
+		$result = $ability->execute( array() );
+
+		$valid_groups = array( 'containers', 'ui', 'interactive', 'widgets', 'forms', 'uncategorized' );
+
+		foreach ( $result['blocks'] as $block ) {
+			$this->assertArrayHasKey( 'group', $block );
+			$this->assertContains( $block['group'], $valid_groups );
+			// The editor category is passed through untouched, never remapped.
+			$this->assertNotEquals( 'layout', $block['category'] );
 		}
 	}
 
@@ -764,7 +789,7 @@ class Test_Abilities_Execution extends WP_UnitTestCase {
 		) );
 
 		$this->assertWPError( $result );
-		$this->assertEquals( 'missing_post_id', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_missing_post_id', $result->get_error_code() );
 	}
 
 	/**
@@ -1516,7 +1541,7 @@ class Test_Abstract_Configurator_Ability extends WP_UnitTestCase {
 		) );
 
 		$this->assertWPError( $result );
-		$this->assertEquals( 'missing_post_id', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_missing_post_id', $result->get_error_code() );
 	}
 
 	/**
@@ -1532,6 +1557,6 @@ class Test_Abstract_Configurator_Ability extends WP_UnitTestCase {
 		) );
 
 		$this->assertWPError( $result );
-		$this->assertEquals( 'missing_settings', $result->get_error_code() );
+		$this->assertEquals( 'designsetgo_missing_settings', $result->get_error_code() );
 	}
 }


### PR DESCRIPTION
## What this is

An audit of the WordPress Abilities API surface — run statically, then against a live WP 7.1 + WooCommerce environment — plus fixes for everything it turned up. Full report is in [`docs/audits/ABILITIES-VERIFICATION.md`](docs/audits/ABILITIES-VERIFICATION.md).

Runtime enumeration via `wp_get_abilities()` matches static enumeration at **20 abilities**, so registration fires correctly.

## The three failures

All three were in the *discovery* abilities — the ones an agent calls first to decide what to do next. None were security issues; all three made the plugin describe itself incorrectly.

### `list-abilities` reported a category vocabulary that doesn't exist

It derived each ability's category from its **name prefix** (`inserter`/`configurator`/`info`/`settings`) rather than reading the `category` it was registered with. The two vocabularies disagreed: no ability was ever reported as `blocks` though 10 register there, `get-global-css` came back as `info` (name starts with `get-`), and `update-global-css` as `configurator`. An agent filtering `{"category": "settings"}` got 2 of 4 and never discovered the global-CSS abilities.

Now reads `$config['category']`; `infer_category()` is deleted.

```
before: category=settings -> 2
after:  category=settings -> 4   all -> {"blocks":10,"info":6,"settings":4}
```

### `list-blocks`'s filter could only ever return one bucket

`normalize_category()` mapped blocks through legacy `designsetgo-*` slugs that no block uses any more. 66 of 68 blocks declare `"category": "designsetgo"` → all became `layout`; the two declaring `"design"` fell through to a `visual` default. `interactive` and `dynamic` returned **zero blocks**, and every block's reported category was wrong.

Blocks now report `category` verbatim from `block.json`, plus a `group` sourced from `includes/admin/blocks-registry.json` — the same file behind the Blocks & Extensions admin screen, so the grouping matches what site owners already see. The filter input is now `group`, with its enum derived from the registry.

```
after: total=68  groups={"containers":3,"forms":12,"interactive":7,
                         "ui":18,"uncategorized":20,"widgets":8}
       verbatim categories={"designsetgo":66,"design":2}
```

### `list-dynamic-tag-sources` couldn't filter the WooCommerce group

The `group` enum hardcoded five values. A sixth, `woocommerce`, is registered by `WooSources` on `init` priority 6. Combined with `additionalProperties: false`, `{"group": "woocommerce"}` was rejected by schema validation **before the callback ran** — so the six `woo-*` binding sources couldn't be scoped to at all, which is exactly the filter you'd reach for building a product loop.

The enum now comes from the live registry (guarded by `class_exists()` with a literal fallback). Sources register at priority 6 and abilities at 9, so it's populated in time — and it correctly *omits* the group when Woo is inactive. Verified live: returns all 6 `designsetgo/woo-*` sources.

## Also fixed

- **Four writers had no annotations at all** — `update-block`, `batch-update`, `configure-custom-css`, `configure-shape-divider`. All 20 abilities now declare `readonly`/`destructive`/`idempotent` explicitly plus `instructions`. `delete-block` stays `idempotent: false` deliberately (it targets by block *index*, and indices shift after a removal).
- **`list-extensions` metadata had drifted both ways** — `interactions`, `schema`, `style-binding` and `visibility` shipped with **empty descriptions**, while a `dynamic-tags` entry had no config file and was never emitted. Now 19/19 exact match.
- **`list-abilities` now returns annotations**, so an agent using it as its entry point can tell readonly from destructive without a second round-trip.
- **Error codes namespaced `designsetgo_*`** (including the HTTP-status map and ~25 test assertions). `rest_forbidden` keeps its unprefixed name — that's the code core uses for the same condition.
- **The eight top-level settings groups now have descriptions.**

## Documentation

`ABILITIES-API.md` documented **14 of 20** abilities — missing all four settings abilities, `configure-custom-css`, and `list-dynamic-tag-sources`. Now complete, with a category table, a runtime-verified permissions matrix, and a corrected error-code table. `ARCHITECTURE.md` referenced a `class-abilities-provider.php` and a `register_ability()` function that don't exist; replaced with the real auto-discovery architecture.

## What I deliberately left alone

- **The `read` gate** on `list-abilities`/`list-blocks`/`list-extensions`. I'd flagged it as over-permissive, but `abilities-security-test.php` explicitly asserts subscribers *can* call them — a tested decision about a non-privileged catalog, not drift. Documented instead of changed.
- **Annotation correctness passed cleanly.** Every callback was read end-to-end: no `readonly: true` ability writes anywhere, and per-post `edit_post` checks are correctly enforced inside `Block_Inserter`/`Block_Configurator`, so `edit_posts` doesn't grant write access to a post the user can't edit.

## Open item, not addressed here

`includes/admin/blocks-registry.json` lists only **48 of 68** blocks. The other 20 now honestly report `group: "uncategorized"` — but that file also drives the Blocks & Extensions admin screen, so those blocks appear to have no enable/disable control there. Which groups they belong to is a product call, so I left it.

## Verification

- 1300 PHPUnit tests pass. The 4 `Map_Embed_Render_Test` failures are **pre-existing** — confirmed identical on a stashed clean tree.
- `phpcs` clean on all changed source; test-file totals identical to baseline.
- 7 e2e tests pass (pre-commit hook).
- Runtime enumeration + permission roundtrip across anon/subscriber/editor/admin captured in the report.
