### PR TITLE
fix: stop the scroll-driven slider pinning itself in the editor

### DIFF
--- a/src/blocks/slider/style.scss
+++ b/src/blocks/slider/style.scss
@@ -477,12 +477,20 @@
 	width: 100%;
 }
 
-// Double-class selector (0-2-0) so position: sticky beats
+// Pinning is scoped to the spacer, which ScrollDrivenController creates at
+// runtime. The class alone is on the block in the editor too, where there is
+// no spacer to scroll through — an unscoped sticky pins the block to the top
+// of the canvas and overlaps whatever follows it. Same reasoning covers a
+// no-JS frontend.
+// Double-class selector so position: sticky beats
 // [role="region"] { position: relative } (0-1-0) from wp-components,
 // which CoBlocks/GoDaddy plugins enqueue on the frontend.
-.dsgo-slider.dsgo-slider--scroll-driven {
+.dsgo-slider-pin-spacer > .dsgo-slider.dsgo-slider--scroll-driven {
 	position: sticky;
 	top: 0;
+}
+
+.dsgo-slider.dsgo-slider--scroll-driven {
 	overflow: hidden;
 	padding-bottom: 36px; // Room for the scroll progress bar (16px bottom + 4px bar + 16px breathing)
 

--- a/tests/unit/blocks/slider-scroll-driven-sticky.test.js
+++ b/tests/unit/blocks/slider-scroll-driven-sticky.test.js
@@ -1,0 +1,56 @@
+/**
+ * Scroll-driven slider: sticky pinning must depend on the pin spacer.
+ *
+ * The pin spacer is created at runtime by ScrollDrivenController
+ * (src/blocks/slider/view/scroll-driven.js), which never runs in the editor.
+ * If `position: sticky` hangs off the `dsgo-slider--scroll-driven` class alone
+ * it also applies in the editor canvas — where there is no spacer to scroll
+ * through — so the block pins to the top of the canvas and overlaps whatever
+ * follows it. Scoping the sticky to a descendant of the spacer keeps the
+ * frontend behaviour identical and leaves the editor (and a no-JS frontend)
+ * with a normally-flowed block.
+ */
+const path = require('path');
+const sass = require('sass');
+
+const STYLE = path.join(__dirname, '../../../src/blocks/slider/style.scss');
+
+/**
+ * Selectors in the compiled sheet that declare `position: sticky`.
+ *
+ * @param {string} css Compiled stylesheet.
+ * @return {string[]} Matching selectors.
+ */
+function stickySelectors(css) {
+	const found = [];
+	const ruleRe = /([^{}]+)\{([^{}]*)\}/g;
+	let match;
+	while ((match = ruleRe.exec(css)) !== null) {
+		if (/position\s*:\s*sticky/.test(match[2])) {
+			found.push(match[1].trim().replace(/\s+/g, ' '));
+		}
+	}
+	return found;
+}
+
+describe('scroll-driven slider sticky scoping', () => {
+	const css = sass.compile(STYLE, { loadPaths: [path.dirname(STYLE)] }).css;
+
+	it('never makes the scroll-driven slider sticky outside a pin spacer', () => {
+		const offenders = stickySelectors(css)
+			.filter((sel) => sel.includes('dsgo-slider--scroll-driven'))
+			.filter((sel) => !sel.includes('dsgo-slider-pin-spacer'));
+
+		expect(offenders).toEqual([]);
+	});
+
+	it('still pins the slider once the frontend spacer wraps it', () => {
+		const pinned = stickySelectors(css).filter(
+			(sel) =>
+				sel.includes('dsgo-slider-pin-spacer') &&
+				sel.includes('dsgo-slider--scroll-driven')
+		);
+
+		expect(pinned.length).toBeGreaterThan(0);
+	});
+});

--- a/tests/unit/blocks/slider-scroll-driven-sticky.test.js
+++ b/tests/unit/blocks/slider-scroll-driven-sticky.test.js
@@ -11,9 +11,27 @@
  * with a normally-flowed block.
  */
 const path = require('path');
-const sass = require('sass');
+const { execFileSync } = require('child_process');
 
 const STYLE = path.join(__dirname, '../../../src/blocks/slider/style.scss');
+
+// sass ships as a dart2js bundle that resolves `fs` off the global object; in
+// Jest's jsdom sandbox that lookup comes back undefined on some Node versions,
+// so compile out of process rather than requiring the module here.
+const SASS_CLI = path.join(path.dirname(require.resolve('sass')), 'sass.js');
+
+/**
+ * Compile the block stylesheet through the sass CLI.
+ *
+ * @return {string} Compiled CSS.
+ */
+function compile() {
+	return execFileSync(
+		process.execPath,
+		[SASS_CLI, '--no-source-map', STYLE],
+		{ encoding: 'utf8' }
+	);
+}
 
 /**
  * Selectors in the compiled sheet that declare `position: sticky`.
@@ -34,7 +52,7 @@ function stickySelectors(css) {
 }
 
 describe('scroll-driven slider sticky scoping', () => {
-	const css = sass.compile(STYLE, { loadPaths: [path.dirname(STYLE)] }).css;
+	const css = compile();
 
 	it('never makes the scroll-driven slider sticky outside a pin spacer', () => {
 		const offenders = stickySelectors(css)


### PR DESCRIPTION
## The bug

A Slider with **scroll-driven** mode enabled pinned itself to the top of the editor canvas and scrolled over the top of whatever block followed it. The frontend behaved correctly.

## Root cause

`src/blocks/slider/style.scss` hung the pin off the modifier class alone:

```scss
.dsgo-slider.dsgo-slider--scroll-driven { position: sticky; top: 0; … }
```

That sticky only means anything once `ScrollDrivenController` (`src/blocks/slider/view/scroll-driven.js`) wraps the slider in a `.dsgo-slider-pin-spacer` — the tall element the sticky is supposed to travel through. The controller is frontend-only, but `edit.js` applies the same class in the editor and the block's `style-index.css` loads in the canvas (twice, in fact — `editor.scss` also `@use`s it). No spacer, so the block pinned against the canvas with nothing to scroll through.

## Fix

Scope the pin to the spacer; leave the rest of the scroll-driven styling (overflow, progress-bar chrome) on the class.

```scss
.dsgo-slider-pin-spacer > .dsgo-slider.dsgo-slider--scroll-driven {
	position: sticky;
	top: 0;
}
```

The spacer is already the slider's parent by the time anything on the frontend depends on the sticky, so frontend rendering is unchanged. It also stops the same broken pin on a no-JS frontend. The double-class selector is kept — it's there to beat `[role="region"] { position: relative }` from wp-components.

CSS only: no markup or attribute change, so no deprecation is needed.

## Verification

- New test `tests/unit/blocks/slider-scroll-driven-sticky.test.js` compiles `style.scss` with sass and asserts that no `position: sticky` selector mentions `--scroll-driven` without `pin-spacer`, and that the pinned rule still exists. Both assertions failed before the change and pass after.
- Full unit suite: 124 suites / 2855 tests passing.
- `npm run build`, then grepped the emitted CSS — `build/blocks/slider/style-index.css` and the editor's `index.css` now carry only the spacer-scoped rule.
- stylelint and eslint clean on the touched files.

Not verified in a live browser — the change is confirmed against the compiled stylesheets rather than a visual editor check.
