### PR TITLE
fix(section): migrate unconstrained sections that carry no constrainWidth

### DIFF
--- a/src/blocks/section/deprecated.js
+++ b/src/blocks/section/deprecated.js
@@ -16,6 +16,8 @@ import {
 	hoverVariationClasses,
 } from './utils/has-overlay-style';
 import { getDeprecatedBlockHTML } from '../../utils/deprecated-block-html';
+import metadata from './block.json';
+import currentSave from './save';
 // The SAME predicate the live renderer uses. Migration and render must agree on
 // what counts as an explicit size, or a pinned clearance can desync from the
 // divider it is meant to clear — see isUntouchedLegacyShapeSize below.
@@ -446,6 +448,55 @@ function V7ShapeDivider({
 
 	return <div className={className} {...styleProps} aria-hidden="true" />;
 }
+
+// Version 10: Unconstrained inner container with no `constrainWidth` in the
+// block comment. This entry is the CURRENT save(), reused verbatim; the only
+// thing it changes is the default `constrainWidth` parses to — `false` instead
+// of `true` — so a stored `.dsgo-stack__inner` carrying no width style is read
+// back as "the constraint was off" rather than as broken markup.
+//
+// Two kinds of content land here, and the stored HTML says the same thing in
+// both cases:
+//
+// 1. Sections saved during the 92 minutes on 2025-11-10 between 6cbf8183 (which
+//    introduced `constrainWidth` with `default: false`) and 1bbdbefa (which
+//    flipped it to `true`). WordPress omits default-valued attributes from the
+//    block comment, so those sections stored no `constrainWidth` at all and are
+//    indistinguishable — by attributes alone — from a current section that
+//    simply left the toggle on.
+// 2. Markup that never came from save(): generated or hand-edited content that
+//    turns the constraint off the way it looks like it works, by putting
+//    `dsgo-no-width-constraint` on `className`, and writes the inner container
+//    with no style. The class is inert (the block reads `constrainWidth`), so
+//    the current save() emits a `max-width` the stored HTML lacks.
+//
+// The attributes are ambiguous but the markup is not: an inner container with no
+// width style is what an unconstrained section renders as, under every version
+// of this block. migrate() therefore writes that intent back into
+// `constrainWidth` explicitly, so it lands in the comment and the block stops
+// depending on whatever the default happens to be.
+//
+// No isEligible: a section reaching this entry is INVALID (its stored HTML does
+// not match the current save()), and WordPress skips isEligible for invalid
+// blocks — it picks the version whose save() reproduces the stored HTML. A VALID
+// section must never be claimed here, and none can be: one that left the toggle
+// on stored the inner width style, which this save() does not emit under a
+// `false` default, and one that explicitly turned it off already carries
+// `"constrainWidth":false` in its comment and matches the current save() outright.
+const v10 = {
+	apiVersion: 3,
+	// Current-era supports and schema, taken from block.json so they cannot drift
+	// out of step with the save() below, which IS the current save().
+	supports: metadata.supports,
+	attributes: {
+		...metadata.attributes,
+		constrainWidth: { type: 'boolean', default: false },
+	},
+	save: currentSave,
+	migrate(attributes) {
+		return { ...attributes, constrainWidth: false };
+	},
+};
 
 // Version 9: Height-derived pixel clearance padding. Before this version the
 // inner container's shape-divider clearance was computed from the divider
@@ -2154,4 +2205,4 @@ const v1 = {
 };
 
 // Export deprecations in reverse chronological order (newest first)
-export default [v9, v8, v7, v6, v5, v4, v3, v2, v1];
+export default [v10, v9, v8, v7, v6, v5, v4, v3, v2, v1];

--- a/src/blocks/section/test/deprecated.test.js
+++ b/src/blocks/section/test/deprecated.test.js
@@ -72,8 +72,8 @@ const OLD_SVG_MARKUP = `<!-- wp:designsetgo/section {"shapeDividerTop":"wave","s
 // background color (no explicit shapeDividerBottomColor set), matching
 // V4ShapeDivider's inheritance behavior used by deprecations v4/v5/v6.
 // Built from v4's own save() so the fixture is byte-exact.
-// deprecated.js exports deprecations newest-first: [v9, v8, v7, v6, v5, v4, v3, v2, v1].
-const [, , , , , v4Deprecation] = deprecated;
+// deprecated.js exports deprecations newest-first: [v10, v9, v8, v7, v6, v5, v4, v3, v2, v1].
+const [, , , , , , v4Deprecation] = deprecated;
 const OLD_SVG_MARKUP_BOTTOM_INHERITED = buildOldMarkup(
 	{
 		shapeDividerBottom: 'tilt',
@@ -124,7 +124,7 @@ describe('section deprecations - shape divider SVG to class-based migration', ()
 	// wave/tilt, which were NOT redesigned, so they can't catch this.
 	test('deprecations reproduce frozen legacy geometry for redesigned shapes (drops)', () => {
 		// deprecated.js exports newest-first: [v9, v8, v7, v6, v5, v4, v3, v2, v1].
-		const [, , , , , v4Dep, v3Dep] = deprecated;
+		const [, , , , , , v4Dep, v3Dep] = deprecated;
 
 		[v3Dep, v4Dep].forEach((deprecation) => {
 			const markup = buildOldMarkup(
@@ -141,7 +141,7 @@ describe('section deprecations - shape divider SVG to class-based migration', ()
 
 describe('section deprecations - style-kit overlay variation migration (v7)', () => {
 	// deprecated.js exports newest-first: [v9, v8, v7, v6, v5, v4, v3, v2, v1].
-	const [, , v7Deprecation] = deprecated;
+	const [, , , v7Deprecation] = deprecated;
 
 	// Reproduce content saved BEFORE this change by taking what the block
 	// ACTUALLY serializes today (carrying block.json defaults such as the
@@ -265,7 +265,7 @@ describe('section deprecations - style-kit overlay variation migration (v7)', ()
 
 describe('section deprecations - style-kit hover variation migration (v8)', () => {
 	// deprecated.js exports newest-first: [v9, v8, v7, v6, v5, v4, v3, v2, v1].
-	const [, v8Deprecation] = deprecated;
+	const [, , v8Deprecation] = deprecated;
 
 	// Reproduce content saved BEFORE hover-variation classes existed by taking
 	// the block's REAL current serialization and stripping the hover-text
@@ -422,7 +422,7 @@ describe('section deprecations - style-kit hover variation migration (v8)', () =
 
 describe('section deprecations - height-derived px clearance migration (v9)', () => {
 	// deprecated.js exports newest-first: [v9, v8, v7, v6, v5, v4, v3, v2, v1].
-	const [v9Deprecation] = deprecated;
+	const [, v9Deprecation] = deprecated;
 
 	// v9's own save() reproduces the pre-change output: the inner container's
 	// shape-divider clearance is derived from the divider height and emitted as
@@ -621,5 +621,89 @@ describe('section - nullable shape divider height/width (theme inheritance)', ()
 		expect(block.attributes.shapeDividerTopWidth).toBe(140);
 		expect(getBlockContent(block)).toContain('--dsgo-shape-height:80px');
 		expect(getBlockContent(block)).toContain('--dsgo-shape-width:140%');
+	});
+});
+
+describe('section deprecations - unconstrained markup without the attribute (v10)', () => {
+	// Real-world content (page builders, generated markup, hand-edited post
+	// content) turns the width constraint off the way it LOOKS like it works —
+	// by putting `dsgo-no-width-constraint` on the block's `className` — and then
+	// writes an inner container with no `style` at all, which is exactly what an
+	// unconstrained section renders as.
+	//
+	// The block, though, reads `constrainWidth`, not the class. That attribute
+	// defaults to `true`, so it is absent from the comment, so the current
+	// save() emits `max-width:…;margin-left:auto;margin-right:auto` on
+	// `.dsgo-stack__inner` — one attribute the stored HTML does not have, and the
+	// section is invalid ("Attempt Recovery"). The same shape reaches us from the
+	// 92-minute window on 2025-11-10 (6cbf8183…1bbdbefa) when `constrainWidth`
+	// itself defaulted to `false`, and from any handoff that dropped the inline
+	// style.
+	//
+	// The stored markup is unambiguous about intent — no inner width style means
+	// no width constraint — so the deprecation reads it back into the attribute.
+	const unconstrainedAttrs = { className: 'dsgo-no-width-constraint' };
+	const currentHTML = getSaveContent(
+		{ ...metadata, save },
+		{ ...createBlock(metadata.name, unconstrainedAttrs).attributes },
+		[]
+	);
+	// Strip the inner width style, leaving the class list untouched — the exact
+	// difference the editor reports between generated and stored content.
+	const storedHTML = currentHTML.replace(
+		/(<div class="dsgo-stack__inner")[^>]*>/,
+		'$1>'
+	);
+	const UNCONSTRAINED_MARKUP = `<!-- wp:designsetgo/section ${JSON.stringify(
+		unconstrainedAttrs
+	)} -->\n${storedHTML}\n<!-- /wp:designsetgo/section -->`;
+
+	test('the fixture differs from current save() only by the inner width style', () => {
+		expect(currentHTML).toContain(
+			'<div class="dsgo-stack__inner" style="max-width:'
+		);
+		expect(storedHTML).toContain('<div class="dsgo-stack__inner">');
+		expect(storedHTML).not.toContain('max-width');
+	});
+
+	test('the section stays valid instead of asking for recovery', () => {
+		const [block] = parse(UNCONSTRAINED_MARKUP);
+
+		// A silent deprecation migration logs "Block successfully updated" —
+		// the desired outcome, and it must be consumed explicitly here (see the
+		// shape-divider describe above).
+		expect(console).toHaveInformed();
+
+		expect(block.name).toBe('designsetgo/section');
+		expect(block.isValid).toBe(true);
+	});
+
+	test('migration records the intent the markup expressed', () => {
+		const [block] = parse(UNCONSTRAINED_MARKUP);
+		expect(console).toHaveInformed();
+
+		expect(block.attributes.constrainWidth).toBe(false);
+	});
+
+	test('the migrated block re-serializes to the same unconstrained markup', () => {
+		const [block] = parse(UNCONSTRAINED_MARKUP);
+		expect(console).toHaveInformed();
+
+		expect(getBlockContent(block)).toContain(
+			'<div class="dsgo-stack__inner">'
+		);
+		expect(getBlockContent(block)).not.toContain('max-width');
+	});
+
+	test('a constrained section is untouched by the new deprecation', () => {
+		const constrained = `<!-- wp:designsetgo/section -->\n${getSaveContent(
+			{ ...metadata, save },
+			createBlock(metadata.name).attributes,
+			[]
+		)}\n<!-- /wp:designsetgo/section -->`;
+		const [block] = parse(constrained);
+
+		expect(block.isValid).toBe(true);
+		expect(block.attributes.constrainWidth).toBe(true);
 	});
 });


### PR DESCRIPTION
## The failure

Sections whose stored `.dsgo-stack__inner` carries no width style fail validation with "Attempt Recovery". The editor console reports one delta and nothing else (class order differs too, but WordPress compares classes as an unordered set):

```
generated: <div class="dsgo-stack__inner" style="max-width:800px;margin-left:auto;margin-right:auto">
stored:    <div class="dsgo-stack__inner">
```

`constrainWidth` defaults to `true`, so WordPress omits it from the block comment, so `save()` emits a max-width the stored HTML never had.

## Why no existing deprecation catches it

All nine entries declare `constrainWidth: { type: 'boolean', default: true }` — including the oldest. Every one of them therefore emits the same inner max-width the current `save()` does, so none can byte-match the stored HTML, and the block stays invalid.

Two kinds of content land in that hole:

1. **Sections saved between `6cbf8183` and `1bbdbefa`** (both 2025-11-10, 92 minutes apart) — the window when `constrainWidth` existed with `default: false`. Those sections stored the attribute nowhere and are indistinguishable, by attributes alone, from a current section that simply left the toggle on.
2. **Markup that never came from `save()`** — generated or hand-edited content that turns the constraint off the way it looks like it works, by putting `dsgo-no-width-constraint` on `className`. That class is inert: the block reads `constrainWidth`, not the class. This is the shape in the reported console log, where the generated output carries *both* `dsgo-no-width-constraint` *and* a max-width — impossible from one attribute value, so the class is coming from `className`.

## The fix

Add `v10`: the current `save()` reused verbatim, with one thing changed — `constrainWidth` parses with `default: false`. An inner container with no width style then reads back as "the constraint was off", which is what that markup means under every version of this block. `migrate()` writes the intent into the attribute explicitly, so it lands in the comment and the section stops depending on whichever default is current.

Schema and supports come from `block.json` rather than being transcribed, so they cannot drift out of step with the `save()` they are paired with.

**It cannot claim a valid section.** One that left the toggle on stored the inner width style, which this `save()` does not emit under a `false` default. One that explicitly turned it off already carries `"constrainWidth":false` and matches the current `save()` outright — and a valid block is gated on `isEligible`, which this entry deliberately does not declare.

## Scope note

This makes the affected sections load clean and self-describing. It does **not** license `dsgo-no-width-constraint` as an authoring API — content that sets it on `className` is still doing something inert, and the migration is what converts it into the real attribute once.

## Tests

New describe in `src/blocks/section/test/deprecated.test.js`, built from the current `save()` output with the inner style stripped, so the fixture is the exact reported difference rather than hand-transcribed. Written failing first — it reproduced the reported `Expected attributes (2) […], instead saw […1]` warning verbatim before `v10` existed.

- fixture differs from current `save()` only by the inner width style
- the section stays valid instead of asking for recovery
- migration records the intent the markup expressed (`constrainWidth === false`)
- the migrated block re-serializes to the same unconstrained markup
- a constrained section is untouched by the new deprecation

The positional destructuring in that file (`const [, v9Deprecation] = deprecated`) is shifted by one for the new head entry.

## Verification

- `npx jest` — 9542 passed, 440 suites, 0 failures
- `tests/unit/deprecations-isEligible.test.js` — passes; `v10` declares no `isEligible`, so it cannot claim current content
- `npx eslint` on both changed files — clean
- `npm run build` — compiles (one pre-existing postcss-calc warning)
- pre-commit e2e block tests — 7 passed