### PR TITLE
fix: size the chart's axis gutter to the labels it actually draws

### DIFF
--- a/src/blocks/chart/chart-geometry.php
+++ b/src/blocks/chart/chart-geometry.php
@@ -261,6 +261,68 @@ if ( ! function_exists( 'designsetgo_chart_nice_bounds' ) ) {
 	}
 }
 
+if ( ! function_exists( 'designsetgo_chart_text_width' ) ) {
+	/**
+	 * Estimate how wide a string paints, in SVG user units.
+	 *
+	 * The SVG is built on the server, so there is nothing to measure against
+	 * -- the width has to be predicted from the characters. Digits, letters
+	 * and currency symbols are treated as one width and separators as a
+	 * narrower one, which is the only distinction that matters for axis
+	 * labels.
+	 *
+	 * Calibrated against the rendered output at font-size 14: "$0" measures
+	 * 16.2 user units and "$2,000,000" measures 71.9. The ratios below round
+	 * slightly high on purpose. Over-reserving costs a few units of plot
+	 * width; under-reserving paints the label outside the block.
+	 *
+	 * @param string $text      Text to measure.
+	 * @param float  $font_size Font size in user units. Matches the 14 the
+	 *                          stylesheet sets on .dsgo-chart__tick.
+	 * @return float Estimated width in user units.
+	 */
+	function designsetgo_chart_text_width( $text, $font_size = 14 ) {
+		$narrow = array( ',', '.', ' ', "'", ':', '|', 'i', 'l', 'I', 'j', 't', 'f', 'r' );
+		$width  = 0.0;
+
+		foreach ( preg_split( '//u', (string) $text, -1, PREG_SPLIT_NO_EMPTY ) as $char ) {
+			$width += in_array( $char, $narrow, true ) ? 0.30 : 0.60;
+		}
+
+		return $width * (float) $font_size;
+	}
+}
+
+if ( ! function_exists( 'designsetgo_chart_tick_gutter' ) ) {
+	/**
+	 * Width to reserve left of the plot for the y-axis tick labels.
+	 *
+	 * The labels are drawn 8 units left of the plot edge, anchored at their
+	 * end, so the gutter has to cover the widest label plus that gap. A fixed
+	 * 44 used to be assumed, which was enough for a bare "1000" and not for a
+	 * formatted "$2,000,000" -- and because .dsgo-chart__canvas is
+	 * `overflow: visible`, the excess was painted outside the block rather
+	 * than clipped.
+	 *
+	 * Clamped at both ends: never below the historic 44, so charts with short
+	 * labels keep the proportions they have always had, and never above 240,
+	 * so an outlandish prefix cannot squeeze the plot out of existence.
+	 *
+	 * @param array $labels Formatted tick labels.
+	 * @return int Gutter width in user units.
+	 */
+	function designsetgo_chart_tick_gutter( array $labels ) {
+		$widest = 0.0;
+
+		foreach ( $labels as $label ) {
+			$widest = max( $widest, designsetgo_chart_text_width( $label ) );
+		}
+
+		// 8 for the gap the label is offset by, 4 so it never sits flush.
+		return (int) min( 240, max( 44, (int) ceil( $widest ) + 12 ) );
+	}
+}
+
 if ( ! function_exists( 'designsetgo_chart_format_value' ) ) {
 	/**
 	 * Format a value for display, dropping meaningless trailing decimals.

--- a/src/blocks/chart/render.php
+++ b/src/blocks/chart/render.php
@@ -48,10 +48,10 @@ if ( ! function_exists( 'designsetgo_chart_geometry' ) ) {
 	function designsetgo_chart_geometry( array $attributes, array $rows, $has_grid, $type = 'bar' ) {
 		$height      = max( 80, min( 800, (int) ( isset( $attributes['height'] ) ? $attributes['height'] : 240 ) ) );
 		$show_values = ! isset( $attributes['showValues'] ) || (bool) $attributes['showValues'];
-		$pad_left    = $has_grid ? 44 : 0;
 		$pad_top     = $show_values ? 18 : 0;
 		$bounds      = designsetgo_chart_bounds( wp_list_pluck( $rows, 'value' ) );
 		$tick_count  = 5;
+		$format      = designsetgo_chart_value_format( $attributes );
 
 		// Reserve room under the plot for the x-axis category labels, but only
 		// when there is something to write there.
@@ -68,6 +68,22 @@ if ( ! function_exists( 'designsetgo_chart_geometry' ) ) {
 			$tick_count = $nice['count'];
 		}
 
+		// Size the left gutter to the labels that will actually be drawn.
+		// Formatting can widen a tick well past the old fixed 44 ("1000000"
+		// becomes "$1,000,000"), and the canvas does not clip, so a gutter
+		// that is too narrow paints the axis outside the block.
+		$pad_left = 0;
+
+		if ( $has_grid ) {
+			$labels = array();
+
+			foreach ( designsetgo_chart_ticks( $bounds['min'], $bounds['max'], $tick_count ) as $tick ) {
+				$labels[] = designsetgo_chart_format_value( $tick, $format );
+			}
+
+			$pad_left = designsetgo_chart_tick_gutter( $labels );
+		}
+
 		return array(
 			'width'       => 600,
 			'height'      => $height,
@@ -80,7 +96,7 @@ if ( ! function_exists( 'designsetgo_chart_geometry' ) ) {
 			'max'         => $bounds['max'],
 			'tick_count'  => $tick_count,
 			'show_values' => $show_values,
-			'format'      => designsetgo_chart_value_format( $attributes ),
+			'format'      => $format,
 		);
 	}
 }

--- a/tests/phpunit/chart-geometry-test.php
+++ b/tests/phpunit/chart-geometry-test.php
@@ -97,6 +97,76 @@ class Chart_Geometry_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Text width grows with the string and treats commas as narrow.
+	 *
+	 * The estimate is calibrated against the browser: at font-size 14,
+	 * "$0" measures 16.2 user units and "$2,000,000" measures 71.9.
+	 */
+	public function test_text_width_estimates_the_measured_widths() {
+		$narrow = designsetgo_chart_text_width( '$0' );
+		$wide   = designsetgo_chart_text_width( '$2,000,000' );
+
+		// Within a reasonable margin of the measured values, and never under
+		// -- under-reserving is what puts labels outside the container.
+		$this->assertGreaterThanOrEqual( 16.2, $narrow );
+		$this->assertLessThan( 22.0, $narrow );
+
+		$this->assertGreaterThanOrEqual( 71.9, $wide );
+		$this->assertLessThan( 85.0, $wide );
+	}
+
+	/**
+	 * A comma takes less room than a digit.
+	 */
+	public function test_text_width_treats_separators_as_narrow() {
+		$this->assertLessThan(
+			designsetgo_chart_text_width( '11' ),
+			designsetgo_chart_text_width( ',,' )
+		);
+	}
+
+	/**
+	 * The gutter never drops below the previous fixed value.
+	 *
+	 * Short labels kept the old 44-unit gutter, so unchanged charts keep
+	 * their proportions.
+	 */
+	public function test_tick_gutter_keeps_the_historic_minimum() {
+		$this->assertSame( 44, designsetgo_chart_tick_gutter( array( '0', '5', '10' ) ) );
+	}
+
+	/**
+	 * A wide label widens the gutter enough to hold it.
+	 *
+	 * This is the regression: a fixed 44-unit gutter left "$2,000,000"
+	 * hanging 35 units outside the chart's own box.
+	 */
+	public function test_tick_gutter_grows_for_a_wide_label() {
+		$labels = array( '$0', '$1,000,000', '$2,000,000', '$3,000,000' );
+		$gutter = designsetgo_chart_tick_gutter( $labels );
+
+		$this->assertGreaterThan( 44, $gutter );
+
+		// The label is drawn 8 units left of the plot edge, so the gutter has
+		// to cover the widest label plus that gap.
+		$this->assertGreaterThanOrEqual(
+			designsetgo_chart_text_width( '$3,000,000' ) + 8,
+			$gutter
+		);
+	}
+
+	/**
+	 * An absurd affix cannot eat the whole plot.
+	 */
+	public function test_tick_gutter_is_capped() {
+		$gutter = designsetgo_chart_tick_gutter(
+			array( str_repeat( 'M', 200 ) )
+		);
+
+		$this->assertLessThanOrEqual( 240, $gutter );
+	}
+
+	/**
 	 * The midpoint of the input range maps to the midpoint of the output range.
 	 */
 	public function test_scale_maps_the_midpoint() {

--- a/tests/phpunit/chart-render-test.php
+++ b/tests/phpunit/chart-render-test.php
@@ -170,6 +170,86 @@ class Chart_Render_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Wide axis labels widen the gutter instead of escaping the chart box.
+	 *
+	 * The canvas is `overflow: visible`, so a label that does not fit the
+	 * gutter is not clipped -- it is painted outside the block's own border,
+	 * over whatever sits to the left of it.
+	 */
+	public function test_wide_axis_labels_widen_the_plot_gutter() {
+		$html = $this->render(
+			array(
+				'chartType'      => 'bar',
+				'data'           => array(
+					array(
+						'label' => 'Q1',
+						'value' => 1234567,
+					),
+					array(
+						'label' => 'Q2',
+						'value' => 2345678,
+					),
+				),
+				'valuePrefix'    => '$',
+				'groupThousands' => true,
+				'showGrid'       => true,
+			)
+		);
+
+		$this->assertSame(
+			1,
+			preg_match( '/class="dsgo-chart__plot" transform="translate\((\d+), /', $html, $m ),
+			'The plot group is missing its transform.'
+		);
+
+		$gutter = (int) $m[1];
+
+		// "$3,000,000" is the widest tick this data produces.
+		$this->assertGreaterThanOrEqual(
+			designsetgo_chart_text_width( '$3,000,000' ) + 8,
+			$gutter,
+			'The gutter is too narrow to hold the widest tick label.'
+		);
+	}
+
+	/**
+	 * A plain chart keeps the gutter it has always had.
+	 */
+	public function test_narrow_axis_labels_keep_the_original_gutter() {
+		$html = $this->render(
+			array(
+				'chartType' => 'bar',
+				'data'      => $this->sample(),
+				'showGrid'  => true,
+			)
+		);
+
+		$this->assertStringContainsString(
+			'class="dsgo-chart__plot" transform="translate(44, ',
+			$html
+		);
+	}
+
+	/**
+	 * A gridless chart still has no left gutter at all.
+	 */
+	public function test_a_gridless_chart_has_no_gutter() {
+		$html = $this->render(
+			array(
+				'chartType'   => 'bar',
+				'data'        => $this->sample(),
+				'valuePrefix' => '$',
+				'showGrid'    => false,
+			)
+		);
+
+		$this->assertStringContainsString(
+			'class="dsgo-chart__plot" transform="translate(0, ',
+			$html
+		);
+	}
+
+	/**
 	 * The block is registered, so the test suite is exercising real markup.
 	 */
 	public function test_the_block_is_registered() {


### PR DESCRIPTION
Follow-up to #533. The y-axis tick labels were painted outside the block's own box.

## Cause

The plot's left gutter was a fixed 44 user units, a constant chosen back when a tick label read `1000000`. Measured in the browser at font-size 14:

| label | width |
|---|---|
| `$0` | 16.2 |
| `$1,000,000` | 68.7 |
| `$2,000,000` | 71.9 |

The label is drawn 8 units left of the plot edge, anchored at its end, so `$2,000,000` needed ~80 units and had 44. It ran 35 units past the viewBox origin.

That would normally just clip, but `.dsgo-chart__canvas` is `overflow: visible` — so instead of being cut off, the label was painted outside the block, over whatever sat to its left.

The bug predates value formatting: a bare `3000000` overflowed by ~18 units too. Adding `$` and thousands separators roughly doubled the overflow and made it obvious.

## Fix

The gutter is measured from the tick labels the chart will actually draw. Nothing can be measured server-side, so `designsetgo_chart_text_width()` estimates from the characters — one width for digits, letters and symbols, a narrower one for separators, which is the only distinction axis labels need.

It is calibrated against the measurements above and rounds high deliberately: over-reserving costs a few units of plot width, under-reserving puts the label outside the block.

Clamped at both ends:

- **Never below 44**, so charts with short labels keep the proportions they have always had. Covered by a test.
- **Never above 240**, so an outlandish prefix cannot squeeze the plot out of existence. Also covered.

## Verified

Before: gutter 44, `$2,000,000` starting 35 units outside the box.
After: gutter 88, and no label paints left of the SVG's own edge.

```
gutter: 88
svgLeft: 174px
ticks:  $0 @ 291px, $1,000,000 @ 194.7px, $2,000,000 @ 188.9px, $3,000,000 @ 189.3px
overflowingLabels: []
```

Confirmed visually in the editor — the axis now sits inside the block's border.

## Testing

- 1347 PHPUnit tests pass (1 pre-existing documented skip), 9550 JS unit tests pass
- `phpcs` clean on all changed PHP

8 new tests: width estimation against the measured values, separators measuring narrower than digits, the gutter's floor and cap, the gutter growing for a wide label, a plain chart keeping `translate(44, …)`, and a gridless chart keeping no gutter at all.
